### PR TITLE
feat(codex): add native plugin marketplace metadata

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,32 @@
+{
+  "name": "compound-engineering",
+  "interface": {
+    "displayName": "Compound Engineering"
+  },
+  "plugins": [
+    {
+      "name": "compound-engineering",
+      "source": {
+        "source": "local",
+        "path": "./plugins/compound-engineering"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "coding-tutor",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coding-tutor"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Education"
+    }
+  ]
+}

--- a/plugins/coding-tutor/.codex-plugin/plugin.json
+++ b/plugins/coding-tutor/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "coding-tutor",
+  "version": "1.2.1",
+  "description": "Personalized coding tutorials that use your actual codebase for examples with spaced repetition quizzes",
+  "author": {
+    "name": "Nityesh Agarwal"
+  },
+  "homepage": "https://github.com/EveryInc/compound-engineering-plugin",
+  "repository": "https://github.com/EveryInc/compound-engineering-plugin",
+  "license": "MIT",
+  "keywords": [
+    "coding",
+    "programming",
+    "tutorial",
+    "learning",
+    "spaced-repetition"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Coding Tutor",
+    "shortDescription": "Personalized coding tutorials and quiz workflows for your real codebase.",
+    "developerName": "Nityesh Agarwal",
+    "category": "Education",
+    "capabilities": ["Read"],
+    "websiteURL": "https://github.com/EveryInc/compound-engineering-plugin"
+  }
+}

--- a/plugins/coding-tutor/README.md
+++ b/plugins/coding-tutor/README.md
@@ -1,5 +1,9 @@
 # Coding Tutor
 
+## Codex
+
+Codex can install this plugin from the repo-local marketplace in [`../../.agents/plugins/marketplace.json`](../../.agents/plugins/marketplace.json). The Codex manifest lives at [`plugins/coding-tutor/.codex-plugin/plugin.json`](./.codex-plugin/plugin.json).
+
 Your personal AI tutor that creates tutorials tailored to you - using real code from your projects, building on what you already know, and tracking your progress over time.
 
 ## Why

