### PR TITLE
feat(workflows:plan): Add smart research decision logic

### DIFF
--- a/plugins/compound-engineering/commands/workflows/plan.md
+++ b/plugins/compound-engineering/commands/workflows/plan.md
@@ -29,37 +29,65 @@ Before running research, refine the idea through collaborative dialogue using th
 - Focus on understanding: purpose, constraints and success criteria
 - Continue until the idea is clear OR user says "proceed"
 
+**Gather signals for research decision.** During refinement, note:
+
+- **User's familiarity**: Do they know the codebase patterns? Are they pointing to examples?
+- **User's intent**: Speed vs thoroughness? Exploration vs execution?
+- **Topic risk**: Security, payments, external APIs warrant more caution
+- **Uncertainty level**: Is the approach clear or open-ended?
+
 **Skip option:** If the feature description is already detailed, offer:
 "Your description is clear. Should I proceed with research, or would you like to refine it further?"
 
 ## Main Tasks
 
-### 1. Repository Research & Context Gathering
+### 1. Repository Research (Always Runs)
 
 <thinking>
-First, I need to understand the project's conventions and existing patterns, leveraging all available resources and use paralel subagents to do this.
+First, I need to understand the project's conventions and existing patterns. This is fast and local - it informs whether external research is needed.
 </thinking>
 
-Runn these three agents in paralel at the same time:
+Run repo research to understand the codebase:
 
 - Task repo-research-analyst(feature_description)
+
+**What to look for:** existing patterns, CLAUDE.md guidance, technology familiarity, pattern consistency. These findings inform the next step.
+
+### 1.5. Research Decision
+
+Based on signals from Step 0 and findings from Step 1, decide on external research.
+
+**High-risk topics → always research.** Security, payments, external APIs, data privacy. The cost of missing something is too high. This takes precedence over speed signals.
+
+**Strong local context → skip external research.** Codebase has good patterns, CLAUDE.md has guidance, user knows what they want. External research adds little value.
+
+**Uncertainty or unfamiliar territory → research.** User is exploring, codebase has no examples, new technology. External perspective is valuable.
+
+**Announce the decision and proceed.** Brief explanation, then continue. User can redirect if needed.
+
+Examples:
+- "Your codebase has solid patterns for this. Proceeding without external research."
+- "This involves payment processing, so I'll research current best practices first."
+
+### 1.5b. External Research (Conditional)
+
+**Only run if Step 1.5 indicates external research is valuable.**
+
+Run these agents in parallel:
+
 - Task best-practices-researcher(feature_description)
 - Task framework-docs-researcher(feature_description)
 
-**Reference Collection:**
+### 1.6. Consolidate Research
 
-- [ ] Document all research findings with specific file paths (e.g., `app/services/example_service.rb:42`)
-- [ ] Include URLs to external documentation and best practices guides
-- [ ] Create a reference list of similar issues or PRs (e.g., `#123`, `#456`)
-- [ ] Note any team conventions discovered in `CLAUDE.md` or team documentation
+After all research steps complete, consolidate findings:
 
-### Research Validation (Optional)
+- Document relevant file paths from repo research (e.g., `app/services/example_service.rb:42`)
+- Note external documentation URLs and best practices (if external research was done)
+- List related issues or PRs discovered
+- Capture CLAUDE.md conventions
 
-After research agents complete, briefly validate alignment:
-
-- Summarize key findings from research
-- Ask if anything looks off or is missing
-- User can confirm or request additional research on specific topics
+**Optional validation:** Briefly summarize findings and ask if anything looks off or missing before proceeding to planning.
 
 ### 2. Issue Planning & Structure
 


### PR DESCRIPTION
## Summary

- Makes `/workflows:plan` smarter about when to run external web research
- Previously always ran all 3 research agents regardless of task complexity
- Now repo research runs first, then decides on external research based on context

This will make it more automatic to want to use the compound engineering workflows instead of thinking whether or not the task at hand warrants it.

Note: In a follow-up PR I'm going to suggest addition of a `/workflows:brainstorm` step that optionally precedes the plan step but that's a much larger proposal. Will be curious to what @kieranklaassen will think about that one ;) 

## Changes

**Step 0 (Idea Refinement):** Now gathers signals about user familiarity, intent, topic risk, and uncertainty level.

**Step 1 (Repo Research):** Always runs (fast, local). Findings inform the research decision.

**Step 1.5 (Research Decision):** New step that decides on external research:
- High-risk topics (security, payments, external APIs) → always research
- Strong local context (good patterns, CLAUDE.md guidance) → skip external
- Uncertainty or unfamiliar territory → research

**Step 1.5b (External Research):** Conditional - only runs when decision indicates value.

**Step 1.6 (Consolidate Research):** New step to consolidate findings from all applicable research.
