### PR TITLE
feat(ce-plan): add interactive deepening mode for on-demand plan strengthening

### DIFF
--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -898,7 +898,7 @@ When presenting findings from multiple agents targeting the same section, presen
 
 After all agents have been reviewed, carry only the accepted findings forward to 5.3.7.
 
-If the user accepted no findings, report "No findings accepted — plan unchanged" and proceed directly to Phase 5.4 (skip document-review and synthesis — the plan was not modified).
+If the user accepted no findings, report "No findings accepted — plan unchanged." If artifact-backed mode was used, clean up the scratch directory before continuing. Then proceed directly to Phase 5.4 (skip document-review and synthesis — the plan was not modified).
 
 If findings were accepted and the plan was modified, proceed through 5.3.7 and 5.3.8 as normal — document-review acts as a quality gate on the changes.
 


### PR DESCRIPTION
## Summary

When the `deepen-plan` command was folded into `ce:plan`, the ability to review sub-agent findings individually before they modified the plan was lost. Users working on complex multi-phase projects want to accept or reject each reviewer's suggestions rather than having them auto-integrated.

This adds an **interactive deepening mode** that activates when a user explicitly asks to deepen an existing plan (e.g., "deepen the plan", `/ce:plan deepen`). Auto-deepening during plan generation is unchanged.

Fixes #429

## What changed

- **Skill description and argument-hint** updated so ce:plan auto-triggers for deepening requests
- **Phase 0.1** — deepen intent now targets plan docs (not requirements docs), with light-touch discovery that confirms with the user when the match isn't obvious
- **Phase 5.3** — two deepening modes: auto (default during generation, unchanged) and interactive (on-demand, per-agent accept/reject/discuss review)
- **New Phase 5.3.6b** — interactive finding review gate between agent dispatch and synthesis. Findings presented one agent at a time; only accepted findings are integrated
- **Phase 5.3.7** — interactive mode only synthesizes accepted findings
- **Pipeline mode** — always auto, no behavioral change for automated workflows
- **Signal word tightening** — only "deepen"/"deepening" auto-enter the fast path. Generic words like "strengthen", "confidence", "gaps" require user confirmation when targeting the whole plan, and route to normal editing when they name a specific section. Prevents false-positive deepening triggers from requests like "strengthen the risk section"

## Design decisions

- One skill, one entry point — behavior adapts to invocation intent rather than adding a separate `/deepen-plan` command back
- "Discuss" leads to one exchange then a binary accept/reject re-ask — no automatic fallback that modifies the plan without explicit consent
- When all findings are rejected, document-review is skipped (plan unchanged) and flow proceeds to post-generation options
- When findings are accepted, document-review runs as a quality gate on the modifications
- Three-tier signal word hierarchy: "deepen" (auto-trigger) > "strengthen"/"confidence"/"gaps" on whole plan (confirm first) > same words on a specific section (normal edit). This came from eval testing that showed generic words could false-positive into a full deepening pass when the user just wanted a targeted edit

## Eval results

Ran 8 test cases across 2 iterations using skill-creator evals:

| Eval | Category | Result |
|---|---|---|
| Plan creation (new feature) | No regression | 8/8 |
| Explicit "deepen the plan" | Deepening | 6/6 |
| "Strengthen" (whole plan) | Signal words | 3/3 (confirms first) |
| Normal edit ("update test scenarios") | Disambiguation | 4/4 |
| Indirect intent ("confidence gaps") | Signal words | 4/4 (confirms first) |
| "Strengthen the risk section" | Disambiguation | 3/3 (normal edit) |

## Test plan

- [ ] `/ce:plan` on a new feature — auto-deepening runs as before, no interactive prompts
- [ ] `/ce:plan deepen` with a plan in `docs/plans/` — enters interactive mode
- [ ] "deepen the plan" without slash command — skill auto-triggers
- [ ] "strengthen the plan" — confirms deepening intent before entering interactive mode
- [ ] "strengthen the risk section" — routes to normal editing, not deepening
- [ ] Interactive mode: accept some findings, reject others — only accepted ones integrated
- [ ] Interactive mode: reject all findings — plan unchanged, skips to 5.4
- [ ] Pipeline/headless mode — always auto, no interaction

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)