### PR TITLE
fix: quote argument-hint values to prevent YAML object parsing

### DIFF
--- a/plugins/compound-engineering/commands/create-agent-skill.md
+++ b/plugins/compound-engineering/commands/create-agent-skill.md
@@ -2,7 +2,7 @@
 name: create-agent-skill
 description: Create or edit Claude Code skills with expert guidance on structure and best practices
 allowed-tools: Skill(create-agent-skills)
-argument-hint: [skill description or requirements]
+argument-hint: "[skill description or requirements]"
 disable-model-invocation: true
 ---
 

--- a/plugins/compound-engineering/commands/heal-skill.md
+++ b/plugins/compound-engineering/commands/heal-skill.md
@@ -1,7 +1,7 @@
 ---
 name: heal-skill
 description: Fix incorrect SKILL.md files when a skill has wrong instructions or outdated API references
-argument-hint: [optional: specific issue to fix]
+argument-hint: "[optional: specific issue to fix]"
 allowed-tools: [Read, Edit, Bash(ls:*), Bash(git:*)]
 disable-model-invocation: true
 ---


### PR DESCRIPTION
## Summary

Two commands have unquoted `argument-hint` values in their YAML frontmatter that cause Claude Code's TUI to crash when tab-completing.

## Problem

YAML bracket syntax without quotes is parsed as arrays/mappings, not strings:

```yaml
# Before (broken) — YAML parses as [{optional: "specific issue to fix"}]
argument-hint: [optional: specific issue to fix]

# After (fixed) — YAML parses as the string "[optional: specific issue to fix]"
argument-hint: "[optional: specific issue to fix]"
```

When Claude Code's tab-completion renderer tries to display the parsed object as a React child, it crashes with React error #31: "Objects are not valid as a React child (found: object with keys {optional})".

## Changes

| File | Before | After |
|---|---|---|
| `commands/heal-skill.md` | `[optional: specific issue to fix]` | `"[optional: specific issue to fix]"` |
| `commands/create-agent-skill.md` | `[skill description or requirements]` | `"[skill description or requirements]"` |

The other 18 commands in the plugin already quote their `argument-hint` values correctly.

## Related

- Claude Code issue: https://github.com/anthropics/claude-code/issues/29422 (the TUI should also handle non-string values gracefully)
