### PR TITLE
fix(workflows:review): fix formatting issues causing broken rendering

### DIFF
--- a/plugins/compound-engineering/commands/workflows/review.md
+++ b/plugins/compound-engineering/commands/workflows/review.md
@@ -38,7 +38,7 @@ First, I need to determine the review target type and set up the code for analys
 - [ ] Determine review type: PR number (numeric), GitHub URL, file path (.md), or empty (current branch)
 - [ ] Check current git branch
 - [ ] If ALREADY on the target branch (PR branch, requested branch name, or the branch already checked out for review) → proceed with analysis on current branch
-- [ ] If DIFFERENT branch than the review target → offer to use worktree: "Use git-worktree skill for isolated Call `skill: git-worktree` with branch name
+- [ ] If DIFFERENT branch than the review target → offer to use worktree: "Use git-worktree skill for isolated Call `skill: git-worktree` with branch name"
 - [ ] Fetch PR metadata using `gh pr view --json` for title, body, files, linked issues
 - [ ] Set up language-specific analysis tools
 - [ ] Prepare security scanning environment


### PR DESCRIPTION
## Summary

- Fixed "Next Steps" items 3 & 4 and Severity Breakdown that leaked outside the Summary Report markdown template
- Fixed section numbering jumping from 5 to 7 (renumbered to 6)
- Removed two orphaned fenced code block delimiters that caused the entire End-to-End Testing section to render as a code block
- Fixed unclosed quoted string in section 1 task list