### PR TITLE
feat(plan): add bite-sized work item decomposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,11 +78,6 @@ Release numbering now follows the repository `v*` tag line. Starting at `v2.34.0
 
 * **lfg:** enforce plan phase with explicit step gating ([b07f43d](https://github.com/EveryInc/compound-engineering-plugin/commit/b07f43ddf59cd7f2fe54b2e0a00d2b5b508b7f11)), closes [#227](https://github.com/EveryInc/compound-engineering-plugin/issues/227)
 
-## [Unreleased]
-
-### Added
-
-* **plan:** add bite-sized work item decomposition to ce:plan. Plans now include structured `## Work Items` sections with exact file paths, complete code snippets, verification commands, and commit boundaries. Only for MORE and A LOT detail levels. Inspired by Superpowers' task granularity. Closes [#146](https://github.com/EveryInc/compound-engineering-plugin/issues/146)
 ## [2.34.4](https://github.com/EveryInc/compound-engineering-plugin/compare/v2.34.3...v2.34.4) (2026-03-04)
 
 


### PR DESCRIPTION
## Summary

- Adds **Phase 5.5: Work Item Decomposition** to `/ce:plan` that generates structured, bite-sized work items
- Each task is 2-5 minutes with exact file paths, complete code, verification commands, and commit boundaries
- `## Work Items` section added to MORE template (3-8 tasks) and A LOT template (5-15 tasks grouped by phase)
- MINIMAL template unchanged - quick issues stay quick
- No changes to ce:work needed - structured format is valid markdown it already parses

## Motivation

`/ce:work` Phase 1 Step 3 says "Use TodoWrite to break plan into actionable tasks" - but this decomposition happens ad-hoc at runtime, without the planning context. Plans should do the heavy lifting (80/20 philosophy).

[Superpowers](https://github.com/obra/superpowers) (42K stars) attributes much of its quality to this exact pattern - their plans produce 2-5 minute steps with exact paths, complete code, run commands, and expected output.

Related: #146 "Plan with files"

## Changes

| File | Lines | What |
|------|-------|------|
| `commands/ce/plan.md` | +98 | Phase 5.5 instructions + Work Items in MORE and A LOT templates |
| `.claude-plugin/plugin.json` | +1/-1 | Version bump 2.38.1 -> 2.38.2 |
| `CHANGELOG.md` | +6 | Entry for this change |

## Test plan

- [ ] Run `/ce:plan "add user auth"` and select MORE - verify Work Items section appears with file paths, code, and verification commands
- [ ] Run `/ce:plan "simple typo fix"` and select MINIMAL - verify no Work Items section
- [ ] Run `/ce:plan "major refactor"` and select A LOT - verify Work Items grouped into phases
- [ ] Run `/ce:work` on a plan with Work Items - verify TodoWrite picks up tasks correctly

---

Closes #245
Refs #146

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) Generated with [Claude Code](https://claude.com/claude-code)