### PR TITLE
Add --skip-frameworks flag to /workflows:review

### DIFF
--- a/plugins/compound-engineering/commands/workflows/review.md
+++ b/plugins/compound-engineering/commands/workflows/review.md
@@ -1,7 +1,7 @@
 ---
 name: workflows:review
 description: Perform exhaustive code reviews using multi-agent analysis, ultra-thinking, and worktrees
-argument-hint: "[PR number, GitHub URL, branch name, or latest]"
+argument-hint: "[PR number, GitHub URL, branch name, or latest] [--skip-frameworks]"
 ---
 
 # Review Command
@@ -26,6 +26,12 @@ argument-hint: "[PR number, GitHub URL, branch name, or latest]"
 ### 1. Determine Review Target & Setup (ALWAYS FIRST)
 
 <review_target> #$ARGUMENTS </review_target>
+
+<flag_parsing>
+Check if `$ARGUMENTS` contains `--skip-frameworks`:
+- If present: Set SKIP_FRAMEWORKS=true. Remove the flag from the review target string before proceeding.
+- If absent: Set SKIP_FRAMEWORKS=false (default). Run all agents including framework-specific ones.
+</flag_parsing>
 
 <thinking>
 First, I need to determine the review target type and set up the code for analysis.
@@ -63,21 +69,24 @@ If a review agent flags any file in these directories for cleanup or removal, di
 
 <parallel_tasks>
 
-Run ALL or most of these agents at the same time:
+Run ALL of these generic agents at the same time:
 
-1. Task kieran-rails-reviewer(PR content)
-2. Task dhh-rails-reviewer(PR title)
-3. If turbo is used: Task rails-turbo-expert(PR content)
-4. Task git-history-analyzer(PR content)
-5. Task dependency-detective(PR content)
-6. Task pattern-recognition-specialist(PR content)
-7. Task architecture-strategist(PR content)
-8. Task code-philosopher(PR content)
-9. Task security-sentinel(PR content)
-10. Task performance-oracle(PR content)
-11. Task devops-harmony-analyst(PR content)
-12. Task data-integrity-guardian(PR content)
-13. Task agent-native-reviewer(PR content) - Verify new features are agent-accessible
+1. Task git-history-analyzer(PR content)
+2. Task dependency-detective(PR content)
+3. Task pattern-recognition-specialist(PR content)
+4. Task architecture-strategist(PR content)
+5. Task code-philosopher(PR content)
+6. Task security-sentinel(PR content)
+7. Task performance-oracle(PR content)
+8. Task devops-harmony-analyst(PR content)
+9. Task data-integrity-guardian(PR content)
+10. Task agent-native-reviewer(PR content) - Verify new features are agent-accessible
+
+**Unless `--skip-frameworks` flag was passed**, also run these framework-specific agents:
+
+11. Task kieran-rails-reviewer(PR content)
+12. Task dhh-rails-reviewer(PR title)
+13. If turbo is used: Task rails-turbo-expert(PR content)
 
 </parallel_tasks>
 


### PR DESCRIPTION
@kieranklaassen I am an absolute fan of the compound engineering plugin and mindset in general. I am implementing it right now in our own product which is on a completely different stack, and has a huge codebase. I want to extend our PR review specific with your sub-agents, but don't want to invoke your sub-agents directly, because there might be more in the future, but rather would like to exclude the ones who are not relevant for us. 

## Why

The `/workflows:review` command always runs Rails-specific agents (kieran-rails-reviewer, dhh-rails-reviewer, rails-turbo-expert) even on non-Rails codebases. These agents produce irrelevant findings on non-Rails repos while consuming valuable context window. The other generic agents (security, performance, architecture, etc.) are still super valuable regardless of framework. The `--skip-frameworks` flag lets you skip the framework-specific ones, saving context for the agents that matter.

## Summary

- Adds `--skip-frameworks` flag to the `/workflows:review` command
- When passed, skips the 3 framework-specific agents (kieran-rails-reviewer, dhh-rails-reviewer, rails-turbo-expert) so non-Rails codebases get faster, more relevant reviews
- Default behavior (no flag) is unchanged — all agents run as before

## Test plan

- [ ] Run `/workflows:review 123` — all 13 agents should run (unchanged default)
- [ ] Run `/workflows:review 123 --skip-frameworks` — only 10 generic agents should run, framework-specific agents skipped
- [ ] Verify `--skip-frameworks` is stripped from the review target before PR lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)