### PR TITLE
feat(ce-plan): add conditional visual aids to plan documents

### DIFF
--- a/docs/plans/2026-03-29-002-feat-plan-visual-aids-plan.md
+++ b/docs/plans/2026-03-29-002-feat-plan-visual-aids-plan.md
@@ -30,7 +30,7 @@ Evidence from real plans:
 - R3. Visual aids are distinct from Section 3.4 (High-Level Technical Design) — they improve *plan document readability*, not the *solution's technical design*
 - R4. Three diagram types at the plan level: implementation unit dependency graphs, system-wide interaction diagrams, and comparison tables for modes/decisions
 - R5. The existing plan template, Section 3.4, and planning rules remain intact; the pre-finalization checklist in Phase 5.1 gains one additional visual-aid check
-- R6. Format selection reuses brainstorm's established framework (mermaid default, ASCII for annotated flows, markdown tables for comparisons)
+- R6. Format selection is self-contained, following the same structure as brainstorm's guidance (mermaid default, ASCII for annotated flows, markdown tables for comparisons) but restated with plan-appropriate detail
 
 ## Scope Boundaries
 
@@ -68,7 +68,7 @@ Evidence from real plans:
 
 - **Content triggers, not depth triggers**: Reuses brainstorm's established principle. A Lightweight plan about a complex workflow may warrant a dependency graph; a Deep plan about a straightforward feature may not.
 
-- **Reuse brainstorm's format selection framework**: Mermaid default, ASCII for annotated flows, markdown tables for comparisons. No need to define a separate format framework.
+- **Self-contained format selection, same structure as brainstorm**: Skills are self-contained and cannot reference each other's guidance. The format selection section restates the framework (mermaid default, ASCII for annotated flows, markdown tables for comparisons) with plan-appropriate detail rather than pointing to brainstorm.
 
 - **Relationship to existing Section 4.3 mermaid rule**: Section 4.3 Planning Rules already contains a line encouraging mermaid diagrams "when they clarify relationships or flows that prose alone would make hard to follow — ERDs for data model changes, sequence diagrams for multi-service interactions, state diagrams for lifecycle transitions, flowcharts for complex branching logic." That existing rule applies to solution-design diagrams within the High-Level Technical Design section and per-unit technical design fields — it's an extension of Section 3.4's guidance into the planning rules. The new visual communication guidance applies to plan-readability diagrams in other sections (dependency graphs, interaction diagrams in System-Wide Impact, comparison tables in Overview). Leave the existing Section 4.3 rule as-is and add the new guidance after it as a distinct subsection. The introductory paragraph should distinguish from both Section 3.4 and the existing 4.3 mermaid rule.
 
@@ -118,11 +118,11 @@ Add a new subsection after Section 4.3 (Planning Rules) and before Phase 5 (Fina
    - The visual would duplicate what Section 3.4's High-Level Technical Design already shows
    - The visual describes code-level detail (specific method names, SQL columns, API field lists)
 
-4. **Format selection** — Reference brainstorm's framework rather than restating it:
-   - Mermaid (default) for dependency graphs and interaction diagrams
+4. **Format selection** — Self-contained guidance matching brainstorm's structure but with plan-appropriate detail:
+   - Mermaid (default) for dependency graphs and interaction diagrams — 5-15 nodes, no in-box annotations, TB direction
+   - ASCII/box-drawing for annotated flows needing rich in-box content — file path layouts, decision logic branches
    - Markdown tables for mode/variant/decision comparisons
-   - ASCII only when rich in-box annotations (commands, decision branches) are needed
-   - Keep proportionate — a 6-unit plan gets a simple 6-node graph, not an elaborate diagram
+   - Proportionality, inline placement, plan-structure level only, prose-is-authoritative
 
 5. **Pre-finalization check addition** — Add one check to Phase 5.1: "Would a visual aid (dependency graph, interaction diagram, comparison table) help a reader grasp the plan structure faster than scanning prose alone?"
 

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -600,11 +600,12 @@ Visual aids are conditional on content patterns, not on plan depth classificatio
 - The visual describes code-level detail (specific method names, SQL columns, API field lists)
 
 **Format selection:**
-- **Mermaid** (default) for dependency graphs and interaction diagrams. Use `TB` (top-to-bottom) direction. Source should be readable as fallback in diff views and terminals.
+- **Mermaid** (default) for dependency graphs and interaction diagrams -- 5-15 nodes, no in-box annotations, standard flowchart shapes. Use `TB` (top-to-bottom) direction so diagrams stay narrow in both rendered and source form. Source should be readable as fallback in diff views and terminals.
+- **ASCII/box-drawing diagrams** for annotated flows that need rich in-box content -- file path layouts, decision logic branches, multi-column spatial arrangements. More expressive than mermaid when the diagram's value comes from annotations within nodes. Follow 80-column max for code blocks, use vertical stacking.
 - **Markdown tables** for mode/variant comparisons and decision/approach comparisons.
-- **ASCII/box-drawing** only when rich in-box annotations (commands, decision logic branches) are needed. Follow 80-column max for code blocks.
-- Keep proportionate -- a 6-unit plan gets a simple 6-node graph, not an elaborate diagram. Every node should earn its place.
+- Keep diagrams proportionate to the plan. A 6-unit linear chain gets a simple 6-node graph. A complex dependency graph with fan-out and fan-in may need 10-15 nodes -- that is fine if every node earns its place.
 - Place inline at the point of relevance, not in a separate section.
+- Plan-structure level only -- unit dependencies, component interactions, mode comparisons, impact surfaces. Not implementation architecture, data schemas, or code structure (those belong in Section 3.4).
 - Prose is authoritative: when a visual aid and its surrounding prose disagree, the prose governs.
 
 After generating a visual aid, verify it accurately represents the plan sections it illustrates -- correct dependency edges, no missing surfaces, no merged units.


### PR DESCRIPTION
## Summary

- Adds Section 4.4 "Visual Communication in Plan Documents" to ce:plan -- content-pattern triggers for when to include dependency graphs, interaction diagrams, and comparison tables in plan documents
- Distinct from Section 3.4 (solution-level technical design) and the existing Section 4.3 mermaid rule -- this guidance covers plan-document readability
- Adds one pre-finalization checklist item to Phase 5.1 for visual aid consideration
- Preserves existing template structure, Section 3.4, and planning rules intact

## Context

Extends the visual aids work from #437 (ce:brainstorm) to the planning level. Evidence from real plans (release automation, merge-deepen-into-plan, adversarial review agents) showed that plans with 5+ non-linear units and dense System-Wide Impact sections would benefit from inline visual aids for reader comprehension.

## Test plan

- [x] Verify `bun test` passes (506 tests, all green)
- [x] Verify `bun run release:validate` passes
- [ ] Run ce:plan on a multi-unit feature -- should produce inline dependency graph when 4+ non-linear units exist
- [ ] Run ce:plan on a simple 2-unit feature -- should produce no plan-readability visual aids
- [ ] Run ce:plan on a feature with complex System-Wide Impact -- should produce interaction diagram
- [ ] Verify Section 3.4 High-Level Technical Design is unchanged and not duplicated

## Post-Deploy Monitoring & Validation

No additional operational monitoring required -- this is a skill prompt change with no runtime infrastructure impact. Quality validation is behavioral: observe plan output documents for appropriate diagram inclusion over the next few uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)