### PR TITLE
feat(git-worktree): auto-trust mise and direnv configs in new worktrees

### DIFF
--- a/plugins/compound-engineering/skills/git-worktree/SKILL.md
+++ b/plugins/compound-engineering/skills/git-worktree/SKILL.md
@@ -16,7 +16,7 @@ This skill provides a unified interface for managing Git worktrees across your d
 - **Interactive confirmations** at each step
 - **Automatic .gitignore management** for worktree directory
 - **Automatic .env file copying** from main repo to new worktrees
-- **Automatic dev tool trusting** for mise and direnv configs (safe: only unchanged configs)
+- **Automatic dev tool trusting** for mise and direnv configs with review-safe guardrails
 
 ## CRITICAL: Always Use the Manager Script
 
@@ -24,7 +24,9 @@ This skill provides a unified interface for managing Git worktrees across your d
 
 The script handles critical setup that raw git commands don't:
 1. Copies `.env`, `.env.local`, `.env.test`, etc. from main repo
-2. Trusts dev tool configs (mise, direnv) so hooks and scripts work immediately
+2. Trusts dev tool configs with branch-aware safety rules:
+   - mise: auto-trust only when unchanged from a trusted baseline branch
+   - direnv: auto-allow only for trusted base branches; review worktrees stay manual
 3. Ensures `.worktrees` is in `.gitignore`
 4. Creates consistent directory structure
 
@@ -97,7 +99,10 @@ bash ${CLAUDE_PLUGIN_ROOT}/skills/git-worktree/scripts/worktree-manager.sh creat
 2. Updates the base branch from remote
 3. Creates new worktree and branch
 4. **Copies all .env files from main repo** (.env, .env.local, .env.test, etc.)
-5. **Trusts dev tool configs** (mise, direnv) if unchanged from the default branch; flags modified configs for manual review
+5. **Trusts dev tool configs** with branch-aware safety rules:
+   - trusted bases (`main`, `develop`, `dev`, `trunk`, `staging`, `release/*`) compare against themselves
+   - other branches compare against the default branch
+   - direnv auto-allow is skipped on non-trusted bases because `.envrc` can source unchecked files
 6. Shows path for cd-ing to the worktree
 
 ### `list` or `ls`

--- a/plugins/compound-engineering/skills/git-worktree/scripts/worktree-manager.sh
+++ b/plugins/compound-engineering/skills/git-worktree/scripts/worktree-manager.sh
@@ -65,20 +65,56 @@ copy_env_files() {
   echo -e "  ${GREEN}✓ Copied $copied environment file(s)${NC}"
 }
 
