### PR TITLE
fix(git-worktree): detect worktrees where .git is a file, not a directory

### DIFF
--- a/plugins/compound-engineering/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/compound-engineering/skills/git-worktree/scripts/worktree-manager.sh
@@ -134,7 +134,7 @@ list_worktrees() {
 
   local count=0
   for worktree_path in "$WORKTREE_DIR"/*; do
-    if [[ -d "$worktree_path" && -d "$worktree_path/.git" ]]; then
+    if [[ -d "$worktree_path" && -e "$worktree_path/.git" ]]; then
       count=$((count + 1))
       local worktree_name=$(basename "$worktree_path")
       local branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
@@ -231,7 +231,7 @@ cleanup_worktrees() {
   local to_remove=()
 
   for worktree_path in "$WORKTREE_DIR"/*; do
-    if [[ -d "$worktree_path" && -d "$worktree_path/.git" ]]; then
+    if [[ -d "$worktree_path" && -e "$worktree_path/.git" ]]; then
       local worktree_name=$(basename "$worktree_path")
 
       # Skip if current worktree


### PR DESCRIPTION
## Summary

- Fix `list` and `cleanup` commands silently failing to detect any worktrees
- Change `.git` existence check from `-d` (is directory) to `-e` (exists) on lines 137 and 234
- In git worktrees, `.git` is a regular file containing a `gitdir:` pointer — not a directory — so the `-d` check always fails

Fixes #158

## Test plan

- [ ] Create a worktree with `worktree-manager.sh create test-branch`
- [ ] Run `worktree-manager.sh list` and verify the worktree appears
- [ ] Run `worktree-manager.sh cleanup` and verify the worktree is offered for removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)