### PR TITLE
fix(ci): add npm registry auth to release publish job

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -90,6 +90,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24"
+          registry-url: https://registry.npmjs.org
 
       - name: Publish package
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `registry-url: https://registry.npmjs.org` to `actions/setup-node@v4` step
- Add `NODE_AUTH_TOKEN` env var to the npm publish step

## Why
The `publish-cli` job in the release workflow calls `npm publish --provenance --access public` but the Node.js setup step doesn't configure the npm registry URL or auth token. This causes `ENEEDAUTH` on every release attempt.

Closes #317

## Test plan
- [x] Verified the setup-node step now configures registry-url
- [x] Verified NODE_AUTH_TOKEN is passed to the publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)