### PR TITLE
fix: sync plugin version to 2.41.0 and correct skill counts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
   "plugins": [
     {
       "name": "compound-engineering",
-      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 29 specialized agents and 47 skills.",
-      "version": "2.40.0",
+      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 29 specialized agents and 42 skills.",
+      "version": "2.41.0",
       "author": {
         "name": "Kieran Klaassen",
         "url": "https://github.com/kieranklaassen",

--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
-  "version": "2.40.0",
-  "description": "AI-powered development tools. 29 agents, 47 skills, 1 MCP server for code review, research, design, and workflow automation.",
+  "version": "2.41.0",
+  "description": "AI-powered development tools. 29 agents, 42 skills, 1 MCP server for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -7,8 +7,7 @@ AI-powered development tools that get smarter with every use. Make each unit of 
 | Component | Count |
 |-----------|-------|
 | Agents | 29 |
-| Commands | 23 |
-| Skills | 20 |
+| Skills | 42 |
 | MCP Servers | 1 |
 
 ## Agents


### PR DESCRIPTION
## Summary

- Bumps plugin.json and marketplace.json version from `2.40.0` → `2.41.0` to match root package.json
- Fixes skill count from `47` → `42` (actual count of skill directories)
- Removes stale "Commands | 23" row from README (commands were migrated to skills in v2.39.0)

This is why `/plugin` was reporting `2.40.0` instead of the latest release.

## Post-Deploy Monitoring & Validation

`No additional operational monitoring required: metadata-only change`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>