### PR TITLE
Fix repository URL in plugin.json

### DIFF
--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/kieranklaassen"
   },
   "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",
-  "repository": "https://github.com/kieranklaassen/every-marketplace",
+  "repository": "https://github.com/EveryInc/compound-engineering-plugin",
   "license": "MIT",
   "keywords": [
     "ai-powered",


### PR DESCRIPTION
## Summary
- Update repository link from `kieranklaassen/every-marketplace` to `EveryInc/compound-engineering-plugin`

## Test plan
- [ ] Verify the repository URL in plugin.json points to the correct upstream repo