### PR TITLE
feat(ce-work-beta): add user-selectable sandbox options to Codex delegation

### DIFF
--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -470,7 +470,7 @@ When external delegation is active, follow this workflow for each tagged task. D
 
 6. **Review diff** — After the delegate finishes, verify the diff is non-empty and in-scope. Run the project's test/lint commands. If the diff is empty or out-of-scope, fall back to standard mode for that task.
 
-7. **Commit** — The current agent handles all git operations. The delegate's sandbox blocks `.git/index.lock` writes, so the delegate cannot commit. Stage changes and commit with a conventional message.
+7. **Commit** — The current agent handles all git operations. In default and workspace-write modes the delegate's sandbox blocks `.git/index.lock` writes, so the delegate cannot commit. In `--yolo` mode the sandbox is disabled and the delegate *could* commit, but the prompt in step 3 already instructs it not to. Stage changes and commit with a conventional message.
 
 8. **Error handling** — On any delegate failure (rate limit, error, empty diff), fall back to standard mode for that task. Track consecutive failures - after 3 consecutive failures, disable delegation for remaining tasks and print "Delegate disabled after 3 consecutive failures - completing remaining tasks in standard mode."
 

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -457,12 +457,12 @@ When external delegation is active, follow this workflow for each tagged task. D
    | Option | Flags | What it allows | Risks |
    |--------|-------|---------------|-------|
    | **Default (no flags)** | *(none)* | Codex defaults: read-only sandbox, approval prompts enabled. | Will almost certainly fail in `exec` mode -- there is no interactive user to approve operations, so Codex gives up on the first command that needs approval (e.g., `npm install`). Only works if the user has permissive settings in `~/.codex/config.toml`. |
-   | **Workspace write** (`--full-auto`) | `-s workspace-write -a on-request` | Grants disk writes inside the workspace directory and network access. Approval is set to `on-request`. | May still fail if the task needs system-level access outside the workspace directory. Moderate risk. |
+   | **Workspace write** (`--full-auto`) | `-s workspace-write -a on-request` | Grants disk writes inside the workspace directory. Approval is set to `on-request`. Network access depends on the user's Codex config and may still be disabled. | May still fail if the task needs network access or system-level access outside the workspace directory. Moderate risk. |
    | **Full access** (`--yolo`) | `--dangerously-bypass-approvals-and-sandbox` | Disables ALL sandbox restrictions and ALL approval prompts. The delegate can read/write anywhere on disk, make network requests, and execute arbitrary commands without confirmation. | **High risk.** The delegate can delete files outside the workspace, leak secrets via network requests, install packages globally, and run destructive commands -- all without asking. Only use in disposable environments or when the prompt is fully trusted. This is the only option likely to produce a complete solution in `exec` mode for non-trivial tasks. |
 
    Store the user's choice for the session. Apply the corresponding flags in step 5 below.
 
-3. **Build prompt** — For each task, assemble a prompt from the plan's implementation unit (Goal, Files, Approach, Conventions from `compound-engineering.local.md`). Include rules: no git commits, no PRs, run `git status` and `git diff --stat` when done. Never embed credentials or tokens in the prompt - pass auth through environment variables.
+3. **Build prompt** — For each task, assemble a prompt from the plan's implementation unit (Goal, Files, Approach, Conventions from `AGENTS.md`; use `CLAUDE.md` only if the repo keeps it as a compatibility shim; append any workflow-specific notes from `compound-engineering.local.md`). Include rules: no git commits, no PRs, run `git status` and `git diff --stat` when done. Never embed credentials or tokens in the prompt - pass auth through environment variables.
 
 4. **Write prompt to file** — Save the assembled prompt to a unique temporary file to avoid shell quoting issues and cross-task races. Use a unique filename per task.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -452,17 +452,27 @@ When external delegation is active, follow this workflow for each tagged task. D
 
    Verify the delegate CLI is installed. If not found, print "Delegate CLI not installed - continuing with standard mode." and proceed normally.
 
-2. **Build prompt** — For each task, assemble a prompt from the plan's implementation unit (Goal, Files, Approach, Conventions from project CLAUDE.md/AGENTS.md). Include rules: no git commits, no PRs, run `git status` and `git diff --stat` when done. Never embed credentials or tokens in the prompt - pass auth through environment variables.
+2. **Select security posture** — Ask the user once per delegation session (not per task) to choose a Codex sandbox and approval policy. Use the platform's blocking question tool (e.g., `AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini). If no structured question tool is available, present the options as a numbered list and wait for a reply before proceeding.
 
-3. **Write prompt to file** — Save the assembled prompt to a unique temporary file to avoid shell quoting issues and cross-task races. Use a unique filename per task.
+   | Option | Flags | What it allows | Risks |
+   |--------|-------|---------------|-------|
+   | **Default (no flags)** | *(none)* | Codex defaults: read-only sandbox, approval prompts enabled. | Will almost certainly fail in `exec` mode -- there is no interactive user to approve operations, so Codex gives up on the first command that needs approval (e.g., `npm install`). Only works if the user has permissive settings in `~/.codex/config.toml`. |
+   | **Workspace write** (`--full-auto`) | `-s workspace-write -a on-request` | Grants disk writes inside the workspace directory and network access. Approval is set to `on-request`. | May still fail if the task needs system-level access outside the workspace directory. Moderate risk. |
+   | **Full access** (`--yolo`) | `--dangerously-bypass-approvals-and-sandbox` | Disables ALL sandbox restrictions and ALL approval prompts. The delegate can read/write anywhere on disk, make network requests, and execute arbitrary commands without confirmation. | **High risk.** The delegate can delete files outside the workspace, leak secrets via network requests, install packages globally, and run destructive commands -- all without asking. Only use in disposable environments or when the prompt is fully trusted. This is the only option likely to produce a complete solution in `exec` mode for non-trivial tasks. |
 
