### PR TITLE
Add .worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 .codex/
 todos/
+.worktrees


### PR DESCRIPTION
This aligns with [ensure_gitignore](https://github.com/EveryInc/compound-engineering-plugin/blob/63e76cf67f08aac6f0dccf275ce328e47deae541/plugins/compound-engineering/skills/git-worktree/scripts/worktree-manager.sh#L21) method in `git-worktree` skill, which will be triggered by the `workflows:review` command.