### PR TITLE
fix(lfg): enforce plan phase with explicit step gating

### DIFF
--- a/plugins/compound-engineering/commands/lfg.md
+++ b/plugins/compound-engineering/commands/lfg.md
@@ -5,16 +5,30 @@ argument-hint: "[feature description]"
 disable-model-invocation: true
 ---
 
-Run these slash commands in order. Do not do anything else. Do not stop between steps — complete every step through to the end.
+CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any step. Do NOT jump ahead to coding or implementation. The plan phase (steps 2-3) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
 1. **Optional:** If the `ralph-wiggum` skill is available, run `/ralph-wiggum:ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
+
 2. `/ce:plan $ARGUMENTS`
+
+   GATE: STOP. Verify that `/ce:plan` produced a plan file in `docs/plans/`. If no plan file was created, run `/ce:plan $ARGUMENTS` again. Do NOT proceed to step 3 until a written plan exists.
+
 3. `/compound-engineering:deepen-plan`
+
+   GATE: STOP. Confirm the plan has been deepened and updated. The plan file in `docs/plans/` should now contain additional detail. Do NOT proceed to step 4 without a deepened plan.
+
 4. `/ce:work`
+
+   GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 5 if no code changes were made.
+
 5. `/ce:review`
+
 6. `/compound-engineering:resolve_todo_parallel`
+
 7. `/compound-engineering:test-browser`
+
 8. `/compound-engineering:feature-video`
+
 9. Output `<promise>DONE</promise>` when video is in PR
 
-Start with step 2 now (or step 1 if ralph-wiggum is available).
+Start with step 2 now (or step 1 if ralph-wiggum is available). Remember: plan FIRST, then work. Never skip the plan.


### PR DESCRIPTION
## Summary
- Adds a CRITICAL instruction block at the top of `/lfg` emphasizing that steps must be executed in order and the plan phase must complete before any coding begins
- Adds explicit GATE checkpoints after steps 2, 3, and 4 that require verification of expected output before proceeding
- Reinforces plan-first ordering in the closing instruction

## Problem
`/lfg` was skipping the plan phase (`/ce:plan`) and jumping straight to coding. The existing "Run these slash commands in order" instruction was not forceful enough to prevent Claude from bypassing the plan step.

Closes #227

## Test plan
- [ ] Run `/lfg "small feature"` and verify that `/ce:plan` executes and produces a plan file before `/ce:work` begins
- [ ] Verify that if `/ce:plan` fails to produce a plan file, the gate catches it and re-runs the plan step

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>