### PR TITLE
fix: remove hardcoded CORA project references

### DIFF
--- a/plugins/compound-engineering/agents/research/learnings-researcher.md
+++ b/plugins/compound-engineering/agents/research/learnings-researcher.md
@@ -66,7 +66,7 @@ Grep: pattern="email" path=docs/solutions/ output_mode=files_with_matches -i=tru
 **Regardless of Grep results**, always read the critical patterns file:
 
 ```bash
-Read: docs/solutions/patterns/cora-critical-patterns.md
+Read: docs/solutions/patterns/critical-patterns.md
 ```
 
 This file contains must-know patterns that apply across all work - high-severity issues promoted to required reading. Scan for patterns relevant to the current feature/task.
@@ -182,7 +182,7 @@ Structure your findings as:
 - **Relevant Matches**: [Y files]
 
 ### Critical Patterns (Always Check)
-[Any matching patterns from cora-critical-patterns.md]
+[Any matching patterns from critical-patterns.md]
 
 ### Relevant Learnings
 

--- a/plugins/compound-engineering/commands/workflows/compound.md
+++ b/plugins/compound-engineering/commands/workflows/compound.md
@@ -28,7 +28,7 @@ This command launches multiple specialized subagents IN PARALLEL to maximize eff
 ### 1. **Context Analyzer** (Parallel)
    - Extracts conversation history
    - Identifies problem type, component, symptoms
-   - Validates against CORA schema
+   - Validates against solution schema
    - Returns: YAML frontmatter skeleton
 
 ### 2. **Solution Extractor** (Parallel)

--- a/plugins/compound-engineering/commands/workflows/work.md
+++ b/plugins/compound-engineering/commands/workflows/work.md
@@ -181,7 +181,7 @@ This command takes a work document (plan, specification, or todo file) and execu
    - **kieran-rails-reviewer**: Verify Rails conventions (Rails projects)
    - **performance-oracle**: Check for performance issues
    - **security-sentinel**: Scan for security vulnerabilities
-   - **cora-test-reviewer**: Review test quality (CORA projects)
+   - **cora-test-reviewer**: Review test quality (Rails projects with comprehensive test coverage)
 
    Run reviewers in parallel with Task tool:
 

--- a/plugins/compound-engineering/skills/compound-docs/SKILL.md
+++ b/plugins/compound-engineering/skills/compound-docs/SKILL.md
@@ -61,7 +61,7 @@ Extract from conversation history:
 
 **Required information:**
 
-- **Module name**: Which CORA module had the problem
+- **Module name**: Which module or component had the problem
 - **Symptom**: Observable error/behavior (exact error messages)
 - **Investigation attempts**: What didn't work and why
 - **Root cause**: Technical explanation of actual problem
@@ -249,7 +249,7 @@ But **NEVER auto-promote**. User decides via decision menu (Option 2).
 
 **Template for critical pattern addition:**
 
-When user selects Option 2 (Add to Required Reading), use the template from `assets/critical-pattern-template.md` to structure the pattern entry. Number it sequentially based on existing patterns in `docs/solutions/patterns/cora-critical-patterns.md`.
+When user selects Option 2 (Add to Required Reading), use the template from `assets/critical-pattern-template.md` to structure the pattern entry. Number it sequentially based on existing patterns in `docs/solutions/patterns/critical-patterns.md`.
 </step>
 
 </critical_sequence>
@@ -270,7 +270,7 @@ File created:
 
 What's next?
 1. Continue workflow (recommended)
-2. Add to Required Reading - Promote to critical patterns (cora-critical-patterns.md)
+2. Add to Required Reading - Promote to critical patterns (critical-patterns.md)
 3. Link related issues - Connect to similar problems
 4. Add to existing skill - Add to a learning skill (e.g., hotwire-native)
 5. Create new skill - Extract into new learning skill
@@ -295,7 +295,7 @@ User selects this when:
 Action:
 1. Extract pattern from the documentation
 2. Format as ❌ WRONG vs ✅ CORRECT with code examples
-3. Add to `docs/solutions/patterns/cora-critical-patterns.md`
+3. Add to `docs/solutions/patterns/critical-patterns.md`
 4. Add cross-reference back to this doc
 5. Confirm: "✓ Added to Required Reading. All subagents will see this pattern before code generation."
 
@@ -317,7 +317,7 @@ Action:
 4. Confirm: "✓ Added to [skill-name] skill in [file]"
 
 Example: For Hotwire Native Tailwind variants solution:
-- Add to `hotwire-native/references/resources.md` under "CORA-Specific Resources"
+- Add to `hotwire-native/references/resources.md` under "Project-Specific Resources"
 - Add to `hotwire-native/references/examples.md` with link to solution doc
 
 **Option 5: Create new skill**
@@ -397,11 +397,11 @@ Documentation is successful when ALL of the following are true:
 - Present multiple matches
 - Let user choose: new doc, update existing, or link as duplicate
 
-**Module not in CORA-MODULES.md:**
+**Module not in modules documentation:**
 
 - Warn but don't block
 - Proceed with documentation
-- Suggest: "Add [Module] to CORA-MODULES.md if not there"
+- Suggest: "Add [Module] to modules documentation if not there"
 
 ---
 
