### PR TITLE
chore: update package description and readme tweaks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/kieranklaassen"
   },
   "metadata": {
-    "description": "Plugin marketplace for Claude Code extensions",
+    "description": "Plugin marketplace for Claude Code and Codex extensions",
     "version": "1.0.2"
   },
   "plugins": [

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Compound Marketplace
+# Compound Engineering
 
 [![Build Status](https://github.com/EveryInc/compound-engineering-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/EveryInc/compound-engineering-plugin/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/@every-env/compound-plugin)](https://www.npmjs.com/package/@every-env/compound-plugin)
 
-A Claude Code plugin marketplace featuring the **Compound Engineering Plugin** — tools that make each unit of engineering work easier than the last.
+A plugin marketplace featuring the [Compound Engineering plugin](plugins/compound-engineering/README.md) — AI skills and agents that make each unit of engineering work easier than the last.
 
 ## Philosophy
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@every-env/compound-plugin",
   "version": "2.55.0",
+  "description": "Official Compound Engineering plugin for Claude Code, Codex, and more",
   "type": "module",
   "private": false,
   "bin": {


### PR DESCRIPTION
The npm package page, README, and marketplace metadata all used generic names — "Compound Marketplace", "Plugin marketplace for Claude Code extensions" — that didn't identify the project as the Compound Engineering plugin. Aligned all public-facing naming surfaces to say "Compound Engineering" consistently.

- **README.md**: `# Compound Marketplace` -> `# Compound Engineering`; subtitle rewritten to lead with "plugin marketplace" and link to the plugin's own README
- **package.json**: Added missing `description` field ("Official Compound Engineering plugin for Claude Code, Codex, and more")
- **marketplace.json**: Description now mentions Codex alongside Claude Code

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)