### PR TITLE
feat: replace manual review agent config with ce:review delegation

### DIFF
--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -67,7 +67,7 @@ The primary entry points for engineering work, invoked as slash commands:
 |-------|-------------|
 | `claude-permissions-optimizer` | Optimize Claude Code permissions from session history |
 | `document-review` | Review documents using parallel persona agents for role-specific feedback |
-| `setup` | Configure which review agents run for your project |
+| `setup` | Reserved for future project-level workflow configuration; code review agent selection is automatic |
 
 ### Content & Collaboration
 

--- a/plugins/compound-engineering/skills/ce-compound/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound/SKILL.md
@@ -427,7 +427,6 @@ Based on problem type, these agents can enhance documentation:
 ### When to Invoke
 - **Auto-triggered** (optional): Agents can run post-documentation for enhancement
 - **Manual trigger**: User can invoke agents after /ce:compound completes for deeper review
-- **Customize agents**: Edit `compound-engineering.local.md` or invoke the `setup` skill to configure which review agents are used across all workflows
 
 ## Related Commands
 

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -244,11 +244,9 @@ This command takes a work document (plan, specification, or todo file) and execu
    # Use linting-agent before pushing to origin
    ```
 
-2. **Consider Reviewer Agents** (Optional)
+2. **Consider Code Review** (Optional)
 
-   Use for complex, risky, or large changes. Read agents from `compound-engineering.local.md` frontmatter (`review_agents`). If no settings file, invoke the `setup` skill to create one.
-
-   Run configured agents in parallel with Task tool. Present findings and address critical issues.
+   Use for complex, risky, or large changes. Load the `ce:review` skill with `mode:autofix` to fix safe issues and flag the rest before shipping.
 
 3. **Final Validation**
    - All tasks marked completed
@@ -470,7 +468,7 @@ When external delegation is active, follow this workflow for each tagged task. D
 
    Verify the delegate CLI is installed. If not found, print "Delegate CLI not installed - continuing with standard mode." and proceed normally.
 
-2. **Build prompt** — For each task, assemble a prompt from the plan's implementation unit (Goal, Files, Approach, Conventions from `compound-engineering.local.md`). Include rules: no git commits, no PRs, run `git status` and `git diff --stat` when done. Never embed credentials or tokens in the prompt - pass auth through environment variables.
+2. **Build prompt** — For each task, assemble a prompt from the plan's implementation unit (Goal, Files, Approach, Conventions from project CLAUDE.md/AGENTS.md). Include rules: no git commits, no PRs, run `git status` and `git diff --stat` when done. Never embed credentials or tokens in the prompt - pass auth through environment variables.
 
 3. **Write prompt to file** — Save the assembled prompt to a unique temporary file to avoid shell quoting issues and cross-task races. Use a unique filename per task.
 

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -235,11 +235,9 @@ This command takes a work document (plan, specification, or todo file) and execu
    # Use linting-agent before pushing to origin
    ```
 
-2. **Consider Reviewer Agents** (Optional)
+2. **Consider Code Review** (Optional)
 
-   Use for complex, risky, or large changes. Read agents from `compound-engineering.local.md` frontmatter (`review_agents`). If no settings file, invoke the `setup` skill to create one.
-
-   Run configured agents in parallel with Task tool. Present findings and address critical issues.
+   Use for complex, risky, or large changes. Load the `ce:review` skill with `mode:autofix` to fix safe issues and flag the rest before shipping.
 
 3. **Final Validation**
    - All tasks marked completed

--- a/plugins/compound-engineering/skills/setup/SKILL.md
+++ b/plugins/compound-engineering/skills/setup/SKILL.md
@@ -1,150 +1,21 @@
 ---
 name: setup
-description: Configure which review agents run for your project. Auto-detects stack and writes compound-engineering.local.md.
+description: Configure project-level settings for compound-engineering workflows. Currently a placeholder — review agent selection is handled automatically by ce:review.
 disable-model-invocation: true
 ---
 
 # Compound Engineering Setup
 
-## Interaction Method
+Project-level configuration for compound-engineering workflows.
 
-Ask the user each question below using the platform's blocking question tool (e.g., `AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini). If no structured question tool is available, present each question as a numbered list and wait for a reply before proceeding. For multiSelect questions, accept comma-separated numbers (e.g. `1, 3`). Never skip or auto-configure.
+## Current State
 
-Interactive setup for `compound-engineering.local.md` — configures which agents run during `ce:review` and `ce:work`.
+Review agent selection is handled automatically by the `ce:review` skill, which uses intelligent tiered selection based on diff content. No per-project configuration is needed for code reviews.
 
-## Step 1: Check Existing Config
+If this skill is invoked, inform the user:
 
-Read `compound-engineering.local.md` in the project root. If it exists, display current settings and ask:
+> Review agent configuration is no longer needed — `ce:review` automatically selects the right reviewers based on your diff. Project-specific review context (e.g., "we serve 10k req/s" or "watch for N+1 queries") belongs in your project's CLAUDE.md or AGENTS.md, where all agents already read it.
 
