### PR TITLE
fix: quote frontend-design skill description

### DIFF
--- a/plugins/compound-engineering/skills/frontend-design/SKILL.md
+++ b/plugins/compound-engineering/skills/frontend-design/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: frontend-design
-description: Build web interfaces with genuine design quality, not AI slop. Use for
-  any frontend work: landing pages, web apps, dashboards, admin panels, components,
-  interactive experiences. Activates for both greenfield builds and modifications to
-  existing applications. Detects existing design systems and respects them. Covers
-  composition, typography, color, motion, and copy. Verifies results via screenshots
-  before declaring done.
+description: 'Build web interfaces with genuine design quality, not AI slop. Use for any frontend work - landing pages, web apps, dashboards, admin panels, components, interactive experiences. Activates for both greenfield builds and modifications to existing applications. Detects existing design systems and respects them. Covers composition, typography, color, motion, and copy. Verifies results via screenshots before declaring done.'
 ---
 
 # Frontend Design


### PR DESCRIPTION
## Summary
- Quotes the `frontend-design` skill YAML description to prevent parsing issues with colons in the value
- Collapses multiline description into a single quoted line for clarity

Pulls out fix from #350

## Test plan
- [ ] Verify `bun run release:validate` passes
- [ ] Confirm skill description renders correctly in Claude Code