### PR TITLE
Fix: install by name always fetches from GitHub

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -131,12 +131,15 @@ type ResolvedPluginPath = {
 }
 
 async function resolvePluginPath(input: string): Promise<ResolvedPluginPath> {
-  const directPath = path.resolve(input)
-  if (await pathExists(directPath)) return { path: directPath }
+  // Only treat as a local path if it explicitly looks like one
+  if (input.startsWith(".") || input.startsWith("/") || input.startsWith("~")) {
+    const expanded = expandHome(input)
+    const directPath = path.resolve(expanded)
+    if (await pathExists(directPath)) return { path: directPath }
+    throw new Error(`Local plugin path not found: ${directPath}`)
+  }
 
-  const pluginsPath = path.join(process.cwd(), "plugins", input)
-  if (await pathExists(pluginsPath)) return { path: pluginsPath }
-
+  // Otherwise, always fetch the latest from GitHub
   return await resolveGitHubPluginPath(input)
 }
 


### PR DESCRIPTION
## Summary

- Bare plugin names (e.g., `compound-engineering`) now always fetch from GitHub
- Only explicit paths (`./plugin`, `/path/to/plugin`, `~/plugin`) resolve locally
- Fixes bug where a same-named local directory would shadow the GitHub fetch

## The Bug

Running `bunx @every-env/compound-plugin install compound-engineering --to codex` from `~` would find `~/compound-engineering/` (not a plugin) and fail with:

```
Could not find .claude-plugin/plugin.json under /Users/kieranklaassen/compound-engineering
```

## Test Plan

- [x] New test: bare name ignores same-named local directory, fetches from GitHub
- [x] All 86 tests pass

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)