### PR TITLE
feat: add OpenPackage support

### DIFF
--- a/openpackage.yml
+++ b/openpackage.yml
@@ -1,0 +1,9 @@
+name: compound-engineering-marketplace
+version: 1.0.0
+description: Plugin marketplace for Claude Code extensions. Includes compound-engineering and coding-tutor plugins.
+author: Kieran Klaassen
+license: MIT
+
+includes:
+  - plugins/compound-engineering/**/*
+  - plugins/coding-tutor/**/*


### PR DESCRIPTION
Enables installation via opkg install compound-engineering-plugin

Adds openpackage.yml manifest for opkg compatibility.