### PR TITLE
fix: scope commit-push-pr descriptions to full branch diff

### DIFF
--- a/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
+++ b/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
@@ -99,7 +99,15 @@ If none resolve, ask the user to specify the target branch. Use the platform's b
 
 Once the base branch and remote are known:
 
-1. Find the merge base:
+1. Verify the remote-tracking ref exists locally and fetch if needed:
+   ```bash
+   command git rev-parse --verify <base-remote>/<base-branch>
+   ```
+   If this fails (ref missing or stale), fetch it:
+   ```bash
+   command git fetch --no-tags <base-remote> <base-branch>
+   ```
+2. Find the merge base:
    ```bash
    command git merge-base <base-remote>/<base-branch> HEAD
    ```


### PR DESCRIPTION
The `git-commit-push-pr` skill wrote PR descriptions from `git diff HEAD` (uncommitted changes only), so when a branch had prior commits the description silently ignored them — covering only whatever happened to be uncommitted at invocation time.

Adds a base-branch and remote detection step before the PR description is written. The detection uses the same fallback chain as `ce-review`: PR `baseRefName` + base-repo remote resolution, `origin/HEAD`, GitHub default-branch metadata, then common branch names (`main`, `master`, `develop`, `trunk`). This handles fork-based PRs where the base lives on a remote other than `origin`, and repos whose default branch isn't `main`.

The full branch diff (`git diff <merge-base>...HEAD`) and commit list (`git log <merge-base>..HEAD`) now drive the PR description instead of the working-tree diff.

---

[![Compound Engineering v2.53.0](https://img.shields.io/badge/Compound_Engineering-v2.53.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via Claude Code