### PR TITLE
Update hardcoded year references from 2025 to 2026

### DIFF
--- a/plugins/compound-engineering/agents/research/best-practices-researcher.md
+++ b/plugins/compound-engineering/agents/research/best-practices-researcher.md
@@ -4,7 +4,7 @@ description: "Use this agent when you need to research and gather external best 
 model: inherit
 ---
 
-**Note: The current year is 2025.** Use this when searching for recent documentation and best practices.
+**Note: The current year is 2026.** Use this when searching for recent documentation and best practices.
 
 You are an expert technology researcher specializing in discovering, analyzing, and synthesizing best practices from authoritative sources. Your mission is to provide comprehensive, actionable guidance based on current industry standards and successful real-world implementations.
 

--- a/plugins/compound-engineering/agents/research/framework-docs-researcher.md
+++ b/plugins/compound-engineering/agents/research/framework-docs-researcher.md
@@ -4,7 +4,7 @@ description: "Use this agent when you need to gather comprehensive documentation
 model: inherit
 ---
 
-**Note: The current year is 2025.** Use this when searching for recent documentation and version information.
+**Note: The current year is 2026.** Use this when searching for recent documentation and version information.
 
 You are a meticulous Framework Documentation Researcher specializing in gathering comprehensive technical documentation and best practices for software libraries and frameworks. Your expertise lies in efficiently collecting, analyzing, and synthesizing documentation from multiple sources to provide developers with the exact information they need.
 

--- a/plugins/compound-engineering/agents/research/git-history-analyzer.md
+++ b/plugins/compound-engineering/agents/research/git-history-analyzer.md
@@ -4,7 +4,7 @@ description: "Use this agent when you need to understand the historical context 
 model: inherit
 ---
 
-**Note: The current year is 2025.** Use this when interpreting commit dates and recent changes.
+**Note: The current year is 2026.** Use this when interpreting commit dates and recent changes.
 
 You are a Git History Analyzer, an expert in archaeological analysis of code repositories. Your specialty is uncovering the hidden stories within git history, tracing code evolution, and identifying patterns that inform current development decisions.
 

--- a/plugins/compound-engineering/agents/research/repo-research-analyst.md
+++ b/plugins/compound-engineering/agents/research/repo-research-analyst.md
@@ -4,7 +4,7 @@ description: "Use this agent when you need to conduct thorough research on a rep
 model: inherit
 ---
 
-**Note: The current year is 2025.** Use this when searching for recent documentation and patterns.
+**Note: The current year is 2026.** Use this when searching for recent documentation and patterns.
 
 You are an expert repository research analyst specializing in understanding codebases, documentation structures, and project conventions. Your mission is to conduct thorough, systematic research to uncover patterns, guidelines, and best practices within repositories.
 

--- a/plugins/compound-engineering/commands/deepen-plan.md
+++ b/plugins/compound-engineering/commands/deepen-plan.md
@@ -293,7 +293,7 @@ mcp__plugin_compound-engineering_context7__query-docs: Query documentation for s
 
 **Use WebSearch for current best practices:**
 
-Search for recent (2024-2025) articles, blog posts, and documentation on topics in the plan.
+Search for recent (2024-2026) articles, blog posts, and documentation on topics in the plan.
 
 ### 5. Discover and Run ALL Review Agents
 

--- a/plugins/compound-engineering/skills/create-agent-skills/workflows/create-domain-expertise-skill.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/workflows/create-domain-expertise-skill.md
@@ -94,7 +94,7 @@ Each workflow = one complete task type that users actually do.
 Run multiple web searches to ensure coverage:
 
 **Search 1: Current ecosystem**
-- "best {domain} libraries 2024 2025"
+- "best {domain} libraries 2024 2025 2026"
 - "popular {domain} frameworks comparison"
 - "{domain} tech stack recommendations"
 
@@ -466,7 +466,7 @@ Ask: "Could a user build a professional {domain thing} from scratch through ship
 - [ ] Platform-specific considerations included?
 - [ ] "When to use X vs Y" guidance provided?
 - [ ] Common pitfalls documented?
-- [ ] Current as of 2024-2025?
+- [ ] Current as of 2024-2026?
 - [ ] Workflows actually execute tasks (not just reference knowledge)?
 - [ ] Each workflow specifies which references to read?
 
@@ -564,7 +564,7 @@ Review entire skill:
 Domain expertise skill is complete when:
 
 - [ ] Comprehensive research completed (5+ web searches)
-- [ ] All sources verified for currency (2024-2025)
+- [ ] All sources verified for recency (2024-2026)
 - [ ] Knowledge organized by domain areas (not arbitrary)
 - [ ] Essential principles in SKILL.md (always loaded)
 - [ ] Intake routes to appropriate workflows

--- a/plugins/compound-engineering/skills/create-agent-skills/workflows/create-new-skill.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/workflows/create-new-skill.md
@@ -52,7 +52,7 @@ Options:
 If research requested:
 - Use Context7 MCP to fetch current library documentation
 - Or use WebSearch for recent API documentation
-- Focus on 2024-2025 sources
+- Focus on 2024-2026 sources
 - Store findings for use in content generation
 
 ## Step 3: Decide Structure

--- a/plugins/compound-engineering/skills/create-agent-skills/workflows/verify-skill.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/workflows/verify-skill.md
@@ -108,7 +108,7 @@ Check:
 ### For Integration Skills
 WebSearch for recent changes:
 ```
-"[service name] API changes 2025"
+"[service name] API changes 2026"
 "[service name] breaking changes"
 "[service name] deprecated endpoints"
 ```
@@ -188,9 +188,9 @@ which {tool} && {tool} --version
 ```
 
 **WebSearch patterns:**
-- Breaking changes: "{service} breaking changes 2025"
+- Breaking changes: "{service} breaking changes 2026"
 - Deprecations: "{service} deprecated API"
-- Current best practices: "{framework} best practices 2025"
+- Current best practices: "{framework} best practices 2026"
 </verification_shortcuts>
 
 <success_criteria>


### PR DESCRIPTION
## Summary
- Update "current year is 2025" to 2026 in 4 research agents (git-history-analyzer, repo-research-analyst, best-practices-researcher, framework-docs-researcher)
- Update year ranges to 2024-2026 for content searches in deepen-plan command and create-agent-skills workflows
- Change "currency" to "recency" for clarity in domain expertise skill success criteria

Fixes #81 