### PR TITLE
Add one-command installation option via Claude Plugins CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The official Every marketplace where engineers from Every.to share their workflo
 
 ## Quick start
 
+### Standard Installation
 Run Claude and add the marketplace:
 
 ```
@@ -15,6 +16,13 @@ Then install the plugin:
 ```
 /plugin install compounding-engineering
 ```
+### One-Command Installation
+Use the [Claude Plugins CLI](https://claude-plugins.dev) to skip the marketplace setup:
+```bash
+npx claude-plugins install @EveryInc/every-marketplace/compounding-engineering
+```
+
+This automatically adds the marketplace and installs the plugin in a single step.
 
 ## Available plugins
 


### PR DESCRIPTION
## Changes
- Added "One-Command Installation" section to Quick Start
- Preserves existing installation instructions as the primary method
- Links to Claude Plugins CLI documentation

## Rationale

The standard Claude Code workflow requires users to:
1. Add marketplace: `/plugin marketplace add https://github.com/EveryInc/every-marketplace`
2. Install plugin: `/plugin install compounding-engineering`

This CLI tool automates both steps:
```bash
npx claude-plugins install @EveryInc/every-marketplace/compounding-engineering
```

Benefits:
- Reduces friction for first-time users
- Simplifies one-off installations
- Cleaner for documentation examples

## Notes
- CLI is open-source and maintained at https://github.com/Kamalnrf/claude-plugins
- No changes to plugin functionality or dependencies