### PR TITLE
Refine 'Tools as Primitives' principle with spectrum-based guidance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
   "plugins": [
     {
       "name": "compound-engineering",
-      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 27 specialized agents, 20 commands, and 12 skills.",
-      "version": "2.21.0",
+      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 27 specialized agents, 21 commands, and 13 skills.",
+      "version": "2.23.2",
       "author": {
         "name": "Kieran Klaassen",
         "url": "https://github.com/kieranklaassen",

--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compound-engineering",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "AI-powered development tools. 27 agents, 21 commands, 13 skills, 2 MCP servers for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",

--- a/plugins/compound-engineering/CHANGELOG.md
+++ b/plugins/compound-engineering/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the compound-engineering plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.23.2] - 2026-01-08
+
+### Changed
+
+- **`agent-native-architecture` skill** - Major refinement of the "Tools as Primitives" principle
+  - Added **Primitives** vocabulary section defining key terms (Pure Primitive, Guided Primitive, Domain Tool, Orchestrated Action, Sub-Agent, Harness)
+  - Replaced binary "primitives vs workflows" with spectrum-based guidance
+  - Added **Decision Framework**: "Who should own this decision?" (business rule → code, tool-specific → description, context-dependent → prompt, agent judgment → neither)
+  - Added **"What IS a Tool?"** philosophical section clarifying that tool calls are mechanisms, not design constraints
+  - Added **JIT Context Injection** pattern: tool descriptions as modular prompting that travels with tools
+  - Added **Harness Pattern** for business invariants that must always execute together
+  - Refined anti-patterns section with "when it's wrong" vs "when it's fine" guidance
+  - Applied pragmatic writing style with concrete story openings throughout
+  - Updated architecture checklist with new tool design checkboxes
+
+### Summary
+
+- 27 agents, 21 commands, 13 skills, 2 MCP servers
+
+---
+
 ## [2.23.1] - 2026-01-08
 
 ### Changed


### PR DESCRIPTION
## Summary

Addresses #71 - This PR refines the agent-native-architecture skill's guidance on tool design, replacing the binary "primitives vs workflows" stance with a more nuanced spectrum-based approach.

## Key Changes

### New Sections Added

1. **Primitives Vocabulary** - Defines key terms upfront:
   - Pure Primitive, Guided Primitive, Domain Tool, Orchestrated Action, Sub-Agent, Harness
   - Clarifies that a "tool call" is just a mechanism—what you wire to it determines its nature

2. **"What IS a Tool?"** - Philosophical section covering:
   - API doesn't distinguish between file reads and sub-agent spawns
   - Sub-agents break the primitive model (they make their own decisions)
   - Tool descriptions as JIT context injection

3. **Decision Framework** - New mental model:
   | Decision Owner | Implementation |
   |----------------|----------------|
   | Business rule (always this way) | Code in tool execution |
   | Tool-specific strategy (usually this way) | Tool description |
   | Conversation-dependent | System prompt |
   | Agent judgment | Neither—trust the model |

4. **Harness Pattern** - When to use code to enforce business invariants

### Updated Sections

1. **Granularity Principle** - Now shows the spectrum:
   ```
   Pure Primitive → Guided Primitive → Domain Tool → Orchestrated Action
   ```
   With guidance on when to use each.

2. **Anti-Patterns** - Restructured with:
   - "When it's wrong" vs "When it's fine" for each pattern
   - Acknowledges that logic in tools isn't automatically wrong
   - Separates "judgment calls" from "actual anti-patterns"

3. **Architecture Checklist** - Updated with new checkboxes:
   - Right level of granularity
   - Decision ownership clear
   - JIT Context Injection

## Closes

Closes #71