### PR TITLE
Fix broken markdown table in dhh-rails-style skill

### DIFF
--- a/plugins/compound-engineering/skills/dhh-rails-style/SKILL.md
+++ b/plugins/compound-engineering/skills/dhh-rails-style/SKILL.md
@@ -54,15 +54,16 @@ What are you working on?
 </intake>
 
 <routing>
+
 | Response | Reference to Read |
 |----------|-------------------|
-| 1, "controller" | [controllers.md](./references/controllers.md) |
-| 2, "model" | [models.md](./references/models.md) |
-| 3, "view", "frontend", "turbo", "stimulus", "css" | [frontend.md](./references/frontend.md) |
-| 4, "architecture", "routing", "auth", "job", "cache" | [architecture.md](./references/architecture.md) |
-| 5, "test", "testing", "minitest", "fixture" | [testing.md](./references/testing.md) |
-| 6, "gem", "dependency", "library" | [gems.md](./references/gems.md) |
-| 7, "review" | Read all references, then review code |
+| 1, controller | [controllers.md](./references/controllers.md) |
+| 2, model | [models.md](./references/models.md) |
+| 3, view, frontend, turbo, stimulus, css | [frontend.md](./references/frontend.md) |
+| 4, architecture, routing, auth, job, cache | [architecture.md](./references/architecture.md) |
+| 5, test, testing, minitest, fixture | [testing.md](./references/testing.md) |
+| 6, gem, dependency, library | [gems.md](./references/gems.md) |
+| 7, review | Read all references, then review code |
 | 8, general task | Read relevant references based on context |
 
 **After reading relevant references, apply patterns to the user's code.**


### PR DESCRIPTION
## Summary
- Remove quotes from the routing table's Response column to fix markdown table rendering on GitHub

<img width="2076" height="470" alt="CleanShot 2026-01-21 at 05 38 34@2x" src="https://github.com/user-attachments/assets/f260ce25-f3f1-4a19-9cbe-80758c42eeda" />

## Before
The table rendered incorrectly because quotes in the first column confused the markdown parser.

## After
Clean table without quotes renders correctly.

<img width="790" height="578" alt="CleanShot 2026-01-21 at 05 39 17@2x" src="https://github.com/user-attachments/assets/2635b0b9-1140-4432-ab80-2d88c84ad796" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)