### PR TITLE
feat(compound-engineering): add ce:review-beta skill with tiered persona agents

### DIFF
--- a/docs/plans/2026-03-23-001-feat-ce-review-beta-pipeline-mode-beta-plan.md
+++ b/docs/plans/2026-03-23-001-feat-ce-review-beta-pipeline-mode-beta-plan.md
@@ -1,0 +1,316 @@
+---
+title: "feat: Make ce:review-beta autonomous and pipeline-safe"
+type: feat
+status: active
+date: 2026-03-23
+origin: direct user request and planning discussion on ce:review-beta standalone vs. autonomous pipeline behavior
+---
+
+# Make ce:review-beta Autonomous and Pipeline-Safe
+
+## Overview
+
+Redesign `ce:review-beta` from a purely interactive standalone review workflow into a policy-driven review engine that supports three explicit modes: `interactive`, `autonomous`, and `report-only`. The redesign should preserve the current standalone UX for manual review, enable hands-off review and safe autofix in automated workflows, and define a clean residual-work handoff for anything that should not be auto-fixed. This plan remains beta-only; promotion to stable `ce:review` and any `lfg` / `slfg` cutover should happen only in a follow-up plan after the beta behavior is validated.
+
+## Problem Frame
+
+`ce:review-beta` currently mixes three responsibilities in one loop:
+
+1. Review and synthesis
+2. Human approval on what to fix
+3. Local fixing, re-review, and push/PR next steps
+
+That is acceptable for standalone use, but it is the wrong shape for autonomous orchestration:
+
+- `lfg` currently treats review as an upstream producer before downstream resolution and browser testing
+- `slfg` currently runs review and browser testing in parallel, which is only safe if review is non-mutating
+- `resolve-todo-parallel` expects a durable residual-work contract (`todos/`), while `ce:review-beta` currently tries to resolve accepted findings inline
+- The findings schema lacks routing metadata, so severity is doing too much work; urgency and autofix eligibility are distinct concerns
+
+The result is a workflow that is hard to promote safely: it can be interactive, or autonomous, or mutation-owning, but not all three at once without an explicit mode model and clearer ownership boundaries.
+
+## Requirements Trace
+
+- R1. `ce:review-beta` supports explicit execution modes: `interactive` (default), `autonomous`, and `report-only`
+- R2. `autonomous` mode never asks the user questions, never waits for approval, and applies only policy-allowed safe fixes
+- R3. `report-only` mode is strictly read-only and safe to run in parallel with other read-only verification steps
+- R4. Findings are routed by explicit fixability metadata, not by severity alone
+- R5. `ce:review-beta` can run one bounded in-skill autofix pass for `safe_auto` findings and then re-review the changed scope
+- R6. Residual actionable findings are emitted as durable downstream work artifacts; advisory outputs remain report-only
+- R7. CE helper outputs (`learnings`, `agent-native`, `schema-drift`, `deployment-verification`) are preserved but only some become actionable work items
+- R8. The beta contract makes future orchestration constraints explicit so a later `lfg` / `slfg` cutover does not run a mutating review concurrently with browser testing on the same checkout
+- R9. Repeated regression classes around interaction mode, routing, and orchestration boundaries gain lightweight contract coverage
+
+## Scope Boundaries
+
+- Keep the existing persona ensemble, confidence gate, and synthesis model as the base architecture
+- Do not redesign every reviewer persona's prompt beyond the metadata they need to emit
+- Do not introduce a new general-purpose orchestration framework; reuse existing skill patterns where possible
+- Do not auto-fix deployment checklists, residual risks, or other advisory-only outputs
+- Do not attempt broad converter/platform work in this change unless the review skill's frontmatter or references require it
+- Beta remains the only implementation target in this plan; stable promotion is intentionally deferred to a follow-up plan after validation
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `plugins/compound-engineering/skills/ce-review-beta/SKILL.md`
+  - Current staged review pipeline with interactive severity acceptance, inline fixer, re-review offer, and post-fix push/PR actions
+- `plugins/compound-engineering/skills/ce-review-beta/references/findings-schema.json`
+  - Structured persona finding contract today; currently missing routing metadata for autonomous handling
+- `plugins/compound-engineering/skills/ce-review/SKILL.md`
+  - Current stable review workflow; creates durable `todos/` artifacts rather than fixing findings inline
+- `plugins/compound-engineering/skills/resolve-todo-parallel/SKILL.md`
+  - Existing residual-work resolver; parallelizes item handling once work has already been externalized
+- `plugins/compound-engineering/skills/file-todos/SKILL.md`
+  - Existing review -> triage -> todo -> resolve integration contract
+- `plugins/compound-engineering/skills/lfg/SKILL.md`
+  - Sequential orchestrator whose future cutover constraints should inform the beta contract, even though this plan does not modify it
+- `plugins/compound-engineering/skills/slfg/SKILL.md`
+  - Swarm orchestrator whose current review/browser parallelism defines an important future integration constraint, even though this plan does not modify it
+- `plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md`
+  - Strong repo precedent for explicit `mode:autonomous` argument handling and conservative non-interactive behavior
+- `plugins/compound-engineering/skills/ce-plan/SKILL.md`
+  - Strong repo precedent for pipeline mode skipping interactive questions
+
+### Institutional Learnings
+
+- `docs/solutions/skill-design/compound-refresh-skill-improvements.md`
+  - Explicit autonomous mode beats tool-based auto-detection
+  - Ambiguous cases in autonomous mode should be recorded conservatively, not guessed
+  - Report structure should distinguish applied actions from recommended follow-up
+- `docs/solutions/skill-design/beta-skills-framework.md`
+  - Beta skills should remain isolated until validated
+  - Promotion is the right time to rewire `lfg` / `slfg`, which is out of scope for this plan
+
+### External Research Decision
+
+Skipped. This is a repo-internal orchestration and skill-design change with strong existing local patterns for autonomous mode, beta promotion, and residual-work handling.
+
+## Key Technical Decisions
+
+- **Use explicit mode arguments instead of auto-detection.** Follow `ce:compound-refresh` and require `mode:autonomous` / `mode:report-only` arguments. Interactive remains the default. This avoids conflating "no question tool" with "headless workflow."
+- **Split review from mutation semantically, not by creating two separate skills.** `ce:review-beta` should always perform the same review and synthesis stages. Mutation behavior becomes a mode-controlled phase layered on top.
+- **Route by fixability, not severity.** Add explicit per-finding routing fields such as `autofix_class`, `owner`, and `requires_verification`. Severity remains urgency; it no longer implies who acts.
+- **Keep one in-skill fixer, but only for `safe_auto` findings.** The current "one fixer subagent" rule is still right for consistent-tree edits. The change is that the fixer is selected by policy and routing metadata, not by an interactive severity prompt.
+- **Emit both ephemeral and durable outputs.** Use `.context/compound-engineering/ce-review-beta/<run-id>/` for the per-run machine-readable report and create durable `todos/` items only for unresolved actionable findings that belong downstream.
+- **Treat CE helper outputs by artifact class.**
+  - `learnings-researcher`: contextual/advisory unless a concrete finding corroborates it
+  - `agent-native-reviewer`: often `gated_auto` or `manual`, occasionally `safe_auto` when the fix is purely local and mechanical
+  - `schema-drift-detector`: default `manual` or `gated_auto`; never auto-fix blindly by default
+  - `deployment-verification-agent`: always advisory / operational, never autofix
+- **Design the beta contract so future orchestration cutover is safe.** The beta must make it explicit that mutating review cannot run concurrently with browser testing on the same checkout. That requirement is part of validation and future cutover criteria, not a same-plan rewrite of `slfg`.
+- **Move push / PR creation decisions out of autonomous review.** Interactive standalone mode may still offer next-step prompts. Autonomous and report-only modes should stop after producing fixes and/or residual artifacts; any future parent workflow decides commit, push, and PR timing.
+- **Add lightweight contract tests.** Repeated regressions have come from instruction-boundary drift. String- and structure-level contract tests are justified here even though the behavior is prompt-driven.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `ce:review-beta` keep any embedded fix loop?** Yes, but only for `safe_auto` findings under an explicit mode/policy. Residual work is handed off.
+- **Should autonomous mode be inferred from lack of interactivity?** No. Use explicit `mode:autonomous`.
+- **Should `slfg` keep review and browser testing in parallel?** No, not once review can mutate the checkout. Run browser testing after the mutating review phase on the stabilized tree.
+- **Should residual work be `todos/`, `.context/`, or both?** Both. `.context` holds the run artifact; `todos/` is only for durable unresolved actionable work.
+
+### Deferred to Implementation
+
+- Exact metadata field names in `findings-schema.json`
+- Whether `report-only` should imply a different default output template section ordering than `interactive` / `autonomous`
+- Whether residual `todos/` should be created directly by `ce:review-beta` or via a small shared helper/reference template used by both review and resolver flows
+
+## High-Level Technical Design
+
+This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.
+
+```text
+review stages -> synthesize -> classify outputs by autofix_class/owner
+               -> if mode=report-only: emit report + stop
+               -> if mode=interactive: acquire policy from user
+               -> if mode=autonomous: use policy from arguments/defaults
+               -> run single fixer on safe_auto set
+               -> verify tests + focused re-review
+               -> emit residual todos for unresolved actionable items
+               -> emit advisory/report sections for non-actionable outputs
+```
+
+## Implementation Units
+
+- [x] **Unit 1: Add explicit mode handling and routing metadata to ce:review-beta**
+
+**Goal:** Give `ce:review-beta` a clear execution contract for standalone, autonomous, and read-only pipeline use.
+
+**Requirements:** R1, R2, R3, R4, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `plugins/compound-engineering/skills/ce-review-beta/SKILL.md`
+- Modify: `plugins/compound-engineering/skills/ce-review-beta/references/findings-schema.json`
+- Modify: `plugins/compound-engineering/skills/ce-review-beta/references/review-output-template.md`
+- Modify: `plugins/compound-engineering/skills/ce-review-beta/references/subagent-template.md` (if routing metadata needs to be spelled out in spawn prompts)
+
+**Approach:**
+- Add a Mode Detection section near the top of `SKILL.md` using the established `mode:autonomous` argument pattern from `ce:compound-refresh`
+- Introduce `mode:report-only` alongside `mode:autonomous`
+- Scope all interactive question instructions so they apply only to interactive mode
+- Extend `findings-schema.json` with routing-oriented fields such as:
+  - `autofix_class`: `safe_auto | gated_auto | manual | advisory`
+  - `owner`: `review-fixer | downstream-resolver | human | release`
+  - `requires_verification`: boolean
+- Update the review output template so the final report can distinguish:
+  - applied fixes
+  - residual actionable work
+  - advisory / operational notes
+
+**Patterns to follow:**
+- `plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md` explicit autonomous mode structure
+- `plugins/compound-engineering/skills/ce-plan/SKILL.md` pipeline-mode question skipping
+
+**Test scenarios:**
+- Interactive mode still presents questions and next-step prompts
+- `mode:autonomous` never asks a question and never waits for user input
+- `mode:report-only` performs no edits and no commit/push/PR actions
+- A helper-agent output can be preserved in the final report without being treated as auto-fixable work
+
+**Verification:**
+- `tests/review-skill-contract.test.ts` asserts the three mode markers and interactive scoping rules
+- `bun run release:validate` passes
+
+- [x] **Unit 2: Redesign the fix loop around policy-driven safe autofix and bounded re-review**
+
+**Goal:** Replace the current severity-prompt-centric fix loop with one that works in both interactive and autonomous contexts.
+
+**Requirements:** R2, R4, R5, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `plugins/compound-engineering/skills/ce-review-beta/SKILL.md`
+- Add: `plugins/compound-engineering/skills/ce-review-beta/references/fix-policy.md` (if the classification and policy table becomes too large for `SKILL.md`)
+- Modify: `plugins/compound-engineering/skills/ce-review-beta/references/review-output-template.md`
+
+**Approach:**
+- Replace "Severity Acceptance" as the primary decision point with a classification stage that groups synthesized findings by `autofix_class`
+- In interactive mode, ask the user only for policy decisions that remain ambiguous after classification
+- In autonomous mode, use conservative defaults:
+  - apply `safe_auto`
+  - leave `gated_auto`, `manual`, and `advisory` unresolved
+- Keep the "exactly one fixer subagent" rule for consistency
+- Bound the loop with `max_rounds` (for example 2) and require targeted verification plus focused re-review after any applied fix set
+- Restrict commit / push / PR creation steps to interactive mode only; autonomous and report-only modes stop after emitting outputs
+
+**Patterns to follow:**
+- `docs/solutions/skill-design/compound-refresh-skill-improvements.md` applied-vs-recommended distinction
+- Existing `ce-review-beta` single-fixer rule
+
+**Test scenarios:**
+- A `safe_auto` testing finding gets fixed and re-reviewed without user input in autonomous mode
+- A `gated_auto` API contract or authz finding is preserved as residual actionable work, not auto-fixed
+- A deployment checklist remains advisory and never enters the fixer queue
+- Zero findings skip the fix phase entirely
+- Re-review is bounded and does not recurse indefinitely
+
+**Verification:**
+- `tests/review-skill-contract.test.ts` asserts that autonomous mode has no mandatory user-question step in the fix path
+- Manual dry run: read the fix-loop prose end-to-end and verify there is no mutation-owning step outside the policy gate
+
+- [x] **Unit 3: Define residual artifact and downstream handoff behavior**
+
+**Goal:** Make autonomous review compatible with downstream workflows instead of competing with them.
+
+**Requirements:** R5, R6, R7
+
+**Dependencies:** Unit 2
+
+**Files:**
+- Modify: `plugins/compound-engineering/skills/ce-review-beta/SKILL.md`
+- Modify: `plugins/compound-engineering/skills/resolve-todo-parallel/SKILL.md`
+- Modify: `plugins/compound-engineering/skills/file-todos/SKILL.md`
+- Add: `plugins/compound-engineering/skills/ce-review-beta/references/residual-work-template.md` (if a dedicated durable-work shape helps keep review prose smaller)
+
+**Approach:**
+- Write a per-run review artifact under `.context/compound-engineering/ce-review-beta/<run-id>/` containing:
+  - synthesized findings
+  - what was auto-fixed
+  - what remains unresolved
+  - advisory-only outputs
+- Create durable `todos/` items only for unresolved actionable findings whose `owner` is downstream resolution
+- Update `resolve-todo-parallel` to acknowledge this source explicitly so residual review work can be picked up without pretending everything came from stable `ce:review`
+- Update `file-todos` integration guidance to reflect the new flow:
+  - review-beta autonomous -> residual todos -> resolve-todo-parallel
+  - advisory-only outputs do not become todos
+
+**Patterns to follow:**
+- `.context/compound-engineering/<workflow>/<run-id>/` scratch-space convention from `AGENTS.md`
+- Existing `file-todos` review/resolution lifecycle
+
+**Test scenarios:**
+- Autonomous review with only advisory outputs creates no todos
+- Autonomous review with 2 unresolved actionable findings creates exactly 2 residual todos
+- Residual work items exclude protected-artifact cleanup suggestions
+- The run artifact is sufficient to explain what the in-skill fixer changed vs. what remains
+
+**Verification:**
+- `tests/review-skill-contract.test.ts` asserts the documented `.context` and `todos/` handoff rules
+- `bun run release:validate` passes after any skill inventory/reference changes
+
+- [x] **Unit 4: Add contract-focused regression coverage for mode, handoff, and future-integration boundaries**
+
+**Goal:** Catch the specific instruction-boundary regressions that have repeatedly escaped manual review.
+
+**Requirements:** R8, R9
+
+**Dependencies:** Units 1-3
+
+**Files:**
+- Add: `tests/review-skill-contract.test.ts`
+- Optionally modify: `package.json` only if a new test entry point is required (prefer using the existing Bun test setup without package changes)
+
+**Approach:**
+- Add a focused test that reads the relevant skill files and asserts contract-level invariants instead of brittle full-file snapshots
+- Cover:
+  - `ce-review-beta` mode markers and mode-specific behavior phrases
+  - absence of unconditional interactive prompts in autonomous/report-only paths
+  - explicit residual-work handoff language
+  - explicit documentation that mutating review must not run concurrently with browser testing on the same checkout
+- Keep assertions semantic and localized; avoid snapshotting large markdown files
+
+**Patterns to follow:**
+- Existing Bun tests that read repository files directly for release/config validation
+
+**Test scenarios:**
+- Missing `mode:autonomous` block fails
+- Reintroduced unconditional "Ask the user" text in the autonomous path fails
+- Missing residual todo handoff text fails
+- Missing future integration constraint around mutating review vs. browser testing fails
+
+**Verification:**
+- `bun test tests/review-skill-contract.test.ts`
+- full `bun test`
+
+## Risks & Dependencies
+
+- **Over-aggressive autofix classification.**
+  - Mitigation: conservative defaults, `gated_auto` bucket, bounded rounds, focused re-review
+- **Dual ownership confusion between `ce:review-beta` and `resolve-todo-parallel`.**
+  - Mitigation: explicit owner/routing metadata and durable residual-work contract
+- **Brittle contract tests.**
+  - Mitigation: assert only boundary invariants, not full markdown snapshots
+- **Promotion churn.**
+  - Mitigation: keep beta isolated until Unit 4 contract coverage and manual verification pass
+
+## Sources & References
+
+- Related skills:
+  - `plugins/compound-engineering/skills/ce-review-beta/SKILL.md`
+  - `plugins/compound-engineering/skills/ce-review/SKILL.md`
+  - `plugins/compound-engineering/skills/resolve-todo-parallel/SKILL.md`
+  - `plugins/compound-engineering/skills/file-todos/SKILL.md`
+  - `plugins/compound-engineering/skills/lfg/SKILL.md`
+  - `plugins/compound-engineering/skills/slfg/SKILL.md`
+- Institutional learnings:
+  - `docs/solutions/skill-design/compound-refresh-skill-improvements.md`
+  - `docs/solutions/skill-design/beta-skills-framework.md`
+- Supporting pattern reference:
+  - `plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md`
+  - `plugins/compound-engineering/skills/ce-plan/SKILL.md`

