### PR TITLE
feat(document-review): add headless mode for programmatic callers

### DIFF
--- a/plugins/compound-engineering/skills/document-review/SKILL.md
+++ b/plugins/compound-engineering/skills/document-review/SKILL.md
@@ -34,7 +34,7 @@ If `mode:headless` is not present, the skill runs in its default interactive mod
 
 **If no document is specified (interactive mode):** Ask which document to review, or find the most recent in `docs/brainstorms/` or `docs/plans/` using a file-search/glob tool (e.g., Glob in Claude Code).
 
-**If no document is specified (headless mode):** Output "Headless mode requires a document path. Re-invoke with: Skill(\"compound-engineering:document-review\", \"<path> mode:headless\")" and return "Review complete" without dispatching agents.
+**If no document is specified (headless mode):** Output "Review failed: headless mode requires a document path. Re-invoke with: Skill(\"compound-engineering:document-review\", \"<path> mode:headless\")" without dispatching agents.
 
 ### Classify Document Type
 


### PR DESCRIPTION
## Summary

- Adds `mode:headless` support to document-review for programmatic callers (other skills, pipelines)
- In headless mode: `auto` fixes applied silently, `batch_confirm` + `present` findings returned as structured text with classifications intact — no interactive prompts
- Headless mode changes the interaction model, not the classification boundaries
- Interactive mode completely unchanged when `mode:headless` is not present

## Motivation

Other plugins (e.g., open-source-contributor) want to use document-review as a utility in their plan-creation pipelines. The current interactive flow (AskUserQuestion for batch confirms, present-tier findings) doesn't fit pipelines where the calling skill should handle remaining findings with domain-specific knowledge.

Headless mode enables a multi-tier auto-fix cascade:
1. **document-review** auto-fixes `auto` items (deterministic, same as interactive)
2. **document-review** returns `batch_confirm` + `present` findings as structured text with classifications
3. **Calling skill** resolves findings using its domain knowledge (e.g., maintainer preferences, repo conventions)
4. **User** handles only truly ambiguous items

## Changes

Single file: `plugins/compound-engineering/skills/document-review/SKILL.md`

- **Phase 0**: Detect `mode:headless` in skill arguments. `mode:*` tokens are flags, not file paths — stripped from arguments before the remainder is used as the document path.
- **Phase 1**: Headless mode requires a document path. Returns `"Review failed: ..."` with re-invocation guidance if missing — distinct from `"Review complete"` so callers can tell a bad invocation from a successful review.
- **Phase 4 Batch Confirm**: Headless path returns findings to caller with classification intact (not auto-applied). Interactive path unchanged.
- **Phase 4 Present**: Headless path outputs structured text summary with `[batch_confirm]` and `[present]` tags. Interactive path unchanged.
- **Phase 5**: Headless path returns immediately with "Review complete". Interactive path unchanged.
- **What NOT to Do**: Broadened caller list to include external plugin skills.

## Test plan

- [ ] Run `/document-review` interactively on a plan doc — verify no behavior change
- [ ] Run `/document-review docs/plans/some-plan.md mode:headless` — verify only `auto` items applied, `batch_confirm` + `present` returned as text, no AskUserQuestion calls
- [ ] Run `/document-review mode:headless` (no path) — verify `"Review failed:"` returned, no agents dispatched, distinct from `"Review complete"`
- [ ] Verify headless output includes classification tags (`[batch_confirm]` vs `[present]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)