### PR TITLE
fix(skills): update ralph-wiggum references to ralph-loop in lfg/slfg

### DIFF
--- a/plugins/compound-engineering/skills/lfg/SKILL.md
+++ b/plugins/compound-engineering/skills/lfg/SKILL.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 2, and step 3 when warranted) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
-1. **Optional:** If the `ralph-wiggum` skill is available, run `/ralph-wiggum:ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
+1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop:ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 
 2. `/ce:plan $ARGUMENTS`
 
@@ -33,4 +33,4 @@ CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required s
 
 9. Output `<promise>DONE</promise>` when video is in PR
 
-Start with step 2 now (or step 1 if ralph-wiggum is available). Remember: plan FIRST, then work. Never skip the plan.
+Start with step 2 now (or step 1 if ralph-loop is available). Remember: plan FIRST, then work. Never skip the plan.

--- a/plugins/compound-engineering/skills/slfg/SKILL.md
+++ b/plugins/compound-engineering/skills/slfg/SKILL.md
@@ -9,7 +9,7 @@ Swarm-enabled LFG. Run these steps in order, parallelizing where indicated. Do n
 
 ## Sequential Phase
 
-1. **Optional:** If the `ralph-wiggum` skill is available, run `/ralph-wiggum:ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
+1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop:ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 2. `/ce:plan $ARGUMENTS`
 3. **Conditionally** run `/compound-engineering:deepen-plan`
    - Run the `deepen-plan` workflow only if the plan is `Standard` or `Deep`, touches a high-risk area (auth, security, payments, migrations, external APIs, significant rollout concerns), or still has obvious confidence gaps in decisions, sequencing, system-wide impact, risks, or verification


### PR DESCRIPTION
## Summary

Updates 3 stale `ralph-wiggum` references to `ralph-loop` in the `lfg` and `slfg` skills. The plugin was renamed from `ralph-wiggum` to `ralph-loop` (per [#306 comment](https://github.com/EveryInc/compound-engineering-plugin/issues/306#issuecomment-2737063839) by @iuriguilherme - renamed due to legal advice), but these skill files were not updated.

## Why this matters

Both `/lfg` and `/slfg` always skip Step 1 with "ralph-wiggum skill is not available - skipping" because they check for the old plugin name. Users must manually add "use ralph-loop instead of ralph-wiggum" to work around it ([#306](https://github.com/EveryInc/compound-engineering-plugin/issues/306)). Previously reported as [#154](https://github.com/EveryInc/compound-engineering-plugin/issues/154) (closed but not fixed).

## Changes

- `plugins/compound-engineering/skills/lfg/SKILL.md`: Updated skill availability check and invocation from `ralph-wiggum` to `ralph-loop` (lines 10, 36)
- `plugins/compound-engineering/skills/slfg/SKILL.md`: Same update (line 12)
- CHANGELOG.md historical entry left unchanged (it's a record of the rename)

## Testing

- Verified `ralph-wiggum` no longer appears in either skill file
- `bun run release:validate` passes (29 agents, 45 skills, 1 MCP server)

Fixes #306

This contribution was developed with AI assistance (Claude Code).