### PR TITLE
feat: add staleness-detector agent and /ce:prune command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
   "plugins": [
     {
       "name": "compound-engineering",
-      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 29 specialized agents, 22 commands, and 20 skills.",
-      "version": "2.38.1",
+      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 30 specialized agents, 23 commands, and 20 skills.",
+      "version": "2.39.0",
       "author": {
         "name": "Kieran Klaassen",
         "url": "https://github.com/kieranklaassen",

--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
-  "version": "2.38.1",
-  "description": "AI-powered development tools. 29 agents, 22 commands, 20 skills, 1 MCP server for code review, research, design, and workflow automation.",
+  "version": "2.39.0",
+  "description": "AI-powered development tools. 30 agents, 23 commands, 20 skills, 1 MCP server for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",

--- a/plugins/compound-engineering/.cursor-plugin/plugin.json
+++ b/plugins/compound-engineering/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "compound-engineering",
   "displayName": "Compound Engineering",
-  "version": "2.33.0",
-  "description": "AI-powered development tools. 29 agents, 22 commands, 19 skills, 1 MCP server for code review, research, design, and workflow automation.",
+  "version": "2.39.0",
+  "description": "AI-powered development tools. 30 agents, 23 commands, 20 skills, 1 MCP server for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",

--- a/plugins/compound-engineering/CHANGELOG.md
+++ b/plugins/compound-engineering/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the compound-engineering plugin will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.39.0] - 2026-03-14
+
+### Added
+
+- **`staleness-detector` agent** — Scans `docs/solutions/` for stale entries by extracting file references from each doc and checking git history for changes since the doc was written. Reports stale entries with specific changed files, commit counts, and rename detection. Uses `model: haiku` for cost efficiency.
+- **`/ce:prune` command** — Interactive triage for stale `docs/solutions/` entries. Six-phase workflow: prerequisites check → staleness scan → report summary → interactive triage (Keep/Update/Archive/Delete) → batch operations for 10+ entries → summary with critical patterns check. Archived docs go to `docs/solutions/.archived/` and are excluded from `learnings-researcher` searches.
+- **`staleness-detector` wired into `/ce:review`** — Runs as an always-on advisory agent (P3, never blocks merge). Results appear in a dedicated "Documentation Staleness (Advisory)" section in the review summary with a note to run `/ce:prune`. Protected Artifacts rule updated to exempt staleness advisories from the discard filter.
+
+---
+
 ## [2.38.1] - 2026-03-01
 
 ### Fixed

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -6,8 +6,8 @@ AI-powered development tools that get smarter with every use. Make each unit of 
 
 | Component | Count |
 |-----------|-------|
-| Agents | 29 |
-| Commands | 22 |
+| Agents | 30 |
+| Commands | 23 |
 | Skills | 20 |
 | MCP Servers | 1 |
 
@@ -53,7 +53,7 @@ Agents are organized into categories for easier discovery.
 | `design-iterator` | Iteratively refine UI through systematic design iterations |
 | `figma-design-sync` | Synchronize web implementations with Figma designs |
 
-### Workflow (5)
+### Workflow (6)
 
 | Agent | Description |
 |-------|-------------|
@@ -62,6 +62,7 @@ Agents are organized into categories for easier discovery.
 | `lint` | Run linting and code quality checks on Ruby and ERB files |
 | `pr-comment-resolver` | Address PR comments and implement fixes |
 | `spec-flow-analyzer` | Analyze user flows and identify gaps in specifications |
+| `staleness-detector` | Detect stale docs/solutions/ entries by checking git history of referenced files |
 
 ### Docs (1)
 
@@ -82,6 +83,7 @@ Core workflow commands use `ce:` prefix to unambiguously identify them as compou
 | `/ce:review` | Run comprehensive code reviews |
 | `/ce:work` | Execute work items systematically |
 | `/ce:compound` | Document solved problems to compound team knowledge |
+| `/ce:prune` | Detect and triage stale docs/solutions/ entries |
 
 > **Deprecated aliases:** `/workflows:plan`, `/workflows:work`, `/workflows:review`, `/workflows:brainstorm`, `/workflows:compound` still work but show a deprecation warning. Use `ce:*` equivalents.
 

--- a/plugins/compound-engineering/agents/workflow/staleness-detector.md
+++ b/plugins/compound-engineering/agents/workflow/staleness-detector.md
@@ -1,0 +1,201 @@
+---
+name: staleness-detector
+description: "Scans docs/solutions/ for entries whose referenced code has changed significantly since the doc was written. Use during /ce:review or via /ce:prune to detect stale institutional knowledge."
+model: haiku
+---
+
+<examples>
+<example>
+Context: User is running a code review on a project with documented solutions.
+user: "Review PR #42 for the payments module"
+assistant: "I'll use the staleness-detector agent to check if any docs/solutions/ entries reference code that has changed since they were written."
+<commentary>During /ce:review, the staleness-detector runs alongside other review agents to flag outdated documentation that might mislead future planning.</commentary>
+</example>
+<example>
+Context: User wants to clean up their knowledge base.
+user: "/ce:prune"
+assistant: "I'll use the staleness-detector agent to scan all docs/solutions/ files and identify entries that may be outdated based on git history changes."
+<commentary>The user explicitly invoked /ce:prune, which dispatches the staleness-detector to scan the full knowledge base.</commentary>
+</example>
+<example>
+Context: User notices a learnings-researcher result that seems outdated.
+user: "That solution about brief generation doesn't look right anymore — we refactored that whole module"
+assistant: "Let me run the staleness-detector agent to check which docs/solutions/ entries reference files in the brief module that have changed."
+<commentary>The user suspects stale documentation. The staleness-detector can verify by checking git history for referenced files.</commentary>
+</example>
+</examples>
+
+You are an institutional knowledge auditor that detects stale documentation in `docs/solutions/` by checking whether the code referenced in each doc has changed significantly since the doc was written. Your goal is accurate, low-noise staleness detection.
+
+## Prerequisites Check
+
+Before scanning, verify:
+
+```bash
+# Must be a git repository
+git rev-parse --is-inside-work-tree 2>/dev/null || echo "NOT_GIT"
+
+# docs/solutions/ must exist
+test -d docs/solutions/ && echo "EXISTS" || echo "MISSING"
+```
+
+**If not a git repository:** Return immediately:
+```
+Staleness check requires a git repository. Skipping.
+```
+
+**If docs/solutions/ does not exist:** Return immediately:
+```
+No docs/solutions/ directory found. No knowledge base to check.
+```
+
+## Scanning Algorithm
+
+### Step 1: Find All Solution Docs
+
+```bash
+# Recursively find all markdown files in docs/solutions/
+find docs/solutions/ -name "*.md" -type f | sort
+```
+
+Count total files for the summary.
+
+### Step 2: Extract Doc Date (per file)
+
+Read the first 30 lines of each file to get YAML frontmatter. Extract the doc date using this fallback chain:
+
+1. `date:` field in frontmatter
+2. `created:` field in frontmatter
+3. Git first-commit date: `git log --diff-filter=A --format=%aI -- <file> | tail -1`
+
+If none can be determined, skip the file and note it as "no date available."
+
+### Step 3: Extract File References (per file)
+
+Read the full doc body. Extract file paths using these rules:
+
+**Include** paths matching this pattern in code blocks and inline backticks:
+- Contains at least one `/` separator
+- Ends with a file extension (`.rb`, `.py`, `.ts`, `.js`, `.md`, `.yml`, `.json`, `.html`, `.erb`, `.css`, `.scss`, etc.)
+- Optional line number suffix (`:42`)
+
+**Exclude:**
+- URLs containing `://`
+- Template paths containing `{` or `}`
+- Relative doc links starting with `../` or `./` and ending in `.md`
+- Paths that are clearly not project files (e.g., `/usr/`, `/etc/`, `/tmp/`)
+
+Deduplicate extracted paths (strip line numbers before deduplication).
+
+### Step 4: Check Git History (per referenced file)
+
+For each unique extracted file path, run these checks **in parallel where possible**:
+
+**A. File existence:**
+```bash
+test -f <path> && echo "EXISTS" || echo "MISSING"
+```
+
+**B. If file exists — count commits since doc date:**
+```bash
+git log --oneline --since="<doc_date>" -- "<path>" | wc -l
+```
+
+**C. If file is missing — check for rename:**
+```bash
+git log --follow --diff-filter=R --name-only --format="" -- "<path>" | head -5
+```
+
+If a rename is detected, report the new path.
+
+### Step 5: Determine Staleness
+
+Flag a doc as **potentially stale** if ANY of these conditions are true:
+- A referenced file no longer exists and no rename was detected
+- A referenced file has **more than 5 commits** since the doc date
+- A referenced file was renamed (report old and new paths)
+
+Flag a doc as **unable to verify** if:
+- Zero file references were extracted from the doc body
+
+Flag a doc as **current** if:
+- All referenced files exist and have 5 or fewer commits since the doc date
+
+### Step 6: Check critical-patterns.md (if it exists)
+
+```bash
+test -f docs/solutions/patterns/critical-patterns.md && echo "EXISTS" || echo "MISSING"
+```
+
+If it exists, parse each `## Pattern` section independently:
+
+1. **Check "Documented in:" links** — verify the referenced file exists
+2. **Grep WRONG code blocks** — search codebase for the anti-pattern. If found, pattern is still relevant.
+3. **Grep CORRECT code blocks** — search codebase for the correct pattern. If NOT found, pattern may be outdated.
+4. Flag patterns where the "Documented in:" link is broken or where neither WRONG nor CORRECT code is found in the codebase.
+
+## Output Format
+
+Return a structured staleness report:
+
+```markdown
+## Staleness Report
+
+### Summary
+- **Files scanned:** X
+- **Potentially stale:** Y
+- **Unable to verify:** Z (no file references)
+- **Current:** W
+
+### Potentially Stale Entries
+
+#### 1. [doc_path]
+- **Date:** YYYY-MM-DD (N days ago)
+- **Stale references:**
+  - `path/to/file.rb` — N commits since doc date
+  - `path/to/other.rb` — file no longer exists
+  - `path/to/renamed.rb` — renamed to `path/to/new_name.rb`
+- **Staleness signal:** High/Medium
+  - High: file deleted/renamed OR >15 commits
+  - Medium: 6-15 commits
+
+#### 2. [doc_path]
+...
+
+### Stale Critical Patterns
+
+#### Pattern N: [title]
+- **Issue:** [broken link / code not found / etc.]
+- **Details:** [specific check that failed]
+
+### Unable to Verify
+- `doc_path` — no file references found (age: N days)
+- ...
+
+### Current (no action needed)
+[Count] documents are current. All referenced files exist with minimal changes.
+```
+
+## Efficiency Guidelines
+
+**DO:**
+- Read frontmatter (first 30 lines) of each file to get the date before reading the full body
+- Run git log checks in parallel for multiple files
+- Skip files in `docs/solutions/.archived/` (already pruned)
+- Batch git operations where possible
+- Report results grouped by staleness severity (high first)
+
+**DON'T:**
+- Read files outside `docs/solutions/`
+- Modify any files (this agent is read-only)
+- Flag files in `docs/solutions/.archived/`
+- Count merge commits or trivial changes differently (keep it simple — count all commits)
+- Use `git log --follow` for files that exist (only use for missing files to detect renames)
+
+## Integration Points
+
+This agent is invoked by:
+- `/ce:prune` — standalone knowledge base audit with interactive triage
+- `/ce:review` — advisory parallel agent alongside `learnings-researcher` and `agent-native-reviewer`
+
+When invoked from `/ce:review`, findings are advisory (P3) and never block merge. The review synthesis includes them in a dedicated "Documentation Staleness" section.

--- a/plugins/compound-engineering/commands/ce/prune.md
+++ b/plugins/compound-engineering/commands/ce/prune.md
@@ -1,0 +1,210 @@
+---
+name: ce:prune
+description: Detect and triage stale docs/solutions/ entries whose referenced code has changed
+argument-hint: "[optional: path to specific doc or category to check]"
+---
+
+# /ce:prune
+
+Audit the `docs/solutions/` knowledge base for stale entries and interactively triage them.
+
+## Purpose
+
+Over time, documented solutions become outdated as code is refactored, dependencies change, and architecture evolves. The `learnings-researcher` agent surfaces these docs during `/ce:plan` as if they were current. `/ce:prune` detects stale entries and lets you decide what to do with them.
+
+**Why prune?** Stale documentation is worse than no documentation — it gives wrong advice with the authority of institutional knowledge.
+
+## Usage
+
+```bash
+/ce:prune                              # Scan all docs/solutions/
+/ce:prune docs/solutions/performance-issues/  # Scan a specific category
+```
+
+## Execution Flow
+
+### Phase 1: Prerequisites
+
+Check that the environment supports staleness detection:
+
+```bash
+# Must be a git repository
+git rev-parse --is-inside-work-tree 2>/dev/null
+```
+
+**If not a git repo:** Exit with message:
+```
+/ce:prune requires a git repository with commit history. Not a git repository.
+```
+
+**If docs/solutions/ does not exist:** Exit with message:
+```
+No docs/solutions/ directory found.
+
+To start building your knowledge base, run /ce:compound after solving non-trivial problems.
+The staleness detector will help keep it accurate over time.
+```
+
+**If docs/solutions/ is empty (no .md files):** Exit with message:
+```
+docs/solutions/ exists but contains no documentation files. Nothing to prune.
+```
+
+### Phase 2: Scan
+
+Invoke the staleness-detector agent to scan the knowledge base:
+
+```
+Task staleness-detector(docs/solutions/)
+```
+
+If a specific path was provided as argument, pass it to the agent to narrow the scan.
+
+**Wait for the agent to complete** before proceeding to Phase 3.
+
+### Phase 3: Report Summary
+
+Present the scan results summary:
+
+```
+Staleness scan complete.
+
+Scanned: X documents
+Potentially stale: Y
+Unable to verify: Z (no file references)
+Current: W
+
+[If Y == 0]: All documents are current. No action needed.
+[If Y > 0]: Ready to triage Y stale entries. Proceed?
+```
+
+If no stale entries, exit here.
+
+### Phase 4: Interactive Triage
+
+Present stale entries one at a time, ordered by staleness severity (high first).
+
+For each stale entry, use **AskUserQuestion** to present the triage options:
+
+```
+question: "[1/Y] docs/solutions/category/filename.md\nDate: YYYY-MM-DD (N days ago)\nStale: path/to/file.rb (N commits), path/to/other.rb (deleted)\n\nWhat should we do with this entry?"
+header: "Prune"
+options:
+  - label: "Keep"
+    description: "Mark as reviewed today. Add last_reviewed: YYYY-MM-DD to frontmatter. No other changes."
+  - label: "Update"
+    description: "Display the doc and update it to reflect current code. Updates date to today."
+  - label: "Archive"
+    description: "Move to docs/solutions/.archived/. Excluded from future learnings-researcher searches."
+  - label: "Delete"
+    description: "Remove permanently via git rm."
+```
+
+**Action implementations:**
+
+#### Keep
+Read the file, add or update `last_reviewed: YYYY-MM-DD` in the YAML frontmatter using the Edit tool. This resets the staleness clock — the entry will not be flagged again until referenced files accumulate more changes.
+
+#### Update
+1. Display the full document content to the user
+2. Use AskUserQuestion: "What changed? Describe the update needed, or say 'edit manually' to skip."
+3. If the user describes changes: apply edits to the doc using the Edit tool
+4. Update the `date:` field in frontmatter to today's date
+5. If the user says "edit manually": print the file path and move to the next entry
+
+#### Archive
+```bash
+# Preserve directory structure under .archived/
+RELATIVE_PATH="<path relative to docs/solutions/>"
+ARCHIVE_DIR="docs/solutions/.archived/$(dirname "$RELATIVE_PATH")"
+mkdir -p "$ARCHIVE_DIR"
+mv "<full_path>" "$ARCHIVE_DIR/"
+```
+
+The `.archived/` directory is excluded from `learnings-researcher` searches by convention — files there do not appear during `/ce:plan`.
+
+#### Delete
+Use AskUserQuestion for confirmation:
+```
+question: "Permanently delete docs/solutions/category/filename.md? This will run git rm."
+header: "Confirm"
+options:
+  - label: "Yes, delete"
+    description: "Remove the file permanently. Git history preserves it if needed later."
+  - label: "No, skip"
+    description: "Keep the file and move to the next entry."
+```
+
+If confirmed:
+```bash
+git rm "<path>"
+```
+
+### Phase 4b: Batch Operations
+
+**If more than 10 stale entries remain** after triaging the first 3 individually, offer batch operations:
+
+```
+question: "N entries remaining. Apply a batch action to all remaining?"
+header: "Batch"
+options:
+  - label: "Continue one by one"
+    description: "Keep triaging entries individually."
+  - label: "Keep all remaining"
+    description: "Add last_reviewed to all remaining entries."
+  - label: "Archive all remaining"
+    description: "Move all remaining to .archived/"
+```
+
+### Phase 5: Summary
+
+After all entries are triaged, present the final summary:
+
+```
+Pruning complete.
+
+  Kept (reviewed): X
+  Updated: Y
+  Archived: Z
+  Deleted: W
+  Skipped: V
+
+[If Y > 0]: Some docs were updated. Consider running /ce:compound if any
+solutions need to be fully rewritten with current context.
+
+[If Z > 0]: Archived docs are in docs/solutions/.archived/ and excluded
+from learnings-researcher. Restore with: mv docs/solutions/.archived/<path> docs/solutions/<path>
+```
+
+### Phase 6: Critical Patterns Check
+
+If the staleness-detector reported stale critical patterns:
+
+```
+Additionally, N critical pattern(s) in docs/solutions/patterns/critical-patterns.md may be outdated:
+
+- Pattern 3: "Documented in:" link broken (file deleted)
+- Pattern 7: CORRECT code block not found in codebase
+
+Critical patterns are read on EVERY /ce:plan. Stale patterns here are the most damaging.
+Edit critical-patterns.md to update or remove these patterns.
+```
+
+Display the file path and offer to open it for editing.
+
+## Preconditions
+
+<preconditions enforcement="hard">
+  <check condition="git_repository">
+    Must be inside a git repository with commit history.
+  </check>
+  <check condition="docs_solutions_exists">
+    docs/solutions/ directory must exist with at least one .md file.
+  </check>
+</preconditions>
+
+## Related Commands
+
+- `/ce:compound` — create new solution docs (the input to this system)
+- `/ce:review` — runs staleness-detector as advisory agent alongside code review
+- `/ce:plan` — consumes docs/solutions/ via learnings-researcher (benefits from pruning)

--- a/plugins/compound-engineering/commands/ce/review.md
+++ b/plugins/compound-engineering/commands/ce/review.md
@@ -57,6 +57,8 @@ The following paths are compound-engineering pipeline artifacts and must never b
 - `docs/solutions/*.md` — Solution documents created during the pipeline.
 
 If a review agent flags any file in these directories for cleanup or removal, discard that finding during synthesis. Do not create a todo for it.
+
+**Exception:** The staleness-detector agent may report that docs in these directories are outdated. These are advisory findings ("documentation may need updating"), not recommendations for deletion. Include staleness advisories in the review synthesis as a separate informational section.
 </protected_artifacts>
 
 #### Load Review Agents
@@ -78,6 +80,7 @@ Task {agent-name}(PR content + review context from settings body)
 Additionally, always run these regardless of settings:
 - Task agent-native-reviewer(PR content) - Verify new features are agent-accessible
 - Task learnings-researcher(PR content) - Search docs/solutions/ for past issues related to this PR's modules and patterns
+- Task staleness-detector(docs/solutions/) - Check for stale solution docs (advisory, P3 — never blocks merge)
 
 </parallel_tasks>
 
@@ -220,7 +223,8 @@ Remove duplicates, prioritize by severity and impact.
 
 - [ ] Collect findings from all parallel agents
 - [ ] Surface learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files
-- [ ] Discard any findings that recommend deleting or gitignoring files in `docs/plans/` or `docs/solutions/` (see Protected Artifacts above)
+- [ ] Surface staleness-detector results: if stale docs were found, include them in a dedicated "Documentation Staleness (Advisory)" section — do NOT create todos for these, just report them with a note to run `/ce:prune`
+- [ ] Discard any findings that recommend deleting or gitignoring files in `docs/plans/` or `docs/solutions/` (see Protected Artifacts above), except staleness-detector advisories which use the dedicated section
 - [ ] Categorize by type: security, performance, architecture, quality, etc.
 - [ ] Assign severity levels: 🔴 CRITICAL (P1), 🟡 IMPORTANT (P2), 🔵 NICE-TO-HAVE (P3)
 - [ ] Remove duplicate or overlapping findings
@@ -379,6 +383,16 @@ After creating all todo files, present comprehensive summary:
 
 - `005-pending-p3-{finding}.md` - {description}
 
+### Documentation Staleness (Advisory)
+
+[If staleness-detector found stale entries:]
+- X stale entries detected in docs/solutions/
+- Run `/ce:prune` to review and triage
+- [list stale doc paths with brief reason, e.g., "docs/solutions/performance-issues/n-plus-one.md — 12 commits to referenced files"]
+
+[If staleness-detector found nothing or docs/solutions/ missing:]
+[Omit this section entirely]
+
 ### Review Agents Used:
 
 - kieran-rails-reviewer
@@ -386,6 +400,7 @@ After creating all todo files, present comprehensive summary:
 - performance-oracle
 - architecture-strategist
 - agent-native-reviewer
+- staleness-detector (advisory)
 - [other agents]
 
 ### Next Steps:


### PR DESCRIPTION
**Summary**

- staleness-detector agent: scans docs/solutions/ for stale entries by checking git history of referenced files. Uses model: haiku for cost efficiency.
- /ce:prune command: interactive triage workflow (Keep/Update/Archive/Delete) with batch operations for large knowledge bases.
- ce:review integration: staleness-detector runs as always-on advisory agent (P3, never blocks merge) with results in a dedicated summary section.

Closes the gap in the knowledge compounding loop: solutions are captured via /ce:compound and surfaced by learnings-researcher, but until now there was no mechanism to detect when they become outdated.

**Changes**

- 2 new files: agents/workflow/staleness-detector.md, commands/ce/prune.md
- 1 modified file: commands/ce/review.md (always-on agent + Protected Artifacts exemption + synthesis section)
- Metadata bumped to v2.39.0 (30 agents, 23 commands)

**Design**

- Brainstorm
- Git-based detection (no LLM inference for staleness checks)
- Interactive triage with Archive option (docs/solutions/.archived/ excluded from learnings-researcher)
- Advisory only in ce:review: never blocks merge