### PR TITLE
fix: Update file-todos paths to use docs/todos/

### DIFF
--- a/plugins/compound-engineering/commands/resolve_todo_parallel.md
+++ b/plugins/compound-engineering/commands/resolve_todo_parallel.md
@@ -10,7 +10,7 @@ Resolve all TODO comments using parallel processing.
 
 ### 1. Analyze
 
-Get all unresolved TODOs from the /todos/\*.md directory
+Get all unresolved TODOs from the /docs/todos/\*.md directory
 
 ### 2. Plan
 

--- a/plugins/compound-engineering/commands/triage.md
+++ b/plugins/compound-engineering/commands/triage.md
@@ -5,7 +5,7 @@ argument-hint: "[findings list or source type]"
 ---
 
 - First set the /model to Haiku
-- Then read all pending todos in the todos/ directory
+- Then read all pending todos in the docs/todos/ directory
 
 Present all findings, decisions, or issues here one by one for triage. The goal is to go through each item and decide whether to add it to the CLI todo system.
 
@@ -148,7 +148,7 @@ Do you want to add this to the todo list?
 
 **When user says "next":**
 
-- **Delete the todo file** - Remove it from todos/ directory since it's not relevant
+- **Delete the todo file** - Remove it from docs/todos/ directory since it's not relevant
 - Skip to the next item
 - Track skipped items for summary
 
@@ -181,22 +181,22 @@ After all items processed:
 
 ### Skipped Items (Deleted):
 
-- Item #5: [reason] - Removed from todos/
-- Item #12: [reason] - Removed from todos/
+- Item #5: [reason] - Removed from docs/todos/
+- Item #12: [reason] - Removed from docs/todos/
 
 ### Summary of Changes Made:
 
 During triage, the following status updates occurred:
 
 - **Pending → Ready:** Filenames and frontmatter updated to reflect approved status
-- **Deleted:** Todo files for skipped findings removed from todos/ directory
+- **Deleted:** Todo files for skipped findings removed from docs/todos/ directory
 - Each approved file now has `status: ready` in YAML frontmatter
 
 ### Next Steps:
 
 1. View approved todos ready for work:
    ```bash
-   ls todos/*-ready-*.md
+   ls docs/todos/*-ready-*.md
    ```
 ````
 
@@ -271,7 +271,7 @@ Do you want to add this to the todo list?
 4. Confirm: "✅ Approved: `{filename}` (Issue #{issue_id}) - Status: **ready**"
 
 **When "next" is selected:**
-1. Delete the todo file from todos/ directory
+1. Delete the todo file from docs/todos/ directory
 2. Skip to next item
 3. No file remains in the system
 

--- a/plugins/compound-engineering/commands/workflows/review.md
+++ b/plugins/compound-engineering/commands/workflows/review.md
@@ -171,7 +171,7 @@ Run the Task code-simplicity-reviewer() to see if we can simplify the code.
 
 ### 5. Findings Synthesis and Todo Creation Using file-todos Skill
 
-<critical_requirement> ALL findings MUST be stored in the todos/ directory using the file-todos skill. Create todo files immediately after synthesis - do NOT present findings for user approval first. Use the skill for structured todo management. </critical_requirement>
+<critical_requirement> ALL findings MUST be stored in the docs/todos/ directory using the file-todos skill. Create todo files immediately after synthesis - do NOT present findings for user approval first. Use the skill for structured todo management. </critical_requirement>
 
 #### Step 1: Synthesize All Findings
 
@@ -360,7 +360,7 @@ After creating all todo files, present comprehensive summary:
 
 2. **Triage All Todos**:
    ```bash
-   ls todos/*-pending-*.md  # View all pending todos
+   ls docs/todos/*-pending-*.md  # View all pending todos
    /triage                  # Use slash command for interactive triage
    ```
 ````
@@ -374,7 +374,7 @@ After creating all todo files, present comprehensive summary:
 4. **Track Progress**:
    - Rename file when status changes: pending → ready → complete
    - Update Work Log as you work
-   - Commit todos: `git add todos/ && git commit -m "refactor: add code review findings"`
+   - Commit todos: `git add docs/todos/ && git commit -m "refactor: add code review findings"`
 
 ### Severity Breakdown:
 


### PR DESCRIPTION
## Summary

The `file-todos` skill documentation (`SKILL.md`) was updated to use `docs/todos/` as the canonical location for todo files, but several command files still referenced the old `todos/` path. This PR updates those commands for consistency.

## Changes

Updated path references in:
- `commands/resolve_todo_parallel.md` - Line 13
- `commands/triage.md` - Lines 8, 151, 184-185, 192, 199, 274
- `commands/workflows/review.md` - Lines 174, 363, 377

All `todos/` → `docs/todos/`

## Rationale

Keeping todos under `docs/` follows best practices for documentation organization:
- `docs/solutions/` - Problem-solution knowledge base
- `docs/issues/` - Issue tracking docs
- `docs/todos/` - File-based work item tracking

## Test plan

- [ ] Verified commands reference correct `docs/todos/` path
- [ ] No functional changes, only path string updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)