### PR TITLE
fix(agents): update learnings-researcher model from haiku to inherit

### DIFF
--- a/plugins/compound-engineering/agents/research/learnings-researcher.md
+++ b/plugins/compound-engineering/agents/research/learnings-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: learnings-researcher
 description: "Searches docs/solutions/ for relevant past solutions by frontmatter metadata. Use before implementing features or fixing problems to surface institutional knowledge and prevent repeated mistakes."
-model: haiku
+model: inherit
 ---
 
 <examples>


### PR DESCRIPTION
## Summary

- Change `learnings-researcher` agent model from `haiku` to `inherit`
- CHANGELOG states: "All 26 agents now use `model: inherit`. Only `lint` keeps `model: haiku` for cost efficiency." But `learnings-researcher` was missed and still had `model: haiku`

Fixes #188

## Changes

**`agents/research/learnings-researcher.md`**: `model: haiku` -> `model: inherit`

After this change, only `agents/workflow/lint.md` retains `model: haiku`, matching the documented convention.

## Test plan

- [ ] Verify `learnings-researcher` agent works with user's configured model
- [ ] Confirm only `lint.md` has `model: haiku`

This contribution was developed with AI assistance (Claude Code).