### PR TITLE
docs(AGENTS): recommend component scope in commit conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ cat plugins/compound-engineering/.claude-plugin/plugin.json | jq .
 ## Commit Conventions
 
 - **Prefix is based on intent, not file type.** Use conventional prefixes (`feat:`, `fix:`, `docs:`, `refactor:`, etc.) but classify by what the change does, not the file extension. Files under `plugins/*/skills/`, `plugins/*/agents/`, and `.claude-plugin/` are product code even though they are Markdown or JSON. Reserve `docs:` for files whose sole purpose is documentation (`README.md`, `docs/`, `CHANGELOG.md`).
-- Component scope is optional. Example: `feat(coding-tutor): add quiz reset`.
+- **Include a component scope.** The scope appears verbatim in the changelog. Pick the narrowest useful label: skill/agent name (`document-review`, `learnings-researcher`), plugin or CLI area (`coding-tutor`, `cli`), or shared area when cross-cutting (`review`, `research`, `converters`). Never use `compound-engineering` — it's the entire plugin and tells the reader nothing. Omit scope only when no single label adds clarity.
 - Breaking changes must be explicit with `!` or a breaking-change footer so release automation can classify them correctly.
 
 ## Adding a New Target Provider


### PR DESCRIPTION
Commit scopes feed directly into changelog generation, so they should be specific enough to help readers scanning release notes. Changes the scope guidance from "optional" to "recommended" with a narrowest-useful-label hierarchy: skill/agent name > plugin/CLI area > cross-cutting area. Explicitly prohibits `compound-engineering` as a scope since it covers the entire plugin.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)