### PR TITLE
fix: gitignore .context/ directory for Conductor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .codex/
 todos/
 .worktrees
+.context/


### PR DESCRIPTION
## Summary
- Add `.context/` to `.gitignore` — this directory is created by [Conductor](https://www.conductor.build/blog/context) for inter-agent collaboration and shouldn't be tracked
