### PR TITLE
fix(plan): replace deprecated /technical_review with /ce:review

### DIFF
--- a/plugins/compound-engineering/commands/ce/plan.md
+++ b/plugins/compound-engineering/commands/ce/plan.md
@@ -579,7 +579,7 @@ After writing the plan file, use the **AskUserQuestion tool** to present these o
 **Options:**
 1. **Open plan in editor** - Open the plan file for review
 2. **Run `/deepen-plan`** - Enhance each section with parallel research agents (best practices, performance, UI)
-3. **Run `/technical_review`** - Technical feedback from code-focused reviewers (DHH, Kieran, Simplicity)
+3. **Run `/ce:review`** - Technical feedback from code-focused reviewers
 4. **Review and refine** - Improve the document through structured self-review
 5. **Share to Proof** - Upload to Proof for collaborative review and sharing
 6. **Start `/ce:work`** - Begin implementing this plan locally
@@ -589,7 +589,7 @@ After writing the plan file, use the **AskUserQuestion tool** to present these o
 Based on selection:
 - **Open plan in editor** → Run `open docs/plans/<plan_filename>.md` to open the file in the user's default editor
 - **`/deepen-plan`** → Call the /deepen-plan command with the plan file path to enhance with research
-- **`/technical_review`** → Call the /technical_review command with the plan file path
+- **`/ce:review`** → Call the /ce:review command with the plan file path
 - **Review and refine** → Load `document-review` skill.
 - **Share to Proof** → Upload the plan to Proof:
   ```bash
@@ -608,7 +608,7 @@ Based on selection:
 
 **Note:** If running `/ce:plan` with ultrathink enabled, automatically run `/deepen-plan` after plan creation for maximum depth and grounding.
 
-Loop back to options after Simplify or Other changes until user selects `/ce:work` or `/technical_review`.
+Loop back to options after Simplify or Other changes until user selects `/ce:work` or `/ce:review`.
 
 ## Issue Creation
 
@@ -638,6 +638,6 @@ When user selects "Create Issue", detect their project tracker from CLAUDE.md:
 
 5. **After creation:**
    - Display the issue URL
-   - Ask if they want to proceed to `/ce:work` or `/technical_review`
+   - Ask if they want to proceed to `/ce:work` or `/ce:review`
 
 NEVER CODE! Just research and write the plan.

--- a/plugins/compound-engineering/commands/deepen-plan.md
+++ b/plugins/compound-engineering/commands/deepen-plan.md
@@ -480,14 +480,14 @@ After writing the enhanced plan, use the **AskUserQuestion tool** to present the
 
 **Options:**
 1. **View diff** - Show what was added/changed
-2. **Run `/technical_review`** - Get feedback from reviewers on enhanced plan
+2. **Run `/ce:review`** - Get feedback from reviewers on enhanced plan
 3. **Start `/ce:work`** - Begin implementing this enhanced plan
 4. **Deepen further** - Run another round of research on specific sections
 5. **Revert** - Restore original plan (if backup exists)
 
 Based on selection:
 - **View diff** → Run `git diff [plan_path]` or show before/after
-- **`/technical_review`** → Call the /technical_review command with the plan file path
+- **`/ce:review`** → Call the /ce:review command with the plan file path
 - **`/ce:work`** → Call the /ce:work command with the plan file path
 - **Deepen further** → Ask which sections need more research, then re-run those agents
 - **Revert** → Restore from git or backup


### PR DESCRIPTION
## Summary

- Replace all 6 references to the removed `/technical_review` command with `/ce:review` in `ce:plan` and `deepen-plan`
- The `/technical_review` command was deleted (see CHANGELOG v2.32.0) but its references remained in the post-generation options

Fixes #244

## Changes

**`commands/ce/plan.md`** (4 references):
- Post-generation option: `/technical_review` -> `/ce:review`
- Selection handler: same
- Options loop: same
- Issue creation follow-up: same

**`commands/deepen-plan.md`** (2 references):
- Post-enhancement option: `/technical_review` -> `/ce:review`
- Selection handler: same

## Test plan

- [ ] Run `/ce:plan` and verify the post-generation options show `/ce:review` instead of `/technical_review`
- [ ] Run `/deepen-plan` and verify the same

This contribution was developed with AI assistance (Claude Code).