### PR TITLE
Fix bare Claude model alias resolution in OpenCode converter

### DIFF
--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -250,8 +250,24 @@ function rewriteClaudePaths(body: string): string {
     .replace(/\.claude\//g, ".opencode/")
 }
 
+// Bare Claude family aliases used in Claude Code (e.g. `model: haiku`).
+// Update these when new model generations are released.
+const CLAUDE_FAMILY_ALIASES: Record<string, string> = {
+  haiku: "claude-haiku-4-5",
+  sonnet: "claude-sonnet-4-5",
+  opus: "claude-opus-4-6",
+}
+
 function normalizeModel(model: string): string {
   if (model.includes("/")) return model
+  if (CLAUDE_FAMILY_ALIASES[model]) {
+    const resolved = `anthropic/${CLAUDE_FAMILY_ALIASES[model]}`
+    console.warn(
+      `Warning: bare model alias "${model}" mapped to "${resolved}". ` +
+        `Update CLAUDE_FAMILY_ALIASES if a newer version is available.`,
+    )
+    return resolved
+  }
   if (/^claude-/.test(model)) return `anthropic/${model}`
   if (/^(gpt-|o1-|o3-)/.test(model)) return `openai/${model}`
   if (/^gemini-/.test(model)) return `google/${model}`

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -75,6 +75,35 @@ describe("convertClaudeToOpenCode", () => {
     expect(modelCommand?.model).toBe("openai/gpt-4o")
   })
 
+  test("resolves bare Claude model aliases to full IDs", () => {
+    const plugin: ClaudePlugin = {
+      root: "/tmp/plugin",
+      manifest: { name: "fixture", version: "1.0.0" },
+      agents: [
+        {
+          name: "cheap-agent",
+          description: "Agent using bare alias",
+          body: "Test agent.",
+          sourcePath: "/tmp/plugin/agents/cheap-agent.md",
+          model: "haiku",
+        },
+      ],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToOpenCode(plugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "none",
+    })
+
+    const agent = bundle.agents.find((a) => a.name === "cheap-agent")
+    expect(agent).toBeDefined()
+    const parsed = parseFrontmatter(agent!.content)
+    expect(parsed.data.model).toBe("anthropic/claude-haiku-4-5")
+  })
+
   test("converts hooks into plugin file", async () => {
     const plugin = await loadClaudePlugin(fixtureRoot)
     const bundle = convertClaudeToOpenCode(plugin, {


### PR DESCRIPTION
Thank you all for this amazing plugin and especially for the port to opencode! I use this tool daily at work and it has quickly become my favorite way to do agentic coding. Appreciate Kieran, Every Inc, and all the maintainers of this awesome project.

## Summary

- Fix `ProviderModelNotFoundError` when OpenCode invokes agents that use bare model aliases (e.g., `model: haiku`)
- Add `CLAUDE_FAMILY_ALIASES` map to resolve `haiku`, `sonnet`, `opus` to full model IDs
- Warn during conversion when a bare alias is used, so users know to update if newer models are available

## Problem

When using the compound-engineering plugin in OpenCode, running `/workflows:plan` fails with:

```
ProviderModelNotFoundError: ProviderModelNotFoundError
```

This happens because:

1. The `learnings-researcher` agent (and `lint` agent) use `model: haiku` in their Claude Code frontmatter -- a bare alias that Claude Code resolves internally
2. The `normalizeModel()` function in the OpenCode converter turns `haiku` into `anthropic/haiku` via its catch-all fallback (`return \`anthropic/${model}\``)
3. OpenCode requires fully-qualified model IDs (e.g., `anthropic/claude-haiku-4-5`). The bare `anthropic/haiku` doesn't exist in its model registry

The error occurs every time `/workflows:plan` runs because it always invokes `learnings-researcher` in Step 1 (Local Research).

## Fix

Add a `CLAUDE_FAMILY_ALIASES` map to `normalizeModel()` that resolves bare Claude family names (`haiku`, `sonnet`, `opus`) to their full model IDs before the catch-all fallback. A `console.warn` alerts during conversion so the map can be updated when new model versions are released.

### Changes

| File | Change |
|------|--------|
| `src/converters/claude-to-opencode.ts` | Add `CLAUDE_FAMILY_ALIASES` map and alias resolution to `normalizeModel()` |
| `tests/fixtures/sample-plugin/agents/bare-alias-agent.md` | New fixture agent with `model: haiku` |
| `tests/converter.test.ts` | Test that `haiku` resolves to `anthropic/claude-haiku-4-5` |
| `tests/claude-parser.test.ts` | Update agent count expectation (2 -> 3) for new fixture |

## Test Plan

All 87 tests pass:

```
 87 pass
 0 fail
 308 expect() calls
Ran 87 tests across 12 files. [562.00ms]
```