### PR TITLE
fix(git-commit-push-pr): correct plugin.json path for version badge

### DIFF
--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -311,7 +311,7 @@ This command takes a work document (plan, specification, or todo file) and execu
    | `[THINKING]` | Thinking level (if known) | extended thinking |
    | `[HARNESS]` | Tool running you | Claude Code, Codex, Gemini CLI |
    | `[HARNESS_URL]` | Link to that tool | `https://claude.com/claude-code` |
-   | `[VERSION]` | `plugin.json` → `version` | 2.40.0 |
+   | `[VERSION]` | `version` from `.claude-plugin/plugin.json` in the compound-engineering plugin root. If not accessible, use `latest` | 2.56.0 |
 
    Subagents creating commits/PRs are equally responsible for accurate attribution.
 

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -302,7 +302,7 @@ This command takes a work document (plan, specification, or todo file) and execu
    | `[THINKING]` | Thinking level (if known) | extended thinking |
    | `[HARNESS]` | Tool running you | Claude Code, Codex, Gemini CLI |
    | `[HARNESS_URL]` | Link to that tool | `https://claude.com/claude-code` |
-   | `[VERSION]` | `plugin.json` → `version` | 2.40.0 |
+   | `[VERSION]` | `version` from `.claude-plugin/plugin.json` in the compound-engineering plugin root. If not accessible, use `latest` | 2.56.0 |
 
    Subagents creating commits/PRs are equally responsible for accurate attribution.
 

--- a/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
+++ b/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
@@ -297,7 +297,7 @@ Fill in at PR creation time:
 | `[THINKING]` | Thinking level (if known) | extended thinking |
 | `[HARNESS]` | Tool running you | Claude Code, Codex, Gemini CLI |
 | `[HARNESS_URL]` | Link to that tool | `https://claude.com/claude-code` |
-| `[VERSION]` | `plugin.json` -> `version` | 2.40.0 |
+| `[VERSION]` | `version` from `.claude-plugin/plugin.json` in the compound-engineering plugin root. If not accessible, use `latest` | 2.56.0 |
 
 ### Step 7: Create or update the PR
 


### PR DESCRIPTION
The `[VERSION]` placeholder in the badge table referenced `plugin.json` without the `.claude-plugin/` subdirectory. Agents found the right plugin cache directory but looked for the file at the root, causing a read failure that cascaded into a JSON parse error. Now specifies `.claude-plugin/plugin.json` and falls back to `latest` when the file is inaccessible.

Same fix applied to `ce-work` and `ce-work-beta` which share the pattern.

---

[![Compound Engineering v2.56.0](https://img.shields.io/badge/Compound_Engineering-v2.56.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)