### PR TITLE
Rewrite workflows:review with context-managed map-reduce architecture

### DIFF
--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compound-engineering",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "AI-powered development tools. 29 agents, 25 commands, 16 skills, 1 MCP server for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",

--- a/plugins/compound-engineering/CHANGELOG.md
+++ b/plugins/compound-engineering/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the compound-engineering plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.31.0] - 2026-02-12
+
+### Changed
+
+- **`/workflows:review` command** — Rewritten as v2 with context-managed map-reduce architecture
+  - **Architecture**: Phased File-Based Map-Reduce — sub-agents write full analysis to `.review/`, return ~100 tokens each to parent. Parent context stays under ~12k tokens vs ~30-50k in v1
+  - **6 phases**: Intent → Map (parallel specialists) → Validate → Judge (dedup + evidence-check) → Deep Analysis (stakeholder impact) → Reduce (todo creation)
+  - **Smart agent selection**: 5 always-run core agents + conditional agents based on PR file types (vs v1's "run ALL agents")
+  - **Cross-platform**: Uses `.review/` scratchpad (not `/tmp/`), Node.js validation (not Python3)
+  - **Judge phase**: Deduplicates findings, discards hallucinated file references, ranks by severity × confidence, caps at 15 findings
+  - **Deep Analysis phase**: Replaces v1's inline Ultra-Thinking with isolated sub-agent for stakeholder perspectives and scenario exploration on P1/P2 findings
+  - **Protected artifacts**: Excluded paths (docs/plans/, docs/solutions/) enforced in both agent prompts and judge phase
+  - **0-findings short-circuit**: Clean PRs get a summary without running deep analysis or todo creation
+
+### Fixed
+
+- Removed 4 ghost agent references (`rails-turbo-expert`, `dependency-detective`, `devops-harmony-analyst`, `code-philosopher`) that don't exist in the plugin
+- Added 5 missing agents to selection matrix: `kieran-typescript-reviewer`, `kieran-python-reviewer`, `julik-frontend-races-reviewer`, `schema-drift-detector`, `learnings-researcher`
+- Replaced Python3 JSON validation with Node.js (cross-platform — Python3 not guaranteed on all systems)
+- Fixed `.gitignore` append duplication on repeated runs (now uses `grep -q` guard)
+- Added excluded paths check to judge prompt (v1 only had it in agent prompts, not synthesis)
+
+---
+
 ## [2.30.0] - 2026-02-05
 
 ### Added


### PR DESCRIPTION
## Summary

- Replaces the v1 review command with a **phased file-based map-reduce** architecture that prevents context overflow
- Sub-agents write full analysis to `.review/` on disk and return only ~100 token summaries to the parent, keeping parent context under ~12k tokens (vs ~30-50k in v1)
- Adds new phases: **PR Intent Analysis** (shared context), **Validation** (catches silent failures), **Judge** (dedup + hallucination removal), and **Deep Analysis** (P1/P2 enrichment)
- Smart agent selection based on PR content instead of running all 13+ agents on every PR
- Cross-platform safe: uses project-relative `.review/` instead of `/tmp/` (fixes Windows path issues)

## Key Architecture Changes

| Phase | What Changed |
|-------|-------------|
| Intent (new) | Single agent produces shared context so specialists don't redundantly re-derive PR intent |
| Map | Agents write JSON to `.review/`, return 1 sentence each (~100 tokens vs 2-4k) |
| Validate (new) | Catches silent agent failures + validates JSON schema before judging |
| Judge (new) | Deduplicates, evidence-checks (removes hallucinated findings), ranks top-N |
| Deep Analysis (new) | Enriches P1/P2 with stakeholder impact, failure scenarios, suggested fixes |
| Reduce | Parent reads only `ENRICHED_FINDINGS.json` (~8k tokens max), spawns todo-creation agents |

## Test plan

- [ ] Run `/workflows:review` on a PR with mixed file types (Ruby + JS) to verify agent selection
- [ ] Verify `.review/` directory is created with expected agent output files
- [ ] Confirm parent context stays under ~14k tokens of agent output
- [ ] Test on Windows to verify cross-platform `.review/` path works
- [ ] Verify hallucinated findings (referencing non-existent files) are removed by judge