+# Resolve the repository default branch, falling back to main when origin/HEAD
+# is unavailable (for example in single-branch clones).
+get_default_branch() {
+  local head_ref
+  head_ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || true)
+
+  if [[ -n "$head_ref" ]]; then
+    echo "${head_ref#refs/remotes/origin/}"
+  else
+    echo "main"
+  fi
+}
+
+# Auto-trust is only safe when the worktree is created from a long-lived branch
+# the developer already controls. Review/PR branches should fall back to the
+# default branch baseline and require manual direnv approval.
+is_trusted_base_branch() {
+  local branch="$1"
+  local default_branch="$2"
+
+  [[ "$branch" == "$default_branch" ]] && return 0
+
+  case "$branch" in
+    develop|dev|trunk|staging|release/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 # Trust development tool configs in a new worktree.
 # Worktrees get a new filesystem path that tools like mise and direnv
 # have never seen. Without trusting, these tools block with interactive
 # prompts or refuse to load configs, which breaks hooks and scripts.
 #
-# Safety: only auto-trusts configs that are unchanged from the default branch.
-# Modified configs (e.g., from a PR) are flagged for manual review.
+# Safety: auto-trusts only configs unchanged from a trusted baseline branch.
+# Review/PR branches fall back to the default-branch baseline, and direnv
+# auto-allow is limited to trusted base branches because .envrc can source
+# additional files that direnv does not validate.
 #
 # TOCTOU between hash-check and trust is acceptable for local dev use.
 trust_dev_tools() {
   local worktree_path="$1"
   local base_ref="$2"
+  local allow_direnv_auto="$3"
   local trusted=0
-  local skipped=()
+  local skipped_messages=()
+  local manual_commands=()
 
   # mise: trust the specific config file if present and unchanged
   if command -v mise &>/dev/null; then
@@ -91,7 +127,8 @@ trust_dev_tools() {
             echo -e "  ${YELLOW}Warning: 'mise trust $f' failed -- run manually in $worktree_path${NC}"
           fi
         else
-          skipped+=("mise trust $f")
+          skipped_messages+=("mise trust $f (config differs from $base_ref)")
+          manual_commands+=("mise trust $f")
         fi
         break
       fi
@@ -101,14 +138,18 @@ trust_dev_tools() {
   # direnv: allow .envrc
   if command -v direnv &>/dev/null; then
     if [[ -f "$worktree_path/.envrc" ]]; then
-      if _config_unchanged ".envrc" "$base_ref" "$worktree_path"; then
+      if [[ "$allow_direnv_auto" != "true" ]]; then
+        skipped_messages+=("direnv allow (.envrc auto-allow is disabled for non-trusted base branches)")
+        manual_commands+=("direnv allow")
+      elif _config_unchanged ".envrc" "$base_ref" "$worktree_path"; then
         if (cd "$worktree_path" && direnv allow); then
           trusted=$((trusted + 1))
         else
           echo -e "  ${YELLOW}Warning: 'direnv allow' failed -- run manually in $worktree_path${NC}"
         fi
       else
-        skipped+=("direnv allow")
+        skipped_messages+=("direnv allow (.envrc differs from $base_ref)")
+        manual_commands+=("direnv allow")
       fi
     fi
   fi
@@ -117,14 +158,16 @@ trust_dev_tools() {
     echo -e "  ${GREEN}✓ Trusted $trusted dev tool config(s)${NC}"
   fi
 
-  if [[ ${#skipped[@]} -gt 0 ]]; then
-    echo -e "  ${YELLOW}Skipped auto-trust for modified config(s):${NC}"
-    for item in "${skipped[@]}"; do
+  if [[ ${#skipped_messages[@]} -gt 0 ]]; then
+    echo -e "  ${YELLOW}Skipped auto-trust for config(s) requiring manual review:${NC}"
+    for item in "${skipped_messages[@]}"; do
       echo -e "    - $item"
     done
-    local joined
-    joined=$(printf ' && %s' "${skipped[@]}")
-    echo -e "  ${BLUE}Review the diff, then run manually: cd $worktree_path${joined}${NC}"
+    if [[ ${#manual_commands[@]} -gt 0 ]]; then
+      local joined
+      joined=$(printf ' && %s' "${manual_commands[@]}")
+      echo -e "  ${BLUE}Review the diff, then run manually: cd $worktree_path${joined}${NC}"
+    fi
   fi
 }
 
@@ -196,20 +239,26 @@ create_worktree() {
   copy_env_files "$worktree_path"
 
   # Trust dev tool configs (mise, direnv) so hooks and scripts work immediately.
-  # Compare against the default branch (not from_branch) so that passing a PR
-  # branch as from_branch doesn't bypass the safety check.
+  # Long-lived integration branches can use themselves as the trust baseline,
+  # while review/PR branches fall back to the default branch and require manual
+  # direnv approval.
   local default_branch
-  default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||')
-  default_branch="${default_branch:-main}"
-  # Ensure the ref is fresh -- create_worktree only fetches from_branch
-  if ! git fetch origin "$default_branch" --quiet; then
-    echo -e "  ${YELLOW}Warning: could not fetch origin/$default_branch -- trust check may use stale data${NC}"
+  default_branch=$(get_default_branch)
+  local trust_branch="$default_branch"
+  local allow_direnv_auto="false"
+  if is_trusted_base_branch "$from_branch" "$default_branch"; then
+    trust_branch="$from_branch"
+    allow_direnv_auto="true"
   fi
-  # Skip trust entirely if the ref doesn't exist locally (no baseline to compare)
-  if git rev-parse --verify "origin/$default_branch" &>/dev/null; then
-    trust_dev_tools "$worktree_path" "origin/$default_branch"
+
+  if ! git fetch origin "$trust_branch" --quiet; then
+    echo -e "  ${YELLOW}Warning: could not fetch origin/$trust_branch -- trust check may use stale data${NC}"
+  fi
+  # Skip trust entirely if the baseline ref doesn't exist locally.
+  if git rev-parse --verify "origin/$trust_branch" &>/dev/null; then
+    trust_dev_tools "$worktree_path" "origin/$trust_branch" "$allow_direnv_auto"
   else
-    echo -e "  ${YELLOW}Skipping dev tool trust -- origin/$default_branch not found locally${NC}"
+    echo -e "  ${YELLOW}Skipping dev tool trust -- origin/$trust_branch not found locally${NC}"
   fi
 
   echo -e "${GREEN}✓ Worktree created successfully!${NC}"
@@ -428,8 +477,10 @@ Environment Files:
 
 Dev Tool Trust:
   - Trusts mise config (.mise.toml, mise.toml, .tool-versions) and direnv (.envrc)
-  - Only auto-trusts configs unchanged from the default branch
-  - Modified configs are flagged for manual review (safety for PR reviews)
+  - Uses trusted base branches directly (main, develop, dev, trunk, staging, release/*)
+  - Other branches fall back to the default branch as the trust baseline
+  - direnv auto-allow is skipped on non-trusted base branches; review manually first
+  - Modified configs are flagged for manual review
   - Only runs if the tool is installed and config exists
   - Prevents hooks/scripts from hanging on interactive trust prompts
 


### PR DESCRIPTION
## Summary

- Add `trust_dev_tools()` function to `worktree-manager.sh` that automatically runs `mise trust` and `direnv allow` after creating a new worktree
- **Safety gate:** only auto-trusts configs that are unchanged from the repo's default branch (detected via `origin/HEAD`, falling back to `main`); modified configs (e.g., from a PR) are flagged for manual review
- Update help text and SKILL.md to document the new behavior

## Problem

When `worktree-manager.sh` creates a new worktree, tools like mise and direnv don't recognize the new filesystem path as trusted. When hooks (e.g. lefthook pre-commit) invoke `mise x -- <command>`, mise opens an interactive trust prompt that hangs indefinitely since hook subprocesses can't forward user input. direnv has the same trust model with `direnv allow`.

## Approach

Follows the existing `copy_env_files` pattern: a dedicated function called from `create_worktree()` immediately after env file copying. Double-guarded by `command -v` (tool installed?) and file existence checks (config present?) -- completely invisible to developers who don't use these tools.

**Safety model:** Before auto-trusting, each config file is hash-compared against the repo's default branch via `_config_unchanged()`. The comparison always uses the default branch (not `from_branch`), so passing a PR branch as the base doesn't bypass the safety check. This means:
- **Feature work from main:** configs are identical to main -> auto-trusted -> no hanging hooks
- **PR review where configs are unchanged:** same content as main -> auto-trusted -> still convenient  
- **PR review where `.envrc`/`.mise.toml` was modified or added:** configs differ -> skipped with a yellow warning listing what was skipped and how to trust manually

**mise:** trusts `.mise.toml`, `mise.toml`, or `.tool-versions` if unchanged from default branch
**direnv:** allows `.envrc` if unchanged from default branch

**Error handling:** Trust failures surface warnings (no `2>/dev/null`). When all attempts fail, an explicit warning with manual instructions is shown. Attempted vs successful trusts are tracked separately so "nothing to do" is distinguishable from "everything failed."

## Test evidence

All tests run against a temporary git repo. direnv was tested via a mock script (same `_config_unchanged` gate as mise). Trust failures simulated with mock scripts that exit non-zero.

<details>
<summary>✅ Test 1: Auto-trusts unchanged config</summary>

Scenario: `.mise.toml` exists on main, worktree created from main (config unchanged).

```
Creating worktree: test-unchanged-config
  From: main
Updating main...
Already on 'main'
Already up to date.
Creating worktree...
Preparing worktree (new branch 'test-unchanged-config')
HEAD is now at ae35a78 add mise config
Copying environment files...
  ℹ️  No .env files found in main repository
  ✓ Trusted 1 dev tool config(s)
✓ Worktree created successfully!
```

Verified with `mise trust --show`:
```
/tmp/.../test-repo: untrusted
/tmp/.../test-repo/.worktrees/test-unchanged-config: trusted
```

</details>

<details>
<summary>✅ Test 2: Skips modified config with warning</summary>

Scenario: Branch modifies `.mise.toml` (changes node version, adds python). Worktree created from that branch.

```
Creating worktree: test-modified-config
  From: pr-modifies-mise
Updating pr-modifies-mise...
Creating worktree...
Preparing worktree (new branch 'test-modified-config')
HEAD is now at 0588ab0 modify mise config
Copying environment files...
  ℹ️  No .env files found in main repository
  Skipped auto-trust for modified config(s):
    - .mise.toml (mise)
  Review the diff, then trust manually: cd .../.worktrees/test-modified-config && mise trust && direnv allow
✓ Worktree created successfully!
```

</details>

<details>
<summary>✅ Test 3: Silent when no configs present</summary>

Scenario: No `.mise.toml`, `.tool-versions`, or `.envrc` in the repo.

```
Creating worktree: test-no-configs
  From: main
Updating main...
Creating worktree...
Preparing worktree (new branch 'test-no-configs')
Copying environment files...
  ℹ️  No .env files found in main repository
✓ Worktree created successfully!
```

No trust output at all -- completely invisible.

</details>

<details>
<summary>✅ Test 4: Help output shows new section</summary>

```
Dev Tool Trust:
  - Trusts mise config (.mise.toml, mise.toml, .tool-versions) and direnv (.envrc)
  - Only auto-trusts configs unchanged from the base branch
  - Modified configs are flagged for manual review (safety for PR reviews)
  - Only runs if the tool is installed and config exists
  - Prevents hooks/scripts from hanging on interactive trust prompts
```

</details>

<details>
<summary>✅ Test 5: Skips newly added config</summary>

Scenario: Branch adds `.mise.toml` that doesn't exist on main.

```
Creating worktree: test-new-mise
  From: pr-adds-mise
Updating pr-adds-mise...
Creating worktree...
Preparing worktree (new branch 'test-new-mise')
HEAD is now at 5d3ff33 add mise config
Copying environment files...
  ℹ️  No .env files found in main repository
  Skipped auto-trust for modified config(s):
    - .mise.toml (mise)
  Review the diff, then trust manually: cd .../.worktrees/test-new-mise && mise trust && direnv allow
✓ Worktree created successfully!
```

</details>

<details>
<summary>✅ Test 6: direnv allow runs for unchanged .envrc</summary>

Scenario: Both `.mise.toml` and `.envrc` exist on main, unchanged. direnv tested via mock script.

```
Creating worktree: test-direnv-unchanged
  From: main
Updating main...
Creating worktree...
Preparing worktree (new branch 'test-direnv-unchanged')
HEAD is now at a358134 add mise and envrc configs
Copying environment files...
  ⚠️  .envrc already exists, backing up to .envrc.backup
  ✓ Copied .envrc
  ✓ Copied 1 environment file(s)
direnv: loading .envrc
  ✓ Trusted 2 dev tool config(s)
✓ Worktree created successfully!
```

</details>

<details>
<summary>✅ Test 7: PR branch as from_branch -- still compares against default branch</summary>

Scenario: PR branch modifies both `.mise.toml` and `.envrc`. Passed as `from_branch`. Safety gate should still compare against `main`.

```
Creating worktree: test-from-pr-branch
  From: pr-modifies-both
Updating pr-modifies-both...
Creating worktree...
Preparing worktree (new branch 'test-from-pr-branch')
HEAD is now at 283f31f modify both configs
Copying environment files...
  ⚠️  .envrc already exists, backing up to .envrc.backup
  ✓ Copied .envrc
  ✓ Copied 1 environment file(s)
  Skipped auto-trust for modified config(s):
    - .mise.toml (mise)
    - .envrc (direnv)
  Review the diff, then trust manually: cd .../.worktrees/test-from-pr-branch && mise trust && direnv allow
✓ Worktree created successfully!
```

Both configs correctly skipped despite `from_branch` being the PR branch.

</details>

<details>
<summary>✅ Test 8: Trust failure shows warnings</summary>

Scenario: Both `mise trust` and `direnv allow` fail (simulated via mock scripts that exit non-zero). Configs are unchanged from main.

```
Creating worktree: test-trust-failure
  From: main
Updating main...
Creating worktree...
Preparing worktree (new branch 'test-trust-failure')
HEAD is now at a358134 add mise and envrc configs
Copying environment files...
  ⚠️  .envrc already exists, backing up to .envrc.backup
  ✓ Copied .envrc
  ✓ Copied 1 environment file(s)
mise error: permission denied writing trust database
  Warning: 'mise trust' failed -- run manually in .../.worktrees/test-trust-failure
direnv: error: permission denied
  Warning: 'direnv allow' failed -- run manually in .../.worktrees/test-trust-failure
  Warning: dev tool trust was attempted but all 2 config(s) failed
  Run 'mise trust' / 'direnv allow' manually in .../.worktrees/test-trust-failure
✓ Worktree created successfully!
```

Errors surfaced clearly. Worktree creation still succeeds (trust is non-blocking).

</details>

## Test plan

- [x] Auto-trust unchanged `.mise.toml` (Test 1)
- [x] Skip modified `.mise.toml` with warning (Test 2)
- [x] Silent when no configs present (Test 3)
- [x] Help output shows Dev Tool Trust section (Test 4)
- [x] Skip newly added `.mise.toml` with warning (Test 5)
- [x] `direnv allow` runs for unchanged `.envrc` (Test 6)
- [x] PR branch as `from_branch` still compares against default branch (Test 7)
- [x] Trust failure shows warnings, worktree creation continues (Test 8)