### PR TITLE
fix(plan): remove deprecated /technical_review references

### DIFF
--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -579,17 +579,15 @@ After writing the plan file, use the **AskUserQuestion tool** to present these o
 **Options:**
 1. **Open plan in editor** - Open the plan file for review
 2. **Run `/deepen-plan`** - Enhance each section with parallel research agents (best practices, performance, UI)
-3. **Run `/technical_review`** - Technical feedback from code-focused reviewers (DHH, Kieran, Simplicity)
-4. **Review and refine** - Improve the document through structured self-review
-5. **Share to Proof** - Upload to Proof for collaborative review and sharing
-6. **Start `/ce:work`** - Begin implementing this plan locally
-7. **Start `/ce:work` on remote** - Begin implementing in Claude Code on the web (use `&` to run in background)
-8. **Create Issue** - Create issue in project tracker (GitHub/Linear)
+3. **Review and refine** - Improve the document through structured self-review
+4. **Share to Proof** - Upload to Proof for collaborative review and sharing
+5. **Start `/ce:work`** - Begin implementing this plan locally
+6. **Start `/ce:work` on remote** - Begin implementing in Claude Code on the web (use `&` to run in background)
+7. **Create Issue** - Create issue in project tracker (GitHub/Linear)
 
 Based on selection:
 - **Open plan in editor** → Run `open docs/plans/<plan_filename>.md` to open the file in the user's default editor
 - **`/deepen-plan`** → Call the /deepen-plan command with the plan file path to enhance with research
-- **`/technical_review`** → Call the /technical_review command with the plan file path
 - **Review and refine** → Load `document-review` skill.
 - **Share to Proof** → Upload the plan to Proof:
   ```bash
@@ -608,7 +606,7 @@ Based on selection:
 
 **Note:** If running `/ce:plan` with ultrathink enabled, automatically run `/deepen-plan` after plan creation for maximum depth and grounding.
 
-Loop back to options after Simplify or Other changes until user selects `/ce:work` or `/technical_review`.
+Loop back to options after Simplify or Other changes until user selects `/ce:work` or another action.
 
 ## Issue Creation
 
@@ -638,6 +636,6 @@ When user selects "Create Issue", detect their project tracker from CLAUDE.md:
 
 5. **After creation:**
    - Display the issue URL
-   - Ask if they want to proceed to `/ce:work` or `/technical_review`
+   - Ask if they want to proceed to `/ce:work`
 
 NEVER CODE! Just research and write the plan.

--- a/plugins/compound-engineering/skills/deepen-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/deepen-plan/SKILL.md
@@ -480,14 +480,12 @@ After writing the enhanced plan, use the **AskUserQuestion tool** to present the
 
 **Options:**
 1. **View diff** - Show what was added/changed
-2. **Run `/technical_review`** - Get feedback from reviewers on enhanced plan
-3. **Start `/ce:work`** - Begin implementing this enhanced plan
-4. **Deepen further** - Run another round of research on specific sections
-5. **Revert** - Restore original plan (if backup exists)
+2. **Start `/ce:work`** - Begin implementing this enhanced plan
+3. **Deepen further** - Run another round of research on specific sections
+4. **Revert** - Restore original plan (if backup exists)
 
 Based on selection:
 - **View diff** → Run `git diff [plan_path]` or show before/after
-- **`/technical_review`** → Call the /technical_review command with the plan file path
 - **`/ce:work`** → Call the /ce:work command with the plan file path
 - **Deepen further** → Ask which sections need more research, then re-run those agents
 - **Revert** → Restore from git or backup


### PR DESCRIPTION
## Summary

- Remove all references to the deprecated `/technical_review` command from `ce:plan` and `deepen-plan` skill files
- Renumber menu options after removal to keep numbering sequential
- The `/technical_review` command was removed in v2.32.0 but 6 references remained in the post-generation menus and selection handlers

## Why removal instead of replacement

The closed PR #247 took the wrong approach by replacing `/technical_review` with `/ce:review`. That's incorrect because `/ce:review` is a **code review** tool (for reviewing PRs/diffs), not a **plan review** tool. The plan menu already has the correct tool for plan review - "Review and refine" (option 4, now option 3), which loads the `document-review` skill. There's nothing to replace these references with - they just need to be removed.

Supersedes #247.
Fixes #244

## Changes

**`plugins/compound-engineering/skills/ce-plan/SKILL.md`** (4 removals):
- Removed option 3 (`/technical_review`) from post-generation menu, renumbered remaining options
- Removed `/technical_review` selection handler
- Updated loop-back text to remove `/technical_review` mention
- Removed `/technical_review` from issue creation follow-up prompt

**`plugins/compound-engineering/skills/deepen-plan/SKILL.md`** (2 removals):
- Removed option 2 (`/technical_review`) from post-enhancement menu, renumbered remaining options
- Removed `/technical_review` selection handler

## Test plan

- [ ] Run `/ce:plan` and verify the post-generation menu shows correct options without `/technical_review`
- [ ] Run `/deepen-plan` and verify the post-enhancement menu shows correct options without `/technical_review`
- [ ] Verify "Review and refine" (document-review) still works as the plan review option

🤖 Generated with [Claude Code](https://claude.com/claude-code)