### PR TITLE
fix: stabilize compound-engineering component counts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
   "plugins": [
     {
       "name": "compound-engineering",
-      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes 29 specialized agents and 44 skills.",
+      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last.",
       "version": "2.42.0",
       "author": {
         "name": "Kieran Klaassen",

--- a/plugins/compound-engineering/.claude-plugin/plugin.json
+++ b/plugins/compound-engineering/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
   "version": "2.42.0",
-  "description": "AI-powered development tools. 29 agents, 44 skills, 1 MCP server for code review, research, design, and workflow automation.",
+  "description": "AI-powered development tools for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",

--- a/plugins/compound-engineering/.cursor-plugin/plugin.json
+++ b/plugins/compound-engineering/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "compound-engineering",
   "displayName": "Compound Engineering",
   "version": "2.42.0",
-  "description": "AI-powered development tools. 29 agents, 44 skills, 1 MCP server for code review, research, design, and workflow automation.",
+  "description": "AI-powered development tools for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -6,15 +6,15 @@ AI-powered development tools that get smarter with every use. Make each unit of 
 
 | Component | Count |
 |-----------|-------|
-| Agents | 29 |
-| Skills | 44 |
+| Agents | 25+ |
+| Skills | 40+ |
 | MCP Servers | 1 |
 
 ## Agents
 
 Agents are organized into categories for easier discovery.
 
-### Review (15)
+### Review
 
 | Agent | Description |
 |-------|-------------|
@@ -34,7 +34,7 @@ Agents are organized into categories for easier discovery.
 | `schema-drift-detector` | Detect unrelated schema.rb changes in PRs |
 | `security-sentinel` | Security audits and vulnerability assessments |
 
-### Research (6)
+### Research
 
 | Agent | Description |
 |-------|-------------|
@@ -45,7 +45,7 @@ Agents are organized into categories for easier discovery.
 | `learnings-researcher` | Search institutional learnings for relevant past solutions |
 | `repo-research-analyst` | Research repository structure and conventions |
 
-### Design (3)
+### Design
 
 | Agent | Description |
 |-------|-------------|
@@ -53,7 +53,7 @@ Agents are organized into categories for easier discovery.
 | `design-iterator` | Iteratively refine UI through systematic design iterations |
 | `figma-design-sync` | Synchronize web implementations with Figma designs |
 
-### Workflow (4)
+### Workflow
 
 | Agent | Description |
 |-------|-------------|
@@ -62,7 +62,7 @@ Agents are organized into categories for easier discovery.
 | `pr-comment-resolver` | Address PR comments and implement fixes |
 | `spec-flow-analyzer` | Analyze user flows and identify gaps in specifications |
 
-### Docs (1)
+### Docs
 
 | Agent | Description |
 |-------|-------------|

--- a/scripts/release/validate.ts
+++ b/scripts/release/validate.ts
@@ -1,18 +1,21 @@
 #!/usr/bin/env bun
 import path from "path"
 import { validateReleasePleaseConfig } from "../../src/release/config"
-import { syncReleaseMetadata } from "../../src/release/metadata"
+import { getCompoundEngineeringCounts, syncReleaseMetadata } from "../../src/release/metadata"
 import { readJson } from "../../src/utils/files"
 
 const releasePleaseConfig = await readJson<{ packages: Record<string, unknown> }>(
   path.join(process.cwd(), ".github", "release-please-config.json"),
 )
 const configErrors = validateReleasePleaseConfig(releasePleaseConfig)
+const counts = await getCompoundEngineeringCounts(process.cwd())
 const result = await syncReleaseMetadata({ write: false })
 const changed = result.updates.filter((update) => update.changed)
 
 if (configErrors.length === 0 && changed.length === 0) {
-  console.log("Release metadata is in sync.")
+  console.log(
+    `Release metadata is in sync. compound-engineering currently has ${counts.agents} agents, ${counts.skills} skills, and ${counts.mcpServers} MCP server${counts.mcpServers === 1 ? "" : "s"}.`,
+  )
   process.exit(0)
 }
 
@@ -28,5 +31,8 @@ if (changed.length > 0) {
   for (const update of changed) {
     console.error(`- ${update.path}`)
   }
+  console.error(
+    `Current compound-engineering counts: ${counts.agents} agents, ${counts.skills} skills, ${counts.mcpServers} MCP server${counts.mcpServers === 1 ? "" : "s"}.`,
+  )
 }
 process.exit(1)

--- a/src/release/metadata.ts
+++ b/src/release/metadata.ts
@@ -41,6 +41,18 @@ export type MetadataSyncResult = {
   updates: FileUpdate[]
 }
 
+export type CompoundEngineeringCounts = {
+  agents: number
+  skills: number
+  mcpServers: number
+}
+
+const COMPOUND_ENGINEERING_DESCRIPTION =
+  "AI-powered development tools for code review, research, design, and workflow automation."
+
+const COMPOUND_ENGINEERING_MARKETPLACE_DESCRIPTION =
+  "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last."
+
 function resolveExpectedVersion(
   explicitVersion: string | undefined,
   fallbackVersion: string,
@@ -90,12 +102,23 @@ export async function countMcpServers(pluginRoot: string): Promise<number> {
   return Object.keys(manifest.mcpServers ?? {}).length
 }
 
-export async function buildCompoundEngineeringDescription(root: string): Promise<string> {
+export async function getCompoundEngineeringCounts(root: string): Promise<CompoundEngineeringCounts> {
   const pluginRoot = path.join(root, "plugins", "compound-engineering")
-  const agents = await countMarkdownFiles(path.join(pluginRoot, "agents"))
-  const skills = await countSkillDirectories(path.join(pluginRoot, "skills"))
-  const mcpServers = await countMcpServers(pluginRoot)
-  return `AI-powered development tools. ${agents} agents, ${skills} skills, ${mcpServers} MCP server${mcpServers === 1 ? "" : "s"} for code review, research, design, and workflow automation.`
+  const [agents, skills, mcpServers] = await Promise.all([
+    countMarkdownFiles(path.join(pluginRoot, "agents")),
+    countSkillDirectories(path.join(pluginRoot, "skills")),
+    countMcpServers(pluginRoot),
+  ])
+
+  return { agents, skills, mcpServers }
+}
+
+export async function buildCompoundEngineeringDescription(_root: string): Promise<string> {
+  return COMPOUND_ENGINEERING_DESCRIPTION
+}
+
+export async function buildCompoundEngineeringMarketplaceDescription(_root: string): Promise<string> {
+  return COMPOUND_ENGINEERING_MARKETPLACE_DESCRIPTION
 }
 
 export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<MetadataSyncResult> {
@@ -105,6 +128,7 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
   const updates: FileUpdate[] = []
 
   const compoundDescription = await buildCompoundEngineeringDescription(root)
+  const compoundMarketplaceDescription = await buildCompoundEngineeringMarketplaceDescription(root)
 
   const compoundClaudePath = path.join(root, "plugins", "compound-engineering", ".claude-plugin", "plugin.json")
   const compoundCursorPath = path.join(root, "plugins", "compound-engineering", ".cursor-plugin", "plugin.json")
@@ -178,8 +202,8 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
         plugin.version = expectedCompoundVersion
         changed = true
       }
-      if (plugin.description !== `AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes ${await countMarkdownFiles(path.join(root, "plugins", "compound-engineering", "agents"))} specialized agents and ${await countSkillDirectories(path.join(root, "plugins", "compound-engineering", "skills"))} skills.`) {
-        plugin.description = `AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last. Includes ${await countMarkdownFiles(path.join(root, "plugins", "compound-engineering", "agents"))} specialized agents and ${await countSkillDirectories(path.join(root, "plugins", "compound-engineering", "skills"))} skills.`
+      if (plugin.description !== compoundMarketplaceDescription) {
+        plugin.description = compoundMarketplaceDescription
         changed = true
       }
     }

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp, mkdir, writeFile } from "fs/promises"
 import os from "os"
 import path from "path"
 import { afterEach, describe, expect, test } from "bun:test"
-import { buildCompoundEngineeringDescription, syncReleaseMetadata } from "../src/release/metadata"
+import {
+  buildCompoundEngineeringDescription,
+  getCompoundEngineeringCounts,
+  syncReleaseMetadata,
+} from "../src/release/metadata"
 
 const tempRoots: string[] = []
 
@@ -83,10 +87,24 @@ async function makeFixtureRoot(): Promise<string> {
 }
 
 describe("release metadata", () => {
-  test("builds the current compound-engineering manifest description from repo counts", async () => {
+  test("reports current compound-engineering counts from the repo", async () => {
+    const counts = await getCompoundEngineeringCounts(process.cwd())
+
+    expect(counts).toEqual({
+      agents: expect.any(Number),
+      skills: expect.any(Number),
+      mcpServers: expect.any(Number),
+    })
+    expect(counts.agents).toBeGreaterThan(0)
+    expect(counts.skills).toBeGreaterThan(0)
+    expect(counts.mcpServers).toBeGreaterThanOrEqual(0)
+  })
+
+  test("builds a stable compound-engineering manifest description", async () => {
     const description = await buildCompoundEngineeringDescription(process.cwd())
+
     expect(description).toBe(
-      "AI-powered development tools. 29 agents, 44 skills, 1 MCP server for code review, research, design, and workflow automation.",
+      "AI-powered development tools for code review, research, design, and workflow automation.",
     )
   })
 


### PR DESCRIPTION
## Summary
- remove exact component counts from committed release metadata descriptions so skill and agent additions do not cause routine merge conflicts
- keep release validation count-aware by reporting live filesystem totals during validation
- replace exact README totals with durable thresholds and remove exact per-category agent counts

## Testing
- bun run release:validate
- bun test tests/release-metadata.test.ts
- bun test