--- a/docs/solutions/skill-design/beta-skills-framework.md
+++ b/docs/solutions/skill-design/beta-skills-framework.md
@@ -13,6 +13,7 @@ severity: medium
 description: "Pattern for trialing new skill versions alongside stable ones using a -beta suffix. Covers naming, plan file naming, internal references, and promotion path."
 related:
   - docs/solutions/skill-design/compound-refresh-skill-improvements.md
+  - docs/solutions/skill-design/review-skill-promotion-orchestration-contract.md
 ---
 
 ## Problem
@@ -78,6 +79,8 @@ When the beta version is validated:
 7. Update README.md: remove from Beta Skills section, verify counts
 8. Verify `lfg`/`slfg` work with the promoted skill
 9. Verify `ce:work` consumes plans from the promoted skill
+
+If the beta skill changed its invocation contract, promotion must also update all orchestration callers in the same PR instead of relying on the stable default behavior. See [review-skill-promotion-orchestration-contract.md](./review-skill-promotion-orchestration-contract.md) for the concrete review-skill example.
 
 ## Validation
 

--- a/docs/solutions/skill-design/review-skill-promotion-orchestration-contract.md
+++ b/docs/solutions/skill-design/review-skill-promotion-orchestration-contract.md
@@ -1,0 +1,80 @@
+---
+title: "Promoting review-beta to stable must update orchestration callers in the same change"
+category: skill-design
+date: 2026-03-23
+module: plugins/compound-engineering/skills
+component: SKILL.md
+tags:
+  - skill-design
+  - beta-testing
+  - rollout-safety
+  - orchestration
+  - review-workflow
+severity: medium
+description: "When ce:review-beta is promoted to stable, update lfg/slfg in the same PR so they pass the correct mode instead of inheriting the interactive default."
+related:
+  - docs/solutions/skill-design/beta-skills-framework.md
+  - docs/plans/2026-03-23-001-feat-ce-review-beta-pipeline-mode-beta-plan.md
+---
+
+## Problem
+
+`ce:review-beta` introduces an explicit mode contract:
+
+- default `interactive`
+- `mode:autonomous`
+- `mode:report-only`
+
+That is correct for direct user invocation, but it creates a promotion hazard. If the beta skill is later promoted over stable `ce:review` without updating its orchestration callers, the surrounding workflows will silently inherit the interactive default.
+
+For the current review workflow family, that would be wrong:
+
+- `lfg` should run review in `mode:autonomous`
+- `slfg` should run review in `mode:report-only` during its parallel review/browser phase
+
+Without those caller changes, promotion would keep the skill name stable while changing its contract, which is exactly the kind of boundary drift that tends to escape manual review.
+
+## Solution
+
+Treat promotion as an orchestration contract change, not a file rename.
+
+When promoting `ce:review-beta` to stable:
+
+1. Replace stable `ce:review` with the promoted content
+2. Update every workflow that invokes `ce:review` in the same PR
+3. Hardcode the intended mode at each callsite instead of relying on the default
+4. Add or update contract tests so the orchestration assumptions are executable
+
+For the review workflow family, the expected caller contract is:
+
+- `lfg` -> `ce:review mode:autonomous`
+- `slfg` parallel phase -> `ce:review mode:report-only`
+- any mutating review step in `slfg` must happen later, sequentially, or in an isolated checkout/worktree
+
+## Why This Lives Here
+
+This is not a good `AGENTS.md` note:
+
+- it is specific to one beta-to-stable promotion
+- it is easy for a temporary repo-global reminder to become stale
+- future planning and review work is more likely to search `docs/solutions/skill-design/` than to rediscover an old ad hoc note in `AGENTS.md`
+
+The durable memory should live with the other skill-design rollout patterns.
+
+## Prevention
+
+- When a beta skill changes invocation semantics, its promotion plan must include caller updates as a first-class implementation unit
+- Promotion PRs should be atomic: promote the skill and update orchestrators in the same branch
+- Add contract coverage for the promoted callsites so future refactors cannot silently drop required mode flags
+- Do not rely on “remembering later” for orchestration mode changes; encode them in docs, plans, and tests
+
+## Lifecycle Note
+
+This note is intentionally tied to the `ce:review-beta` -> `ce:review` promotion window.
+
+Once that promotion is complete and the stable orchestrators/tests already encode the contract:
+
+- update or archive this doc if it no longer adds distinct value
+- do not leave it behind as a stale reminder for a promotion that already happened
+
+If the final stable design differs from the current expectation, revise this doc during the promotion PR so the historical note matches what actually shipped.

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -19,20 +19,28 @@ Agents are organized into categories for easier discovery.
 | Agent | Description |
 |-------|-------------|
 | `agent-native-reviewer` | Verify features are agent-native (action + context parity) |
+| `api-contract-reviewer` | Detect breaking API contract changes (ce:review-beta persona) |
 | `architecture-strategist` | Analyze architectural decisions and compliance |
 | `code-simplicity-reviewer` | Final pass for simplicity and minimalism |
+| `correctness-reviewer` | Logic errors, edge cases, state bugs (ce:review-beta persona) |
 | `data-integrity-guardian` | Database migrations and data integrity |
 | `data-migration-expert` | Validate ID mappings match production, check for swapped values |
+| `data-migrations-reviewer` | Migration safety with confidence calibration (ce:review-beta persona) |
 | `deployment-verification-agent` | Create Go/No-Go deployment checklists for risky data changes |
 | `dhh-rails-reviewer` | Rails review from DHH's perspective |
 | `julik-frontend-races-reviewer` | Review JavaScript/Stimulus code for race conditions |
 | `kieran-rails-reviewer` | Rails code review with strict conventions |
 | `kieran-python-reviewer` | Python code review with strict conventions |
 | `kieran-typescript-reviewer` | TypeScript code review with strict conventions |
+| `maintainability-reviewer` | Coupling, complexity, naming, dead code (ce:review-beta persona) |
 | `pattern-recognition-specialist` | Analyze code for patterns and anti-patterns |
 | `performance-oracle` | Performance analysis and optimization |
+| `performance-reviewer` | Runtime performance with confidence calibration (ce:review-beta persona) |
+| `reliability-reviewer` | Production reliability and failure modes (ce:review-beta persona) |
 | `schema-drift-detector` | Detect unrelated schema.rb changes in PRs |
+| `security-reviewer` | Exploitable vulnerabilities with confidence calibration (ce:review-beta persona) |
 | `security-sentinel` | Security audits and vulnerability assessments |
+| `testing-reviewer` | Test coverage gaps, weak assertions (ce:review-beta persona) |
 
 ### Research
 
@@ -160,9 +168,10 @@ Experimental versions of core workflow skills. These are being tested before rep
 | Skill | Description | Replaces |
 |-------|-------------|----------|
 | `ce:plan-beta` | Decision-first planning focused on boundaries, sequencing, and verification | `ce:plan` |
+| `ce:review-beta` | Structured review with tiered persona agents, confidence gating, and dedup pipeline | `ce:review` |
 | `deepen-plan-beta` | Selective stress-test that targets weak sections with research | `deepen-plan` |
 
-To test: invoke `/ce:plan-beta` or `/deepen-plan-beta` directly. Plans produced by the beta skills are compatible with `/ce:work`.
+To test: invoke `/ce:plan-beta`, `/ce:review-beta`, or `/deepen-plan-beta` directly. Plans produced by the beta skills are compatible with `/ce:work`.
 
 ### Image Generation
 

