### PR TITLE
feat(hooks): add PreCompact hook to auto-trigger /ce:compound

### DIFF
--- a/plugins/compound-engineering/hooks/hooks.json
+++ b/plugins/compound-engineering/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Before context compaction, check if this session contains a solved problem, debugging insight, or pattern worth documenting. If so, run /ce:compound to capture it before context is lost. If nothing significant was solved, skip silently."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `PreCompact` prompt hook that checks if the session contains compoundable knowledge before context compaction
- Uses `type: "prompt"` so the AI evaluates whether `/ce:compound` is warranted - skips silently if nothing significant was solved
- Placed in `plugins/compound-engineering/hooks/hooks.json` which is auto-loaded by the parser's default path convention

Fixes #95

## How it works

When Claude Code is about to compact context, the hook injects a prompt asking the AI to:
1. Check if the session contains a solved problem, debugging insight, or discovered pattern
2. If yes, run `/ce:compound` to capture it in `docs/solutions/`
3. If nothing significant, skip silently (no disruption to user)

This ensures knowledge gets captured at the optimal moment - when full context is still available, before compaction loses the details.

## Test plan

- [ ] Install plugin and work through a debugging session
- [ ] Trigger context compaction and verify the hook fires
- [ ] Verify it skips silently when no significant problems were solved
- [ ] Verify it triggers `/ce:compound` when a problem was solved

This contribution was developed with AI assistance (Claude Code).