@@ -488,7 +488,7 @@ File created:
 
 What's next?
 1. Continue workflow (recommended)
-2. Add to Required Reading - Promote to critical patterns (cora-critical-patterns.md)
+2. Add to Required Reading - Promote to critical patterns (critical-patterns.md)
 3. Link related issues - Connect to similar problems
 4. Add to existing skill - Add to a learning skill (e.g., hotwire-native)
 5. Create new skill - Extract into new learning skill

--- a/plugins/compound-engineering/skills/compound-docs/assets/critical-pattern-template.md
+++ b/plugins/compound-engineering/skills/compound-docs/assets/critical-pattern-template.md
@@ -1,6 +1,6 @@
 # Critical Pattern Template
 
-Use this template when adding a pattern to `docs/solutions/patterns/cora-critical-patterns.md`:
+Use this template when adding a pattern to `docs/solutions/patterns/critical-patterns.md`:
 
 ---
 

--- a/plugins/compound-engineering/skills/compound-docs/assets/resolution-template.md
+++ b/plugins/compound-engineering/skills/compound-docs/assets/resolution-template.md
@@ -1,5 +1,5 @@
 ---
-module: [Module name or "CORA" for system-wide]
+module: [Module name or "System" for system-wide]
 date: [YYYY-MM-DD]
 problem_type: [build_error|test_failure|runtime_error|performance_issue|database_issue|security_issue|ui_bug|integration_issue|logic_error]
 component: [rails_model|rails_controller|rails_view|service_object|background_job|database|frontend_stimulus|hotwire_turbo|email_processing|brief_system|assistant|authentication|payments]
@@ -19,7 +19,7 @@ tags: [keyword1, keyword2, keyword3]
 [1-2 sentence clear description of the issue and what the user experienced]
 
 ## Environment
-- Module: [Name or "CORA system"]
+- Module: [Name or "System-wide"]
 - Rails Version: [e.g., 7.1.2]
 - Affected Component: [e.g., "Email Processing model", "Brief System service", "Authentication controller"]
 - Date: [YYYY-MM-DD when this was solved]
@@ -78,7 +78,7 @@ tags: [keyword1, keyword2, keyword3]
 
 ## Prevention
 
-[How to avoid this problem in future CORA development:]
+[How to avoid this problem in future development:]
 - [Specific coding practice, check, or pattern to follow]
 - [What to watch out for]
 - [How to catch this early]

--- a/plugins/compound-engineering/skills/compound-docs/references/yaml-schema.md
+++ b/plugins/compound-engineering/skills/compound-docs/references/yaml-schema.md
@@ -4,7 +4,7 @@
 
 ## Required Fields
 
-- **module** (string): Module name (e.g., "EmailProcessing") or "CORA" for system-wide issues
+- **module** (string): Module name (e.g., "EmailProcessing") or "System" for system-wide issues
 - **date** (string): ISO 8601 date (YYYY-MM-DD)
 - **problem_type** (enum): One of [build_error, test_failure, runtime_error, performance_issue, database_issue, security_issue, ui_bug, integration_issue, logic_error, developer_experience, workflow_issue, best_practice, documentation_gap]
 - **component** (enum): One of [rails_model, rails_controller, rails_view, service_object, background_job, database, frontend_stimulus, hotwire_turbo, email_processing, brief_system, assistant, authentication, payments, development_workflow, testing_framework, documentation, tooling]


### PR DESCRIPTION
## Problem

The compound-engineering plugin contains hardcoded references to "CORA" (Every's internal project name) throughout the documentation workflow. This makes the plugin appear project-specific rather than the advertised generic tool, and causes confusion for users applying it to their own projects.

Example issues:
- References to `cora-critical-patterns.md` instead of generic `critical-patterns.md`
- Prompts asking "Which CORA module" instead of "Which module"
- References to `CORA-MODULES.md` which doesn't exist in the plugin
- "CORA-Specific Resources" labels

## Solution

This PR removes all hardcoded CORA references and replaces them with generic equivalents:

- `cora-critical-patterns.md` → `critical-patterns.md`
- "Which CORA module" → "Which module or component"
- "CORA-Specific Resources" → "Project-Specific Resources"
- "CORA-MODULES.md" → "modules documentation" (optional)
- "CORA system" → "System-wide"
- "CORA schema" → "solution schema"
- cora-test-reviewer description made generic

## Files Changed

- `learnings-researcher.md`: Fixed critical patterns file reference
- `compound-docs/SKILL.md`: Removed module and filename hardcoding
- `compound-docs/assets/*.md`: Generalized template references
- `workflows/compound.md`: Changed schema reference
- `workflows/work.md`: Made test reviewer description generic

## Impact

- ✅ Plugin works seamlessly with any project name
- ✅ No breaking changes (new filename doesn't conflict with existing setups)
- ✅ Clearer for new users that the plugin is project-agnostic
- ✅ Existing CORA projects unaffected (can rename their file or keep using old name)

## Testing

Verified zero remaining "CORA" references in plugin markdown files:
```bash
grep -r "\bCORA\b" --include="*.md" ./plugins/compound-engineering/ | wc -l
# Output: 0
```