### PR TITLE
feat(ce-plan): add decision matrix form, unchanged invariants, and risk table format

### DIFF
--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -311,6 +311,7 @@ Before detailing implementation units, decide whether an overview would help a r
 | Data pipeline or transformation | Data flow sketch |
 | State-heavy lifecycle | State diagram |
 | Complex branching logic | Flowchart |
+| Mode/flag combinations or multi-input behavior | Decision matrix (inputs -> outcomes) |
 | Single-component with non-obvious shape | Pseudo-code sketch |
 
 **When to skip it:**
@@ -508,10 +509,13 @@ deepened: YYYY-MM-DD  # optional, set when the confidence check substantively st
 - **State lifecycle risks:** [Partial-write, cache, duplicate, or cleanup concerns]
 - **API surface parity:** [Other interfaces that may require the same change]
 - **Integration coverage:** [Cross-layer scenarios unit tests alone will not prove]
+- **Unchanged invariants:** [Existing APIs, interfaces, or behaviors that this plan explicitly does not change — and how the new work relates to them. Include when the change touches shared surfaces and reviewers need blast-radius assurance]
 
 ## Risks & Dependencies
 
-- [Meaningful risk, dependency, or sequencing concern]
+| Risk | Mitigation |
+|------|------------|
+| [Meaningful risk] | [How it is addressed or accepted] |
 
 ## Documentation / Operational Notes
 
@@ -542,7 +546,9 @@ For larger `Deep` plans, extend the core template only when useful with sections
 
 ## Risk Analysis & Mitigation
 
-- [Risk]: [Mitigation]
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| [Risk] | [Low/Med/High] | [Low/Med/High] | [How addressed] |
 
 ## Phased Delivery
 


### PR DESCRIPTION
Three targeted improvements to the ce:plan template, informed by analyzing well-crafted external plan specs and identifying patterns that genuinely strengthen our output.

**Decision matrix as a named design form** — The section 3.4 table (High-Level Technical Design) lists pseudo-code, diagrams, flowcharts, etc. but didn't name decision/behavior matrices. For work involving flag combinations or multi-input behavior, a compact inputs-to-outcomes table is the clearest communication form. Two independent external specs both used this pattern unprompted.

**Unchanged invariants in System-Wide Impact** — The template already asks "what may be affected" but never prompts for the inverse: what explicitly doesn't change. When a plan touches shared surfaces, listing unchanged APIs and behaviors gives reviewers blast-radius assurance that Scope Boundaries (deliberate non-goals) doesn't cover. Added as an optional bullet in the existing section.

**Risk | Mitigation table format** — Changed from loose bullets (`- [risk]`) to a table that forces pairing each risk with how it's addressed. The core template uses a 2-column table; the Deep plan extension uses a 4-column table adding Likelihood and Impact. Prevents orphaned risks without mitigation plans.

## Test plan

- [x] `bun test` passes (497 tests, 0 failures)
- Template changes are in markdown fenced blocks — no parser or converter impact

---

[![Compound Engineering v2.55.0](https://img.shields.io/badge/Compound_Engineering-v2.55.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)