### PR TITLE
fix: improve agent-native-reviewer with triage, prioritization, and stack-aware search

### DIFF
--- a/plugins/compound-engineering/agents/review/agent-native-reviewer.md
+++ b/plugins/compound-engineering/agents/review/agent-native-reviewer.md
@@ -128,7 +128,7 @@ After building the capability map, run a second pass organized by domain objects
 2. Have a tool to interact with it (action parity)
 3. See it documented in the system prompt (discoverability)
 
-Any noun that fails all three is a Critical finding. Any noun that fails one or two is a Warning.
+Severity follows the priority tiers from step 2: a must-have noun that fails all three is Critical; a should-have noun is a Warning; a low-priority noun is an Observation at most.
 
 ## What You Don't Flag
 


### PR DESCRIPTION
The agent-native-reviewer had the right philosophy but couldn't navigate real codebases -- it told the agent WHAT to check without helping it figure out HOW to find things in an unfamiliar project. This rewrites the system prompt to close that gap.

**Key changes:**

- **Triage step** (step 0) -- before any review work, the agent determines whether agent integration exists, identifies the tech stack, and decides whether this is an incremental review or full audit. Previously it dove straight into "Map the Landscape" with no orientation.
- **Stack-specific search strategies** -- a table mapping 6 common stacks (Vercel AI SDK, LangChain, OpenAI Assistants, Claude Code plugins, Rails + MCP, generic) to concrete file patterns for finding UI actions and agent tools.
- **Prioritization heuristics** -- three tiers (must-have / should-have / low-priority parity) so core domain CRUD gets flagged as Critical while missing parity on a settings page is an Observation at most.
- **"What You Don't Flag" section** -- prevents false positives on intentionally human-only flows (CAPTCHA, 2FA, OAuth consent, biometrics, platform gates).
- **Noun Test** (step 6) -- restored from the original's "Write to Location" heuristic. For every domain entity, checks context injection + action parity + discoverability in one pass.
- **Confidence calibration** -- aligns with the ce-review ensemble pattern used by peer agents like correctness-reviewer.
- **Nuanced "primitives over workflows"** -- workflow tools flagged for review, not categorically rejected. Safety-critical atomic sequences and external system orchestration are acknowledged exceptions.

Also adds missing frontmatter fields (`color: cyan`, `tools: Read, Grep, Glob, Bash`) and collapses the original's 7 verbose anti-pattern subsections into a scannable reference table. Net result: 192 lines down from 262, with substantially more actionable guidance.

---

[![Compound Engineering v2.54.0](https://img.shields.io/badge/Compound_Engineering-v2.54.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)