-```
-Settings file already exists. What would you like to do?
+## Future Use
 
-1. Reconfigure - Run the interactive setup again from scratch
-2. View current - Show the file contents, then stop
-3. Cancel - Keep current settings
-```
-
-If "View current": read and display the file, then stop.
-If "Cancel": stop.
-
-## Step 2: Detect and Ask
-
-Auto-detect the project stack:
-
-```bash
-test -f Gemfile && test -f config/routes.rb && echo "rails" || \
-test -f Gemfile && echo "ruby" || \
-test -f tsconfig.json && echo "typescript" || \
-test -f package.json && echo "javascript" || \
-test -f pyproject.toml && echo "python" || \
-test -f requirements.txt && echo "python" || \
-echo "general"
-```
-
-Ask:
-
-```
-Detected {type} project. How would you like to configure?
-
-1. Auto-configure (Recommended) - Use smart defaults for {type}. Done in one click.
-2. Customize - Choose stack, focus areas, and review depth.
-```
-
-### If Auto-configure → Skip to Step 4 with defaults:
-
-- **Rails:** `[kieran-rails-reviewer, dhh-rails-reviewer, code-simplicity-reviewer, security-sentinel, performance-oracle]`
-- **Python:** `[kieran-python-reviewer, code-simplicity-reviewer, security-sentinel, performance-oracle]`
-- **TypeScript:** `[kieran-typescript-reviewer, code-simplicity-reviewer, security-sentinel, performance-oracle]`
-- **General:** `[code-simplicity-reviewer, security-sentinel, performance-oracle, architecture-strategist]`
-
-### If Customize → Step 3
-
-## Step 3: Customize (3 questions)
-
-**a. Stack** — confirm or override:
-
-```
-Which stack should we optimize for?
-
-1. {detected_type} (Recommended) - Auto-detected from project files
-2. Rails - Ruby on Rails, adds DHH-style and Rails-specific reviewers
-3. Python - Adds Pythonic pattern reviewer
-4. TypeScript - Adds type safety reviewer
-```
-
-Only show options that differ from the detected type.
-
-**b. Focus areas** — multiSelect (user picks one or more):
-
-```
-Which review areas matter most? (comma-separated, e.g. 1, 3)
-
-1. Security - Vulnerability scanning, auth, input validation (security-sentinel)
-2. Performance - N+1 queries, memory leaks, complexity (performance-oracle)
-3. Architecture - Design patterns, SOLID, separation of concerns (architecture-strategist)
-4. Code simplicity - Over-engineering, YAGNI violations (code-simplicity-reviewer)
-```
-
-**c. Depth:**
-
-```
-How thorough should reviews be?
-
-1. Thorough (Recommended) - Stack reviewers + all selected focus agents.
-2. Fast - Stack reviewers + code simplicity only. Less context, quicker.
-3. Comprehensive - All above + git history, data integrity, agent-native checks.
-```
-
-## Step 4: Build Agent List and Write File
-
-**Stack-specific agents:**
-- Rails → `kieran-rails-reviewer, dhh-rails-reviewer`
-- Python → `kieran-python-reviewer`
-- TypeScript → `kieran-typescript-reviewer`
-- General → (none)
-
-**Focus area agents:**
-- Security → `security-sentinel`
-- Performance → `performance-oracle`
-- Architecture → `architecture-strategist`
-- Code simplicity → `code-simplicity-reviewer`
-
-**Depth:**
-- Thorough: stack + selected focus areas
-- Fast: stack + `code-simplicity-reviewer` only
-- Comprehensive: all above + `git-history-analyzer, data-integrity-guardian, agent-native-reviewer`
-
-**Plan review agents:** stack-specific reviewer + `code-simplicity-reviewer`.
-
-Write `compound-engineering.local.md`:
-
-```markdown
----
-review_agents: [{computed agent list}]
-plan_review_agents: [{computed plan agent list}]
----
-
-# Review Context
-
-Add project-specific review instructions here.
-These notes are passed to all review agents during ce:review and ce:work.
-
-Examples:
-- "We use Turbo Frames heavily — check for frame-busting issues"
-- "Our API is public — extra scrutiny on input validation"
-- "Performance-critical: we serve 10k req/s on this endpoint"
-```
-
-## Step 5: Confirm
-
-```
-Saved to compound-engineering.local.md
-
-Stack:        {type}
-Review depth: {depth}
-Agents:       {count} configured
-              {agent list, one per line}
-
-Tip: Edit the "Review Context" section to add project-specific instructions.
-     Re-run this setup anytime to reconfigure.
-```
+This skill is reserved for future project-level configuration needs beyond review agent selection.


### PR DESCRIPTION
ce:work's Phase 3 review step previously read agent lists from `compound-engineering.local.md` and ran them directly — a model that was superseded when ce:review gained intelligent tiered selection in #371. This removes the stale indirection and delegates to `ce:review` with `mode:autofix`, which fixes safe issues automatically and flags the rest before shipping.

**What changed:**

- **ce:work / ce:work-beta** — Phase 3 step 2 now loads `ce:review` with `mode:autofix` instead of reading agents from `.local.md`. The delegate prompt section references CLAUDE.md/AGENTS.md instead of the removed settings file.
- **setup skill** — Reduced to a placeholder. The interactive wizard that generated `.local.md` is removed since review agent selection is fully automatic. The skill is preserved for future project-level config needs in coming later in #345
- **ce:compound** — Removed stale line referencing `.local.md` and the setup skill for agent customization.
- **README** — Updated setup skill description to reflect current state.

---

[![Compound Engineering v2.53.0](https://img.shields.io/badge/Compound_Engineering-v2.53.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (200K context, extended thinking) via [Claude Code](https://claude.com/claude-code)