### PR TITLE
docs: add skillkit as multi-agent installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@ A Claude Code plugin marketplace featuring the **Compound Engineering Plugin** â
 
 ## Install
 
+### Option 1: SkillKit (Multi-Agent Support)
+
+Use [skillkit](https://github.com/rohitg00/skillkit) to install across multiple AI agents:
+
+```bash
+# Install compound engineering skills
+npx skillkit install EveryInc/compound-engineering-plugin
+
+# Install to multiple agents at once
+npx skillkit install EveryInc/compound-engineering-plugin --agent cursor --agent claude-code --agent windsurf
+```
+
+**Why SkillKit?**
+- **Multi-agent sync**: Install and sync skills across 17+ AI agents (Claude Code, Cursor, Codex, Gemini CLI, Windsurf, Goose, Amp, and more)
+- **Auto-detection**: Automatically detects which AI agent you're using
+- **Global or project-level**: Install skills globally (`--global`) or per-project
+
+### Option 2: Claude Code Plugin
+
 ```bash
 /plugin marketplace add https://github.com/kieranklaassen/compound-engineering-plugin
 /plugin install compound-engineering


### PR DESCRIPTION
This pull request updates the `README.md` to provide improved installation instructions for the Compound Engineering Plugin. The main enhancement is the addition of a new installation method using SkillKit, which allows users to install and synchronize the plugin across multiple AI agents. The documentation now also explains the advantages of using SkillKit and clarifies the available installation options.

**Installation instructions update:**

* Added a new section describing how to install the plugin using SkillKit, including commands for multi-agent installation and a summary of SkillKit's key benefits.
* Clarified the existing method for installing the plugin directly in Claude Code.