### PR TITLE
Fix terminology: third person → passive voice

### DIFF
--- a/plugins/compound-engineering/CHANGELOG.md
+++ b/plugins/compound-engineering/CHANGELOG.md
@@ -371,7 +371,7 @@ These updates operationalize a key insight from building agent-native mobile app
 
 - **All skills** - Fixed spec compliance issues across 12 skills:
   - Reference files now use proper markdown links (`[file.md](./references/file.md)`) instead of backtick text
-  - Descriptions now use third person ("This skill should be used when...") per skill-creator spec
+  - Descriptions now use passive voice ("This skill should be used when...") per skill-creator spec
   - Affected skills: agent-native-architecture, andrew-kane-gem-writer, compound-docs, create-agent-skills, dhh-rails-style, dspy-ruby, every-style-editor, file-todos, frontend-design, gemini-imagegen
 
 ### Added

--- a/plugins/compound-engineering/CLAUDE.md
+++ b/plugins/compound-engineering/CLAUDE.md
@@ -59,7 +59,7 @@ When adding or modifying skills, verify compliance with skill-creator spec:
 ### YAML Frontmatter (Required)
 
 - [ ] `name:` present and matches directory name (lowercase-with-hyphens)
-- [ ] `description:` present and uses **third person** ("This skill should be used when..." NOT "Use this skill when...")
+- [ ] `description:` is present and uses **passive voice** ("This skill should be used when..." NOT "Use this skill when...")
 
 ### Reference Links (Required if references/ exists)
 
@@ -82,7 +82,7 @@ grep -E '`(references|assets|scripts)/[^`]+`' skills/*/SKILL.md
 
 # Check description format
 grep -E '^description:' skills/*/SKILL.md | grep -v 'This skill'
-# Should return nothing if all use third person
+# Should return nothing if all use passive voice
 ```
 
 ## Documentation

--- a/plugins/compound-engineering/skills/create-agent-skills/SKILL.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/SKILL.md
@@ -49,7 +49,7 @@ my-skill/
 
 ### 4. Effective Descriptions
 
-The description field enables skill discovery. Include both what the skill does AND when to use it. Write in third person.
+The description field enables skill discovery. Include both what the skill does AND when to use it. Write in passive voice.
 
 **Good:**
 ```yaml

--- a/plugins/compound-engineering/skills/create-agent-skills/references/best-practices.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/references/best-practices.md
@@ -107,7 +107,7 @@ Use **gerund form** (verb + -ing) for Skill names:
 
 ## Writing Effective Descriptions
 
-**Always write in third person.** The description is injected into the system prompt.
+**Always write in passive voice.** The description is injected into the system prompt.
 
 **Be specific and include key terms:**
 

--- a/plugins/compound-engineering/skills/create-agent-skills/references/common-patterns.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/references/common-patterns.md
@@ -276,7 +276,7 @@ description: I can help you process Excel files and generate reports
 description: Processes Excel files and generates reports. Use when analyzing spreadsheets or .xlsx files.
 ```
 
-**Why it matters**: Skills must use third person. First/second person breaks the skill metadata pattern.
+**Why it matters**: Skills must use passive voice. First/second person breaks the skill metadata pattern.
 </pitfall>
 
 <pitfall name="wrong_naming_convention">

--- a/plugins/compound-engineering/skills/create-agent-skills/references/official-spec.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/references/official-spec.md
@@ -116,7 +116,7 @@ Benefits:
 
 The `description` field enables Skill discovery and should include both what the Skill does and when to use it.
 
-**Always write in third person.** The description is injected into the system prompt.
+**Always write in passive voice.** The description is injected into the system prompt.
 
 - **Good:** "Processes Excel files and generates reports"
 - **Avoid:** "I can help you process Excel files"

--- a/plugins/compound-engineering/skills/create-agent-skills/references/skill-structure.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/references/skill-structure.md
@@ -81,7 +81,7 @@ Be consistent within your skill. If you use `<workflow>`, don't also use `<proce
 ```yaml
 ---
 name: skill-name-here
-description: What it does and when to use it (third person, specific triggers)
+description: What it does and when to use it (passive voice, specific triggers)
 ---
 ```
 </required_fields>
@@ -107,10 +107,10 @@ description: What it does and when to use it (third person, specific triggers)
 **Validation rules**:
 - Non-empty, maximum 1024 characters
 - No XML tags
-- Third person (never first or second person)
+- Passive voice (never first or second person)
 - Include what it does AND when to use it
 
-**Critical rule**: Always write in third person.
+**Critical rule**: Always write in passive voice.
 - ✅ "Processes Excel files and generates reports"
 - ❌ "I can help you process Excel files"
 - ❌ "You can use this to process Excel files"
@@ -360,7 +360,7 @@ Every skill must have: `<objective>`, `<quick_start>`, and `<success_criteria>` 
 <validation_checklist>
 Before finalizing a skill, verify:
 
-- ✅ YAML frontmatter valid (name matches directory, description in third person)
+- ✅ YAML frontmatter valid (name matches directory, description in passive voice)
 - ✅ No markdown headings in body (pure XML structure)
 - ✅ Required tags present: objective, quick_start, success_criteria
 - ✅ Conditional tags appropriate for complexity level

--- a/plugins/compound-engineering/skills/create-agent-skills/workflows/audit-skill.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/workflows/audit-skill.md
@@ -50,7 +50,7 @@ Evaluate against each criterion:
 - [ ] Name matches directory name
 - [ ] Has `description:` field
 - [ ] Description says what it does AND when to use it
-- [ ] Description is third person ("Use when...")
+- [ ] Description is passive voice ("This skill should be used when...")
 
 ### Structure
 - [ ] SKILL.md under 500 lines

--- a/plugins/compound-engineering/skills/create-agent-skills/workflows/create-new-skill.md
+++ b/plugins/compound-engineering/skills/create-agent-skills/workflows/create-new-skill.md
@@ -144,7 +144,7 @@ Domain knowledge that:
 Check:
 - [ ] YAML frontmatter valid
 - [ ] Name matches directory (lowercase-with-hyphens)
-- [ ] Description says what it does AND when to use it (third person)
+- [ ] Description says what it does AND when to use it (passive voice)
 - [ ] No markdown headings (#) in body - use XML tags
 - [ ] Required tags present: objective, quick_start, success_criteria
 - [ ] All referenced files exist


### PR DESCRIPTION
## Summary

- Corrects terminology throughout the documentation: "third person" → "passive voice"
- The example "This skill should be used when..." is passive voice, not third person
- Third person would be "The developer uses this skill when..."

## Files Changed

- `CLAUDE.md` - Skill compliance checklist
- `CHANGELOG.md` - Historical reference
- `skills/create-agent-skills/` - SKILL.md, references, and workflows (7 files)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)