### PR TITLE
fix: document SwiftUI Text link tap limitation in test-xcode skill

### DIFF
--- a/plugins/compound-engineering/skills/test-xcode/SKILL.md
+++ b/plugins/compound-engineering/skills/test-xcode/SKILL.md
@@ -94,6 +94,9 @@ Call `get_sim_logs` with the simulator UUID. Look for:
 - Error-level log messages
 - Failed network requests
 
+**Known automation limitation — SwiftUI Text links:**
+Simulated taps (via XcodeBuildMCP or any simulator automation tool) do not trigger gesture recognizers on SwiftUI `Text` views with inline `AttributedString` links. Taps report success but have no effect. This is a platform limitation — inline links are not exposed as separate elements in the accessibility tree. When a tap on a Text link has no visible effect, prompt the user to tap manually in the simulator. If the target URL is known, `xcrun simctl openurl <device> <URL>` can open it directly as a fallback.
+
 ### 6. Human Verification (When Required)
 
 Pause for human input when testing touches flows that require device interaction.
@@ -105,6 +108,7 @@ Pause for human input when testing touches flows that require device interaction
 | In-app purchases | "Complete a sandbox purchase" |
 | Camera/Photos | "Grant permissions and verify camera works" |
 | Location | "Allow location access and verify map updates" |
+| SwiftUI Text links | "Please tap on [element description] manually — automated taps cannot trigger inline text links" |
 
 Ask the user (using the platform's question tool — e.g., `AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini — or present numbered options and wait):
 


### PR DESCRIPTION
Simulated taps via XcodeBuildMCP (and all other iOS simulator automation tools — idb, XCUITest, Appium) silently fail on SwiftUI `Text` views with inline `AttributedString` links. This is a fundamental platform limitation: inline links are not exposed as separate elements in the accessibility tree, so no automation tool can target them. Taps report success but have no effect.

This adds a known-limitation note in Step 5 (Test Key Screens) and a human-verification table entry in Step 6 so the agent detects the silent failure pattern and prompts the user to tap manually. Also documents `xcrun simctl openurl` as a fallback when the target URL is known.

Closes #59

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)