### PR TITLE
feat: add PR reviewability analysis and scope monitoring

### DIFF
--- a/docs/plans/2026-03-17-001-feat-pr-reviewability-and-scope-monitoring-plan.md
+++ b/docs/plans/2026-03-17-001-feat-pr-reviewability-and-scope-monitoring-plan.md
@@ -1,0 +1,273 @@
+---
+title: "feat: Add PR reviewability analysis and scope monitoring"
+type: feat
+status: active
+date: 2026-03-17
+---
+
+# Add PR Reviewability Analysis and Scope Monitoring
+
+Add a new review agent and scope monitoring to catch oversized PRs before they become unreviewable -- and prevent them from growing too large during `/ce:work`.
+
+Motivated by [PR #536](https://github.com/EveryInc/proof/pull/536): 172 files changed, ~50K lines, closed because it introduced 3 independent regressions across unrelated concerns that nobody caught in review.
+
+## Acceptance Criteria
+
+### New Agent: `pr-reviewability-analyst`
+
+- [x] Create `plugins/compound-engineering/agents/review/pr-reviewability-analyst.md`
+- [x] Agent analyzes PR diff for: effective line count, file count, directory spread, and concern count
+- [x] Weighted counting: test files at 50%, generated/lock files excluded, deletions at 10%
+- [x] Default thresholds: >400 effective lines, >7 files, or >2 distinct concerns triggers a flag
+- [x] When flagged: propose concrete split into 2-5 stacked PRs by clustering files by concern
+- [x] Each proposed sub-PR includes: one-sentence description, file list, estimated line count
+- [x] Output: reviewability score (0-100) + pass/fail + split proposal (if failing)
+- [x] Agent description stays under 250 chars for context budget
+
+### Integration into `/ce:review`
+
+- [x] Add reviewability check as a **pre-flight step** in `ce-review/SKILL.md` between Step 1 (setup) and the parallel agent dispatch
+- [x] Runs as a hardcoded system check, not part of the user-configured `review_agents` list
+- [x] If score < 60: present split recommendation as a P2 finding, then continue running all other review agents (do NOT gate/block)
+- [x] If score >= 60: proceed normally with no extra output
+- [x] Split recommendation appears in the findings synthesis alongside other agent results
+
+### Scope Monitor in `/ce:work`
+
+- [x] After each task completion in Phase 2 execution loop, measure total branch divergence: `git diff $(git merge-base HEAD <default_branch>)..HEAD --stat`
+- [x] Soft warning at 300 effective lines or 5 files: "You're at X lines across Y files. Consider checkpointing."
+- [x] Hard warning at 500 effective lines or 10 files: strongly recommend splitting, suggest split point based on completed vs remaining tasks
+- [x] After user declines a hard warning: downgrade to a single reminder after next 100 additional lines (no warning fatigue)
+- [x] Offer: create checkpoint commit + push + start new stacked branch for remaining tasks
+- [x] Scope monitor disabled in swarm mode (add note for team lead to check periodically)
+
+### Configuration
+
+- [x] Add `reviewability` section to `compound-engineering.local.md` YAML frontmatter schema (documented in ce-review SKILL.md Step 1.5 and agent defaults):
+  ```yaml
+  reviewability:
+    line_threshold: 400        # effective lines to trigger review flag
+    file_threshold: 7          # files changed to trigger review flag
+    concern_threshold: 2       # distinct concerns to trigger review flag
+    work_soft_threshold: 300   # soft warning during ce:work
+    work_hard_threshold: 500   # hard warning during ce:work
+    exclude_patterns:          # files excluded from line counts
+      - "*.lock"
+      - "db/schema.rb"
+      - "db/structure.sql"
+    test_weight: 0.5           # multiplier for test file lines
+    deletion_weight: 0.1       # multiplier for deleted lines
+  ```
+- [ ] Setup skill updated to include reviewability defaults when creating new settings files (follow-up)
+
+### Counting Rules
+
+- [x] **Effective lines** = (added lines x 1.0) + (deleted lines x 0.1) + (test lines x 0.5)
+- [x] Exclude files matching `exclude_patterns` from line counts entirely
+- [x] Include excluded files in the file list but not in thresholds
+- [x] Detect test files by path convention: `test/`, `spec/`, `__tests__/`, `*.test.*`, `*.spec.*`
+- [x] Detect concerns by clustering changed files into groups by: top-level directory, then by semantic similarity (model+migration = 1 concern, controller+route = 1 concern)
+
+### Documentation
+
+- [x] Update `plugins/compound-engineering/README.md` with new agent
+- [x] Update plugin.json description with new agent count
+- [x] Update marketplace.json description with new agent count
+- [ ] Run `/release-docs` after changes (deferred — docs site rebuild)
+
+## Context
+
+### Why This Matters
+
+PR #536 was a well-intentioned refactor ("remove macOS app surface, make Proof web-only") that grew to 172 files and ~50K lines. It was closed because:
+
+1. Removed web editor agent entry points (`keybindings.ts`, `editor/index.ts`, `context-menu.ts`) with no replacement
+2. Removed `@proof` comment/reply trigger plumbing that stopped existing agent workflows
+3. Regressed a hosted setup/help route by falling back to wrong skill
+
+All three regressions were in **unrelated areas** -- classic symptom of a PR that mixes too many concerns. No reviewer could reasonably catch all three in a single pass through 172 files.
+
+### Industry Research
+
+- **SmartBear/Cisco**: Reviews of 200-400 LOC find 70-90% of defects. Beyond 400, detection drops sharply.
+- **Graphite (1.5M PRs)**: Beyond 3 files, merge time more than doubles.
+- **Google eng-practices**: 100 lines ideal, 1000 too large. Stacking is recommended.
+- **GitLab**: 500 changes is the hard threshold requiring justification.
+
+### Design Decisions
+
+1. **Non-blocking**: The reviewability check is P2 (informational), not P1 (blocks merge). Teams should adopt gradually.
+2. **No automated splitting in v1**: Agent outputs a structured split proposal. Automated branch creation/cherry-picking is a v2 enhancement.
+3. **Hardcoded pre-flight**: Not part of user-configurable agent list -- always runs, like a linter. Users configure thresholds, not whether it runs.
+4. **Measure branch divergence in ce:work**: Total diff from default branch (not just uncommitted changes), so incremental commits don't reset the counter.
+
+## MVP
+
+### pr-reviewability-analyst.md
+
+```markdown
+---
+name: pr-reviewability-analyst
+description: Analyzes PR size, concern count, and file spread. Proposes stacked PR splits when thresholds are exceeded. Run automatically as pre-flight check during /ce:review.
+subagent_type: general-purpose
+---
+
+# PR Reviewability Analyst
+
+You are a PR reviewability analyst. Your job is to evaluate whether a pull request is reviewable as-is or should be split into smaller, independently shippable PRs.
+
+## Input
+
+You will receive:
+- PR metadata (title, description, files changed, additions, deletions)
+- The full diff or file list
+
+## Analysis Steps
+
+### 1. Calculate Effective Size
+
+Measure the PR using weighted counting:
+
+- **Added lines**: weight 1.0
+- **Deleted lines**: weight 0.1 (deletions are easy to review)
+- **Test file lines**: weight 0.5 (tests accompany implementation)
+- **Excluded files**: skip entirely (lock files, generated schemas)
+
+Detect test files by path: `test/`, `spec/`, `__tests__/`, files matching `*.test.*` or `*.spec.*`
+
+### 2. Count Distinct Concerns
+
+Cluster changed files by concern:
+- Group by top-level directory first
+- Then merge groups that are semantically one concern:
+  - `db/migrate/` + `app/models/` + model tests = "Schema/Model change"
+  - `app/controllers/` + `config/routes.rb` + controller tests = "API/Route change"
+  - `app/views/` + `app/javascript/` + view tests = "UI change"
+  - `config/` + CI files = "Configuration change"
+- Count the resulting groups
+
+A single concern touching multiple directories is 1 concern, not many.
+
+### 3. Score Reviewability
+
+Start at 100, subtract:
+- Lines over threshold: -2 per 50 lines over (max -30)
+- Files over threshold: -5 per file over (max -30)
+- Concerns over threshold: -15 per concern over (max -30)
+- No tests for new code: -10
+
+Score interpretation:
+- 80-100: Excellent reviewability
+- 60-79: Acceptable, proceed with review
+- 40-59: Poor, recommend splitting
+- 0-39: Unreviewable, strongly recommend splitting
+
+### 4. Generate Split Proposal (if score < 60)
+
+For each identified concern cluster:
+1. List the files in that cluster
+2. Write a one-sentence PR description
+3. Estimate effective line count
+4. Identify dependencies on other clusters
+5. Order the stack (independent PRs first, dependent PRs later)
+
+Format:
+```
+## Reviewability Score: [SCORE]/100 — [PASS/FAIL]
+
+### Metrics
+- Effective lines: X (threshold: Y)
+- Files changed: X (threshold: Y)
+- Distinct concerns: X (threshold: Y)
+- Test coverage: [present/missing for new code]
+
+### [If FAIL] Proposed Split
+
+**Stack Order:**
+
+PR 1/N: "[one-sentence description]" (base: main)
+  Files: [list]
+  ~X effective lines, Y files
+
+PR 2/N: "[one-sentence description]" (base: PR 1)
+  Files: [list]
+  ~X effective lines, Y files
+  Depends on: PR 1 (needs [specific thing])
+
+...
+```
+
+### 5. If PASS
+
+Output only the score summary. No split proposal needed.
+
+## Important
+
+- A PR can be large in lines but still reviewable if it is a single concern (e.g., mechanical rename across 50 files)
+- Weight your judgment by concern count more than raw line count
+- Deletion-heavy PRs (removing dead code) are generally more reviewable than addition-heavy PRs
+- Generated code (migrations, lock files) should be noted but not counted
+```
+
+### ce-review SKILL.md integration point
+
+Insert after Step 1 (Determine Review Target & Setup), before the parallel agent dispatch:
+
+```markdown
+### 1.5. Pre-Flight Reviewability Check (Always Runs)
+
+Before dispatching review agents, run a quick reviewability analysis:
+
+- Task compound-engineering:review:pr-reviewability-analyst(PR metadata + file list + diff stats)
+
+**Read thresholds from `compound-engineering.local.md`** frontmatter `reviewability` section. If not configured, use defaults: 400 lines, 7 files, 2 concerns.
+
+**If score >= 60**: Log "Reviewability: [SCORE]/100 — PASS" and proceed to agent dispatch.
+
+**If score < 60**:
+- Log the full reviewability report (score, metrics, split proposal)
+- Add the split recommendation as a P2 finding during synthesis (Step 5)
+- **Continue running all review agents** — do not gate or block
+- In the summary report, add a "Reviewability" section before the findings
+```
+
+### ce-work SKILL.md integration point
+
+Insert into Phase 2 Task Execution Loop, after "Mark task as completed" and before "Evaluate for incremental commit":
+
+```markdown
+   **Scope Check** — After completing each task, measure total branch size:
+
+   ```bash
+   default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+   [ -z "$default_branch" ] && default_branch=$(git rev-parse --verify origin/main >/dev/null 2>&1 && echo "main" || echo "master")
+   merge_base=$(git merge-base HEAD origin/$default_branch)
+
+   # Get stats excluding generated files
+   stats=$(git diff $merge_base..HEAD --stat --stat-width=999 | tail -1)
+   # Parse: "X files changed, Y insertions(+), Z deletions(-)"
+   ```
+
+   Read thresholds from `compound-engineering.local.md` frontmatter `reviewability` section. Defaults: soft=300, hard=500.
+
+   | Effective Lines | Files | Action |
+   |----------------|-------|--------|
+   | < soft threshold | < 5 | Continue silently |
+   | >= soft threshold | >= 5 | Warn: "Scope check: ~X effective lines across Y files. Consider checkpointing before continuing." |
+   | >= hard threshold | >= 10 | Strongly recommend: "This branch has grown to ~X lines across Y files. Recommend creating a checkpoint PR now." Offer: (1) Create checkpoint commit + push + new stacked branch, (2) Continue anyway |
+
+   After user declines a hard warning, suppress until 100+ additional effective lines accumulate.
+
+   In swarm mode: skip scope checks (team lead should monitor manually).
+```
+
+## Sources
+
+- PR #536: https://github.com/EveryInc/proof/pull/536
+- SmartBear/Cisco study on code review effectiveness
+- Graphite research on 1.5M PRs: file count strongly correlates with merge time
+- Google eng-practices: https://google.github.io/eng-practices/review/developer/small-cls.html
+- GitLab contribution guide: 500-change hard threshold
+- Martin Fowler: Feature Toggles, Branch by Abstraction
+- Existing plugin: `plugins/compound-engineering/skills/ce-review/SKILL.md`
+- Existing plugin: `plugins/compound-engineering/skills/ce-work/SKILL.md`

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -31,6 +31,7 @@ Agents are organized into categories for easier discovery.
 | `kieran-typescript-reviewer` | TypeScript code review with strict conventions |
 | `pattern-recognition-specialist` | Analyze code for patterns and anti-patterns |
 | `performance-oracle` | Performance analysis and optimization |
+| `pr-reviewability-analyst` | Analyze PR size, concern count, and file spread; propose splits |
 | `schema-drift-detector` | Detect unrelated schema.rb changes in PRs |
 | `security-sentinel` | Security audits and vulnerability assessments |
 

--- a/plugins/compound-engineering/agents/review/pr-reviewability-analyst.md
+++ b/plugins/compound-engineering/agents/review/pr-reviewability-analyst.md
@@ -1,0 +1,160 @@
+---
+name: pr-reviewability-analyst
+description: "Analyzes PR size, concern count, and file spread to score reviewability. Proposes stacked PR splits when thresholds are exceeded. Use as pre-flight check during code review."
+model: inherit
+---
+
+<examples>
+<example>
+Context: A PR touches 15 files across 4 directories with 600 lines changed.
+user: "Review PR #536 for reviewability"
+assistant: "I'll analyze this PR's size, concern distribution, and file spread to determine if it should be split into smaller PRs."
+<commentary>Large PR with wide file spread — the reviewability analyst will score it and propose a split.</commentary>
+</example>
+<example>
+Context: A focused PR with 180 lines changing 3 files in one directory.
+user: "Check if this PR is reviewable"
+assistant: "I'll run the reviewability analyst to confirm this PR is within healthy review thresholds."
+<commentary>Small focused PR — the analyst will give a passing score quickly.</commentary>
+</example>
+</examples>
+
+You are a PR reviewability analyst. Your job is to evaluate whether a pull request is reviewable as-is or should be split into smaller, independently shippable PRs.
+
+## Input
+
+You will receive PR metadata: title, description, file list with additions/deletions per file, and optionally the full diff. You may also receive threshold overrides from project settings.
+
+## Default Thresholds
+
+| Metric | Default | Override key |
+|--------|---------|-------------|
+| Effective lines | 400 | `line_threshold` |
+| Files changed | 7 | `file_threshold` |
+| Distinct concerns | 2 | `concern_threshold` |
+| Test line weight | 0.5 | `test_weight` |
+| Deletion line weight | 0.1 | `deletion_weight` |
+
+## Analysis Steps
+
+### 1. Calculate Effective Size
+
+Classify each changed file:
+
+- **Test files**: paths containing `test/`, `spec/`, `__tests__/`, or matching `*.test.*`, `*.spec.*`
+- **Generated/excluded files**: `*.lock`, `db/schema.rb`, `db/structure.sql`, `package-lock.json`, `yarn.lock`, plus any patterns from `exclude_patterns` setting
+- **Implementation files**: everything else
+
+Calculate effective lines per file:
+- Implementation: additions × 1.0, deletions × deletion_weight
+- Test: (additions × 1.0, deletions × deletion_weight) × test_weight
+- Generated/excluded: 0 (excluded from count but listed in report)
+
+Sum for total effective lines.
+
+### 2. Count Distinct Concerns
+
+Cluster changed files into concern groups. A concern is a cohesive unit of change:
+
+1. Start by grouping files by their top-level application directory
+2. Merge groups that are semantically one concern:
+   - `db/migrate/` + `app/models/` + model tests → "Schema/Model change"
+   - `app/controllers/` + `config/routes.rb` + controller tests → "API/Route change"
+   - `app/views/` + `app/javascript/` + `app/assets/` + view/component tests → "UI change"
+   - `config/` + CI/CD files + infrastructure → "Configuration change"
+   - `lib/` + corresponding tests → "Library change"
+   - `docs/` → "Documentation" (does not count toward concern threshold)
+3. Count the resulting non-documentation groups
+
+A single concern touching multiple directories is 1 concern. For example, a Rails migration + model change + model test = 1 concern ("Schema/Model"), not 3.
+
+### 3. Assess Coupling
+
+Check whether changed files have cross-dependencies:
+- Files that import/require each other belong to the same concern
+- Files with no mutual dependencies could potentially be separate PRs
+- Note tightly coupled clusters that must ship together
+
+### 4. Score Reviewability
+
+Start at 100, subtract:
+
+| Condition | Penalty | Max |
+|-----------|---------|-----|
+| Effective lines over threshold | -2 per 50 lines over | -30 |
+| Files over threshold | -5 per file over | -30 |
+| Concerns over threshold | -15 per concern over | -30 |
+| New implementation code with no tests | -10 | -10 |
+
+Score interpretation:
+- **80-100**: Excellent — well-scoped, proceed with review
+- **60-79**: Acceptable — on the larger side but reviewable
+- **40-59**: Poor — recommend splitting before review
+- **0-39**: Unreviewable — strongly recommend splitting
+
+### 5. Generate Split Proposal (if score < 60)
+
+For each identified concern cluster:
+1. List the files in that cluster with their line counts
+2. Write a one-sentence PR description that passes the "no and" test
+3. Calculate effective line count for the sub-PR
+4. Identify dependencies on other clusters
+5. Order as a stack: independent PRs first, dependent PRs later
+
+### 6. Output
+
+Always output this format:
+
+```markdown
+## Reviewability Score: [SCORE]/100 — [PASS/FAIL]
+
+### Metrics
+| Metric | Value | Threshold | Status |
+|--------|-------|-----------|--------|
+| Effective lines | X | Y | ✅/⚠️ |
+| Files changed | X | Y | ✅/⚠️ |
+| Distinct concerns | X | Y | ✅/⚠️ |
+| Test coverage | present/missing | — | ✅/⚠️ |
+
+### Concern Breakdown
+1. **[Concern name]** (X files, ~Y effective lines)
+   - file1.ext (+A, -D)
+   - file2.ext (+A, -D)
+2. **[Concern name]** (X files, ~Y effective lines)
+   - ...
+
+### Excluded from counts
+- file.lock (generated)
+- ...
+```
+
+**If score < 60, add:**
+
+```markdown
+### Proposed Split
+
+**Stack Order:**
+
+**PR 1/N: "[one-sentence description]"** (base: main)
+- Files: [list]
+- ~X effective lines, Y files
+- Independently deployable: yes/no
+
+**PR 2/N: "[one-sentence description]"** (base: PR 1)
+- Files: [list]
+- ~X effective lines, Y files
+- Depends on: PR 1 ([specific dependency])
+- Independently deployable: yes/no
+
+### Why Split?
+[Brief explanation of which concerns are mixed and why separating them improves reviewability and reduces regression risk]
+```
+
+## Important Judgment Rules
+
+- A PR can be large in lines but still reviewable if it is a **single concern** (e.g., mechanical rename across 50 files). Favor concern count over raw size.
+- **Deletion-heavy PRs** (removing dead code, deprecating features) are generally more reviewable than addition-heavy PRs. The deletion weight (default 0.1) reflects this.
+- **Generated code** (migrations, lock files, schema dumps) should be noted but excluded from effective line counts.
+- Do not penalize thorough testing. Test files are weighted at 0.5 specifically to avoid punishing good test coverage.
+- A split proposal where any sub-PR would be broken or meaningless alone is worse than keeping the PR together. Only propose splits that produce independently shippable units.
+- When the PR is a single atomic operation (e.g., a library upgrade touching many files), note this and do not recommend splitting even if thresholds are exceeded.

--- a/plugins/compound-engineering/skills/ce-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-review/SKILL.md
@@ -60,6 +60,36 @@ The following paths are compound-engineering pipeline artifacts and must never b
 If a review agent flags any file in these directories for cleanup or removal, discard that finding during synthesis. Do not create a todo for it.
 </protected_artifacts>
 
+### 1.5. Pre-Flight Reviewability Check (Always Runs)
+
+Before dispatching review agents, run a quick reviewability analysis to detect oversized or multi-concern PRs:
+
+- Task compound-engineering:review:pr-reviewability-analyst(PR metadata + file list + diff stats from Step 1)
+
+**Read thresholds** from `compound-engineering.local.md` frontmatter `reviewability` section. If not configured, use defaults: 400 effective lines, 7 files, 2 concerns.
+
+**Threshold overrides (pass to agent):**
+```yaml
+# Example compound-engineering.local.md reviewability section
+reviewability:
+  line_threshold: 400
+  file_threshold: 7
+  concern_threshold: 2
+  exclude_patterns: ["*.lock", "db/schema.rb"]
+  test_weight: 0.5
+  deletion_weight: 0.1
+```
+
+**If score >= 60 (PASS):** Log `"Reviewability: [SCORE]/100 — PASS"` and proceed to agent dispatch.
+
+**If score < 60 (FAIL):**
+- Display the full reviewability report (score, metrics, concern breakdown, split proposal)
+- **Continue running all review agents** — do NOT gate or block the review
+- Carry the split recommendation forward as a **P2 finding** during synthesis (Step 5)
+- In the summary report (Step 5, Step 3), add a "Reviewability" section before the findings breakdown
+
+This check is a **hardcoded system step**, not part of the user-configured `review_agents` list. It always runs regardless of agent configuration.
+
 #### Load Review Agents
 
 Read `compound-engineering.local.md` in the project root. If found, use `review_agents` from YAML frontmatter. If the markdown body contains review context, pass it to each agent as additional instructions.
@@ -390,11 +420,14 @@ After creating all todo files, present comprehensive summary:
 
 **Review Target:** PR #XXXX - [PR Title] **Branch:** [branch-name]
 
+### Reviewability: [SCORE]/100 — [PASS/FAIL]
+[If FAIL: brief summary of concerns and link to split proposal below]
+
 ### Findings Summary:
 
 - **Total Findings:** [X]
 - **🔴 CRITICAL (P1):** [count] - BLOCKS MERGE
-- **🟡 IMPORTANT (P2):** [count] - Should Fix
+- **🟡 IMPORTANT (P2):** [count] - Should Fix (includes reviewability finding if score < 60)
 - **🔵 NICE-TO-HAVE (P3):** [count] - Enhancements
 
 ### Created Todo Files:

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -125,7 +125,9 @@ This command takes a work document (plan, specification, or todo file) and execu
      - Write tests for new functionality
      - Run System-Wide Test Check (see below)
      - Run tests after changes
-     - Mark task as completed
+     - Mark task as completed in TodoWrite
+     - Mark off the corresponding checkbox in the plan file ([ ] -> [x])
+     - Run Scope Check (see below)
      - Evaluate for incremental commit (see below)
    ```
 
@@ -150,6 +152,35 @@ This command takes a work document (plan, specification, or todo file) and execu
    **When to skip:** Leaf-node changes with no callbacks, no state persistence, no parallel interfaces. If the change is purely additive (new helper method, new view partial), the check takes 10 seconds and the answer is "nothing fires, skip."
 
    **When this matters most:** Any change that touches models with callbacks, error handling with fallback/retry, or functionality exposed through multiple interfaces.
+
+   **Scope Check** -- After completing each task, measure total branch size to catch scope creep before the PR becomes unreviewable:
+
+   ```bash
+   default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+   [ -z "$default_branch" ] && default_branch=$(git rev-parse --verify origin/main >/dev/null 2>&1 && echo "main" || echo "master")
+   merge_base=$(git merge-base HEAD "origin/$default_branch")
+   git diff "$merge_base"..HEAD --stat | tail -1
+   ```
+
+   Read thresholds from `compound-engineering.local.md` frontmatter `reviewability` section. Defaults: soft warning = 300 effective lines or 5 files, hard warning = 500 effective lines or 10 files.
+
+   | Branch Size | Action |
+   |-------------|--------|
+   | Under soft threshold | Continue silently |
+   | At soft threshold (~300 lines, ~5 files) | Inform: "Scope check: ~X lines across Y files. Consider checkpointing before the PR gets too large." |
+   | At hard threshold (~500 lines, ~10 files) | Recommend: "This branch has grown to ~X lines across Y files. Recommend creating a checkpoint PR now." Offer two options: (1) Create checkpoint commit, push, and start a new stacked branch for remaining tasks. (2) Continue anyway. |
+
+   **After user declines a hard warning:** Suppress further warnings until 100+ additional effective lines accumulate. Do not warn on every task completion -- warning fatigue erodes trust.
+
+   **Checkpoint flow (if accepted):**
+   1. Create an incremental commit with current changes
+   2. Push the branch: `git push -u origin <branch>`
+   3. Note the branch name for PR creation later
+   4. Create a new branch from current HEAD: `git checkout -b <branch>-part-2`
+   5. Continue remaining tasks on the new branch
+   6. At Phase 4, create stacked PRs: first PR targets default branch, second PR targets first branch
+
+   **In swarm mode:** Skip scope checks. The team lead agent should monitor branch size periodically instead.
 
 
 2. **Incremental Commits**

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -124,7 +124,9 @@ This command takes a work document (plan, specification, or todo file) and execu
      - Write tests for new functionality
      - Run System-Wide Test Check (see below)
      - Run tests after changes
-     - Mark task as completed
+     - Mark task as completed in TodoWrite
+     - Mark off the corresponding checkbox in the plan file ([ ] → [x])
+     - Run Scope Check (see below)
      - Evaluate for incremental commit (see below)
    ```
 
@@ -150,6 +152,35 @@ This command takes a work document (plan, specification, or todo file) and execu
 
    **When this matters most:** Any change that touches models with callbacks, error handling with fallback/retry, or functionality exposed through multiple interfaces.
 
+
+   **Scope Check** — After completing each task, measure total branch size to catch scope creep before the PR becomes unreviewable:
+
+   ```bash
+   default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+   [ -z "$default_branch" ] && default_branch=$(git rev-parse --verify origin/main >/dev/null 2>&1 && echo "main" || echo "master")
+   merge_base=$(git merge-base HEAD "origin/$default_branch")
+   git diff "$merge_base"..HEAD --stat | tail -1
+   ```
+
+   Read thresholds from `compound-engineering.local.md` frontmatter `reviewability` section. Defaults: soft warning = 300 effective lines or 5 files, hard warning = 500 effective lines or 10 files.
+
+   | Branch Size | Action |
+   |-------------|--------|
+   | Under soft threshold | Continue silently |
+   | At soft threshold (~300 lines, ~5 files) | Inform: "Scope check: ~X lines across Y files. Consider checkpointing before the PR gets too large." |
+   | At hard threshold (~500 lines, ~10 files) | Recommend: "This branch has grown to ~X lines across Y files. Recommend creating a checkpoint PR now." Offer two options: (1) Create checkpoint commit, push, and start a new stacked branch for remaining tasks. (2) Continue anyway. |
+
+   **After user declines a hard warning:** Suppress further warnings until 100+ additional effective lines accumulate. Do not warn on every task completion — warning fatigue erodes trust.
+
+   **Checkpoint flow (if accepted):**
+   1. Create an incremental commit with current changes
+   2. Push the branch: `git push -u origin <branch>`
+   3. Note the branch name for PR creation later
+   4. Create a new branch from current HEAD: `git checkout -b <branch>-part-2`
+   5. Continue remaining tasks on the new branch
+   6. At Phase 4, create stacked PRs: first PR targets default branch, second PR targets first branch
+
+   **In swarm mode:** Skip scope checks. The team lead agent should monitor branch size periodically instead.
 
 2. **Incremental Commits**
 


### PR DESCRIPTION
## Summary

- **New agent**: `pr-reviewability-analyst` — scores PRs on reviewability (0-100) using weighted line counts, file counts, and concern analysis. Proposes concrete stacked PR splits when score < 60.
- **ce:review integration**: Added Step 1.5 "Pre-Flight Reviewability Check" that runs before all other review agents. Non-blocking (P2 finding). Updated summary report template.
- **ce:work integration**: Added "Scope Check" to the task execution loop. Measures total branch divergence after each task. Soft warning at 300 lines/5 files, hard warning at 500 lines/10 files with checkpoint + stacked branch flow.
- **ce:work-beta parity**: Mirrored the same task-completion and scope-check behavior into `ce:work-beta` so this guidance does not get lost if `ce:work-beta` is later promoted to stable.

Motivated by [EveryInc/proof#536](https://github.com/EveryInc/proof/pull/536) — a 172-file, ~50K-line PR that was closed because it mixed too many concerns and introduced 3 independent regressions across unrelated areas.

## Key Design Decisions

- **Non-blocking**: Reviewability check is P2 (informational), not P1. Teams adopt gradually.
- **No automated splitting in v1**: Agent outputs a structured split proposal. Automated cherry-picking is a v2 enhancement.
- **Hardcoded pre-flight**: Always runs during `/ce:review`, not part of user-configured agent list.
- **Branch divergence measurement in ce:work/ce:work-beta**: Total diff from default branch, so incremental commits don't reset the counter.
- **Stable/beta workflow parity**: `ce:work-beta` keeps the same reviewability guardrails as `ce:work`, while preserving its beta-only delegation guidance.
- **Warning fatigue prevention**: After user declines a hard warning, suppresses until 100+ additional lines.

## Testing

- Verified all JSON files valid (`jq .`)
- Verified `ce:work-beta` mirrors the new `ce:work` scope-check/task-completion guidance while preserving beta-only delegation sections

## Post-Deploy Monitoring & Validation

- `No additional operational monitoring required: plugin content change only — no runtime code, no deployed services`

## Follow-up

- [ ] Update setup skill to include `reviewability` defaults in new settings files
- [ ] Run `/release-docs` to rebuild documentation site

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)
