### PR TITLE
Fix mermaid diagram legibility in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ graph LR
     C --> D[Codify<br/>Record<br/>learnings]
     D --> A
 
-    style A fill:#f9f,stroke:#333,stroke-width:2px
-    style B fill:#bbf,stroke:#333,stroke-width:2px
-    style C fill:#bfb,stroke:#333,stroke-width:2px
-    style D fill:#ffb,stroke:#333,stroke-width:2px
+    style A fill:#f9f,stroke:#fff,stroke-width:2px,color:#333
+    style B fill:#bbf,stroke:#fff,stroke-width:2px,color:#333
+    style C fill:#bfb,stroke:#fff,stroke-width:2px,color:#333
+    style D fill:#ffb,stroke:#fff,stroke-width:2px,color:#333
 ```
 
 ## How It Works


### PR DESCRIPTION
## Summary

- Fix mermaid diagram stroke and text colors for dark mode compatibility

## Changes

Changed the mermaid diagram styling from:
- `stroke:#333` (dark gray - invisible on dark backgrounds)

To:
- `stroke:#fff` (white - visible on both light and dark backgrounds)
- `color:#333` (explicit dark text - readable on the pastel fill colors)

The pastel fill colors (#f9f, #bbf, #bfb, #ffb) remain unchanged as they work well in both modes.

## Test plan

- [x] View README on GitHub in light mode - diagram should be legible
- [x] View README on GitHub in dark mode - diagram should be legible

Fixes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)