### PR TITLE
feat(ce-work): accept bare prompts and add test discovery

### DIFF
--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -103,7 +103,7 @@ Determine how to proceed based on what was provided in `<input_document>`.
    - You want to keep the default branch clean while experimenting
    - You plan to switch between branches frequently
 
-3. **Create Todo List** _(skip if Phase 0 already built one)_
+3. **Create Todo List** _(skip if Phase 0 already built one, or if Phase 0 routed as Trivial)_
    - Use your available task tracking tool (e.g., TodoWrite, task lists) to break the plan into actionable tasks
    - Derive tasks from the plan's implementation units, dependencies, files, test targets, and verification criteria
    - Carry each unit's `Execution note` into the task when present

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -102,7 +102,7 @@ Determine how to proceed based on what was provided in `<input_document>`.
    - You want to keep the default branch clean while experimenting
    - You plan to switch between branches frequently
 
-3. **Create Todo List** _(skip if Phase 0 already built one)_
+3. **Create Todo List** _(skip if Phase 0 already built one, or if Phase 0 routed as Trivial)_
    - Use your available task tracking tool (e.g., TodoWrite, task lists) to break the plan into actionable tasks
    - Derive tasks from the plan's implementation units, dependencies, files, test targets, and verification criteria
    - Carry each unit's `Execution note` into the task when present


### PR DESCRIPTION
## Summary

ce:work now handles bare prompts (not just plan files) and includes test discovery as a first-class execution step.

**Phase 0 — Input Triage** routes bare prompts through a complexity assessment before execution. Trivial work skips ceremony entirely, small/medium work gets an inline task list, and large work surfaces a recommendation toward brainstorm/plan without forcing it. When a plan document is provided, Phase 0 is skipped entirely — no overhead for the existing pipeline.

**Test Discovery** is a new universal step in the Phase 2 execution loop. Before changing a file, the agent finds its existing test files (by import, naming pattern, or shared references). When a plan specifies test scenarios, the agent starts there and supplements with any coverage the plan missed. Test guidance throughout the skill now uses "add/update/remove" instead of just "add new tests."

Both changes propagated to ce:work-beta — they're orthogonal to the delegate mode that beta exists to test.

---

[![Compound Engineering v2.54.1](https://img.shields.io/badge/Compound_Engineering-v2.54.1-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)