--- a/plugins/compound-engineering/agents/review/api-contract-reviewer.md
+++ b/plugins/compound-engineering/agents/review/api-contract-reviewer.md
@@ -1,0 +1,48 @@
+---
+name: api-contract-reviewer
+description: Conditional code-review persona, selected when the diff touches API routes, request/response types, serialization, versioning, or exported type signatures. Reviews code for breaking contract changes. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# API Contract Reviewer
+
+You are an API design and contract stability expert who evaluates changes through the lens of every consumer that depends on the current interface. You think about what breaks when a client sends yesterday's request to today's server -- and whether anyone would know before production.
+
+## What you're hunting for
+
+- **Breaking changes to public interfaces** -- renamed fields, removed endpoints, changed response shapes, narrowed accepted input types, or altered status codes that existing clients depend on. Trace whether the change is additive (safe) or subtractive/mutative (breaking).
+- **Missing versioning on breaking changes** -- a breaking change shipped without a version bump, deprecation period, or migration path. If old clients will silently get wrong data or errors, that's a contract violation.
+- **Inconsistent error shapes** -- new endpoints returning errors in a different format than existing endpoints. Mixed `{ error: string }` and `{ errors: [{ message }] }` in the same API. Clients shouldn't need per-endpoint error parsing.
+- **Undocumented behavior changes** -- response field that silently changes semantics (e.g., `count` used to include deleted items, now it doesn't), default values that change, or sort order that shifts without announcement.
+- **Backward-incompatible type changes** -- widening a return type (string -> string | null) without updating consumers, narrowing an input type (accepts any string -> must be UUID), or changing a field from required to optional or vice versa.
+
+## Confidence calibration
+
+Your confidence should be **high (0.80+)** when the breaking change is visible in the diff -- a response type changes shape, an endpoint is removed, a required field becomes optional. You can point to the exact line where the contract changes.
+
+Your confidence should be **moderate (0.60-0.79)** when the contract impact is likely but depends on how consumers use the API -- e.g., a field's semantics change but the type stays the same, and you're inferring consumer dependency.
+
+Your confidence should be **low (below 0.60)** when the change is internal and you're guessing about whether it surfaces to consumers. Suppress these.
+
+## What you don't flag
+
+- **Internal refactors that don't change public interface** -- renaming private methods, restructuring internal data flow, changing implementation details behind a stable API. If the contract is unchanged, it's not your concern.
+- **Style preferences in API naming** -- camelCase vs snake_case, plural vs singular resource names. These are conventions, not contract issues (unless they're inconsistent within the same API).
+- **Performance characteristics** -- a slower response isn't a contract violation. That belongs to the performance reviewer.
+- **Additive, non-breaking changes** -- new optional fields, new endpoints, new query parameters with defaults. These extend the contract without breaking it.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "api-contract",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/agents/review/correctness-reviewer.md
+++ b/plugins/compound-engineering/agents/review/correctness-reviewer.md
@@ -1,0 +1,48 @@
+---
+name: correctness-reviewer
+description: Always-on code-review persona. Reviews code for logic errors, edge cases, state management bugs, error propagation failures, and intent-vs-implementation mismatches. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# Correctness Reviewer
+
+You are a logic and behavioral correctness expert who reads code by mentally executing it -- tracing inputs through branches, tracking state across calls, and asking "what happens when this value is X?" You catch bugs that pass tests because nobody thought to test that input.
+
+## What you're hunting for
+
+- **Off-by-one errors and boundary mistakes** -- loop bounds that skip the last element, slice operations that include one too many, pagination that misses the final page when the total is an exact multiple of page size. Trace the math with concrete values at the boundaries.
+- **Null and undefined propagation** -- a function returns null on error, the caller doesn't check, and downstream code dereferences it. Or an optional field is accessed without a guard, silently producing undefined that becomes `"undefined"` in a string or `NaN` in arithmetic.
+- **Race conditions and ordering assumptions** -- two operations that assume sequential execution but can interleave. Shared state modified without synchronization. Async operations whose completion order matters but isn't enforced. TOCTOU (time-of-check-to-time-of-use) gaps.
+- **Incorrect state transitions** -- a state machine that can reach an invalid state, a flag set in the success path but not cleared on the error path, partial updates where some fields change but related fields don't. After-error state that leaves the system in a half-updated condition.
+- **Broken error propagation** -- errors caught and swallowed, errors caught and re-thrown without context, error codes that map to the wrong handler, fallback values that mask failures (returning empty array instead of propagating the error so the caller thinks "no results" instead of "query failed").
+
+## Confidence calibration
+
+Your confidence should be **high (0.80+)** when you can trace the full execution path from input to bug: "this input enters here, takes this branch, reaches this line, and produces this wrong result." The bug is reproducible from the code alone.
+
+Your confidence should be **moderate (0.60-0.79)** when the bug depends on conditions you can see but can't fully confirm -- e.g., whether a value can actually be null depends on what the caller passes, and the caller isn't in the diff.
+
+Your confidence should be **low (below 0.60)** when the bug requires runtime conditions you have no evidence for -- specific timing, specific input shapes, or specific external state. Suppress these.
+
+## What you don't flag
+
+- **Style preferences** -- variable naming, bracket placement, comment presence, import ordering. These don't affect correctness.
+- **Missing optimization** -- code that's correct but slow belongs to the performance reviewer, not you.
+- **Naming opinions** -- a function named `processData` is vague but not incorrect. If it does what callers expect, it's correct.
+- **Defensive coding suggestions** -- don't suggest adding null checks for values that can't be null in the current code path. Only flag missing checks when the null/undefined can actually occur.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "correctness",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/agents/review/data-migrations-reviewer.md
+++ b/plugins/compound-engineering/agents/review/data-migrations-reviewer.md
@@ -1,0 +1,52 @@
+---
+name: data-migrations-reviewer
+description: Conditional code-review persona, selected when the diff touches migration files, schema changes, data transformations, or backfill scripts. Reviews code for data integrity and migration safety. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# Data Migrations Reviewer
+
+You are a data integrity and migration safety expert who evaluates schema changes and data transformations from the perspective of "what happens during deployment" -- the window where old code runs against new schema, new code runs against old data, and partial failures leave the database in an inconsistent state.
+
+## What you're hunting for
+
+- **Swapped or inverted ID/enum mappings** -- hardcoded mappings where `1 => TypeA, 2 => TypeB` in code but the actual production data has `1 => TypeB, 2 => TypeA`. This is the single most common and dangerous migration bug. When mappings, CASE/IF branches, or constant hashes translate between old and new values, verify each mapping individually. Watch for copy-paste errors that silently swap entries.
+- **Irreversible migrations without rollback plan** -- column drops, type changes that lose precision, data deletions in migration scripts. If `down` doesn't restore the original state (or doesn't exist), flag it. Not every migration needs to be reversible, but destructive ones need explicit acknowledgment.
+- **Missing data backfill for new non-nullable columns** -- adding a `NOT NULL` column without a default value or a backfill step will fail on tables with existing rows. Check whether the migration handles existing data or assumes an empty table.
+- **Schema changes that break running code during deploy** -- renaming a column that old code still references, dropping a column before all code paths stop reading it, adding a constraint that existing data violates. These cause errors during the deploy window when old and new code coexist.
+- **Orphaned references to removed columns or tables** -- when a migration drops a column or table, search for remaining references in serializers, API responses, background jobs, admin pages, rake tasks, eager loads (`includes`, `joins`), and views. An `includes(:deleted_association)` will crash at runtime.
+- **Broken dual-write during transition periods** -- safe column migrations require writing to both old and new columns during the transition window. If new records only populate the new column, rollback to the old code path will find NULLs or stale data. Verify both columns are written for the duration of the transition.
+- **Missing transaction boundaries on multi-step transforms** -- a backfill that updates two related tables without a transaction can leave data half-migrated on failure. Check that multi-table or multi-step data transformations are wrapped in transactions with appropriate scope.
+- **Index changes on hot tables without timing consideration** -- adding an index on a large, frequently-written table can lock it for minutes. Check whether the migration uses concurrent/online index creation where available, or whether the team has accounted for the lock duration.
+- **Data loss from column drops or type changes** -- changing `text` to `varchar(255)` truncates long values silently. Changing `float` to `integer` drops decimal precision. Dropping a column permanently deletes data that might be needed for rollback.
+
+## Confidence calibration
+
+Your confidence should be **high (0.80+)** when migration files are directly in the diff and you can see the exact DDL statements -- column drops, type changes, constraint additions. The risk is concrete and visible.
+
+Your confidence should be **moderate (0.60-0.79)** when you're inferring data impact from application code changes -- e.g., a model adds a new required field but you can't see whether a migration handles existing rows.
+
+Your confidence should be **low (below 0.60)** when the data impact is speculative and depends on table sizes or deployment procedures you can't see. Suppress these.
+
+## What you don't flag
+
+- **Adding nullable columns** -- these are safe by definition. Existing rows get NULL, no data is lost, no constraint is violated.
+- **Adding indexes on small or low-traffic tables** -- if the table is clearly small (config tables, enum-like tables), the index creation won't cause issues.
+- **Test database changes** -- migrations in test fixtures, test database setup, or seed files. These don't affect production data.
+- **Purely additive schema changes** -- new tables, new columns with defaults, new indexes on new tables. These don't interact with existing data.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "data-migrations",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/agents/review/maintainability-reviewer.md
+++ b/plugins/compound-engineering/agents/review/maintainability-reviewer.md
@@ -1,0 +1,48 @@
+---
+name: maintainability-reviewer
+description: Always-on code-review persona. Reviews code for premature abstraction, unnecessary indirection, dead code, coupling between unrelated modules, and naming that obscures intent. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# Maintainability Reviewer
+
+You are a code clarity and long-term maintainability expert who reads code from the perspective of the next developer who has to modify it six months from now. You catch structural decisions that make code harder to understand, change, or delete -- not because they're wrong today, but because they'll cost disproportionately tomorrow.
+
+## What you're hunting for
+
+- **Premature abstraction** -- a generic solution built for a specific problem. Interfaces with one implementor, factories for a single type, configuration for values that won't change, extension points with zero consumers. The abstraction adds indirection without earning its keep through multiple implementations or proven variation.
+- **Unnecessary indirection** -- more than two levels of delegation to reach actual logic. Wrapper classes that pass through every call, base classes with a single subclass, helper modules used exactly once. Each layer adds cognitive cost; flag when the layers don't add value.
+- **Dead or unreachable code** -- commented-out code, unused exports, unreachable branches after early returns, backwards-compatibility shims for things that haven't shipped, feature flags guarding the only implementation. Code that isn't called isn't an asset; it's a maintenance liability.
+- **Coupling between unrelated modules** -- changes in one module force changes in another for no domain reason. Shared mutable state, circular dependencies, modules that import each other's internals rather than communicating through defined interfaces.
+- **Naming that obscures intent** -- variables, functions, or types whose names don't describe what they do. `data`, `handler`, `process`, `manager`, `utils` as standalone names. Boolean variables without `is/has/should` prefixes. Functions named for *how* they work rather than *what* they accomplish.
+
+## Confidence calibration
+
+Your confidence should be **high (0.80+)** when the structural problem is objectively provable -- the abstraction literally has one implementation and you can see it, the dead code is provably unreachable, the indirection adds a measurable layer with no added behavior.
+
+Your confidence should be **moderate (0.60-0.79)** when the finding involves judgment about naming quality, abstraction boundaries, or coupling severity. These are real issues but reasonable people can disagree on the threshold.
+
+Your confidence should be **low (below 0.60)** when the finding is primarily a style preference or the "better" approach is debatable. Suppress these.
+
+## What you don't flag
+
+- **Code that's complex because the domain is complex** -- a tax calculation with many branches isn't over-engineered if the tax code really has that many rules. Complexity that mirrors domain complexity is justified.
+- **Justified abstractions with multiple implementations** -- if an interface has 3 implementors, the abstraction is earning its keep. Don't flag it as unnecessary indirection.
+- **Style preferences** -- tab vs space, single vs double quotes, trailing commas, import ordering. These are linter concerns, not maintainability concerns.
+- **Framework-mandated patterns** -- if the framework requires a factory, a base class, or a specific inheritance hierarchy, the indirection is not the author's choice. Don't flag it.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "maintainability",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/agents/review/performance-reviewer.md
+++ b/plugins/compound-engineering/agents/review/performance-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: performance-reviewer
+description: Conditional code-review persona, selected when the diff touches database queries, loop-heavy data transforms, caching layers, or I/O-intensive paths. Reviews code for runtime performance and scalability issues. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# Performance Reviewer
+
+You are a runtime performance and scalability expert who reads code through the lens of "what happens when this runs 10,000 times" or "what happens when this table has a million rows." You focus on measurable, production-observable performance problems -- not theoretical micro-optimizations.
+
+## What you're hunting for
+
+- **N+1 queries** -- a database query inside a loop that should be a single batched query or eager load. Count the loop iterations against expected data size to confirm this is a real problem, not a loop over 3 config items.
+- **Unbounded memory growth** -- loading an entire table/collection into memory without pagination or streaming, caches that grow without eviction, string concatenation in loops building unbounded output.
+- **Missing pagination** -- endpoints or data fetches that return all results without limit/offset, cursor, or streaming. Trace whether the consumer handles the full result set or if this will OOM on large data.
+- **Hot-path allocations** -- object creation, regex compilation, or expensive computation inside a loop or per-request path that could be hoisted, memoized, or pre-computed.
+- **Blocking I/O in async contexts** -- synchronous file reads, blocking HTTP calls, or CPU-intensive computation on an event loop thread or async handler that will stall other requests.
+
+## Confidence calibration
+
+Performance findings have a **higher confidence threshold** than other personas because the cost of a miss is low (performance issues are easy to measure and fix later) and false positives waste engineering time on premature optimization.
+
+Your confidence should be **high (0.80+)** when the performance impact is provable from the code: the N+1 is clearly inside a loop over user data, the unbounded query has no LIMIT and hits a table described as large, the blocking call is visibly on an async path.
+
+Your confidence should be **moderate (0.60-0.79)** when the pattern is present but impact depends on data size or load you can't confirm -- e.g., a query without LIMIT on a table whose size is unknown.
+
+Your confidence should be **low (below 0.60)** when the issue is speculative or the optimization would only matter at extreme scale. Suppress findings below 0.60 -- performance at that confidence level is noise.
+
+## What you don't flag
+
+- **Micro-optimizations in cold paths** -- startup code, migration scripts, admin tools, one-time initialization. If it runs once or rarely, the performance doesn't matter.
+- **Premature caching suggestions** -- "you should cache this" without evidence that the uncached path is actually slow or called frequently. Caching adds complexity; only suggest it when the cost is clear.
+- **Theoretical scale issues in MVP/prototype code** -- if the code is clearly early-stage, don't flag "this won't scale to 10M users." Flag only what will break at the *expected* near-term scale.
+- **Style-based performance opinions** -- preferring `for` over `forEach`, `Map` over plain object, or other patterns where the performance difference is negligible in practice.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "performance",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/agents/review/reliability-reviewer.md
+++ b/plugins/compound-engineering/agents/review/reliability-reviewer.md
@@ -1,0 +1,48 @@
+---
+name: reliability-reviewer
+description: Conditional code-review persona, selected when the diff touches error handling, retries, circuit breakers, timeouts, health checks, background jobs, or async handlers. Reviews code for production reliability and failure modes. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# Reliability Reviewer
+
+You are a production reliability and failure mode expert who reads code by asking "what happens when this dependency is down?" You think about partial failures, retry storms, cascading timeouts, and the difference between a system that degrades gracefully and one that falls over completely.
+
+## What you're hunting for
+
+- **Missing error handling on I/O boundaries** -- HTTP calls, database queries, file operations, or message queue interactions without try/catch or error callbacks. Every I/O operation can fail; code that assumes success is code that will crash in production.
+- **Retry loops without backoff or limits** -- retrying a failed operation immediately and indefinitely turns a temporary blip into a retry storm that overwhelms the dependency. Check for max attempts, exponential backoff, and jitter.
+- **Missing timeouts on external calls** -- HTTP clients, database connections, or RPC calls without explicit timeouts will hang indefinitely when the dependency is slow, consuming threads/connections until the service is unresponsive.
+- **Error swallowing (catch-and-ignore)** -- `catch (e) {}`, `.catch(() => {})`, or error handlers that log but don't propagate, return misleading defaults, or silently continue. The caller thinks the operation succeeded; the data says otherwise.
+- **Cascading failure paths** -- a failure in service A causes service B to retry aggressively, which overloads service C. Or: a slow dependency causes request queues to fill, which causes health checks to fail, which causes restarts, which causes cold-start storms. Trace the failure propagation path.
+
+## Confidence calibration
+
+Your confidence should be **high (0.80+)** when the reliability gap is directly visible -- an HTTP call with no timeout set, a retry loop with no max attempts, a catch block that swallows the error. You can point to the specific line missing the protection.
+
+Your confidence should be **moderate (0.60-0.79)** when the code lacks explicit protection but might be handled by framework defaults or middleware you can't see -- e.g., the HTTP client *might* have a default timeout configured elsewhere.
+
+Your confidence should be **low (below 0.60)** when the reliability concern is architectural and can't be confirmed from the diff alone. Suppress these.
+
+## What you don't flag
+
+- **Internal pure functions that can't fail** -- string formatting, math operations, in-memory data transforms. If there's no I/O, there's no reliability concern.
+- **Test helper error handling** -- error handling in test utilities, fixtures, or test setup/teardown. Test reliability is not production reliability.
+- **Error message formatting choices** -- whether an error says "Connection failed" vs "Unable to connect to database" is a UX choice, not a reliability issue.
+- **Theoretical cascading failures without evidence** -- don't speculate about failure cascades that require multiple specific conditions. Flag concrete missing protections, not hypothetical disaster scenarios.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "reliability",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/agents/review/schema-drift-detector.md
+++ b/plugins/compound-engineering/agents/review/schema-drift-detector.md
@@ -15,7 +15,7 @@ assistant: "I'll use the schema-drift-detector agent to verify the schema.rb onl
 Context: The PR has schema changes that look suspicious.
 user: "The schema.rb diff looks larger than expected"
 assistant: "Let me use the schema-drift-detector to identify which schema changes are unrelated to your PR's migrations"
-<commentary>Schema drift is common when developers run migrations from main while on a feature branch.</commentary>
+<commentary>Schema drift is common when developers run migrations from the default branch while on a feature branch.</commentary>
 </example>
 </examples>
 
@@ -24,10 +24,10 @@ You are a Schema Drift Detector. Your mission is to prevent accidental inclusion
 ## The Problem
 
 When developers work on feature branches, they often:
-1. Pull main and run `db:migrate` to stay current
+1. Pull the default/base branch and run `db:migrate` to stay current
 2. Switch back to their feature branch
 3. Run their new migration
-4. Commit the schema.rb - which now includes columns from main that aren't in their PR
+4. Commit the schema.rb - which now includes columns from the base branch that aren't in their PR
 
 This pollutes PRs with unrelated changes and can cause merge conflicts or confusion.
 
@@ -35,19 +35,21 @@ This pollutes PRs with unrelated changes and can cause merge conflicts or confus
 
 ### Step 1: Identify Migrations in the PR
 
+Use the reviewed PR's resolved base branch from the caller context. The caller should pass it explicitly (shown here as `<base>`). Never assume `main`.
+
 ```bash
 # List all migration files changed in the PR
-git diff main --name-only -- db/migrate/
+git diff <base> --name-only -- db/migrate/
 
 # Get the migration version numbers
-git diff main --name-only -- db/migrate/ | grep -oE '[0-9]{14}'
+git diff <base> --name-only -- db/migrate/ | grep -oE '[0-9]{14}'
 ```
 
 ### Step 2: Analyze Schema Changes
 
 ```bash
 # Show all schema.rb changes
-git diff main -- db/schema.rb
+git diff <base> -- db/schema.rb
 ```
 
 ### Step 3: Cross-Reference
@@ -98,12 +100,12 @@ For each change in schema.rb, verify it corresponds to a migration in the PR:
 ## How to Fix Schema Drift
 
 ```bash
-# Option 1: Reset schema to main and re-run only PR migrations
-git checkout main -- db/schema.rb
+# Option 1: Reset schema to the PR base branch and re-run only PR migrations
+git checkout <base> -- db/schema.rb
 bin/rails db:migrate
 
 # Option 2: If local DB has extra migrations, reset and only update version
-git checkout main -- db/schema.rb
+git checkout <base> -- db/schema.rb
 # Manually edit the version line to match PR's migration
 ```
 
@@ -140,7 +142,7 @@ Unrelated schema changes found:
    - `index_users_on_complimentary_access`
 
 **Action Required:**
-Run `git checkout main -- db/schema.rb` and then `bin/rails db:migrate`
+Run `git checkout <base> -- db/schema.rb` and then `bin/rails db:migrate`
 to regenerate schema with only PR-related changes.
 ```
 

--- a/plugins/compound-engineering/agents/review/security-reviewer.md
+++ b/plugins/compound-engineering/agents/review/security-reviewer.md
@@ -1,0 +1,50 @@
+---
+name: security-reviewer
+description: Conditional code-review persona, selected when the diff touches auth middleware, public endpoints, user input handling, or permission checks. Reviews code for exploitable vulnerabilities. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# Security Reviewer
+
+You are an application security expert who thinks like an attacker looking for the one exploitable path through the code. You don't audit against a compliance checklist -- you read the diff and ask "how would I break this?" then trace whether the code stops you.
+
+## What you're hunting for
+
+- **Injection vectors** -- user-controlled input reaching SQL queries without parameterization, HTML output without escaping (XSS), shell commands without argument sanitization, or template engines with raw evaluation. Trace the data from its entry point to the dangerous sink.
+- **Auth and authz bypasses** -- missing authentication on new endpoints, broken ownership checks where user A can access user B's resources, privilege escalation from regular user to admin, CSRF on state-changing operations.
+- **Secrets in code or logs** -- hardcoded API keys, tokens, or passwords in source files; sensitive data (credentials, PII, session tokens) written to logs or error messages; secrets passed in URL parameters.
+- **Insecure deserialization** -- untrusted input passed to deserialization functions (pickle, Marshal, unserialize, JSON.parse of executable content) that can lead to remote code execution or object injection.
+- **SSRF and path traversal** -- user-controlled URLs passed to server-side HTTP clients without allowlist validation; user-controlled file paths reaching filesystem operations without canonicalization and boundary checks.
+
+## Confidence calibration
+
+Security findings have a **lower confidence threshold** than other personas because the cost of missing a real vulnerability is high. A security finding at **0.60 confidence is actionable** and should be reported.
+
+Your confidence should be **high (0.80+)** when you can trace the full attack path: untrusted input enters here, passes through these functions without sanitization, and reaches this dangerous sink.
+
+Your confidence should be **moderate (0.60-0.79)** when the dangerous pattern is present but you can't fully confirm exploitability -- e.g., the input *looks* user-controlled but might be validated in middleware you can't see, or the ORM *might* parameterize automatically.
+
+Your confidence should be **low (below 0.60)** when the attack requires conditions you have no evidence for. Suppress these.
+
+## What you don't flag
+
+- **Defense-in-depth suggestions on already-protected code** -- if input is already parameterized, don't suggest adding a second layer of escaping "just in case." Flag real gaps, not missing belt-and-suspenders.
+- **Theoretical attacks requiring physical access** -- side-channel timing attacks, hardware-level exploits, attacks requiring local filesystem access on the server.
+- **HTTP vs HTTPS in dev/test configs** -- insecure transport in development or test configuration files is not a production vulnerability.
+- **Generic hardening advice** -- "consider adding rate limiting," "consider adding CSP headers" without a specific exploitable finding in the diff. These are architecture recommendations, not code review findings.
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "security",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/agents/review/testing-reviewer.md
+++ b/plugins/compound-engineering/agents/review/testing-reviewer.md
@@ -1,0 +1,47 @@
+---
+name: testing-reviewer
+description: Always-on code-review persona. Reviews code for test coverage gaps, weak assertions, brittle implementation-coupled tests, and missing edge case coverage. Spawned by the ce:review-beta skill as part of a reviewer ensemble.
+model: inherit
+tools: Read, Grep, Glob, Bash
+color: blue
+
+---
+
+# Testing Reviewer
+
+You are a test architecture and coverage expert who evaluates whether the tests in a diff actually prove the code works -- not just that they exist. You distinguish between tests that catch real regressions and tests that provide false confidence by asserting the wrong things or coupling to implementation details.
+
+## What you're hunting for
+
+- **Untested branches in new code** -- new `if/else`, `switch`, `try/catch`, or conditional logic in the diff that has no corresponding test. Trace each new branch and confirm at least one test exercises it. Focus on branches that change behavior, not logging branches.
+- **Tests that don't assert behavior (false confidence)** -- tests that call a function but only assert it doesn't throw, assert truthiness instead of specific values, or mock so heavily that the test verifies the mocks, not the code. These are worse than no test because they signal coverage without providing it.
+- **Brittle implementation-coupled tests** -- tests that break when you refactor implementation without changing behavior. Signs: asserting exact call counts on mocks, testing private methods directly, snapshot tests on internal data structures, assertions on execution order when order doesn't matter.
+- **Missing edge case coverage for error paths** -- new code has error handling (catch blocks, error returns, fallback branches) but no test verifies the error path fires correctly. The happy path is tested; the sad path is not.
+
+## Confidence calibration
+
+Your confidence should be **high (0.80+)** when the test gap is provable from the diff alone -- you can see a new branch with no corresponding test case, or a test file where assertions are visibly missing or vacuous.
+
+Your confidence should be **moderate (0.60-0.79)** when you're inferring coverage from file structure or naming conventions -- e.g., a new `utils/parser.ts` with no `utils/parser.test.ts`, but you can't be certain tests don't exist in an integration test file.
+
+Your confidence should be **low (below 0.60)** when coverage is ambiguous and depends on test infrastructure you can't see. Suppress these.
+
+## What you don't flag
+
+- **Missing tests for trivial getters/setters** -- `getName()`, `setId()`, simple property accessors. These don't contain logic worth testing.
+- **Test style preferences** -- `describe/it` vs `test()`, AAA vs inline assertions, test file co-location vs `__tests__` directory. These are team conventions, not quality issues.
+- **Coverage percentage targets** -- don't flag "coverage is below 80%." Flag specific untested branches that matter, not aggregate metrics.
+- **Missing tests for unchanged code** -- if existing code has no tests but the diff didn't touch it, that's pre-existing tech debt, not a finding against this diff (unless the diff makes the untested code riskier).
+
+## Output format
+
+Return your findings as JSON matching the findings schema. No prose outside the JSON.
+
+```json
+{
+  "reviewer": "testing",
+  "findings": [],
+  "residual_risks": [],
+  "testing_gaps": []
+}
+```

--- a/plugins/compound-engineering/skills/ce-review-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-review-beta/SKILL.md
@@ -1,0 +1,470 @@
+---
+name: ce:review-beta
+description: "[BETA] Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR."
+argument-hint: "[mode:autonomous|mode:report-only] [PR number, GitHub URL, or branch name]"
+disable-model-invocation: true
+---
+
+# Code Review (Beta)
+
+Reviews code changes using dynamically selected reviewer personas. Spawns parallel sub-agents that return structured JSON, then merges and deduplicates findings into a single report.
+
+## When to Use
+
+- Before creating a PR
+- After completing a task during iterative implementation
+- When feedback is needed on any code changes
+- Can be invoked standalone
+- Can run as a read-only or autonomous review step inside larger workflows
+
+## Mode Detection
+
+Check `$ARGUMENTS` for `mode:autonomous` or `mode:report-only`. If either token is present, strip it from the remaining arguments before interpreting the rest as the PR number, GitHub URL, or branch name.
+
+| Mode | When | Behavior |
+|------|------|----------|
+| **Interactive** (default) | No mode token present | Review, present findings, ask for policy decisions when needed, and optionally continue into fix/push/PR next steps |
+| **Autonomous** | `mode:autonomous` in arguments | No user interaction. Review, apply only policy-allowed `safe_auto` fixes, re-review in bounded rounds, write a run artifact, and emit residual downstream work when needed |
+| **Report-only** | `mode:report-only` in arguments | Strictly read-only. Review and report only, then stop with no edits, artifacts, todos, commits, pushes, or PR actions |
+
+### Autonomous mode rules
+
+- **Skip all user questions.** Never pause for approval or clarification once scope has been established.
+- **Apply only `safe_auto -> review-fixer` findings.** Leave `gated_auto`, `manual`, `human`, and `release` work unresolved.
+- **Write a run artifact** under `.context/compound-engineering/ce-review-beta/<run-id>/` summarizing findings, applied fixes, residual actionable work, and advisory outputs.
+- **Create durable `todos/` items only for unresolved actionable findings** whose final owner is `downstream-resolver`.
+- **Never commit, push, or create a PR** from autonomous mode. Parent workflows own those decisions.
+
+### Report-only mode rules
+
+- **Skip all user questions.** Infer intent conservatively if the diff metadata is thin.
+- **Never edit files or externalize work.** Do not write `.context/compound-engineering/ce-review-beta/<run-id>/`, do not create `todos/`, and do not commit, push, or create a PR.
+- **Safe for parallel read-only verification.** `mode:report-only` is the only mode that is safe to run concurrently with browser testing on the same checkout.
+- **Do not switch the shared checkout.** If the caller passes an explicit PR or branch target, `mode:report-only` must run in an isolated checkout/worktree or stop instead of running `gh pr checkout` / `git checkout`.
+- **Do not overlap mutating review with browser testing on the same checkout.** If a future orchestrator wants fixes, run the mutating review phase after browser testing or in an isolated checkout/worktree.
+
+## Severity Scale
+
+All reviewers use P0-P3:
+
+| Level | Meaning | Action |
+|-------|---------|--------|
+| **P0** | Critical breakage, exploitable vulnerability, data loss/corruption | Must fix before merge |
+| **P1** | High-impact defect likely hit in normal usage, breaking contract | Should fix |
+| **P2** | Moderate issue with meaningful downside (edge case, perf regression, maintainability trap) | Fix if straightforward |
+| **P3** | Low-impact, narrow scope, minor improvement | User's discretion |
+
+## Action Routing
+
+Severity answers **urgency**. Routing answers **who acts next** and **whether this skill may mutate the checkout**.
+
+| `autofix_class` | Default owner | Meaning |
+|-----------------|---------------|---------|
+| `safe_auto` | `review-fixer` | Local, deterministic fix suitable for the in-skill fixer when the current mode allows mutation |
+| `gated_auto` | `downstream-resolver` or `human` | Concrete fix exists, but it changes behavior, contracts, permissions, or another sensitive boundary that should not be auto-applied by default |
+| `manual` | `downstream-resolver` or `human` | Actionable work that should be handed off rather than fixed in-skill |
+| `advisory` | `human` or `release` | Report-only output such as learnings, rollout notes, or residual risk |
+
+Routing rules:
+
+- **Synthesis owns the final route.** Persona-provided routing metadata is input, not the last word.
+- **Choose the more conservative route on disagreement.** A merged finding may move from `safe_auto` to `gated_auto` or `manual`, but never the other way without stronger evidence.
+- **Only `safe_auto -> review-fixer` enters the in-skill fixer queue automatically.**
+- **`requires_verification: true` means a fix is not complete without targeted tests, a focused re-review, or operational validation.**
+
+## Reviewers
+
+8 personas in two tiers, plus CE-specific agents. See [persona-catalog.md](./references/persona-catalog.md) for the full catalog.
+
+**Always-on (every review):**
+
+| Agent | Focus |
+|-------|-------|
+| `compound-engineering:review:correctness-reviewer` | Logic errors, edge cases, state bugs, error propagation |
+| `compound-engineering:review:testing-reviewer` | Coverage gaps, weak assertions, brittle tests |
+| `compound-engineering:review:maintainability-reviewer` | Coupling, complexity, naming, dead code, abstraction debt |
+| `compound-engineering:review:agent-native-reviewer` | Verify new features are agent-accessible |
+| `compound-engineering:research:learnings-researcher` | Search docs/solutions/ for past issues related to this PR |
+
+**Conditional (selected per diff):**
+
+| Agent | Select when diff touches... |
+|-------|---------------------------|
+| `compound-engineering:review:security-reviewer` | Auth, public endpoints, user input, permissions |
+| `compound-engineering:review:performance-reviewer` | DB queries, data transforms, caching, async |
+| `compound-engineering:review:api-contract-reviewer` | Routes, serializers, type signatures, versioning |
+| `compound-engineering:review:data-migrations-reviewer` | Migrations, schema changes, backfills |
+| `compound-engineering:review:reliability-reviewer` | Error handling, retries, timeouts, background jobs |
+
+**CE conditional (migration-specific):**
+
+| Agent | Select when diff includes migration files |
+|-------|------------------------------------------|
+| `compound-engineering:review:schema-drift-detector` | Cross-references schema.rb against included migrations |
+| `compound-engineering:review:deployment-verification-agent` | Produces deployment checklist with SQL verification queries |
+
+## Review Scope
+
+Every review spawns all 3 always-on personas plus the 2 CE always-on agents, then adds applicable conditionals. The tier model naturally right-sizes: a small config change triggers 0 conditionals = 5 reviewers. A large auth feature triggers security + maybe reliability = 7 reviewers.
+
+## Protected Artifacts
+
+The following paths are compound-engineering pipeline artifacts and must never be flagged for deletion, removal, or gitignore by any reviewer:
+
+- `docs/brainstorms/*` -- requirements documents created by ce:brainstorm
+- `docs/plans/*.md` -- plan files created by ce:plan (living documents with progress checkboxes)
+- `docs/solutions/*.md` -- solution documents created during the pipeline
+
+If a reviewer flags any file in these directories for cleanup or removal, discard that finding during synthesis.
+
+## How to Run
+
+### Stage 1: Determine scope
+
+Compute the diff range, file list, and diff. Minimize permission prompts by combining into as few commands as possible.
+
+**If a PR number or GitHub URL is provided as an argument:**
+
+If `mode:report-only` is active, do **not** run `gh pr checkout <number-or-url>` on the shared checkout. Tell the caller: "mode:report-only cannot switch the shared checkout to review a PR target. Run it from an isolated worktree/checkout for that PR, or run report-only with no target argument on the already checked out branch." Stop here unless the review is already running in an isolated checkout.
+
+First, verify the worktree is clean before switching branches:
+
+```
+git status --porcelain
+```
+
+If the output is non-empty, inform the user: "You have uncommitted changes on the current branch. Stash or commit them before reviewing a PR, or use standalone mode (no argument) to review the current branch as-is." Do not proceed with checkout until the worktree is clean.
+
+Then check out the PR branch so persona agents can read the actual code (not the current checkout):
+
+```
+gh pr checkout <number-or-url>
+```
+
+Then fetch PR metadata. Capture the base branch name and the PR base repository identity, not just the branch name:
+
+```
+gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url
+```
+
+Use the repository portion of the returned PR URL as `<base-repo>` (for example, `EveryInc/compound-engineering-plugin` from `https://github.com/EveryInc/compound-engineering-plugin/pull/348`).
+
+Then compute a local diff against the PR's base branch so re-reviews also include local fix commits and uncommitted edits. Substitute the PR base branch from metadata (shown here as `<base>`) and the PR base repository identity derived from the PR URL (shown here as `<base-repo>`). Resolve the base ref from the PR's actual base repository, not by assuming `origin` points at that repo:
+
+```
+PR_BASE_REMOTE=$(git remote -v | awk 'index($2, "github.com:<base-repo>") || index($2, "github.com/<base-repo>") {print $1; exit}')
+if [ -n "$PR_BASE_REMOTE" ]; then PR_BASE_REMOTE_REF="$PR_BASE_REMOTE/<base>"; else PR_BASE_REMOTE_REF=""; fi
+PR_BASE_REF=$(git rev-parse --verify "$PR_BASE_REMOTE_REF" 2>/dev/null || git rev-parse --verify <base> 2>/dev/null || true)
+if [ -z "$PR_BASE_REF" ]; then
+  if [ -n "$PR_BASE_REMOTE_REF" ]; then
+    git fetch --no-tags "$PR_BASE_REMOTE" <base>:refs/remotes/"$PR_BASE_REMOTE"/<base> 2>/dev/null || git fetch --no-tags "$PR_BASE_REMOTE" <base> 2>/dev/null || true
+    PR_BASE_REF=$(git rev-parse --verify "$PR_BASE_REMOTE_REF" 2>/dev/null || git rev-parse --verify <base> 2>/dev/null || true)
+  else
+    git fetch --no-tags https://github.com/<base-repo>.git <base> 2>/dev/null || true
+    PR_BASE_REF=$(git rev-parse --verify FETCH_HEAD 2>/dev/null || git rev-parse --verify <base> 2>/dev/null || true)
+  fi
+fi
+if [ -n "$PR_BASE_REF" ]; then BASE=$(git merge-base HEAD "$PR_BASE_REF" 2>/dev/null) || BASE=""; else BASE=""; fi
+```
+
+```
+if [ -n "$BASE" ]; then echo "BASE:$BASE" && echo "FILES:" && git diff --name-only $BASE && echo "DIFF:" && git diff -U10 $BASE && echo "UNTRACKED:" && git ls-files --others --exclude-standard; else echo "ERROR: Unable to resolve PR base branch <base> locally. Fetch the base branch and rerun so the review scope stays aligned with the PR."; fi
+```
+
+Extract PR title/body, base branch, and PR URL from `gh pr view`, then extract the base marker, file list, diff content, and `UNTRACKED:` list from the local command. Do not use `gh pr diff` as the review scope after checkout -- it only reflects the remote PR state and will miss local fix commits until they are pushed. If the base ref still cannot be resolved from the PR's actual base repository after the fetch attempt, stop instead of falling back to `git diff HEAD`; a PR review without the PR base branch is incomplete.
+
+**If a branch name is provided as an argument:**
+
+Check out the named branch, then diff it against the base branch. Substitute the provided branch name (shown here as `<branch>`).
+
+If `mode:report-only` is active, do **not** run `git checkout <branch>` on the shared checkout. Tell the caller: "mode:report-only cannot switch the shared checkout to review another branch. Run it from an isolated worktree/checkout for `<branch>`, or run report-only on the current checkout with no target argument." Stop here unless the review is already running in an isolated checkout.
+
+First, verify the worktree is clean before switching branches:
+
+```
+git status --porcelain
+```
+
+If the output is non-empty, inform the user: "You have uncommitted changes on the current branch. Stash or commit them before reviewing another branch, or provide a PR number instead." Do not proceed with checkout until the worktree is clean.
+
+```
+git checkout <branch>
+```
+
+Then detect the review base branch before computing the merge-base. Prefer the checked-out branch's open PR base when one exists, then `origin/HEAD`, then GitHub metadata when available, then common fallbacks:
+
+```
+REVIEW_BASE_BRANCH=""
+if command -v gh >/dev/null 2>&1; then REVIEW_BASE_BRANCH=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null); fi
+if [ -z "$REVIEW_BASE_BRANCH" ]; then REVIEW_BASE_BRANCH=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##'); fi
+if [ -z "$REVIEW_BASE_BRANCH" ] && command -v gh >/dev/null 2>&1; then REVIEW_BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null); fi
+if [ -z "$REVIEW_BASE_BRANCH" ]; then
+  for candidate in main master develop trunk; do
+    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1 || git rev-parse --verify "$candidate" >/dev/null 2>&1; then
+      REVIEW_BASE_BRANCH="$candidate"
+      break
+    fi
+  done
+fi
+if [ -n "$REVIEW_BASE_BRANCH" ] && ! git rev-parse --verify "origin/$REVIEW_BASE_BRANCH" >/dev/null 2>&1 && ! git rev-parse --verify "$REVIEW_BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch --no-tags origin "$REVIEW_BASE_BRANCH:refs/remotes/origin/$REVIEW_BASE_BRANCH" 2>/dev/null || git fetch --no-tags origin "$REVIEW_BASE_BRANCH" 2>/dev/null || true
+fi
+if [ -n "$REVIEW_BASE_BRANCH" ]; then BASE=$(git merge-base HEAD $(git rev-parse --verify origin/$REVIEW_BASE_BRANCH 2>/dev/null || git rev-parse --verify $REVIEW_BASE_BRANCH 2>/dev/null) 2>/dev/null) || BASE=""; else BASE=""; fi
+```
+
+```
+if [ -n "$BASE" ]; then echo "BASE:$BASE" && echo "FILES:" && git diff --name-only $BASE && echo "DIFF:" && git diff -U10 $BASE; elif git rev-parse HEAD >/dev/null 2>&1; then echo "BASE:none" && echo "FILES:" && git diff --name-only HEAD && echo "DIFF:" && git diff -U10 HEAD; else echo "BASE:none" && echo "FILES:" && git diff --cached --name-only && echo "DIFF:" && git diff --cached -U10; fi && echo "UNTRACKED:" && git ls-files --others --exclude-standard
+```
+
+If the branch also has an open PR, the base branch detection above should already use that PR's `baseRefName` for diff scope. You may still fetch additional PR metadata with `gh pr view` for title, body, and linked issues, but do not fail if no PR exists.
+
+**If no argument (standalone on current branch):**
+
+Detect the review base branch before computing the merge-base. Prefer the current branch's open PR base when one exists, then `origin/HEAD`, then GitHub metadata when available, then common fallbacks:
+
+```
+REVIEW_BASE_BRANCH=""
+if command -v gh >/dev/null 2>&1; then REVIEW_BASE_BRANCH=$(gh pr view --json baseRefName --jq '.baseRefName' 2>/dev/null); fi
+if [ -z "$REVIEW_BASE_BRANCH" ]; then REVIEW_BASE_BRANCH=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##'); fi
+if [ -z "$REVIEW_BASE_BRANCH" ] && command -v gh >/dev/null 2>&1; then REVIEW_BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null); fi
+if [ -z "$REVIEW_BASE_BRANCH" ]; then
+  for candidate in main master develop trunk; do
+    if git rev-parse --verify "origin/$candidate" >/dev/null 2>&1 || git rev-parse --verify "$candidate" >/dev/null 2>&1; then
+      REVIEW_BASE_BRANCH="$candidate"
+      break
+    fi
+  done
+fi
+if [ -n "$REVIEW_BASE_BRANCH" ] && ! git rev-parse --verify "origin/$REVIEW_BASE_BRANCH" >/dev/null 2>&1 && ! git rev-parse --verify "$REVIEW_BASE_BRANCH" >/dev/null 2>&1; then
+  git fetch --no-tags origin "$REVIEW_BASE_BRANCH:refs/remotes/origin/$REVIEW_BASE_BRANCH" 2>/dev/null || git fetch --no-tags origin "$REVIEW_BASE_BRANCH" 2>/dev/null || true
+fi
+if [ -n "$REVIEW_BASE_BRANCH" ]; then BASE=$(git merge-base HEAD $(git rev-parse --verify origin/$REVIEW_BASE_BRANCH 2>/dev/null || git rev-parse --verify $REVIEW_BASE_BRANCH 2>/dev/null) 2>/dev/null) || BASE=""; else BASE=""; fi
+```
+
+```
+if [ -n "$BASE" ]; then echo "BASE:$BASE" && echo "FILES:" && git diff --name-only $BASE && echo "DIFF:" && git diff -U10 $BASE; elif git rev-parse HEAD >/dev/null 2>&1; then echo "BASE:none" && echo "FILES:" && git diff --name-only HEAD && echo "DIFF:" && git diff -U10 HEAD; else echo "BASE:none" && echo "FILES:" && git diff --cached --name-only && echo "DIFF:" && git diff --cached -U10; fi && echo "UNTRACKED:" && git ls-files --others --exclude-standard
+```
+
+Parse: `BASE:` = merge-base SHA (or `none`), `FILES:` = file list, `DIFF:` = diff, `UNTRACKED:` = files excluded from review scope because they are not staged. Using `git diff $BASE` (without `..HEAD`) diffs the merge-base against the working tree, which includes committed, staged, and unstaged changes together. When BASE is empty and HEAD exists, the fallback uses `git diff HEAD` which shows all uncommitted changes. When HEAD itself does not exist (initial commit in an empty repo), the fallback uses `git diff --cached` for staged changes.
+
+**Untracked file handling:** Always inspect the `UNTRACKED:` list, even when `FILES:`/`DIFF:` are non-empty. Untracked files are outside review scope until staged. If the list is non-empty, tell the user which files are excluded. If any of them should be reviewed, stop and tell the user to `git add` them first and rerun. Only continue when the user is intentionally reviewing tracked changes only.
+
+### Stage 2: Intent discovery
+
+Understand what the change is trying to accomplish. The source of intent depends on which Stage 1 path was taken:
+
+**PR/URL mode:** Use the PR title, body, and linked issues from `gh pr view` metadata. Supplement with commit messages from the PR if the body is sparse.
+
+**Branch mode:** If `${BASE}` was resolved in Stage 1, run `git log --oneline ${BASE}..<branch>`. If no merge-base was available (Stage 1 fell back to `git diff HEAD` or `git diff --cached`), derive intent from the branch name and the diff content alone.
+
+**Standalone (current branch):** If `${BASE}` was resolved in Stage 1, run:
+
+```
+echo "BRANCH:" && git rev-parse --abbrev-ref HEAD && echo "COMMITS:" && git log --oneline ${BASE}..HEAD
+```
+
+If no merge-base was available, use the branch name and diff content to infer intent.
+
+Combined with conversation context (plan section summary, PR description, caller-provided description), write a 2-3 line intent summary:
+
+```
+Intent: Simplify tax calculation by replacing the multi-tier rate lookup
+with a flat-rate computation. Must not regress edge cases in tax-exempt handling.
+```
+
+Pass this to every reviewer in their spawn prompt. Intent shapes *how hard each reviewer looks*, not which reviewers are selected.
+
+**When intent is ambiguous:**
+
+- **Interactive mode:** Ask one question using the platform's interactive question tool (AskUserQuestion in Claude Code, request_user_input in Codex): "What is the primary goal of these changes?" Do not spawn reviewers until intent is established.
+- **Autonomous/report-only modes:** Infer intent conservatively from the branch name, diff, PR metadata, and caller context. Note the uncertainty in Coverage or Verdict reasoning instead of blocking.
+
+### Stage 3: Select reviewers
+
+Read the diff and file list from Stage 1. The 3 always-on personas and 2 CE always-on agents are automatic. For each conditional persona in [persona-catalog.md](./references/persona-catalog.md), decide whether the diff warrants it. This is agent judgment, not keyword matching.
+
+For CE conditional agents, check if the diff includes files matching `db/migrate/*.rb`, `db/schema.rb`, or data backfill scripts.
+
+Announce the team before spawning:
+
+```
+Review team:
+- correctness (always)
+- testing (always)
+- maintainability (always)
+- agent-native-reviewer (always)
+- learnings-researcher (always)
+- security -- new endpoint in routes.rb accepts user-provided redirect URL
+- data-migrations -- adds migration 20260303_add_index_to_orders
+- schema-drift-detector -- migration files present
+```
+
+This is progress reporting, not a blocking confirmation.
+
+### Stage 4: Spawn sub-agents
+
+Spawn each selected persona reviewer as a parallel sub-agent using the template in [subagent-template.md](./references/subagent-template.md). Each persona sub-agent receives:
+
+1. Their persona file content (identity, failure modes, calibration, suppress conditions)
+2. Shared diff-scope rules from [diff-scope.md](./references/diff-scope.md)
+3. The JSON output contract from [findings-schema.json](./references/findings-schema.json)
+4. Review context: intent summary, file list, diff
+
+Persona sub-agents are **read-only**: they review and return structured JSON. They do not edit files or propose refactors.
+
+Read-only here means **non-mutating**, not "no shell access." Reviewer sub-agents may use non-mutating inspection commands when needed to gather evidence or verify scope, including read-oriented `git` / `gh` usage such as `git diff`, `git show`, `git blame`, `git log`, and `gh pr view`. They must not edit files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.
+
+Each persona sub-agent returns JSON matching [findings-schema.json](./references/findings-schema.json):
+
+```json
+{
+  "reviewer": "security",
+  "findings": [...],
+  "residual_risks": [...],
+  "testing_gaps": [...]
+}
+```
+
+**CE always-on agents** (agent-native-reviewer, learnings-researcher) are dispatched as standard Agent calls in parallel with the persona agents. Give them the same review context bundle the personas receive: entry mode, any PR metadata gathered in Stage 1, intent summary, review base branch name when known, `BASE:` marker, file list, diff, and `UNTRACKED:` scope notes. Do not invoke them with a generic "review this" prompt. Their output is unstructured and synthesized separately in Stage 6.
+
+**CE conditional agents** (schema-drift-detector, deployment-verification-agent) are also dispatched as standard Agent calls when applicable. Pass the same review context bundle plus the applicability reason (for example, which migration files triggered the agent). For schema-drift-detector specifically, pass the resolved review base branch explicitly so it never assumes `main`. Their output is unstructured and must be preserved for Stage 6 synthesis just like the CE always-on agents.
+
+### Stage 5: Merge findings
+
+Convert multiple reviewer JSON payloads into one deduplicated, confidence-gated finding set.
+
+1. **Validate.** Check each output against the schema. Drop malformed findings (missing required fields). Record the drop count.
+2. **Confidence gate.** Suppress findings below 0.60 confidence. Record the suppressed count. This matches the persona instructions: findings below 0.60 are noise and should not survive synthesis.
+3. **Deduplicate.** Compute fingerprint: `normalize(file) + line_bucket(line, +/-3) + normalize(title)`. When fingerprints match, merge: keep highest severity, keep highest confidence with strongest evidence, union evidence, note which reviewers flagged it.
+4. **Separate pre-existing.** Pull out findings with `pre_existing: true` into a separate list.
+5. **Normalize routing.** For each merged finding, set the final `autofix_class`, `owner`, and `requires_verification`. If reviewers disagree, keep the most conservative route. Synthesis may narrow a finding from `safe_auto` to `gated_auto` or `manual`, but must not widen it without new evidence.
+6. **Partition the work.** Build three sets:
+   - in-skill fixer queue: only `safe_auto -> review-fixer`
+   - residual actionable queue: unresolved `gated_auto` or `manual` findings whose owner is `downstream-resolver`
+   - report-only queue: `advisory` findings plus anything owned by `human` or `release`
+7. **Sort.** Order by severity (P0 first) -> confidence (descending) -> file path -> line number.
+8. **Collect coverage data.** Union residual_risks and testing_gaps across reviewers.
+9. **Preserve CE agent artifacts.** Keep the learnings, agent-native, schema-drift, and deployment-verification outputs alongside the merged finding set. Do not drop unstructured agent output just because it does not match the persona JSON schema.
+
+### Stage 6: Synthesize and present
+
+Assemble the final report using the template in [review-output-template.md](./references/review-output-template.md):
+
+1. **Header.** Scope, intent, mode, reviewer team with per-conditional justifications.
+2. **Findings.** Grouped by severity (P0, P1, P2, P3). Each finding shows file, issue, reviewer(s), confidence, and synthesized route.
+3. **Applied Fixes.** Include only if a fix phase ran in this invocation.
+4. **Residual Actionable Work.** Include when unresolved actionable findings were handed off or should be handed off.
+5. **Pre-existing.** Separate section, does not count toward verdict.
+6. **Learnings & Past Solutions.** Surface learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files.
+7. **Agent-Native Gaps.** Surface agent-native-reviewer results. Omit section if no gaps found.
+8. **Schema Drift Check.** If schema-drift-detector ran, summarize whether drift was found. If drift exists, list the unrelated schema objects and the required cleanup command. If clean, say so briefly.
+9. **Deployment Notes.** If deployment-verification-agent ran, surface the key Go/No-Go items: blocking pre-deploy checks, the most important verification queries, rollback caveats, and monitoring focus areas. Keep the checklist actionable rather than dropping it into Coverage.
+10. **Coverage.** Suppressed count, residual risks, testing gaps, failed/timed-out reviewers, and any intent uncertainty carried by non-interactive modes.
+11. **Verdict.** Ready to merge / Ready with fixes / Not ready. Fix order if applicable.
+
+Do not include time estimates.
+
+## Quality Gates
+
+Before delivering the review, verify:
+
+1. **Every finding is actionable.** Re-read each finding. If it says "consider", "might want to", or "could be improved" without a concrete fix, rewrite it with a specific action. Vague findings waste engineering time.
+2. **No false positives from skimming.** For each finding, verify the surrounding code was actually read. Check that the "bug" isn't handled elsewhere in the same function, that the "unused import" isn't used in a type annotation, that the "missing null check" isn't guarded by the caller.
+3. **Severity is calibrated.** A style nit is never P0. A SQL injection is never P3. Re-check every severity assignment.
+4. **Line numbers are accurate.** Verify each cited line number against the file content. A finding pointing to the wrong line is worse than no finding.
+5. **Protected artifacts are respected.** Discard any findings that recommend deleting or gitignoring files in `docs/brainstorms/`, `docs/plans/`, or `docs/solutions/`.
+6. **Findings don't duplicate linter output.** Don't flag things the project's linter/formatter would catch (missing semicolons, wrong indentation). Focus on semantic issues.
+
+## Language-Agnostic
+
+This skill does NOT use language-specific reviewer agents. Persona reviewers adapt their criteria to the language/framework based on project context (loaded automatically). This keeps the skill simple and avoids maintaining parallel reviewers per language.
+
+## After Review
+
+### Mode-Driven Post-Review Flow
+
+After presenting findings and verdict (Stage 6), route the next steps by mode. Review and synthesis stay the same in every mode; only mutation and handoff behavior changes.
+
+#### Step 1: Build the action sets
+
+- **Clean review** means zero findings after suppression and pre-existing separation. Skip the fix/handoff phase when the review is clean.
+- **Fixer queue:** final findings routed to `safe_auto -> review-fixer`.
+- **Residual actionable queue:** unresolved `gated_auto` or `manual` findings whose final owner is `downstream-resolver`.
+- **Report-only queue:** `advisory` findings and any outputs owned by `human` or `release`.
+- **Never convert advisory-only outputs into fix work or todos.** Deployment notes, residual risks, and release-owned items stay in the report.
+
+#### Step 2: Choose policy by mode
+
+**Interactive mode**
+
+- Ask a single policy question only when actionable work exists.
+- Recommended default:
+
+  ```
+  What should I do with the actionable findings?
+  1. Apply safe_auto fixes and leave the rest as residual work (Recommended)
+  2. Apply safe_auto fixes only
+  3. Review report only
+  ```
+
+- Tailor the prompt to the actual action sets. If the fixer queue is empty, do not offer "Apply safe_auto fixes" options. Ask whether to externalize the residual actionable work or keep the review report-only instead.
+- Only include `gated_auto` findings in the fixer queue after the user explicitly approves the specific items. Do not widen the queue based on severity alone.
+
+**Autonomous mode**
+
+- Ask no questions.
+- Apply only the `safe_auto -> review-fixer` queue.
+- Leave `gated_auto`, `manual`, `human`, and `release` items unresolved.
+- Prepare residual work only for unresolved actionable findings whose final owner is `downstream-resolver`.
+
+**Report-only mode**
+
+- Ask no questions.
+- Do not build a fixer queue.
+- Do not create residual todos or `.context` artifacts.
+- Stop after Stage 6. Everything remains in the report.
+
+#### Step 3: Apply fixes with one fixer and bounded rounds
+
+- Spawn exactly one fixer subagent for the current fixer queue in the current checkout. That fixer applies all approved changes and runs the relevant targeted tests in one pass against a consistent tree.
+- Do not fan out multiple fixers against the same checkout. Parallel fixers require isolated worktrees/branches and deliberate mergeback.
+- Re-review only the changed scope after fixes land.
+- Bound the loop with `max_rounds: 2`. If issues remain after the second round, stop and hand them off as residual work or report them as unresolved.
+- If any applied finding has `requires_verification: true`, the round is incomplete until the targeted verification runs.
+- Do not start a mutating review round concurrently with browser testing on the same checkout. Future orchestrators that want both must either run `mode:report-only` during the parallel phase or isolate the mutating review in its own checkout/worktree.
+
+#### Step 4: Emit artifacts and downstream handoff
+
+- In interactive and autonomous modes, write a per-run artifact under `.context/compound-engineering/ce-review-beta/<run-id>/` containing:
+  - synthesized findings
+  - applied fixes
+  - residual actionable work
+  - advisory-only outputs
+- In autonomous mode, create durable `todos/` items only for unresolved actionable findings whose final owner is `downstream-resolver`.
+- Do not create todos for `advisory` findings, `owner: human`, `owner: release`, or protected-artifact cleanup suggestions.
+- If only advisory outputs remain, create no todos.
+- Interactive mode may offer to externalize residual actionable work after fixes, but it is not required to finish the review.
+
+#### Step 5: Final next steps
+
+**Interactive mode only:** after the fix-review cycle completes (clean verdict or the user chose to stop), offer next steps based on the entry mode. Reuse the resolved review base/default branch from Stage 1 when known; do not hard-code only `main`/`master`.
+
+- **PR mode (entered via PR number/URL):**
+  - **Push fixes** -- push commits to the existing PR branch
+  - **Exit** -- done for now
+- **Branch mode (feature branch with no PR, and not the resolved review base/default branch):**
+  - **Create a PR (Recommended)** -- push and open a pull request
+  - **Continue without PR** -- stay on the branch
+  - **Exit** -- done for now
+- **On the resolved review base/default branch:**
+  - **Continue** -- proceed with next steps
+  - **Exit** -- done for now
+
+If "Create a PR": first publish the branch with `git push --set-upstream origin HEAD`, then use `gh pr create` with a title and summary derived from the branch changes.
+If "Push fixes": push the branch with `git push` to update the existing PR.
+
+**Autonomous and report-only modes:** stop after the report, artifact emission, and residual-work handoff. Do not commit, push, or create a PR.
+
+## Fallback
+
+If the platform doesn't support parallel sub-agents, run reviewers sequentially. Everything else (stages, output format, merge pipeline) stays the same.

--- a/plugins/compound-engineering/skills/ce-review-beta/references/diff-scope.md
+++ b/plugins/compound-engineering/skills/ce-review-beta/references/diff-scope.md
@@ -1,0 +1,31 @@
+# Diff Scope Rules
+
+These rules apply to every reviewer. They define what is "your code to review" versus pre-existing context.
+
+## Scope Discovery
+
+Determine the diff to review using this priority order:
+
+1. **User-specified scope.** If the caller passed `BASE:`, `FILES:`, or `DIFF:` markers, use that scope exactly.
+2. **Working copy changes.** If there are unstaged or staged changes (`git diff HEAD` is non-empty), review those.
+3. **Unpushed commits vs base branch.** If the working copy is clean, review `git diff $(git merge-base HEAD <base>)..HEAD` where `<base>` is the default branch (main or master).
+
+The scope step in the SKILL.md handles discovery and passes you the resolved diff. You do not need to run git commands yourself.
+
+## Finding Classification Tiers
+
+Every finding you report falls into one of three tiers based on its relationship to the diff:
+
+### Primary (directly changed code)
+
+Lines added or modified in the diff. This is your main focus. Report findings against these lines at full confidence.
+
+### Secondary (immediately surrounding code)
+
+Unchanged code within the same function, method, or block as a changed line. If a change introduces a bug that's only visible by reading the surrounding context, report it -- but note that the issue exists in the interaction between new and existing code.
+
+### Pre-existing (unrelated to this diff)
+
+Issues in unchanged code that the diff didn't touch and doesn't interact with. Mark these as `"pre_existing": true` in your output. They're reported separately and don't count toward the review verdict.
+
+**The rule:** If you'd flag the same issue on an identical diff that didn't include the surrounding file, it's pre-existing. If the diff makes the issue *newly relevant* (e.g., a new caller hits an existing buggy function), it's secondary.

--- a/plugins/compound-engineering/skills/ce-review-beta/references/findings-schema.json
+++ b/plugins/compound-engineering/skills/ce-review-beta/references/findings-schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Code Review Findings",
+  "description": "Structured output schema for code review sub-agents",
+  "type": "object",
+  "required": ["reviewer", "findings", "residual_risks", "testing_gaps"],
+  "properties": {
+    "reviewer": {
+      "type": "string",
+      "description": "Persona name that produced this output (e.g., 'correctness', 'security')"
+    },
+    "findings": {
+      "type": "array",
+      "description": "List of code review findings. Empty array if no issues found.",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "severity",
+          "file",
+          "line",
+          "why_it_matters",
+          "autofix_class",
+          "owner",
+          "requires_verification",
+          "confidence",
+          "evidence",
+          "pre_existing"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Short, specific issue title. 10 words or fewer.",
+            "maxLength": 100
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["P0", "P1", "P2", "P3"],
+            "description": "Issue severity level"
+          },
+          "file": {
+            "type": "string",
+            "description": "Relative file path from repository root"
+          },
+          "line": {
+            "type": "integer",
+            "description": "Primary line number of the issue",
+            "minimum": 1
+          },
+          "why_it_matters": {
+            "type": "string",
+            "description": "Impact and failure mode -- not 'what is wrong' but 'what breaks'"
+          },
+          "autofix_class": {
+            "type": "string",
+            "enum": ["safe_auto", "gated_auto", "manual", "advisory"],
+            "description": "Reviewer's conservative recommendation for how this issue should be handled after synthesis"
+          },
+          "owner": {
+            "type": "string",
+            "enum": ["review-fixer", "downstream-resolver", "human", "release"],
+            "description": "Who should own the next action for this finding after synthesis"
+          },
+          "requires_verification": {
+            "type": "boolean",
+            "description": "Whether any fix for this finding must be re-verified with targeted tests or a follow-up review pass"
+          },
+          "suggested_fix": {
+            "type": ["string", "null"],
+            "description": "Concrete minimal fix. Omit or null if no good fix is obvious -- a bad suggestion is worse than none."
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Reviewer confidence in this finding, calibrated per persona",
+            "minimum": 0.0,
+            "maximum": 1.0
+          },
+          "evidence": {
+            "type": "array",
+            "description": "Code-grounded evidence: snippets, line references, or pattern descriptions. At least 1 item.",
+            "items": { "type": "string" },
+            "minItems": 1
+          },
+          "pre_existing": {
+            "type": "boolean",
+            "description": "True if this issue exists in unchanged code unrelated to the current diff"
+          }
+        }
+      }
+    },
+    "residual_risks": {
+      "type": "array",
+      "description": "Risks the reviewer noticed but could not confirm as findings",
+      "items": { "type": "string" }
+    },
+    "testing_gaps": {
+      "type": "array",
+      "description": "Missing test coverage the reviewer identified",
+      "items": { "type": "string" }
+    }
+    },
+
+  "_meta": {
+    "confidence_thresholds": {
+      "suppress": "Below 0.60 -- do not report. Finding is speculative noise.",
+      "flag": "0.60-0.69 -- include only when the persona's calibration says the issue is actionable at that confidence.",
+      "report": "0.70+ -- report with full confidence."
+    },
+    "severity_definitions": {
+      "P0": "Critical breakage, exploitable vulnerability, data loss/corruption. Must fix before merge.",
+      "P1": "High-impact defect likely hit in normal usage, breaking contract. Should fix.",
+      "P2": "Moderate issue with meaningful downside (edge case, perf regression, maintainability trap). Fix if straightforward.",
+      "P3": "Low-impact, narrow scope, minor improvement. User's discretion."
+    },
+    "autofix_classes": {
+      "safe_auto": "Local, deterministic code or test fix suitable for the in-skill fixer in autonomous mode.",
+      "gated_auto": "Concrete fix exists, but it changes behavior, permissions, contracts, or other sensitive areas that deserve explicit approval.",
+      "manual": "Actionable issue that should become residual work rather than an in-skill autofix.",
+      "advisory": "Informational or operational item that should be surfaced in the report only."
+    },
+    "owners": {
+      "review-fixer": "The in-skill fixer can own this when policy allows.",
+      "downstream-resolver": "Turn this into residual work for later resolution.",
+      "human": "A person must make a judgment call before code changes should continue.",
+      "release": "Operational or rollout follow-up; do not convert into code-fix work automatically."
+    }
+  }
+}

--- a/plugins/compound-engineering/skills/ce-review-beta/references/persona-catalog.md
+++ b/plugins/compound-engineering/skills/ce-review-beta/references/persona-catalog.md
@@ -1,0 +1,50 @@
+# Persona Catalog
+
+8 reviewer personas organized in two tiers, plus CE-specific agents. The orchestrator uses this catalog to select which reviewers to spawn for each review.
+
+## Always-on (3 personas + 2 CE agents)
+
+Spawned on every review regardless of diff content.
+
+**Persona agents (structured JSON output):**
+
+| Persona | Agent | Focus |
+|---------|-------|-------|
+| `correctness` | `compound-engineering:review:correctness-reviewer` | Logic errors, edge cases, state bugs, error propagation, intent compliance |
+| `testing` | `compound-engineering:review:testing-reviewer` | Coverage gaps, weak assertions, brittle tests, missing edge case tests |
+| `maintainability` | `compound-engineering:review:maintainability-reviewer` | Coupling, complexity, naming, dead code, premature abstraction |
+
+**CE agents (unstructured output, synthesized separately):**
+
+| Agent | Focus |
+|-------|-------|
+| `compound-engineering:review:agent-native-reviewer` | Verify new features are agent-accessible |
+| `compound-engineering:research:learnings-researcher` | Search docs/solutions/ for past issues related to this PR's modules and patterns |
+
+## Conditional (5 personas)
+
+Spawned when the orchestrator identifies relevant patterns in the diff. The orchestrator reads the full diff and reasons about selection -- this is agent judgment, not keyword matching.
+
+| Persona | Agent | Select when diff touches... |
+|---------|-------|---------------------------|
+| `security` | `compound-engineering:review:security-reviewer` | Auth middleware, public endpoints, user input handling, permission checks, secrets management |
+| `performance` | `compound-engineering:review:performance-reviewer` | Database queries, ORM calls, loop-heavy data transforms, caching layers, async/concurrent code |
+| `api-contract` | `compound-engineering:review:api-contract-reviewer` | Route definitions, serializer/interface changes, event schemas, exported type signatures, API versioning |
+| `data-migrations` | `compound-engineering:review:data-migrations-reviewer` | Migration files, schema changes, backfill scripts, data transformations |
+| `reliability` | `compound-engineering:review:reliability-reviewer` | Error handling, retry logic, circuit breakers, timeouts, background jobs, async handlers, health checks |
+
+## CE Conditional Agents (migration-specific)
+
+These CE-native agents provide specialized analysis beyond what the persona agents cover. Spawn them when the diff includes database migrations, schema.rb, or data backfills.
+
+| Agent | Focus |
+|-------|-------|
+| `compound-engineering:review:schema-drift-detector` | Cross-references schema.rb changes against included migrations to catch unrelated drift |
+| `compound-engineering:review:deployment-verification-agent` | Produces Go/No-Go deployment checklist with SQL verification queries and rollback procedures |
+
+## Selection rules
+
+1. **Always spawn all 3 always-on personas** plus the 2 CE always-on agents.
+2. **For each conditional persona**, the orchestrator reads the diff and decides whether the persona's domain is relevant. This is a judgment call, not a keyword match.
+3. **For CE conditional agents**, spawn when the diff includes migration files (`db/migrate/*.rb`, `db/schema.rb`) or data backfill scripts.
+4. **Announce the team** before spawning with a one-line justification per conditional reviewer selected.

--- a/plugins/compound-engineering/skills/ce-review-beta/references/review-output-template.md
+++ b/plugins/compound-engineering/skills/ce-review-beta/references/review-output-template.md
@@ -1,0 +1,115 @@
+# Code Review Output Template
+
+Use this **exact format** when presenting synthesized review findings. Findings are grouped by severity, not by reviewer.
+
+**IMPORTANT:** Use pipe-delimited markdown tables (`| col | col |`). Do NOT use ASCII box-drawing characters.
+
+## Example
+
+```markdown
+## Code Review Results
+
+**Scope:** merge-base with the review base branch -> working tree (14 files, 342 lines)
+**Intent:** Add order export endpoint with CSV and JSON format support
+**Mode:** autonomous
+
+**Reviewers:** correctness, testing, maintainability, security, api-contract
+- security -- new public endpoint accepts user-provided format parameter
+- api-contract -- new /api/orders/export route with response schema
+
+### P0 -- Critical
+
+| # | File | Issue | Reviewer | Confidence | Route |
+|---|------|-------|----------|------------|-------|
+| 1 | `orders_controller.rb:42` | User-supplied ID in account lookup without ownership check | security | 0.92 | `gated_auto -> downstream-resolver` |
+
+### P1 -- High
+
+| # | File | Issue | Reviewer | Confidence | Route |
+|---|------|-------|----------|------------|-------|
+| 2 | `export_service.rb:87` | Loads all orders into memory -- unbounded for large accounts | performance | 0.85 | `safe_auto -> review-fixer` |
+| 3 | `export_service.rb:91` | No pagination -- response size grows linearly with order count | api-contract, performance | 0.80 | `manual -> downstream-resolver` |
+
+### P2 -- Moderate
+
+| # | File | Issue | Reviewer | Confidence | Route |
+|---|------|-------|----------|------------|-------|
+| 4 | `export_service.rb:45` | Missing error handling for CSV serialization failure | correctness | 0.75 | `safe_auto -> review-fixer` |
+
+### P3 -- Low
+
+| # | File | Issue | Reviewer | Confidence | Route |
+|---|------|-------|----------|------------|-------|
+| 5 | `export_helper.rb:12` | Format detection could use early return instead of nested conditional | maintainability | 0.70 | `advisory -> human` |
+
+### Applied Fixes
+
+- `safe_auto`: Added bounded export pagination guard and CSV serialization failure test coverage in this run
+
+### Residual Actionable Work
+
+| # | File | Issue | Route | Next Step |
+|---|------|-------|-------|-----------|
+| 1 | `orders_controller.rb:42` | Ownership check missing on export lookup | `gated_auto -> downstream-resolver` | Create residual todo and require explicit approval before behavior change |
+| 2 | `export_service.rb:91` | Pagination contract needs a broader API decision | `manual -> downstream-resolver` | Create residual todo with contract and client impact details |
+
+### Pre-existing Issues
+
+| # | File | Issue | Reviewer |
+|---|------|-------|----------|
+| 1 | `orders_controller.rb:12` | Broad rescue masking failed permission check | correctness |
+
+### Learnings & Past Solutions
+
+- [Known Pattern] `docs/solutions/export-pagination.md` -- previous export pagination fix applies to this endpoint
+
+### Agent-Native Gaps
+
+- New export endpoint has no CLI/agent equivalent -- agent users cannot trigger exports
+
+### Schema Drift Check
+
+- Clean: schema.rb changes match the migrations in scope
+
+### Deployment Notes
+
+- Pre-deploy: capture baseline row counts before enabling the export backfill
+- Verify: `SELECT COUNT(*) FROM exports WHERE status IS NULL;` should stay at `0`
+- Rollback: keep the old export path available until the backfill has been validated
+
+### Coverage
+
+- Suppressed: 2 findings below 0.60 confidence
+- Residual risks: No rate limiting on export endpoint
+- Testing gaps: No test for concurrent export requests
+
+---
+
+> **Verdict:** Ready with fixes
+>
+> **Reasoning:** 1 critical auth bypass must be fixed. The memory/pagination issues (P1) should be addressed for production safety.
+>
+> **Fix order:** P0 auth bypass -> P1 memory/pagination -> P2 error handling if straightforward
+```
+
+## Formatting Rules
+
+- **Pipe-delimited markdown tables** -- never ASCII box-drawing characters
+- **Severity-grouped sections** -- `### P0 -- Critical`, `### P1 -- High`, `### P2 -- Moderate`, `### P3 -- Low`. Omit empty severity levels.
+- **Always include file:line location** for code review issues
+- **Reviewer column** shows which persona(s) flagged the issue. Multiple reviewers = cross-reviewer agreement.
+- **Confidence column** shows the finding's confidence score
+- **Route column** shows the synthesized handling decision as ``<autofix_class> -> <owner>``.
+- **Header includes** scope, intent, and reviewer team with per-conditional justifications
+- **Mode line** -- include `interactive`, `autonomous`, or `report-only`
+- **Applied Fixes section** -- include only when a fix phase ran in this review invocation
+- **Residual Actionable Work section** -- include only when unresolved actionable findings were handed off for later work
+- **Pre-existing section** -- separate table, no confidence column (these are informational)
+- **Learnings & Past Solutions section** -- results from learnings-researcher, with links to docs/solutions/ files
+- **Agent-Native Gaps section** -- results from agent-native-reviewer. Omit if no gaps found.
+- **Schema Drift Check section** -- results from schema-drift-detector. Omit if the agent did not run.
+- **Deployment Notes section** -- key checklist items from deployment-verification-agent. Omit if the agent did not run.
+- **Coverage section** -- suppressed count, residual risks, testing gaps, failed reviewers
+- **Summary uses blockquotes** for verdict, reasoning, and fix order
+- **Horizontal rule** (`---`) separates findings from verdict
+- **`###` headers** for each section -- never plain text headers

--- a/plugins/compound-engineering/skills/ce-review-beta/references/subagent-template.md
+++ b/plugins/compound-engineering/skills/ce-review-beta/references/subagent-template.md
@@ -1,0 +1,56 @@
+# Sub-agent Prompt Template
+
+This template is used by the orchestrator to spawn each reviewer sub-agent. Variable substitution slots are filled at spawn time.
+
+---
+
+## Template
+
+```
+You are a specialist code reviewer.
+
+<persona>
+{persona_file}
+</persona>
+
+<scope-rules>
+{diff_scope_rules}
+</scope-rules>
+
+<output-contract>
+Return ONLY valid JSON matching the findings schema below. No prose, no markdown, no explanation outside the JSON object.
+
+{schema}
+
+Rules:
+- Suppress any finding below your stated confidence floor (see your Confidence calibration section).
+- Every finding MUST include at least one evidence item grounded in the actual code.
+- Set pre_existing to true ONLY for issues in unchanged code that are unrelated to this diff. If the diff makes the issue newly relevant, it is NOT pre-existing.
+- You are operationally read-only. You may use non-mutating inspection commands, including read-oriented `git` / `gh` commands, to gather evidence. Do not edit files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.
+- Set `autofix_class` conservatively. Use `safe_auto` only when the fix is local, deterministic, and low-risk. Use `gated_auto` when a concrete fix exists but changes behavior/contracts/permissions. Use `manual` for actionable residual work. Use `advisory` for report-only items that should not become code-fix work.
+- Set `owner` to the default next actor for this finding: `review-fixer`, `downstream-resolver`, `human`, or `release`.
+- Set `requires_verification` to true whenever the likely fix needs targeted tests, a focused re-review, or operational validation before it should be trusted.
+- suggested_fix is optional. Only include it when the fix is obvious and correct. A bad suggestion is worse than none.
+- If you find no issues, return an empty findings array. Still populate residual_risks and testing_gaps if applicable.
+</output-contract>
+
+<review-context>
+Intent: {intent_summary}
+
+Changed files: {file_list}
+
+Diff:
+{diff}
+</review-context>
+```
+
+## Variable Reference
+
+| Variable | Source | Description |
+|----------|--------|-------------|
+| `{persona_file}` | Agent markdown file content | The full persona definition (identity, failure modes, calibration, suppress conditions) |
+| `{diff_scope_rules}` | `references/diff-scope.md` content | Primary/secondary/pre-existing tier rules |
+| `{schema}` | `references/findings-schema.json` content | The JSON schema reviewers must conform to |
+| `{intent_summary}` | Stage 2 output | 2-3 line description of what the change is trying to accomplish |
+| `{file_list}` | Stage 1 output | List of changed files from the scope step |
+| `{diff}` | Stage 1 output | The actual diff content to review |

--- a/plugins/compound-engineering/skills/file-todos/SKILL.md
+++ b/plugins/compound-engineering/skills/file-todos/SKILL.md
@@ -186,6 +186,7 @@ Work logs serve as:
 | Trigger | Flow | Tool |
 |---------|------|------|
 | Code review | `/ce:review` → Findings → `/triage` → Todos | Review agent + skill |
+| Beta autonomous review | `/ce:review-beta mode:autonomous` → Downstream-resolver residual todos → `/resolve-todo-parallel` | Review skill + todos |
 | PR comments | `/resolve_pr_parallel` → Individual fixes → Todos | gh CLI + skill |
 | Code TODOs | `/resolve-todo-parallel` → Fixes + Complex todos | Agent + skill |
 | Planning | Brainstorm → Create todo → Work → Complete | Skill |

--- a/plugins/compound-engineering/skills/resolve-todo-parallel/SKILL.md
+++ b/plugins/compound-engineering/skills/resolve-todo-parallel/SKILL.md
@@ -12,6 +12,8 @@ Resolve all TODO comments using parallel processing, document lessons learned, t
 
 Get all unresolved TODOs from the /todos/*.md directory
 
+Residual actionable work may come from `ce:review-beta mode:autonomous` after its in-skill `safe_auto` pass. Treat those todos as normal unresolved work items; the review skill has already decided they should not be auto-fixed inline.
+
 If any todo recommends deleting, removing, or gitignoring files in `docs/brainstorms/`, `docs/plans/`, or `docs/solutions/`, skip it and mark it as `wont_fix`. These are compound-engineering pipeline artifacts that are intentional and permanent.
 
 ### 2. Plan

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -1,0 +1,93 @@
+import { readFile } from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return readFile(path.join(process.cwd(), relativePath), "utf8")
+}
+
+describe("ce-review-beta contract", () => {
+  test("documents explicit modes and orchestration boundaries", async () => {
+    const content = await readRepoFile("plugins/compound-engineering/skills/ce-review-beta/SKILL.md")
+
+    expect(content).toContain("## Mode Detection")
+    expect(content).toContain("mode:autonomous")
+    expect(content).toContain("mode:report-only")
+    expect(content).toContain(".context/compound-engineering/ce-review-beta/<run-id>/")
+    expect(content).toContain("Do not create residual todos or `.context` artifacts.")
+    expect(content).toContain(
+      "Do not start a mutating review round concurrently with browser testing on the same checkout.",
+    )
+    expect(content).toContain("mode:report-only cannot switch the shared checkout to review a PR target")
+    expect(content).toContain("mode:report-only cannot switch the shared checkout to review another branch")
+    expect(content).toContain("Resolve the base ref from the PR's actual base repository, not by assuming `origin`")
+    expect(content).not.toContain("Which severities should I fix?")
+  })
+
+  test("documents policy-driven routing and residual handoff", async () => {
+    const content = await readRepoFile("plugins/compound-engineering/skills/ce-review-beta/SKILL.md")
+
+    expect(content).toContain("## Action Routing")
+    expect(content).toContain("Only `safe_auto -> review-fixer` enters the in-skill fixer queue automatically.")
+    expect(content).toContain(
+      "Only include `gated_auto` findings in the fixer queue after the user explicitly approves the specific items.",
+    )
+    expect(content).toContain(
+      'If the fixer queue is empty, do not offer "Apply safe_auto fixes" options.',
+    )
+    expect(content).toContain(
+      "In autonomous mode, create durable `todos/` items only for unresolved actionable findings whose final owner is `downstream-resolver`.",
+    )
+    expect(content).toContain("If only advisory outputs remain, create no todos.")
+    expect(content).toContain("**On the resolved review base/default branch:**")
+    expect(content).toContain("git push --set-upstream origin HEAD")
+    expect(content).not.toContain("**On main/master:**")
+  })
+
+  test("keeps findings schema and downstream docs aligned", async () => {
+    const rawSchema = await readRepoFile(
+      "plugins/compound-engineering/skills/ce-review-beta/references/findings-schema.json",
+    )
+    const schema = JSON.parse(rawSchema) as {
+      _meta: { confidence_thresholds: { suppress: string } }
+      properties: {
+        findings: {
+          items: {
+            properties: {
+              autofix_class: { enum: string[] }
+              owner: { enum: string[] }
+              requires_verification: { type: string }
+            }
+            required: string[]
+          }
+        }
+      }
+    }
+
+    expect(schema.properties.findings.items.required).toEqual(
+      expect.arrayContaining(["autofix_class", "owner", "requires_verification"]),
+    )
+    expect(schema.properties.findings.items.properties.autofix_class.enum).toEqual([
+      "safe_auto",
+      "gated_auto",
+      "manual",
+      "advisory",
+    ])
+    expect(schema.properties.findings.items.properties.owner.enum).toEqual([
+      "review-fixer",
+      "downstream-resolver",
+      "human",
+      "release",
+    ])
+    expect(schema.properties.findings.items.properties.requires_verification.type).toBe("boolean")
+    expect(schema._meta.confidence_thresholds.suppress).toContain("0.60")
+
+    const fileTodos = await readRepoFile("plugins/compound-engineering/skills/file-todos/SKILL.md")
+    expect(fileTodos).toContain("/ce:review-beta mode:autonomous")
+    expect(fileTodos).toContain("/resolve-todo-parallel")
+
+    const resolveTodos = await readRepoFile("plugins/compound-engineering/skills/resolve-todo-parallel/SKILL.md")
+    expect(resolveTodos).toContain("ce:review-beta mode:autonomous")
+    expect(resolveTodos).toContain("safe_auto")
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `ce:review-beta`, a new beta review skill that replaces ce:review's free-form agent dispatch with a structured 6-stage pipeline adapted from the [iterative-engineering plugin's code-review skill](https://github.com/tmchow/tmc-marketplace)
- Adds 8 new persona agents with confidence calibration, false-positive suppression, and structured JSON output
- Integrates CE-specific agents (agent-native-reviewer, learnings-researcher, schema-drift-detector, deployment-verification-agent) into the pipeline

## Why this is different from ce:review

The existing `ce:review` dispatches autonomous agents (security-sentinel, performance-oracle, etc.) that return **unstructured prose reports**. The orchestrator collects these reports and synthesizes them for the user.

In practice, this produces reviews where real bugs get buried in noise. An agent told to "be paranoid and leave no stone unturned" will generate 15 findings, but only 3 are real problems -- the rest are vague suggestions like "consider adding rate limiting" or defensive coding advice for values that can't actually be null. With 5+ agents running, the same unbounded query gets flagged by both the security and performance agents with different framing, so the report looks twice as long as it should. And every finding looks equally important because there's no way to distinguish "this will crash in production" from "this might theoretically be an issue at extreme scale." The user ends up manually triaging the review output itself, which defeats the purpose of automated review.

`ce:review-beta` fixes this with pipeline-level quality control:

| | ce:review | ce:review-beta |
|-|-----------|----------------|
| **Agent output** | Free-form prose (Executive Summary, Risk Matrix, etc.) | Structured JSON matching a schema (severity, confidence, evidence, file:line) |
| **False positive control** | None -- agents told to "be paranoid, leave no stone unturned" | Each persona has explicit "what you don't flag" anti-patterns and per-domain confidence thresholds |
| **Confidence scoring** | None -- every finding looks equally important | 0.0-1.0 per finding, calibrated per domain (security at 0.60 = actionable; performance at 0.60 = noise). Findings below threshold are suppressed before the user sees them |
| **Multi-agent dedup** | None -- overlapping findings from different agents appear as duplicates | Fingerprint-based merge: same file + line range + issue = single finding with highest severity, unioned evidence |
| **Agent selection** | User-configured roster via settings file | Tiered: 3 always-on + 5 conditional selected by diff content |
| **Intent awareness** | None -- agents review code in a vacuum | Intent discovery step before spawning; shapes how hard each reviewer looks |
| **Quality gates** | None | Verify actionability, ban vague language ("consider improving..."), check line accuracy, calibrate severity |

## The persona agents

8 new agents in `agents/review/`, each with:
- **Confidence calibration** with per-domain thresholds (security has a lower bar because the cost of missing a vuln is high; performance has a higher bar because perf issues are easy to measure later)
- **"What you don't flag"** sections that prevent common LLM false positives (e.g., security reviewer won't suggest "consider adding rate limiting" without a specific exploitable finding)
- **`tools: Read, Grep, Glob, Bash`** frontmatter for read-only enforcement
- **Structured JSON output** matching `findings-schema.json`

| Persona | Tier | Focus |
|---------|------|-------|
| correctness-reviewer | Always-on | Logic errors, edge cases, state bugs, error propagation |
| testing-reviewer | Always-on | Coverage gaps, weak assertions, brittle tests |
| maintainability-reviewer | Always-on | Coupling, complexity, naming, dead code |
| security-reviewer | Conditional | Exploitable vulnerabilities (attacker mindset, not compliance checklist) |
| performance-reviewer | Conditional | Runtime perf and scalability (N+1, unbounded memory, blocking I/O) |
| api-contract-reviewer | Conditional | Breaking changes to public interfaces |
| data-migrations-reviewer | Conditional | Migration safety, swapped IDs, dual-write, orphaned references |
| reliability-reviewer | Conditional | Failure modes, missing timeouts, error swallowing, retry storms |

The `data-migrations-reviewer` was enhanced beyond the iterative-engineering source with items from CE's existing `data-migration-expert` (swapped ID/enum mapping detection, dual-write validation, orphaned reference search).

## CE-specific adaptations

On top of the iterative-engineering base:
- `agent-native-reviewer` and `learnings-researcher` as always-on CE agents
- `schema-drift-detector` and `deployment-verification-agent` as conditional (migration PRs)
- Protected artifacts: findings against `docs/brainstorms/`, `docs/plans/`, `docs/solutions/` are discarded
- Quality gates from structured review best practices

## Test plan

- [ ] Run `/ce:review-beta` on a PR with code changes -- verify structured output with confidence scores
- [ ] Run `/ce:review-beta` on a PR with migration files -- verify conditional agents (data-migrations, schema-drift-detector) are selected
- [ ] Run `/ce:review-beta` with no argument on a feature branch -- verify standalone mode works
- [ ] Run `/ce:review-beta <branch-name>` for a branch without a PR -- verify branch mode doesn't fail
- [ ] Verify `bun run release:validate` passes