### PR TITLE
fix: replace broken markdown link refs in skills

### DIFF
--- a/plugins/compound-engineering/AGENTS.md
+++ b/plugins/compound-engineering/AGENTS.md
@@ -68,12 +68,20 @@ When adding or modifying skills, verify compliance with the skill spec:
 - [ ] `name:` present and matches directory name (lowercase-with-hyphens)
 - [ ] `description:` present and describes **what it does and when to use it** (per official spec: "Explains code with diagrams. Use when exploring how code works.")
 
-### Reference Links (Required if references/ exists)
+### Reference File Inclusion (Required if references/ exists)
 
-- [ ] All files in `references/` that the agent should read into context are linked as `[filename.md](./references/filename.md)`
-- [ ] All files in `assets/` that the agent should read into context are linked as `[filename](./assets/filename)`
-- [ ] For files the agent needs to *read* (references, assets), use markdown links -- these signal "load this into context"
-- [ ] For files the agent needs to *execute* (scripts), backtick paths are sufficient (e.g., `` `scripts/my-script` ``) since the bash code block already provides the invocation
+- [ ] Do NOT use markdown links like `[filename.md](./references/filename.md)` -- agents interpret these as Read instructions with CWD-relative paths, which fail because the CWD is never the skill directory
+- [ ] **Default: use backtick paths.** Most reference files should be referenced with backtick paths so the agent can load them on demand:
+  ```
+  `references/architecture-patterns.md`
+  ```
+  This keeps the skill lean and avoids inflating the token footprint at load time. Use for: large reference docs, routing-table targets, code scaffolds, executable scripts/templates
+- [ ] **Exception: `@` inline for small structural files** that the skill cannot function without and that are under ~150 lines (schemas, output contracts, subagent dispatch templates). Use `@` file inclusion on its own line:
+  ```
+  @./references/schema.json
+  ```
+  This resolves relative to the SKILL.md and substitutes content before the model sees it. If a file is over ~150 lines, prefer a backtick path even if it is always needed
+- [ ] For files the agent needs to *execute* (scripts, shell templates), always use backtick paths -- `@` would inline the script as text content instead of keeping it as an executable file
 
 ### Writing Style
 