--- a/plugins/compound-engineering/.codex-plugin/plugin.json
+++ b/plugins/compound-engineering/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "compound-engineering",
+  "version": "2.54.1",
+  "description": "AI-powered development tools for code review, research, design, and workflow automation.",
+  "author": {
+    "name": "Kieran Klaassen",
+    "email": "kieran@every.to",
+    "url": "https://github.com/kieranklaassen"
+  },
+  "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",
+  "repository": "https://github.com/EveryInc/compound-engineering-plugin",
+  "license": "MIT",
+  "keywords": [
+    "ai-powered",
+    "compound-engineering",
+    "workflow-automation",
+    "code-review",
+    "rails",
+    "ruby",
+    "python",
+    "typescript",
+    "knowledge-management",
+    "image-generation",
+    "agent-browser",
+    "browser-automation"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Compound Engineering",
+    "shortDescription": "AI-powered development workflows for review, research, design, and execution.",
+    "developerName": "Kieran Klaassen",
+    "category": "Developer Tools",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://github.com/EveryInc/compound-engineering-plugin"
+  }
+}

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -209,6 +209,18 @@ The `agent-browser` skill provides comprehensive documentation on usage.
 claude /plugin install compound-engineering
 ```
 
+### Codex
+
+Codex can install this plugin from the repo-local marketplace. From the repo root:
+
+```bash
+codex
+```
+
+Then open `/plugins`, browse the `Compound Engineering` marketplace from [`.agents/plugins/marketplace.json`](../../.agents/plugins/marketplace.json), and install `compound-engineering`.
+
+Codex reads the plugin manifest from [`plugins/compound-engineering/.codex-plugin/plugin.json`](./.codex-plugin/plugin.json).
+
 ## Known Issues
 
 ### MCP Servers Not Auto-Loading

--- a/tests/codex-plugin-marketplace.test.ts
+++ b/tests/codex-plugin-marketplace.test.ts
@@ -1,0 +1,141 @@
+import { access, readFile } from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+type PluginManifest = {
+  name: string
+  version: string
+  description: string
+  author?: {
+    name?: string
+    email?: string
+    url?: string
+  }
+  homepage?: string
+  repository?: string
+  license?: string
+  keywords?: string[]
+  skills?: string
+  mcpServers?: string
+  interface?: {
+    displayName?: string
+    shortDescription?: string
+    longDescription?: string
+    developerName?: string
+    category?: string
+    capabilities?: string[]
+    websiteURL?: string
+  }
+}
+
+type Marketplace = {
+  name: string
+  interface?: {
+    displayName?: string
+  }
+  plugins: Array<{
+    name: string
+    source: {
+      source: string
+      path: string
+    }
+    policy: {
+      installation: string
+      authentication: string
+    }
+    category: string
+  }>
+}
+
+const REPO_ROOT = process.cwd()
+const CODEX_MARKETPLACE_PATH = path.join(REPO_ROOT, ".agents", "plugins", "marketplace.json")
+
+async function readJsonFile<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, "utf8")) as T
+}
+
+async function expectPathExists(filePath: string): Promise<void> {
+  await access(filePath)
+}
+
+describe("native Codex plugin metadata", () => {
+  test("repo marketplace lists local plugin entries with valid relative paths", async () => {
+    const marketplace = await readJsonFile<Marketplace>(CODEX_MARKETPLACE_PATH)
+
+    expect(marketplace.name).toBe("compound-engineering")
+    expect(marketplace.interface?.displayName).toBe("Compound Engineering")
+    expect(marketplace.plugins.map((plugin) => plugin.name).sort()).toEqual([
+      "coding-tutor",
+      "compound-engineering",
+    ])
+
+    for (const plugin of marketplace.plugins) {
+      expect(plugin.source.source).toBe("local")
+      expect(plugin.source.path.startsWith("./")).toBe(true)
+      expect(plugin.policy.installation).toBe("AVAILABLE")
+      expect(plugin.policy.authentication).toBe("ON_INSTALL")
+      expect(plugin.category.length).toBeGreaterThan(0)
+
+      const pluginRoot = path.join(REPO_ROOT, plugin.source.path.slice(2))
+      await expectPathExists(pluginRoot)
+      await expectPathExists(path.join(pluginRoot, ".codex-plugin", "plugin.json"))
+    }
+  })
+
+  test("compound-engineering codex manifest stays aligned with the existing plugin metadata", async () => {
+    const codexManifestPath = path.join(
+      REPO_ROOT,
+      "plugins",
+      "compound-engineering",
+      ".codex-plugin",
+      "plugin.json",
+    )
+    const claudeManifestPath = path.join(
+      REPO_ROOT,
+      "plugins",
+      "compound-engineering",
+      ".claude-plugin",
+      "plugin.json",
+    )
+
+    const codexManifest = await readJsonFile<PluginManifest>(codexManifestPath)
+    const claudeManifest = await readJsonFile<PluginManifest>(claudeManifestPath)
+
+    expect(codexManifest.name).toBe(claudeManifest.name)
+    expect(codexManifest.version).toBe(claudeManifest.version)
+    expect(codexManifest.description).toBe(claudeManifest.description)
+    expect(codexManifest.skills).toBe("./skills/")
+    expect(codexManifest.mcpServers).toBe("./.mcp.json")
+    expect(codexManifest.interface?.displayName).toBe("Compound Engineering")
+    expect(codexManifest.interface?.developerName).toBe("Kieran Klaassen")
+    expect(codexManifest.interface?.category).toBe("Developer Tools")
+  })
+
+  test("coding-tutor codex manifest packages its skills without requiring extra surfaces", async () => {
+    const codexManifestPath = path.join(
+      REPO_ROOT,
+      "plugins",
+      "coding-tutor",
+      ".codex-plugin",
+      "plugin.json",
+    )
+    const claudeManifestPath = path.join(
+      REPO_ROOT,
+      "plugins",
+      "coding-tutor",
+      ".claude-plugin",
+      "plugin.json",
+    )
+
+    const codexManifest = await readJsonFile<PluginManifest>(codexManifestPath)
+    const claudeManifest = await readJsonFile<PluginManifest>(claudeManifestPath)
+
+    expect(codexManifest.name).toBe(claudeManifest.name)
+    expect(codexManifest.version).toBe(claudeManifest.version)
+    expect(codexManifest.description).toBe(claudeManifest.description)
+    expect(codexManifest.skills).toBe("./skills/")
+    expect(codexManifest.mcpServers).toBeUndefined()
+    expect(codexManifest.interface?.displayName).toBe("Coding Tutor")
+    expect(codexManifest.interface?.category).toBe("Education")
+  })
+})


### PR DESCRIPTION
feat(codex): add native plugin marketplace metadata

## Summary
- add a repo-local Codex marketplace under `.agents/plugins/marketplace.json`
- add native `.codex-plugin` manifests for `compound-engineering` and `coding-tutor`
- document Codex installation in both plugin READMEs
- add coverage for Codex marketplace and manifest alignment

## Testing
- bun test tests/codex-plugin-marketplace.test.ts tests/codex-writer.test.ts tests/codex-converter.test.ts tests/sync-codex.test.ts tests/codex-agents.test.ts
- bun run release:validate
