### PR TITLE
Add explicit reference to workflow subdirectory in plugin manifest

### DIFF
--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
-  "version": "2.9.4",
-  "description": "AI-powered development tools. 24 agents, 19 commands, 11 skills, 2 MCP servers for code review, research, design, and workflow automation.",
+  "version": "2.10.0",
+  "description": "AI-powered development tools. 25 agents, 19 commands, 12 skills, 2 MCP servers for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",


### PR DESCRIPTION
Commands are in commands/workflows/ but that path isn't registered in the plugin manifest. Claude Code doesn't automatically discover commands in subdirectories - it only looks in commands/.