### PR TITLE
fix: clarify commit prefix selection for markdown product code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ cat plugins/compound-engineering/.claude-plugin/plugin.json | jq .
 
 ## Commit Conventions
 
-- Use conventional titles such as `feat: ...`, `fix: ...`, `docs: ...`, and `refactor: ...`.
+- **Prefix is based on intent, not file type.** Use conventional prefixes (`feat:`, `fix:`, `docs:`, `refactor:`, etc.) but classify by what the change does, not the file extension. Files under `plugins/*/skills/`, `plugins/*/agents/`, and `.claude-plugin/` are product code even though they are Markdown or JSON. Reserve `docs:` for files whose sole purpose is documentation (`README.md`, `docs/`, `CHANGELOG.md`).
 - Component scope is optional. Example: `feat(coding-tutor): add quiz reset`.
 - Breaking changes must be explicit with `!` or a breaking-change footer so release automation can classify them correctly.
 


### PR DESCRIPTION
Agents default to `docs:` when editing `.md` files, but in this repo many markdown files under `plugins/*/skills/`, `plugins/*/agents/`, and `.claude-plugin/` are product code that ships to users. This replaces the generic "use conventional commits" bullet with guidance to classify by intent, not file extension, reserving `docs:` for files whose sole purpose is documentation.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)