### PR TITLE
fixing marketplace url on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Claude Code plugin marketplace featuring the **Compound Engineering Plugin** â
 ## Claude Code Install
 
 ```bash
-/plugin marketplace add https://github.com/EveryInc/compound-engineering-plugin
+/plugin marketplace add https://github.com/EveryInc/every-marketplace
 /plugin install compound-engineering
 ```
 


### PR DESCRIPTION
Resolves https://github.com/EveryInc/compound-engineering-plugin/issues/211

from EveryInc/compound-engineering-plugin
to EveryInc/every-marketplace

in the README