### PR TITLE
fix(cli-agent-readiness-reviewer): remove top-5 cap on improvements

### DIFF
--- a/plugins/compound-engineering/agents/review/cli-agent-readiness-reviewer.md
+++ b/plugins/compound-engineering/agents/review/cli-agent-readiness-reviewer.md
@@ -296,10 +296,15 @@ Treat fixed thresholds as heuristics, not laws. A default above roughly 500 line
 
 [repeat for each principle]
 
-### Highest-Impact Improvements
+### Prioritized Improvements
 
-1. <highest-impact improvement with framework-specific implementation guidance>
+Include every finding from the detailed section, ordered by impact. Do not cap at 5 — list all actionable improvements. Each item should be self-contained enough to act on: the problem, the affected files or commands, and the specific fix.
+
+1. **<short title>**
+   <affected files or commands>. <what to change and how, using framework-idiomatic guidance>
 2. ...
+
+...continue until all findings are listed
 
 ### What's Working Well
 


### PR DESCRIPTION
The cli-agent-readiness-reviewer was consistently producing only 5 items in its "Highest-Impact Improvements" section, even when more findings existed. The template pattern (`1.` / `2. ...`) was implicitly signaling a short list to the model.

Renamed the section to "Prioritized Improvements" and added explicit instructions to list all findings ordered by impact with enough detail per item (title line + location and fix) to be actionable without cross-referencing the detailed findings section.

---

[![Compound Engineering v2.55.0](https://img.shields.io/badge/Compound_Engineering-v2.55.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)