### PR TITLE
Update Claude Code install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Claude Code plugin marketplace featuring the **Compound Engineering Plugin** â
 ## Claude Code Install
 
 ```bash
-/plugin marketplace add https://github.com/EveryInc/compound-engineering-plugin
+/plugin marketplace add EveryInc/compound-engineering-plugin
 /plugin install compound-engineering
 ```
 


### PR DESCRIPTION
## Summary
This PR fixes the compound-engineering plugin installation command by correcting the marketplace source link.

## The Problem
The previous documentation pointed to an incorrect marketplace path, resulting in the following error during installation:
> Plugin "compound-engineering" not found in any marketplace

## The Fix
Updated the installation command to use the verified marketplace URL. This ensures the plugin is correctly resolved by Claude Code.

Fixes #128, Fixes #211