### PR TITLE
fix(agents): update learnings-researcher model from haiku to inherit

### DIFF
--- a/plugins/compound-engineering/agents/research/learnings-researcher.md
+++ b/plugins/compound-engineering/agents/research/learnings-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: learnings-researcher
 description: "Searches docs/solutions/ for relevant past solutions by frontmatter metadata. Use before implementing features or fixing problems to surface institutional knowledge and prevent repeated mistakes."
-model: haiku
+model: inherit
 ---
 
 <examples>


### PR DESCRIPTION
## Summary

- Replaces hardcoded `model: haiku` with `model: inherit` on the learnings-researcher agent so it uses the caller's model instead of being pinned to haiku

Supersedes #249 (from fork, couldn't push fix for failing CI)

## Test plan

- [x] All 314 tests pass locally (0 failures)
- [x] CI passes on this branch