### PR TITLE
Standardize plan and brainstorm filename conventions

### DIFF
--- a/plugins/compound-engineering/commands/deepen-plan.md
+++ b/plugins/compound-engineering/commands/deepen-plan.md
@@ -24,8 +24,8 @@ The result is a deeply grounded, production-ready plan with concrete implementat
 <plan_path> #$ARGUMENTS </plan_path>
 
 **If the plan path above is empty:**
-1. Check for recent plans: `ls -la plans/`
-2. Ask the user: "Which plan would you like to deepen? Please provide the path (e.g., `plans/my-feature.md`)."
+1. Check for recent plans: `ls -la docs/plans/`
+2. Ask the user: "Which plan would you like to deepen? Please provide the path (e.g., `docs/plans/2026-01-15-feat-my-feature-plan.md`)."
 
 Do not proceed until you have a valid plan file path.
 
@@ -460,7 +460,7 @@ At the top of the plan, add a summary section:
 
 ## Output Format
 
-Update the plan file in place (or create `plans/<original-name>-deepened.md` if requested).
+Update the plan file in place (or if user requests a separate file, append `-deepened` after `-plan`, e.g., `2026-01-15-feat-auth-plan-deepened.md`).
 
 ## Quality Checks
 

--- a/plugins/compound-engineering/commands/workflows/brainstorm.md
+++ b/plugins/compound-engineering/commands/workflows/brainstorm.md
@@ -72,7 +72,7 @@ Use **AskUserQuestion tool** to ask which approach the user prefers.
 
 ### Phase 3: Capture the Design
 
-Write a brainstorm document to `docs/brainstorms/YYYY-MM-DD-<topic>.md`.
+Write a brainstorm document to `docs/brainstorms/YYYY-MM-DD-<topic>-brainstorm.md`.
 
 **Document structure:** See the `brainstorming` skill for the template format. Key sections: What We're Building, Why This Approach, Key Decisions, Open Questions.
 
@@ -96,7 +96,7 @@ When complete, display:
 ```
 Brainstorm complete!
 
-Document: docs/brainstorms/YYYY-MM-DD-<topic>.md
+Document: docs/brainstorms/YYYY-MM-DD-<topic>-brainstorm.md
 
 Key decisions:
 - [Decision 1]

--- a/plugins/compound-engineering/commands/workflows/plan.md
+++ b/plugins/compound-engineering/commands/workflows/plan.md
@@ -124,8 +124,8 @@ Think like a product manager - what would make this issue clear and actionable? 
 
 - [ ] Draft clear, searchable issue title using conventional format (e.g., `feat: Add user authentication`, `fix: Cart total calculation`)
 - [ ] Determine issue type: enhancement, bug, refactor
-- [ ] Convert title to kebab-case filename: strip prefix colon, lowercase, hyphens for spaces
-  - Example: `feat: Add User Authentication` → `feat-add-user-authentication.md`
+- [ ] Convert title to filename: add today's date prefix, strip prefix colon, kebab-case, add `-plan` suffix
+  - Example: `feat: Add User Authentication` → `2026-01-21-feat-add-user-authentication-plan.md`
   - Keep it descriptive (3-5 words after prefix) so plans are findable by context
 
 **Stakeholder Analysis:**
@@ -169,6 +169,14 @@ Select how comprehensive you want the issue to be, simpler is mostly better.
 **Structure:**
 
 ````markdown
+---
+title: [Issue Title]
+type: [feat|fix|refactor]
+date: YYYY-MM-DD
+---
+
+# [Issue Title]
+
 [Brief problem/feature description]
 
 ## Acceptance Criteria
@@ -213,6 +221,14 @@ end
 **Structure:**
 
 ```markdown
+---
+title: [Issue Title]
+type: [feat|fix|refactor]
+date: YYYY-MM-DD
+---
+
+# [Issue Title]
+
 ## Overview
 
 [Comprehensive description]
@@ -269,6 +285,14 @@ end
 **Structure:**
 
 ```markdown
+---
+title: [Issue Title]
+type: [feat|fix|refactor]
+date: YYYY-MM-DD
+---
+
+# [Issue Title]
+
 ## Overview
 
 [Executive summary]
@@ -444,25 +468,26 @@ end
 
 ## Output Format
 
-**Filename:** Use the kebab-case filename from Step 2 Title & Categorization.
+**Filename:** Use the date and kebab-case filename from Step 2 Title & Categorization.
 
 ```