-4. **Delegate** — Run the delegate CLI, piping the prompt file via stdin (not argv expansion, which hits `ARG_MAX` on large prompts). Omit the model flag to use the delegate's default model, which stays current without manual updates.
+   Store the user's choice for the session. Apply the corresponding flags in step 5 below.
 
-5. **Review diff** — After the delegate finishes, verify the diff is non-empty and in-scope. Run the project's test/lint commands. If the diff is empty or out-of-scope, fall back to standard mode for that task.
+3. **Build prompt** — For each task, assemble a prompt from the plan's implementation unit (Goal, Files, Approach, Conventions from `compound-engineering.local.md`). Include rules: no git commits, no PRs, run `git status` and `git diff --stat` when done. Never embed credentials or tokens in the prompt - pass auth through environment variables.
 
-6. **Commit** — The current agent handles all git operations. The delegate's sandbox blocks `.git/index.lock` writes, so the delegate cannot commit. Stage changes and commit with a conventional message.
+4. **Write prompt to file** — Save the assembled prompt to a unique temporary file to avoid shell quoting issues and cross-task races. Use a unique filename per task.
 
-7. **Error handling** — On any delegate failure (rate limit, error, empty diff), fall back to standard mode for that task. Track consecutive failures - after 3 consecutive failures, disable delegation for remaining tasks and print "Delegate disabled after 3 consecutive failures - completing remaining tasks in standard mode."
+5. **Delegate** — Run the delegate CLI with the flags from step 2, piping the prompt file via stdin (not argv expansion, which hits `ARG_MAX` on large prompts). Omit the model flag to use the delegate's default model, which stays current without manual updates.
+
+6. **Review diff** — After the delegate finishes, verify the diff is non-empty and in-scope. Run the project's test/lint commands. If the diff is empty or out-of-scope, fall back to standard mode for that task.
+
+7. **Commit** — The current agent handles all git operations. The delegate's sandbox blocks `.git/index.lock` writes, so the delegate cannot commit. Stage changes and commit with a conventional message.
+
+8. **Error handling** — On any delegate failure (rate limit, error, empty diff), fall back to standard mode for that task. Track consecutive failures - after 3 consecutive failures, disable delegation for remaining tasks and print "Delegate disabled after 3 consecutive failures - completing remaining tasks in standard mode."
 
 ### Mixed-Model Attribution
 


### PR DESCRIPTION
## Summary

Add a security posture selection step to the Codex External Delegation Workflow so users can choose between default, workspace-write, and full-access (`--yolo`) modes before delegation runs.

## Why this matters

Taking over PR #363 after discussing with @mvanhorn .

`codex exec` with default settings fails on the first operation needing approval (e.g., `npm install`) because exec mode is non-interactive. That PR proposed hardcoding `-s workspace-write -a never`, but `workspace-write` still restricts system-level (and network) access outside the workspace directory. For non-trivial one-shot delegations, `--yolo` (`--dangerously-bypass-approvals-and-sandbox`) is the only flag set likely to produce a complete solution -- but it carries real risks (arbitrary file deletion, secret leakage, unapproved command execution).

Rather than hardcoding one posture, this PR lets the user choose with full visibility into the tradeoffs.

## Changes

Added step 2 ("Select security posture") to the External Delegation Workflow in `plugins/compound-engineering/skills/ce-work-beta/SKILL.md`:

- **Default (no flags)** -- Codex defaults. Will almost certainly fail in exec mode.
- **Workspace write** (`--full-auto`) -- `-s workspace-write -a on-request`. Moderate risk, may still fail for tasks needing system access.
- **Full access** (`--yolo`) -- `--dangerously-bypass-approvals-and-sandbox`. Explicit risk warnings about data deletion, secret leakage, and unapproved commands. Only option likely to work for non-trivial exec-mode delegation.

The choice is asked once per session via the platform's blocking question tool (with numbered-list fallback for platforms without one). Renumbered subsequent steps (old 2-7 -> new 3-8).

Supersedes #363.

## Testing

Tested via `claude-code-ce` script that loads updated plugin into claude code CLI, then giving the problem below and checking before/after.

There is an additional oddity uncovered: it tries to redirect the prompt file into `codex` and this fails and it ends up reading help messages several times then deciding to just emit the full prompt in the command line string - other times it randomly decides to cat the plan and pipe it to `codex`, which appears to work.

### Test Prompt

```
/ce:work-beta Run `npm view dive` via Codex.
```

### Before - Does Not Prompt / Simply Fails to Exit Codex Sandbox

### After - Prompts for Mode

<img width="1481" height="849" alt="image" src="https://github.com/user-attachments/assets/6aa17e05-de78-49bb-957d-89c38bdf402b" />

### After - Yolo Selected - Runs with `dangerously-bypass-approvals-and-sandbox`

<img width="1486" height="848" alt="image" src="https://github.com/user-attachments/assets/8c4ed634-f7e2-4eab-9259-0c56bb671470" />

### After - Yolo Selected - Gets Result

<img width="1481" height="851" alt="image" src="https://github.com/user-attachments/assets/e7a8a79a-a841-466c-bb3d-fd5d3e931196" />

### After - Workspace Write Selected - Runs with `full-auto`

<img width="1482" height="847" alt="image" src="https://github.com/user-attachments/assets/d8837cf3-6cb1-4c60-93f1-dc9e8d105d1a" />

### After - Workspace Write Selected - Fails on Network

<img width="1485" height="846" alt="image" src="https://github.com/user-attachments/assets/2e85999e-4f17-4c14-b1d9-1c569fc20019" />
