### PR TITLE
feat: add /lfg-ext — external delegate LFG (Codex/Gemini/OpenCode in parallel worktrees)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
   "plugins": [
     {
       "name": "compound-engineering",
-      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 29 specialized agents, 22 commands, and 20 skills.",
-      "version": "2.38.1",
+      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 29 specialized agents, 23 commands, and 20 skills.",
+      "version": "2.39.0",
       "author": {
         "name": "Kieran Klaassen",
         "url": "https://github.com/kieranklaassen",

--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
-  "version": "2.38.1",
-  "description": "AI-powered development tools. 29 agents, 22 commands, 20 skills, 1 MCP server for code review, research, design, and workflow automation.",
+  "version": "2.39.0",
+  "description": "AI-powered development tools. 29 agents, 23 commands, 20 skills, 1 MCP server for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",

--- a/plugins/compound-engineering/CHANGELOG.md
+++ b/plugins/compound-engineering/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the compound-engineering plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.39.0] - 2026-03-02
+
+### Added
+
+- **`/lfg-ext` command** — LFG variant that delegates execution to external tools (Codex, Gemini CLI, OpenCode) running in parallel git worktrees instead of CE swarm agents. Token-efficient alternative to `/slfg` for teams that have external AI coding tools installed or want to preserve Claude Max20 budget for planning and review. Includes tool availability check with graceful fallback to `/slfg`, worktree isolation via the CE `git-worktree` skill's `worktree-manager.sh`, and a decision table for when to use `/lfg-ext` vs `/slfg`. Validated against a real Rust feature implementation.
+
+---
+
 ## [2.38.1] - 2026-03-01
 
 ### Fixed

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -7,7 +7,7 @@ AI-powered development tools that get smarter with every use. Make each unit of 
 | Component | Count |
 |-----------|-------|
 | Agents | 29 |
-| Commands | 22 |
+| Commands | 23 |
 | Skills | 20 |
 | MCP Servers | 1 |
 
@@ -91,6 +91,7 @@ Core workflow commands use `ce:` prefix to unambiguously identify them as compou
 |---------|-------------|
 | `/lfg` | Full autonomous engineering workflow |
 | `/slfg` | Full autonomous workflow with swarm mode for parallel execution |
+| `/lfg-ext` | LFG with external delegates (Codex/Gemini/OpenCode) in parallel worktrees — token-efficient alternative to /slfg |
 | `/deepen-plan` | Enhance plans with parallel research agents for each section |
 | `/changelog` | Create engaging changelogs for recent merges |
 | `/create-agent-skill` | Create or edit Claude Code skills |

--- a/plugins/compound-engineering/commands/lfg-ext.md
+++ b/plugins/compound-engineering/commands/lfg-ext.md
@@ -1,0 +1,98 @@
+---
+name: lfg-ext
+description: LFG with external delegates (Codex/Gemini/OpenCode) in parallel worktrees — token-efficient alternative to /slfg
+argument-hint: "[feature description]"
+disable-model-invocation: true
+---
+
+External-delegate LFG. Uses CE for planning and review; replaces `/ce:work` swarm with external tools running in isolated git worktrees. Saves Max20 tokens while maintaining parallel execution.
+
+Run these steps in order. Do not stop between steps — complete every step through to the end.
+
+## Phase 1: Plan
+
+1. `/ce:plan $ARGUMENTS`
+2. `/compound-engineering:deepen-plan`
+3. **Commit the plan** — worktrees only see committed git history, not the working tree. Uncommitted plan files are invisible to delegates.
+
+   ```bash
+   git add docs/plans/ && git commit -m "plan: <feature>"
+   ```
+
+## Phase 2: Decompose
+
+4. Read the generated plan. Identify tasks that target **different files/modules with no shared state**.
+
+   Good signal: tasks write to non-overlapping files.
+   Bad signal: tasks share a model, schema, config, or any single file — don't force it, fall back to `/slfg` or sequential `/ce:work`.
+
+   Aim for 2–4 parallel streams. More rarely helps.
+
+## Phase 3: External Swarm
+
+5. **Create one worktree per task** using the CE worktree manager:
+
+   ```bash
+   bash ${CLAUDE_PLUGIN_ROOT}/skills/git-worktree/scripts/worktree-manager.sh create <task-branch>
+   ```
+
+   The script handles `.env` file copying, `.gitignore` management, and directory setup automatically.
+
+6. **Check which external tools are available:**
+
+   ```bash
+   command -v codex   && echo "codex: available"   || echo "codex: not installed"
+   command -v gemini  && echo "gemini: available"  || echo "gemini: not installed"
+   command -v opencode && echo "opencode: available" || echo "opencode: not installed"
+   ```
+
+   Use whichever tools are available. If none are installed, fall back to `/slfg` instead.
+
+7. **Launch all delegates in parallel** — one per worktree, all backgrounded simultaneously.
+
+   Assign tasks to tools by type:
+
+   | Task type | Preferred tool | Command |
+   |-----------|----------------|---------|
+   | Multi-file, repo navigation, test loops | **Codex** | `cd .worktrees/<branch> && codex exec --full-auto "<prompt>"` |
+   | Algorithmic, isolated logic | **Gemini CLI** | `cd .worktrees/<branch> && gemini -p "<prompt>" --yolo` |
+   | Bulk ops, boilerplate, routine refactoring | **OpenCode** | `cd .worktrees/<branch> && opencode run --title "<title>" "<prompt>"` |
+
+   Each delegate prompt must include:
+   - Absolute file paths (let the delegate read — don't inline file contents)
+   - Constraints: "don't modify X", "keep existing patterns"
+   - Verification: "run `npm test` / `bin/rails test` / `pytest` to verify"
+   - "Implement fully. No stubs, no TODOs, no simplified versions."
+
+   ⚠️ **OpenCode note:** OpenCode's sandbox only allows writes inside its worktree and `/tmp`. Tasks that write outside the repo (config files, global tooling) must use Codex instead.
+
+8. **Wait for all delegates to complete.**
+
+## Phase 4: Merge
+
+9. For each worktree — review scope before merging:
+
+   ```bash
+   git diff --stat <task-branch>   # check for unexpected file changes
+   git merge <task-branch>
+   bash ${CLAUDE_PLUGIN_ROOT}/skills/git-worktree/scripts/worktree-manager.sh cleanup
+   ```
+
+   Merge conflicts mean tasks weren't fully independent. Resolve manually, then continue.
+
+## Phase 5: Review & Ship
+
+10. `/ce:review`
+11. `/compound-engineering:resolve_todo_parallel`
+
+---
+
+## When to use vs /slfg
+
+| Signal | Use |
+|--------|-----|
+| Max20 pool healthy, want fully hands-off | `/slfg` |
+| Max20 constrained, or tasks decompose cleanly by file | `/lfg-ext` |
+| Tasks share files or state | `/slfg` or sequential `/ce:work` |
+| Want Codex repo navigation or Gemini algorithmic strength | `/lfg-ext` |
+| No external tools installed | `/slfg` |

--- a/plugins/compound-engineering/commands/lfg-ext.md
+++ b/plugins/compound-engineering/commands/lfg-ext.md
@@ -1,11 +1,11 @@
 ---
 name: lfg-ext
-description: LFG with external delegates (Codex/Gemini/OpenCode) in parallel worktrees — token-efficient alternative to /slfg
+description: LFG with external delegates (Codex/Gemini CLI) in parallel worktrees — preserves Claude token budget while maintaining parallel execution
 argument-hint: "[feature description]"
 disable-model-invocation: true
 ---
 
-External-delegate LFG. Uses CE for planning and review; replaces `/ce:work` swarm with external tools running in isolated git worktrees. Saves Max20 tokens while maintaining parallel execution.
+External-delegate LFG. Uses CE for planning and review; replaces `/ce:work` swarm with external AI tools running in isolated git worktrees. Preserves Claude token budget for planning and review where it adds the most value.
 
 Run these steps in order. Do not stop between steps — complete every step through to the end.
 
@@ -19,9 +19,18 @@ Run these steps in order. Do not stop between steps — complete every step thro
    git add docs/plans/ && git commit -m "plan: <feature>"
    ```
 
-## Phase 2: Decompose
+## Phase 2: Check tools & decompose
 
-4. Read the generated plan. Identify tasks that target **different files/modules with no shared state**.
+4. **Check which external tools are available:**
+
+   ```bash
+   command -v codex  && echo "codex: available"  || echo "codex: not installed"
+   command -v gemini && echo "gemini: available" || echo "gemini: not installed"
+   ```
+
+   If neither is installed, **stop here and run `/slfg` instead** — there's no point creating worktrees without delegates to fill them.
+
+5. Read the generated plan. Identify tasks that target **different files/modules with no shared state**.
 
    Good signal: tasks write to non-overlapping files.
    Bad signal: tasks share a model, schema, config, or any single file — don't force it, fall back to `/slfg` or sequential `/ce:work`.
@@ -30,23 +39,13 @@ Run these steps in order. Do not stop between steps — complete every step thro
 
 ## Phase 3: External Swarm
 
-5. **Create one worktree per task** using the CE worktree manager:
+6. **Create one worktree per task** using the CE worktree manager:
 
    ```bash
    bash ${CLAUDE_PLUGIN_ROOT}/skills/git-worktree/scripts/worktree-manager.sh create <task-branch>
    ```
 
    The script handles `.env` file copying, `.gitignore` management, and directory setup automatically.
-
-6. **Check which external tools are available:**
-
-   ```bash
-   command -v codex   && echo "codex: available"   || echo "codex: not installed"
-   command -v gemini  && echo "gemini: available"  || echo "gemini: not installed"
-   command -v opencode && echo "opencode: available" || echo "opencode: not installed"
-   ```
-
-   Use whichever tools are available. If none are installed, fall back to `/slfg` instead.
 
 7. **Launch all delegates in parallel** — one per worktree, all backgrounded simultaneously.
 
@@ -56,15 +55,12 @@ Run these steps in order. Do not stop between steps — complete every step thro
    |-----------|----------------|---------|
    | Multi-file, repo navigation, test loops | **Codex** | `cd .worktrees/<branch> && codex exec --full-auto "<prompt>"` |
    | Algorithmic, isolated logic | **Gemini CLI** | `cd .worktrees/<branch> && gemini -p "<prompt>" --yolo` |
-   | Bulk ops, boilerplate, routine refactoring | **OpenCode** | `cd .worktrees/<branch> && opencode run --title "<title>" "<prompt>"` |
 
    Each delegate prompt must include:
    - Absolute file paths (let the delegate read — don't inline file contents)
    - Constraints: "don't modify X", "keep existing patterns"
    - Verification: "run `npm test` / `bin/rails test` / `pytest` to verify"
    - "Implement fully. No stubs, no TODOs, no simplified versions."
-
-   ⚠️ **OpenCode note:** OpenCode's sandbox only allows writes inside its worktree and `/tmp`. Tasks that write outside the repo (config files, global tooling) must use Codex instead.
 
 8. **Wait for all delegates to complete.**
 
@@ -85,14 +81,16 @@ Run these steps in order. Do not stop between steps — complete every step thro
 10. `/ce:review`
 11. `/compound-engineering:resolve_todo_parallel`
 
+> Note: `/lfg-ext` omits `/feature-video` — external delegates don't produce a reviewable PR automatically, so a video walkthrough isn't meaningful until you've raised one manually.
+
 ---
 
 ## When to use vs /slfg
 
 | Signal | Use |
 |--------|-----|
-| Max20 pool healthy, want fully hands-off | `/slfg` |
-| Max20 constrained, or tasks decompose cleanly by file | `/lfg-ext` |
+| Want fully hands-off, token cost not a concern | `/slfg` |
+| Token budget constrained, or tasks decompose cleanly by file | `/lfg-ext` |
 | Tasks share files or state | `/slfg` or sequential `/ce:work` |
 | Want Codex repo navigation or Gemini algorithmic strength | `/lfg-ext` |
 | No external tools installed | `/slfg` |


### PR DESCRIPTION
## Summary

Adds `/lfg-ext`, a new workflow command that runs CE planning and review but replaces `/ce:work` swarm with external AI coding tools (Codex, Gemini CLI, OpenCode) running in isolated git worktrees.

## Motivation

Users with Max20 plans burn tokens on CE swarm agents during execution. For teams that already have Codex, Gemini CLI, or OpenCode installed, delegating execution to those tools is free and often faster — while still getting CE's planning depth and review quality.

## How it works

```
/ce:plan → /deepen-plan → [commit plan] → [worktrees + external delegates in parallel] → /ce:review
```

1. Runs `/ce:plan` + `/deepen-plan` as normal
2. Plan is committed (worktrees see git history only, not the working tree)
3. Tasks decomposed by file independence — one worktree per task via `worktree-manager.sh`
4. External tools launched in parallel (backgrounded)
5. Merges worktrees, runs `/ce:review`

## Key design decisions

- **Uses `worktree-manager.sh`** from the existing `git-worktree` skill — no new dependencies
- **Tool availability check** before starting — graceful fallback to `/slfg` if no external tools installed
- **Decision table** for `/lfg-ext` vs `/slfg` — clear guidance on when to use each
- **OpenCode sandbox note** — documents that OpenCode blocks writes outside its worktree (use Codex for those tasks)

## Validated against

A real Rust feature implementation (`.env` file copying + `.gitignore` management in a worktree manager CLI). Codex implemented the feature from a CE plan. 4/4 tests passed, `cargo clippy` clean on first run.

## Gotcha discovered during testing

Worktrees only see committed git history. If `/ce:plan` writes the plan file but it isn't committed before `worktree-manager.sh create`, delegates can't find the plan. Step 3 (commit plan) is explicit in the command for this reason.

## Files changed

- `commands/lfg-ext.md` — new command
- `.claude-plugin/plugin.json` — version 2.38.1 → 2.39.0, commands 22 → 23
- `CHANGELOG.md` — 2.39.0 entry
- `README.md` — commands count + table entry
- `.claude-plugin/marketplace.json` — version + description sync