### PR TITLE
Fix crash when hook entries have no matcher

### DIFF
--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -209,9 +209,11 @@ function renderHookStatements(
 ): string[] {
   if (!matcher.hooks || matcher.hooks.length === 0) return []
   const tools = matcher.matcher
-    .split("|")
-    .map((tool) => tool.trim().toLowerCase())
-    .filter(Boolean)
+    ? matcher.matcher
+        .split("|")
+        .map((tool) => tool.trim().toLowerCase())
+        .filter(Boolean)
+    : []
 
   const useMatcher = useToolMatcher && tools.length > 0 && !tools.includes("*")
   const condition = useMatcher
@@ -232,10 +234,10 @@ function renderHookStatements(
       continue
     }
     if (hook.type === "prompt") {
-      statements.push(`// Prompt hook for ${matcher.matcher}: ${hook.prompt.replace(/\n/g, " ")}`)
+      statements.push(`// Prompt hook for ${matcher.matcher ?? "*"}: ${hook.prompt.replace(/\n/g, " ")}`)
       continue
     }
-    statements.push(`// Agent hook for ${matcher.matcher}: ${hook.agent}`)
+    statements.push(`// Agent hook for ${matcher.matcher ?? "*"}: ${hook.agent}`)
   }
 
   return statements

--- a/src/types/claude.ts
+++ b/src/types/claude.ts
@@ -79,7 +79,7 @@ export type ClaudeHookAgent = {
 export type ClaudeHookEntry = ClaudeHookCommand | ClaudeHookPrompt | ClaudeHookAgent
 
 export type ClaudeHookMatcher = {
-  matcher: string
+  matcher?: string
   hooks: ClaudeHookEntry[]
 }
 


### PR DESCRIPTION
## Summary

- Claude Code allows hook entries without a `matcher` field (e.g., `SessionStart` and `SubagentStop` hooks don't need one)
- The OpenCode converter crashes with `undefined is not an object (evaluating 'matcher.matcher.split')` when converting plugins with matcher-less hooks
- Made `matcher` optional in `ClaudeHookMatcher` type and guarded all accesses in `claude-to-opencode.ts`

## Reproduction

```bash
# With a plugin that has SessionStart or SubagentStop hooks without matchers:
bunx @every-env/compound-plugin install ./plugins/beads-compound --to opencode
# ERROR  undefined is not an object (evaluating 'matcher.matcher.split')
```

## Test plan

- [x] All 34 existing tests pass
- [x] Verified conversion succeeds with a plugin containing matcher-less hooks (SessionStart, SubagentStop)