### PR TITLE
Remove the confirmation prompt when creating git worktrees

### DIFF
--- a/plugins/compound-engineering/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/compound-engineering/skills/git-worktree/scripts/worktree-manager.sh
@@ -91,14 +91,6 @@ create_worktree() {
   echo -e "${BLUE}Creating worktree: $branch_name${NC}"
   echo "  From: $from_branch"
   echo "  Path: $worktree_path"
-  echo ""
-  echo "Proceed? (y/n)"
-  read -r response
-
-  if [[ "$response" != "y" ]]; then
-    echo -e "${YELLOW}Cancelled${NC}"
-    return
-  fi
 
   # Update main branch
   echo -e "${BLUE}Updating $from_branch...${NC}"


### PR DESCRIPTION
This fixes a bug that prevented Claude from creating a worktree by using the `git-worktree` skill on the first try.

Sometimes Claude can figure out and add `echo "y"` in front of the `worktree-manager.sh` on the second try, but sometimes it could fall back to the `git worktree` command.

This PR would stabilize the behavior of worktree creation.