-plans/<type>-<descriptive-name>.md
+docs/plans/YYYY-MM-DD-<type>-<descriptive-name>-plan.md
 ```
 
 Examples:
-- ✅ `plans/feat-user-authentication-flow.md`
-- ✅ `plans/fix-checkout-race-condition.md`
-- ✅ `plans/refactor-api-client-extraction.md`
-- ❌ `plans/plan-1.md` (not descriptive)
-- ❌ `plans/new-feature.md` (too vague)
-- ❌ `plans/feat: user auth.md` (invalid characters)
+- ✅ `docs/plans/2026-01-15-feat-user-authentication-flow-plan.md`
+- ✅ `docs/plans/2026-02-03-fix-checkout-race-condition-plan.md`
+- ✅ `docs/plans/2026-03-10-refactor-api-client-extraction-plan.md`
+- ❌ `docs/plans/2026-01-15-feat-thing-plan.md` (not descriptive - what "thing"?)
+- ❌ `docs/plans/2026-01-15-feat-new-feature-plan.md` (too vague - what feature?)
+- ❌ `docs/plans/2026-01-15-feat: user auth-plan.md` (invalid characters - colon and space)
+- ❌ `docs/plans/feat-user-auth-plan.md` (missing date prefix)
 
 ## Post-Generation Options
 
 After writing the plan file, use the **AskUserQuestion tool** to present these options:
 
-**Question:** "Plan ready at `plans/<issue_title>.md`. What would you like to do next?"
+**Question:** "Plan ready at `docs/plans/YYYY-MM-DD-<type>-<name>-plan.md`. What would you like to do next?"
 
 **Options:**
 1. **Open plan in editor** - Open the plan file for review
@@ -474,11 +499,11 @@ After writing the plan file, use the **AskUserQuestion tool** to present these o
 7. **Simplify** - Reduce detail level
 
 Based on selection:
-- **Open plan in editor** → Run `open plans/<issue_title>.md` to open the file in the user's default editor
+- **Open plan in editor** → Run `open docs/plans/<plan_filename>.md` to open the file in the user's default editor
 - **`/deepen-plan`** → Call the /deepen-plan command with the plan file path to enhance with research
 - **`/plan_review`** → Call the /plan_review command with the plan file path
 - **`/workflows:work`** → Call the /workflows:work command with the plan file path
-- **`/workflows:work` on remote** → Run `/workflows:work plans/<issue_title>.md &` to start work in background for Claude Code web
+- **`/workflows:work` on remote** → Run `/workflows:work docs/plans/<plan_filename>.md &` to start work in background for Claude Code web
 - **Create Issue** → See "Issue Creation" section below
 - **Simplify** → Ask "What should I simplify?" then regenerate simpler version
 - **Other** (automatically provided) → Accept free text for rework or specific changes
@@ -496,16 +521,17 @@ When user selects "Create Issue", detect their project tracker from CLAUDE.md:
    - Or look for mentions of "GitHub Issues" or "Linear" in their workflow section
 
 2. **If GitHub:**
+
+   Use the title and type from Step 2 (already in context - no need to re-read the file):
+
    ```bash
-   # Extract title from plan filename (kebab-case to Title Case)
-   # Read plan content for body
-   gh issue create --title "feat: [Plan Title]" --body-file plans/<issue_title>.md
+   gh issue create --title "<type>: <title>" --body-file <plan_path>
    ```
 
 3. **If Linear:**
+
    ```bash
-   # Use linear CLI if available, or provide instructions
-   # linear issue create --title "[Plan Title]" --description "$(cat plans/<issue_title>.md)"
+   linear issue create --title "<title>" --description "$(cat <plan_path>)"
    ```
 
 4. **If no tracker configured:**

--- a/plugins/compound-engineering/skills/brainstorming/SKILL.md
+++ b/plugins/compound-engineering/skills/brainstorming/SKILL.md
@@ -134,7 +134,7 @@ topic: <kebab-case-topic>
 → `/workflows:plan` for implementation details
 ```
 
-**Output Location:** `docs/brainstorms/YYYY-MM-DD-<topic>.md`
+**Output Location:** `docs/brainstorms/YYYY-MM-DD-<topic>-brainstorm.md`
 
 ### Phase 4: Handoff
 


### PR DESCRIPTION
## Summary

This PR standardizes the filename conventions for workflow artifacts (brainstorms and plans) to improve consistency, discoverability, and self-documentation.

## Problem

Previously, there were several inconsistencies:
1. **Location inconsistency**: Plans were stored in `plans/` while brainstorms and solutions used `docs/` subfolders
2. **No dates in plan filenames**: Brainstorms had `YYYY-MM-DD` prefixes but plans did not, making chronological sorting impossible
3. **No self-documenting suffixes**: When viewing a filename in editor tabs or search results, you couldn't tell if it was a plan or brainstorm without seeing the folder
4. **No structured metadata in plans**: Plans lacked YAML frontmatter, making it harder to extract title/type programmatically

## Solution

### New filename conventions:

| Artifact | Old Format | New Format |
|----------|------------|------------|
| Brainstorm | `docs/brainstorms/YYYY-MM-DD-<topic>.md` | `docs/brainstorms/YYYY-MM-DD-<topic>-brainstorm.md` |
| Plan | `plans/<type>-<name>.md` | `docs/plans/YYYY-MM-DD-<type>-<name>-plan.md` |
| Deepened | `plans/<name>-deepened.md` | `docs/plans/YYYY-MM-DD-<type>-<name>-plan-deepened.md` |

### New plan template structure:

All plan templates (MINIMAL, MORE, A LOT) now include YAML frontmatter:

```markdown
---
title: [Issue Title]
type: [feat|fix|refactor]
date: YYYY-MM-DD
---

# [Issue Title]

## Overview
...
```

### Benefits:
- **Consistent location**: All workflow artifacts now live under `docs/` (`docs/brainstorms/`, `docs/plans/`, `docs/solutions/`)
- **Chronological sorting**: Date prefix enables natural sorting by creation date
- **Self-documenting**: `-brainstorm` and `-plan` suffixes identify artifact type without needing folder context
- **Clear versioning**: Deepened plans use `-plan-deepened` suffix (type, then modifier)
- **Structured metadata**: YAML frontmatter stores title, type, and date for easy extraction
- **Efficient issue creation**: Instructions now use title/type already in context (from Step 2) rather than re-reading the file

## Test plan

- [ ] Verify `/workflows:plan` creates files in `docs/plans/` with correct naming and frontmatter
- [ ] Verify `/workflows:brainstorm` creates files with `-brainstorm` suffix
- [ ] Verify `/deepen-plan` finds plans in new location
- [ ] Verify issue creation uses title/type from context without re-reading plan