### PR TITLE
feat(skills): clean up argument-hint across ce:* skills

### DIFF
--- a/plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ce:compound-refresh
 description: Refresh stale or drifting learnings and pattern docs in docs/solutions/ by reviewing, updating, consolidating, replacing, or deleting them against the current codebase. Use after refactors, migrations, dependency upgrades, or when a retrieved learning feels outdated or wrong. Also use when reviewing docs/solutions/ for accuracy, when a recently solved problem contradicts an existing learning, when pattern docs no longer reflect current code, or when multiple docs seem to cover the same topic and might benefit from consolidation.
-argument-hint: "[mode:autofix] [optional: scope hint]"
 disable-model-invocation: true
 ---
 

--- a/plugins/compound-engineering/skills/ce-compound/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ce:compound
 description: Document a recently solved problem to compound your team's knowledge
-argument-hint: "[optional: brief context about the fix]"
 ---
 
 # /compound

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ce:ideate
 description: "Generate and critically evaluate grounded improvement ideas for the current project. Use when asking what to improve, requesting idea generation, exploring surprising improvements, or wanting the AI to proactively suggest strong project directions before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on this project', 'surprise me with improvements', 'what would you change', or any request for AI-generated project improvement suggestions rather than refining the user's own idea."
-argument-hint: "[optional: feature, focus area, or constraint]"
+argument-hint: "[feature, focus area, or constraint]"
 ---
 
 # Generate Improvement Ideas

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ce:plan
 description: "Transform feature descriptions or requirements into structured implementation plans grounded in repo patterns and research. Use when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', or when a brainstorm/requirements document is ready for technical planning. Best when requirements are at least roughly defined; for exploratory or ambiguous requests, prefer ce:brainstorm first."
-argument-hint: "[feature description, requirements doc path, or improvement idea]"
+argument-hint: "[optional: feature description, requirements doc path, or improvement idea]"
 ---
 
 # Create Technical Plan

--- a/plugins/compound-engineering/skills/ce-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ce:review
 description: "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR."
-argument-hint: "[mode:autofix|mode:report-only|mode:headless] [PR number, GitHub URL, or branch name]"
+argument-hint: "[blank to review current branch, or provide PR link]"
 ---
 
 # Code Review

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: ce:work-beta
 description: "[BETA] Execute work with external delegate support. Same as ce:work but includes experimental Codex delegation mode for token-conserving code implementation."
-argument-hint: "[plan file path or description of work to do]"
 disable-model-invocation: true
+argument-hint: "[Plan doc path or description of work. Blank to auto use latest plan doc]"
 ---
 
 # Work Execution Command

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ce:work
 description: Execute work efficiently while maintaining quality and finishing features
-argument-hint: "[plan file path or description of work to do]"
+argument-hint: "[Plan doc path or description of work. Blank to auto use latest plan doc]"
 ---
 
 # Work Execution Command


### PR DESCRIPTION
The bracket syntax in `argument-hint` was confusing users — square brackets conventionally mean "optional" in CLI man pages, but most people read them as "type something here." Since the core `ce:*` workflow skills all work fine invoked bare, the hints were creating false pressure to provide input.

**Changes by skill:**

| Skill | Before | After |
|-------|--------|-------|
| `ce:review` | `[mode:autofix\|mode:report-only\|mode:headless] [PR number, GitHub URL, or branch name]` | `[blank to review current branch, or provide PR link]` |
| `ce:work` | `[plan file path or description of work to do]` | `[Plan doc path or description of work. Blank to auto use latest plan doc]` |
| `ce:work-beta` | `[plan file path or description of work to do]` | `[Plan doc path or description of work. Blank to auto use latest plan doc]` |
| `ce:plan` | `[feature description, requirements doc path, or improvement idea]` | `[optional: feature description, requirements doc path, or improvement idea]` |
| `ce:ideate` | `[optional: feature, focus area, or constraint]` | `[feature, focus area, or constraint]` |
| `ce:compound` | `[optional: brief context about the fix]` | *(removed)* |
| `ce:compound-refresh` | `[mode:autofix] [optional: scope hint]` | *(removed)* |

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, high effort) via [Claude Code](https://claude.com/claude-code)