@@ -121,9 +129,8 @@ Why: shell-heavy exploration causes avoidable permission prompts in sub-agent wo
 ### Quick Validation Command
 
 ```bash
-# Check for unlinked references in a skill
-grep -E '`(references|assets|scripts)/[^`]+`' skills/*/SKILL.md
-# Should return nothing if all refs are properly linked
+# Check for broken markdown link references (should return nothing)
+grep -E '\[.*\]\(\./references/|\[.*\]\(\./assets/|\[.*\]\(references/|\[.*\]\(assets/' skills/*/SKILL.md
 
 # Check description format - should describe what + when
 grep -E '^description:' skills/*/SKILL.md
@@ -136,11 +143,11 @@ grep -E '^description:' skills/*/SKILL.md
 
 ## Upstream-Sourced Skills
 
-Some skills are exact copies from external upstream repositories, vendored locally so the plugin is self-contained. Do not add local modifications -- sync from upstream instead.
+Some skills are exact copies from external upstream repositories, vendored locally so the plugin is self-contained. Prefer syncing from upstream, but apply the reference file inclusion rules from the skill compliance checklist after each sync -- upstream skills often use markdown links for references which break in plugin contexts.
 
-| Skill | Upstream |
-|-------|----------|
-| `agent-browser` | `github.com/vercel-labs/agent-browser` (`skills/agent-browser/SKILL.md`) |
+| Skill | Upstream | Local deviations |
+|-------|----------|------------------|
+| `agent-browser` | `github.com/vercel-labs/agent-browser` (`skills/agent-browser/SKILL.md`) | Markdown link refs replaced with backtick paths to fix CWD resolution bug (#374) |
 
 ## Beta Skills
 

--- a/plugins/compound-engineering/skills/agent-browser/SKILL.md
+++ b/plugins/compound-engineering/skills/agent-browser/SKILL.md
@@ -102,7 +102,7 @@ agent-browser state load ./auth.json
 agent-browser open https://app.example.com/dashboard
 ```
 
-See [references/authentication.md](references/authentication.md) for OAuth, 2FA, cookie-based auth, and token refresh patterns.
+See `references/authentication.md` for OAuth, 2FA, cookie-based auth, and token refresh patterns.
 
 ## Essential Commands
 
@@ -639,15 +639,15 @@ Priority (lowest to highest): `~/.agent-browser/config.json` < `./agent-browser.
 
 ## Deep-Dive Documentation
 
-| Reference                                                            | When to Use                                               |
-| -------------------------------------------------------------------- | --------------------------------------------------------- |
-| [references/commands.md](references/commands.md)                     | Full command reference with all options                   |
-| [references/snapshot-refs.md](references/snapshot-refs.md)           | Ref lifecycle, invalidation rules, troubleshooting        |
-| [references/session-management.md](references/session-management.md) | Parallel sessions, state persistence, concurrent scraping |
-| [references/authentication.md](references/authentication.md)         | Login flows, OAuth, 2FA handling, state reuse             |
-| [references/video-recording.md](references/video-recording.md)       | Recording workflows for debugging and documentation       |
-| [references/profiling.md](references/profiling.md)                   | Chrome DevTools profiling for performance analysis        |
-| [references/proxy-support.md](references/proxy-support.md)           | Proxy configuration, geo-testing, rotating proxies        |
+| Reference | When to Use |
+| --------- | ----------- |
+| `references/commands.md` | Full command reference with all options |
+| `references/snapshot-refs.md` | Ref lifecycle, invalidation rules, troubleshooting |
+| `references/session-management.md` | Parallel sessions, state persistence, concurrent scraping |
+| `references/authentication.md` | Login flows, OAuth, 2FA handling, state reuse |
+| `references/video-recording.md` | Recording workflows for debugging and documentation |
+| `references/profiling.md` | Chrome DevTools profiling for performance analysis |
+| `references/proxy-support.md` | Proxy configuration, geo-testing, rotating proxies |
 
 ## Browser Engine Selection
 
@@ -673,11 +673,11 @@ Lightpanda does not support `--extension`, `--profile`, `--state`, or `--allow-f
 
 ## Ready-to-Use Templates
 
-| Template                                                                 | Description                         |
-| ------------------------------------------------------------------------ | ----------------------------------- |
-| [templates/form-automation.sh](templates/form-automation.sh)             | Form filling with validation        |
-| [templates/authenticated-session.sh](templates/authenticated-session.sh) | Login once, reuse state             |
-| [templates/capture-workflow.sh](templates/capture-workflow.sh)           | Content extraction with screenshots |
+| Template | Description |
+| -------- | ----------- |
+| `templates/form-automation.sh` | Form filling with validation |
+| `templates/authenticated-session.sh` | Login once, reuse state |
+| `templates/capture-workflow.sh` | Content extraction with screenshots |
 
 ```bash
 ./templates/form-automation.sh https://example.com/form

--- a/plugins/compound-engineering/skills/agent-native-architecture/SKILL.md
+++ b/plugins/compound-engineering/skills/agent-native-architecture/SKILL.md
@@ -176,19 +176,19 @@ The improvement mechanisms are still being discovered. Context and prompt refine
 <routing>
 | Response | Action |
 |----------|--------|
-| 1, "design", "architecture", "plan" | Read [architecture-patterns.md](./references/architecture-patterns.md), then apply Architecture Checklist below |
-| 2, "files", "workspace", "filesystem" | Read [files-universal-interface.md](./references/files-universal-interface.md) and [shared-workspace-architecture.md](./references/shared-workspace-architecture.md) |
-| 3, "tool", "mcp", "primitive", "crud" | Read [mcp-tool-design.md](./references/mcp-tool-design.md) |
-| 4, "domain tool", "when to add" | Read [from-primitives-to-domain-tools.md](./references/from-primitives-to-domain-tools.md) |
-| 5, "execution", "completion", "loop" | Read [agent-execution-patterns.md](./references/agent-execution-patterns.md) |
-| 6, "prompt", "system prompt", "behavior" | Read [system-prompt-design.md](./references/system-prompt-design.md) |
-| 7, "context", "inject", "runtime", "dynamic" | Read [dynamic-context-injection.md](./references/dynamic-context-injection.md) |
-| 8, "parity", "ui action", "capability map" | Read [action-parity-discipline.md](./references/action-parity-discipline.md) |
-| 9, "self-modify", "evolve", "git" | Read [self-modification.md](./references/self-modification.md) |
-| 10, "product", "progressive", "approval", "latent demand" | Read [product-implications.md](./references/product-implications.md) |
-| 11, "mobile", "ios", "android", "background", "checkpoint" | Read [mobile-patterns.md](./references/mobile-patterns.md) |
-| 12, "test", "testing", "verify", "validate" | Read [agent-native-testing.md](./references/agent-native-testing.md) |
-| 13, "review", "refactor", "existing" | Read [refactoring-to-prompt-native.md](./references/refactoring-to-prompt-native.md) |
+| 1, "design", "architecture", "plan" | Read `references/architecture-patterns.md`, then apply Architecture Checklist below |
+| 2, "files", "workspace", "filesystem" | Read `references/files-universal-interface.md` and `references/shared-workspace-architecture.md` |
+| 3, "tool", "mcp", "primitive", "crud" | Read `references/mcp-tool-design.md` |
+| 4, "domain tool", "when to add" | Read `references/from-primitives-to-domain-tools.md` |
+| 5, "execution", "completion", "loop" | Read `references/agent-execution-patterns.md` |
+| 6, "prompt", "system prompt", "behavior" | Read `references/system-prompt-design.md` |
+| 7, "context", "inject", "runtime", "dynamic" | Read `references/dynamic-context-injection.md` |
+| 8, "parity", "ui action", "capability map" | Read `references/action-parity-discipline.md` |
+| 9, "self-modify", "evolve", "git" | Read `references/self-modification.md` |
+| 10, "product", "progressive", "approval", "latent demand" | Read `references/product-implications.md` |
+| 11, "mobile", "ios", "android", "background", "checkpoint" | Read `references/mobile-patterns.md` |
+| 12, "test", "testing", "verify", "validate" | Read `references/agent-native-testing.md` |
+| 13, "review", "refactor", "existing" | Read `references/refactoring-to-prompt-native.md` |
 
 **After reading the reference, apply those patterns to the user's specific context.**
 </routing>
@@ -281,24 +281,24 @@ const result = await agent.run({
 All references in `references/`:
 
 **Core Patterns:**
-- [architecture-patterns.md](./references/architecture-patterns.md) - Event-driven, unified orchestrator, agent-to-UI
-- [files-universal-interface.md](./references/files-universal-interface.md) - Why files, organization patterns, context.md
-- [mcp-tool-design.md](./references/mcp-tool-design.md) - Tool design, dynamic capability discovery, CRUD
-- [from-primitives-to-domain-tools.md](./references/from-primitives-to-domain-tools.md) - When to add domain tools, graduating to code
-- [agent-execution-patterns.md](./references/agent-execution-patterns.md) - Completion signals, partial completion, context limits
-- [system-prompt-design.md](./references/system-prompt-design.md) - Features as prompts, judgment criteria
+- `references/architecture-patterns.md` - Event-driven, unified orchestrator, agent-to-UI
+- `references/files-universal-interface.md` - Why files, organization patterns, context.md
+- `references/mcp-tool-design.md` - Tool design, dynamic capability discovery, CRUD
+- `references/from-primitives-to-domain-tools.md` - When to add domain tools, graduating to code
+- `references/agent-execution-patterns.md` - Completion signals, partial completion, context limits
+- `references/system-prompt-design.md` - Features as prompts, judgment criteria
 
 **Agent-Native Disciplines:**
-- [dynamic-context-injection.md](./references/dynamic-context-injection.md) - Runtime context, what to inject
-- [action-parity-discipline.md](./references/action-parity-discipline.md) - Capability mapping, parity workflow
-- [shared-workspace-architecture.md](./references/shared-workspace-architecture.md) - Shared data space, UI integration
-- [product-implications.md](./references/product-implications.md) - Progressive disclosure, latent demand, approval
-- [agent-native-testing.md](./references/agent-native-testing.md) - Testing outcomes, parity tests
+- `references/dynamic-context-injection.md` - Runtime context, what to inject
+- `references/action-parity-discipline.md` - Capability mapping, parity workflow
+- `references/shared-workspace-architecture.md` - Shared data space, UI integration
+- `references/product-implications.md` - Progressive disclosure, latent demand, approval
+- `references/agent-native-testing.md` - Testing outcomes, parity tests
 
 **Platform-Specific:**
-- [mobile-patterns.md](./references/mobile-patterns.md) - iOS storage, checkpoint/resume, cost awareness
-- [self-modification.md](./references/self-modification.md) - Git-based evolution, guardrails
-- [refactoring-to-prompt-native.md](./references/refactoring-to-prompt-native.md) - Migrating existing code
+- `references/mobile-patterns.md` - iOS storage, checkpoint/resume, cost awareness
+- `references/self-modification.md` - Git-based evolution, guardrails
+- `references/refactoring-to-prompt-native.md` - Migrating existing code
 </reference_index>
 
 <anti_patterns>
@@ -433,3 +433,4 @@ If yes, you've built something agent-native.
 
 If it says "I don't have a feature for that"—your architecture is still too constrained.
 </success_criteria>
+

--- a/plugins/compound-engineering/skills/andrew-kane-gem-writer/SKILL.md
+++ b/plugins/compound-engineering/skills/andrew-kane-gem-writer/SKILL.md
@@ -177,8 +177,8 @@ end
 ## Reference Files
 
 For deeper patterns, see:
-- **[references/module-organization.md](references/module-organization.md)** - Directory layouts, method decomposition
-- **[references/rails-integration.md](references/rails-integration.md)** - Railtie, Engine, on_load patterns
-- **[references/database-adapters.md](references/database-adapters.md)** - Multi-database support patterns
-- **[references/testing-patterns.md](references/testing-patterns.md)** - Multi-version testing, CI setup
-- **[references/resources.md](references/resources.md)** - Links to Kane's repos and articles
+- `references/module-organization.md` - Directory layouts, method decomposition
+- `references/rails-integration.md` - Railtie, Engine, on_load patterns
+- `references/database-adapters.md` - Multi-database support patterns
+- `references/testing-patterns.md` - Multi-version testing, CI setup
+- `references/resources.md` - Links to Kane's repos and articles

--- a/plugins/compound-engineering/skills/ce-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-review/SKILL.md
@@ -73,7 +73,7 @@ Routing rules:
 
 ## Reviewers
 
-13 reviewer personas in layered conditionals, plus CE-specific agents. See [persona-catalog.md](./references/persona-catalog.md) for the full catalog.
+13 reviewer personas in layered conditionals, plus CE-specific agents. See the persona catalog included below for the full catalog.
 
 **Always-on (every review):**
 
@@ -324,7 +324,7 @@ Pass this to every reviewer in their spawn prompt. Intent shapes *how hard each 
 
 ### Stage 3: Select reviewers
 
-Read the diff and file list from Stage 1. The 3 always-on personas and 2 CE always-on agents are automatic. For each cross-cutting and stack-specific conditional persona in [persona-catalog.md](./references/persona-catalog.md), decide whether the diff warrants it. This is agent judgment, not keyword matching.
+Read the diff and file list from Stage 1. The 3 always-on personas and 2 CE always-on agents are automatic. For each cross-cutting and stack-specific conditional persona in the persona catalog included below, decide whether the diff warrants it. This is agent judgment, not keyword matching.
 
 Stack-specific personas are additive. A Rails UI change may warrant `kieran-rails` plus `julik-frontend-races`; a TypeScript API diff may warrant `kieran-typescript` plus `api-contract` and `reliability`.
 
@@ -350,18 +350,18 @@ This is progress reporting, not a blocking confirmation.
 
 ### Stage 4: Spawn sub-agents
 
-Spawn each selected persona reviewer as a parallel sub-agent using the template in [subagent-template.md](./references/subagent-template.md). Each persona sub-agent receives:
+Spawn each selected persona reviewer as a parallel sub-agent using the subagent template included below. Each persona sub-agent receives:
 
 1. Their persona file content (identity, failure modes, calibration, suppress conditions)
-2. Shared diff-scope rules from [diff-scope.md](./references/diff-scope.md)
-3. The JSON output contract from [findings-schema.json](./references/findings-schema.json)
+2. Shared diff-scope rules from the diff-scope reference included below
+3. The JSON output contract from the findings schema included below
 4. Review context: intent summary, file list, diff
 
 Persona sub-agents are **read-only**: they review and return structured JSON. They do not edit files or propose refactors.
 
 Read-only here means **non-mutating**, not "no shell access." Reviewer sub-agents may use non-mutating inspection commands when needed to gather evidence or verify scope, including read-oriented `git` / `gh` usage such as `git diff`, `git show`, `git blame`, `git log`, and `gh pr view`. They must not edit files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.
 
-Each persona sub-agent returns JSON matching [findings-schema.json](./references/findings-schema.json):
+Each persona sub-agent returns JSON matching the findings schema included below:
 
 ```json
 {
@@ -395,7 +395,7 @@ Convert multiple reviewer JSON payloads into one deduplicated, confidence-gated 
 
 ### Stage 6: Synthesize and present
 
-Assemble the final report using the template in [review-output-template.md](./references/review-output-template.md):
+Assemble the final report using the review output template included below:
 
 1. **Header.** Scope, intent, mode, reviewer team with per-conditional justifications.
 2. **Findings.** Grouped by severity (P0, P1, P2, P3). Each finding shows file, issue, reviewer(s), confidence, and synthesized route.
@@ -517,3 +517,27 @@ If "Push fixes": push the branch with `git push` to update the existing PR.
 ## Fallback
 
 If the platform doesn't support parallel sub-agents, run reviewers sequentially. Everything else (stages, output format, merge pipeline) stays the same.
+
+---
+
+## Included References
+
+### Persona Catalog
+
+@./references/persona-catalog.md
+
+### Subagent Template
+
+@./references/subagent-template.md
+
+### Diff Scope Rules
+
+@./references/diff-scope.md
+
+### Findings Schema
+
+@./references/findings-schema.json
+
+### Review Output Template
+
+@./references/review-output-template.md

--- a/plugins/compound-engineering/skills/dhh-rails-style/SKILL.md
+++ b/plugins/compound-engineering/skills/dhh-rails-style/SKILL.md
@@ -57,12 +57,12 @@ What are you working on?
 
 | Response | Reference to Read |
 |----------|-------------------|
-| 1, controller | [controllers.md](./references/controllers.md) |
-| 2, model | [models.md](./references/models.md) |
-| 3, view, frontend, turbo, stimulus, css | [frontend.md](./references/frontend.md) |
-| 4, architecture, routing, auth, job, cache | [architecture.md](./references/architecture.md) |
-| 5, test, testing, minitest, fixture | [testing.md](./references/testing.md) |
-| 6, gem, dependency, library | [gems.md](./references/gems.md) |
+| 1, controller | `references/controllers.md` |
+| 2, model | `references/models.md` |
+| 3, view, frontend, turbo, stimulus, css | `references/frontend.md` |
+| 4, architecture, routing, auth, job, cache | `references/architecture.md` |
+| 5, test, testing, minitest, fixture | `references/testing.md` |
+| 6, gem, dependency, library | `references/gems.md` |
 | 7, review | Read all references, then review code |
 | 8, general task | Read relevant references based on context |
 
@@ -153,12 +153,12 @@ All detailed patterns in `references/`:
 
 | File | Topics |
 |------|--------|
-| [controllers.md](./references/controllers.md) | REST mapping, concerns, Turbo responses, API patterns, HTTP caching |
-| [models.md](./references/models.md) | Concerns, state records, callbacks, scopes, POROs, authorization, broadcasting |
-| [frontend.md](./references/frontend.md) | Turbo Streams, Stimulus controllers, CSS layers, OKLCH colors, partials |
-| [architecture.md](./references/architecture.md) | Routing, authentication, jobs, Current attributes, caching, database patterns |
-| [testing.md](./references/testing.md) | Minitest, fixtures, unit/integration/system tests, testing patterns |
-| [gems.md](./references/gems.md) | What they use vs avoid, decision framework, Gemfile examples |
+| `references/controllers.md` | REST mapping, concerns, Turbo responses, API patterns, HTTP caching |
+| `references/models.md` | Concerns, state records, callbacks, scopes, POROs, authorization, broadcasting |
+| `references/frontend.md` | Turbo Streams, Stimulus controllers, CSS layers, OKLCH colors, partials |
+| `references/architecture.md` | Routing, authentication, jobs, Current attributes, caching, database patterns |
+| `references/testing.md` | Minitest, fixtures, unit/integration/system tests, testing patterns |
+| `references/gems.md` | What they use vs avoid, decision framework, Gemfile examples |
 </reference_index>
 
 <success_criteria>
@@ -183,3 +183,4 @@ Based on [The Unofficial 37signals/DHH Rails Style Guide](https://github.com/mar
 - Code examples from Fizzy are licensed under the O'Saasy License
 - Not affiliated with or endorsed by 37signals
 </credits>
+

--- a/plugins/compound-engineering/skills/document-review/SKILL.md
+++ b/plugins/compound-engineering/skills/document-review/SKILL.md
@@ -76,12 +76,12 @@ Add activated conditional personas:
 
 ### Dispatch
 
-Dispatch all agents in **parallel** using the platform's task/agent tool (e.g., Agent tool in Claude Code, spawn in Codex). Each agent receives the prompt built from the [subagent template](./references/subagent-template.md) with these variables filled:
+Dispatch all agents in **parallel** using the platform's task/agent tool (e.g., Agent tool in Claude Code, spawn in Codex). Each agent receives the prompt built from the subagent template included below with these variables filled:
 
 | Variable | Value |
 |----------|-------|
 | `{persona_file}` | Full content of the agent's markdown file |
-| `{schema}` | Content of [findings-schema.json](./references/findings-schema.json) |
+| `{schema}` | Content of the findings schema included below |
 | `{document_type}` | "requirements" or "plan" from Phase 1 classification |
 | `{document_path}` | Path to the document |
 | `{document_content}` | Full text of the document |
@@ -98,7 +98,7 @@ Process findings from all agents through this pipeline. **Order matters** -- eac
 
 ### 3.1 Validate
 
-Check each agent's returned JSON against [findings-schema.json](./references/findings-schema.json):
+Check each agent's returned JSON against the findings schema included below:
 - Drop findings missing any required field defined in the schema
 - Drop findings with invalid enum values
 - Note the agent name for any malformed output in the Coverage section
@@ -157,7 +157,7 @@ Apply all `auto` findings to the document in a **single pass**:
 
 ### Present Remaining Findings
 
-Present all other findings to the user using the format from [review-output-template.md](./references/review-output-template.md):
+Present all other findings to the user using the review output template included below:
 - Group by severity (P0 -> P3)
 - Include the Coverage table showing which personas ran
 - Show auto-fixes that were applied
@@ -198,3 +198,19 @@ Return "Review complete" as the terminal signal for callers.
 ## Iteration Guidance
 
 On subsequent passes, re-dispatch personas and re-synthesize. The auto-fix mechanism and confidence gating prevent the same findings from recurring once fixed. If findings are repetitive across passes, recommend completion.
+
+---
+
+## Included References
+
+### Subagent Template
+
+@./references/subagent-template.md
+
+### Findings Schema
+
+@./references/findings-schema.json
+
+### Review Output Template
+
+@./references/review-output-template.md

--- a/plugins/compound-engineering/skills/dspy-ruby/SKILL.md
+++ b/plugins/compound-engineering/skills/dspy-ruby/SKILL.md
@@ -647,14 +647,14 @@ end
 
 ## Resources
 
-- [core-concepts.md](./references/core-concepts.md) — Signatures, modules, predictors, type system deep-dive
-- [toolsets.md](./references/toolsets.md) — Tools::Base, Tools::Toolset DSL, type safety, testing
-- [providers.md](./references/providers.md) — Provider adapters, RubyLLM, fiber-local LM context, compatibility matrix
-- [optimization.md](./references/optimization.md) — MIPROv2, GEPA, evaluation framework, storage system
-- [observability.md](./references/observability.md) — Event system, dspy-o11y gems, Langfuse, score reporting
-- [signature-template.rb](./assets/signature-template.rb) — Signature scaffold with T::Enum, Date/Time, defaults, union types
-- [module-template.rb](./assets/module-template.rb) — Module scaffold with .call(), lifecycle callbacks, fiber-local LM
-- [config-template.rb](./assets/config-template.rb) — Rails initializer with RubyLLM, observability, feature flags
+- `references/core-concepts.md` — Signatures, modules, predictors, type system deep-dive
+- `references/toolsets.md` — Tools::Base, Tools::Toolset DSL, type safety, testing
+- `references/providers.md` — Provider adapters, RubyLLM, fiber-local LM context, compatibility matrix
+- `references/optimization.md` — MIPROv2, GEPA, evaluation framework, storage system
+- `references/observability.md` — Event system, dspy-o11y gems, Langfuse, score reporting
+- `assets/signature-template.rb` — Signature scaffold with T::Enum, Date/Time, defaults, union types
+- `assets/module-template.rb` — Module scaffold with .call(), lifecycle callbacks, fiber-local LM
+- `assets/config-template.rb` — Rails initializer with RubyLLM, observability, feature flags
 
 ## Key URLs
 

--- a/plugins/compound-engineering/skills/every-style-editor/SKILL.md
+++ b/plugins/compound-engineering/skills/every-style-editor/SKILL.md
@@ -44,7 +44,7 @@ Review each paragraph systematically, checking for:
 - Word choice and usage (overused words, passive voice)
 - Adherence to Every style guide rules
 
-Reference the complete [EVERY_WRITE_STYLE.md](./references/EVERY_WRITE_STYLE.md) for specific rules when in doubt.
+Reference the complete style guide at `references/EVERY_WRITE_STYLE.md` for specific rules when in doubt.
 
 ### Step 3: Mechanical Review
 
@@ -99,7 +99,7 @@ FINAL RECOMMENDATIONS
 
 ## Style Guide Reference
 
-The complete Every style guide is included in [EVERY_WRITE_STYLE.md](./references/EVERY_WRITE_STYLE.md). Key areas to focus on:
+The complete Every style guide is at `references/EVERY_WRITE_STYLE.md`. Key areas to focus on:
 
 - **Quick Rules**: Title case for headlines, sentence case elsewhere
 - **Tone**: Active voice, avoid overused words (actually, very, just), be specific
@@ -132,3 +132,4 @@ Based on Every's style guide, pay special attention to:
 - Word usage (fewer vs. less, they vs. them)
 - Company references (singular "it", teams as plural "they")
 - Job title capitalization
+

--- a/plugins/compound-engineering/skills/todo-create/SKILL.md
+++ b/plugins/compound-engineering/skills/todo-create/SKILL.md
@@ -34,7 +34,7 @@ The `.context/compound-engineering/todos/` directory is a file-based tracking sy
 
 ## File Structure
 
-Each todo has YAML frontmatter and structured sections. Use the template at [todo-template.md](./assets/todo-template.md) when creating new todos.
+Each todo has YAML frontmatter and structured sections. Use the todo template included below when creating new todos.
 
 ```yaml
 ---
@@ -58,7 +58,7 @@ dependencies: ["001"]     # Issue IDs this is blocked by
 
 1. `mkdir -p .context/compound-engineering/todos/`
 2. Search both paths for `[0-9]*-*.md`, find the highest numeric prefix, increment, zero-pad to 3 digits.
-3. Read [todo-template.md](./assets/todo-template.md), write to canonical path as `{NEXT_ID}-pending-{priority}-{description}.md`.
+3. Use the todo template included below, write to canonical path as `{NEXT_ID}-pending-{priority}-{description}.md`.
 4. Fill Problem Statement, Findings, Proposed Solutions, Acceptance Criteria, and initial Work Log entry.
 5. Set status: `pending` (needs triage) or `ready` (pre-approved).
 
@@ -101,3 +101,9 @@ To check blockers: search for `{dep_id}-complete-*.md` in both paths. Missing ma
 ## Key Distinction
 
 This skill manages **durable, cross-session work items** persisted as markdown files. For temporary in-session step tracking, use platform task tools (`TaskCreate`/`TaskUpdate` in Claude Code, `update_plan` in Codex) instead.
+
+---
+
+## Todo Template
+
+@./assets/todo-template.md


### PR DESCRIPTION
Agents interpret markdown links like `[file.md](./references/file.md)` as Read instructions using CWD-relative paths. Since the CWD is never the skill directory, these reads fail and agents spiral trying to locate the files.

Replaces all markdown link references across 10 skills with two patterns based on file size and purpose:

- **Backtick paths** (`references/file.md`) for large reference docs, routing-table targets, code scaffolds, and executable scripts — agent loads on demand without inflating the skill's token footprint
- **`@` file inclusion** (`@./references/schema.json`) only for small structural files under ~150 lines that the skill cannot function without (schemas, output contracts, dispatch templates)

Updates AGENTS.md with the new reference inclusion rules, a validation grep command, and upstream-sourced skill guidance (apply reference rules after each sync from upstream).

Closes #374

---

[![Compound Engineering v2.54.0](https://img.shields.io/badge/Compound_Engineering-v2.54.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)