### PR TITLE
feat(research): add mandatory API deprecation validation

### DIFF
--- a/plugins/compound-engineering/agents/research/best-practices-researcher.md
+++ b/plugins/compound-engineering/agents/research/best-practices-researcher.md
@@ -37,12 +37,23 @@ Before going online, check if curated knowledge already exists in skills:
 
 4. **Assess Coverage**:
    - If skills provide comprehensive guidance → summarize and deliver
-   - If skills provide partial guidance → note what's covered, proceed to Phase 2 for gaps
-   - If no relevant skills found → proceed to Phase 2
+   - If skills provide partial guidance → note what's covered, proceed to Phase 1.5 and Phase 2 for gaps
+   - If no relevant skills found → proceed to Phase 1.5 and Phase 2
+
+### Phase 1.5: MANDATORY Deprecation Check (for external APIs/services)
+
+**Before recommending any external API, OAuth flow, SDK, or third-party service:**
+
+1. Search for deprecation: `"[API name] deprecated [current year] sunset shutdown"`
+2. Search for breaking changes: `"[API name] breaking changes migration"`
+3. Check official documentation for deprecation banners or sunset notices
+4. **Report findings before proceeding** - do not recommend deprecated APIs
+
+**Why this matters:** Google Photos Library API scopes were deprecated March 2025. Without this check, developers can waste hours debugging "insufficient scopes" errors on dead APIs. 5 minutes of validation saves hours of debugging.
 
 ### Phase 2: Online Research (If Needed)
 
-Only after checking skills, gather additional information:
+Only after checking skills AND verifying API availability, gather additional information:
 
 1. **Leverage External Sources**:
    - Use Context7 MCP to access official documentation from GitHub, framework docs, and library references

--- a/plugins/compound-engineering/agents/research/framework-docs-researcher.md
+++ b/plugins/compound-engineering/agents/research/framework-docs-researcher.md
@@ -41,19 +41,26 @@ You are a meticulous Framework Documentation Researcher specializing in gatherin
    - Determine the installed version from Gemfile.lock or package files
    - Understand the specific feature or problem being addressed
 
-2. **Documentation Collection**:
+2. **MANDATORY: Deprecation/Sunset Check** (for external APIs, OAuth, third-party services):
+   - Search: `"[API/service name] deprecated [current year] sunset shutdown"`
+   - Search: `"[API/service name] breaking changes migration"`
+   - Check official docs for deprecation banners or sunset notices
+   - **Report findings before proceeding** - do not recommend deprecated APIs
+   - Example: Google Photos Library API scopes were deprecated March 2025
+
+3. **Documentation Collection**:
    - Start with Context7 to fetch official documentation
    - If Context7 is unavailable or incomplete, use web search as fallback
    - Prioritize official sources over third-party tutorials
    - Collect multiple perspectives when official docs are unclear
 
-3. **Source Exploration**:
+4. **Source Exploration**:
    - Use `bundle show` to find gem locations
    - Read through key source files related to the feature
    - Look for tests that demonstrate usage patterns
    - Check for configuration examples in the codebase
 
-4. **Synthesis and Reporting**:
+5. **Synthesis and Reporting**:
    - Organize findings by relevance to the current task
    - Highlight version-specific considerations
    - Provide code examples adapted to the project's style
@@ -61,6 +68,7 @@ You are a meticulous Framework Documentation Researcher specializing in gatherin
 
 **Quality Standards:**
 
+- **ALWAYS check for API deprecation first** when researching external APIs or services
 - Always verify version compatibility with the project's dependencies
 - Prioritize official documentation but supplement with community resources
 - Provide practical, actionable insights rather than generic information


### PR DESCRIPTION
## Summary

Add mandatory deprecation/sunset checks to research agents before they recommend external APIs, OAuth flows, or third-party services.

## Problem

Without validation, research agents can recommend deprecated APIs, leading developers to waste hours on implementation and debugging. For example:

- **Google Photos Library API**: The `photoslibrary` and `photoslibrary.readonly` scopes were deprecated in March 2025
- A developer researching "Google Photos API best practices" could receive outdated guidance and waste hours debugging OAuth "insufficient scopes" errors

## Solution

Add deprecation checks to research agents:

### `framework-docs-researcher.md`
- Added new **Step 2: MANDATORY Deprecation/Sunset Check** to the workflow
- Added "ALWAYS check for API deprecation first" to Quality Standards

### `best-practices-researcher.md`  
- Added new **Phase 1.5: MANDATORY Deprecation Check** between skills check and online research
- Includes specific search patterns and rationale

## Changes

```
plugins/compound-engineering/agents/research/best-practices-researcher.md
plugins/compound-engineering/agents/research/framework-docs-researcher.md
```

## Why This Matters

**5 minutes of validation saves hours of debugging dead APIs.**

---

🤖 Generated with [Claude Code](https://claude.ai/code)