### PR TITLE
Improvement: protect plan files from review deletion

### DIFF
--- a/plugins/compound-engineering/agents/research/git-history-analyzer.md
+++ b/plugins/compound-engineering/agents/research/git-history-analyzer.md
@@ -40,3 +40,5 @@ When analyzing, consider:
 - The evolution of coding patterns and practices over time
 
 Your insights should help developers understand not just what the code does, but why it evolved to its current state, informing better decisions for future changes.
+
+Note that files in `docs/plans/` and `docs/solutions/` are compound-engineering pipeline artifacts created by `/workflows:plan`. They are intentional, permanent living documents — do not recommend their removal or characterize them as unnecessary.

--- a/plugins/compound-engineering/agents/review/code-simplicity-reviewer.md
+++ b/plugins/compound-engineering/agents/review/code-simplicity-reviewer.md
@@ -33,7 +33,7 @@ When reviewing code, you will:
    - Eliminate extensibility points without clear use cases
    - Question generic solutions for specific problems
    - Remove "just in case" code
-   - **Exception: Never flag `docs/plans/*.md` or `docs/solutions/*.md` for removal.** These are compound-engineering pipeline artifacts (created by `/workflows:plan` and used as living documents by `/workflows:work`). They are intentional and permanent.
+   - Never flag `docs/plans/*.md` or `docs/solutions/*.md` for removal — these are compound-engineering pipeline artifacts created by `/workflows:plan` and used as living documents by `/workflows:work`
 
 6. **Optimize for Readability**:
    - Prefer self-documenting code over comments

--- a/plugins/compound-engineering/commands/resolve_todo_parallel.md
+++ b/plugins/compound-engineering/commands/resolve_todo_parallel.md
@@ -12,7 +12,7 @@ Resolve all TODO comments using parallel processing.
 
 Get all unresolved TODOs from the /todos/\*.md directory
 
-**Protected Artifacts Check:** Before proceeding, scan each todo's proposed solution. If any todo recommends deleting, removing, or gitignoring files in `docs/plans/` or `docs/solutions/`, **skip that todo entirely** and mark it as `wont_fix`. These directories contain compound-engineering pipeline artifacts that are intentional and permanent.
+If any todo recommends deleting, removing, or gitignoring files in `docs/plans/` or `docs/solutions/`, skip it and mark it as `wont_fix`. These are compound-engineering pipeline artifacts that are intentional and permanent.
 
 ### 2. Plan
 

--- a/plugins/compound-engineering/commands/workflows/review.md
+++ b/plugins/compound-engineering/commands/workflows/review.md
@@ -51,12 +51,12 @@ Ensure that the code is ready for analysis (either in worktree or on current bra
 #### Protected Artifacts
 
 <protected_artifacts>
-The following paths are **compound-engineering pipeline artifacts** and must NEVER be flagged for deletion, removal, or gitignore by any review agent:
+The following paths are compound-engineering pipeline artifacts and must never be flagged for deletion, removal, or gitignore by any review agent:
 
-- `docs/plans/*.md` — Plan files created by `/workflows:plan`. These are living documents that track implementation progress (checkboxes are checked off by `/workflows:work`). They are intentional, permanent project artifacts.
-- `docs/solutions/*.md` — Solution documents created during the pipeline. These are intentional, permanent project artifacts.
+- `docs/plans/*.md` — Plan files created by `/workflows:plan`. These are living documents that track implementation progress (checkboxes are checked off by `/workflows:work`).
+- `docs/solutions/*.md` — Solution documents created during the pipeline.
 
-If a review agent flags any file in these directories for cleanup/removal, **discard that finding** during synthesis. Do not create a todo for it.
+If a review agent flags any file in these directories for cleanup or removal, discard that finding during synthesis. Do not create a todo for it.
 </protected_artifacts>
 
 #### Parallel Agents to review the PR:
@@ -218,7 +218,7 @@ Remove duplicates, prioritize by severity and impact.
 <synthesis_tasks>
 
 - [ ] Collect findings from all parallel agents
-- [ ] **Discard any findings that recommend deleting or gitignoring files in `docs/plans/` or `docs/solutions/`** — these are protected pipeline artifacts (see Protected Artifacts section above)
+- [ ] Discard any findings that recommend deleting or gitignoring files in `docs/plans/` or `docs/solutions/` (see Protected Artifacts above)
 - [ ] Categorize by type: security, performance, architecture, quality, etc.
 - [ ] Assign severity levels: 🔴 CRITICAL (P1), 🟡 IMPORTANT (P2), 🔵 NICE-TO-HAVE (P3)
 - [ ] Remove duplicate or overlapping findings


### PR DESCRIPTION
## Problem

The review/resolve pipeline can delete plan files created by `/workflows:plan`.

Note: this might be heavy-handed, so I'm open to feedback. But deleting such a valuable artifact seems like a no-no :)

When running the full pipeline (plan → work → review → resolve → compound), the review step's parallel agents — specifically `code-simplicity-reviewer` (YAGNI) and `git-history-analyzer` — can flag `docs/plans/*.md` files as unnecessary cleanup candidates. The resolve step then executes those findings, deleting the plan file and adding `docs/plans/` to `.gitignore`.

This directly contradicts `/workflows:work`, which treats plans as living documents and checks off tasks inside them as work progresses.

## Fix

Rather than a single guardrail that could be bypassed, this adds protection at four layers in the pipeline:

| Layer | File | What it does |
|-------|------|-------------|
| Review orchestrator | `commands/workflows/review.md` | New "Protected Artifacts" section before agents launch; discard filter in synthesis checklist |
| YAGNI reviewer | `agents/review/code-simplicity-reviewer.md` | Exception added to the YAGNI rules — skip `docs/plans/` and `docs/solutions/` |
| History analyzer | `agents/research/git-history-analyzer.md` | Note not to characterize pipeline artifacts as unnecessary |
| Resolve executor | `commands/resolve_todo_parallel.md` | Safety net — skip and `wont_fix` any todo targeting these paths |

The same protection covers `docs/solutions/*.md` since those are also pipeline-managed artifacts.

## Testing

This was discovered while running the full compound-engineering pipeline on a fresh Rails project. The plan file (`docs/plans/2026-01-31-feat-projects-crud-plan.md`, 750 lines) was deleted by the resolve step after being flagged as P3 cleanup by two review agents.

Workaround (adding a note to `CLAUDE.md`) confirmed the root cause — agents respect explicit instructions but had no built-in awareness of pipeline artifacts.

Fixes #140
