### PR TITLE
Update installation command for compound-engineering plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Claude Code plugin marketplace featuring the **Compound Engineering Plugin** â
 
 ```bash
 /plugin marketplace add https://github.com/EveryInc/compound-engineering-plugin
-/plugin install compound-engineering
+/plugin install compound-engineering@compound-engineering-plugin
 ```
 
 ## OpenCode + Codex (experimental) Install


### PR DESCRIPTION
On my claude setup this plugin could not be installed like documented.

This ensures that the plugin will be always installed from the correct marketplace.