### PR TITLE
fix(ce-work): make code review invocation mandatory by default

### DIFF
--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -291,17 +291,17 @@ Determine how to proceed based on what was provided in `<input_document>`.
    # Use linting-agent before pushing to origin
    ```
 
-2. **Code Review**
+2. **Code Review** (REQUIRED)
 
-   Every change gets reviewed before shipping. The depth scales with the change's risk profile.
+   Every change gets reviewed before shipping. The depth scales with the change's risk profile, but review itself is never skipped.
 
-   **Tier 1: Inline self-review** — Read the diff and check for logic errors, missed edge cases, and plan drift. No specialized agents. Use this tier only when **all four** criteria are true:
+   **Tier 2: Full review (default)** — REQUIRED unless Tier 1 criteria are explicitly met. Invoke the `ce:review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and surface residual work as todos. When the plan file path is known, pass it as `plan:<path>`. This is the mandatory default — proceed to Tier 1 only after confirming every criterion below.
+
+   **Tier 1: Inline self-review** — A lighter alternative permitted only when **all four** criteria are true. Before choosing Tier 1, explicitly state which criteria apply and why. If any criterion is uncertain, use Tier 2.
    - Purely additive (new files only, no existing behavior modified)
    - Single concern (one skill, one component — not cross-cutting)
    - Pattern-following (implementation mirrors an existing example with no novel logic)
    - Plan-faithful (no scope growth, no deferred questions resolved with surprising answers)
-
-   **Tier 2: Full review (default)** — Load the `ce:review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and surface residual work as todos. When the plan file path is known, pass it as `plan:<path>`. This is the default when working from a plan — use it unless all four Tier 1 criteria are met.
 
 3. **Final Validation**
    - All tasks marked completed
@@ -528,13 +528,13 @@ Before creating PR, verify:
 
 Every change gets reviewed. The tier determines depth, not whether review happens.
 
-**Tier 1 (inline self-review)** — all four must be true:
+**Tier 2 (full review)** — REQUIRED default. Invoke `ce:review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work surfaces as todos. Always use this tier unless all four Tier 1 criteria are explicitly confirmed.
+
+**Tier 1 (inline self-review)** — permitted only when all four are true (state each explicitly before choosing):
 - Purely additive (new files only, no existing behavior modified)
 - Single concern (one skill, one component — not cross-cutting)
 - Pattern-following (mirrors an existing example, no novel logic)
 - Plan-faithful (no scope growth, no surprising deferred-question resolutions)
-
-**Tier 2 (full review)** — the default when working from a plan. Invoke `ce:review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work surfaces as todos.
 
 ## Common Pitfalls to Avoid
 

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -282,17 +282,17 @@ Determine how to proceed based on what was provided in `<input_document>`.
    # Use linting-agent before pushing to origin
    ```
 
-2. **Code Review**
+2. **Code Review** (REQUIRED)
 
-   Every change gets reviewed before shipping. The depth scales with the change's risk profile.
+   Every change gets reviewed before shipping. The depth scales with the change's risk profile, but review itself is never skipped.
 
-   **Tier 1: Inline self-review** — Read the diff and check for logic errors, missed edge cases, and plan drift. No specialized agents. Use this tier only when **all four** criteria are true:
+   **Tier 2: Full review (default)** — REQUIRED unless Tier 1 criteria are explicitly met. Invoke the `ce:review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and surface residual work as todos. When the plan file path is known, pass it as `plan:<path>`. This is the mandatory default — proceed to Tier 1 only after confirming every criterion below.
+
+   **Tier 1: Inline self-review** — A lighter alternative permitted only when **all four** criteria are true. Before choosing Tier 1, explicitly state which criteria apply and why. If any criterion is uncertain, use Tier 2.
    - Purely additive (new files only, no existing behavior modified)
    - Single concern (one skill, one component — not cross-cutting)
    - Pattern-following (implementation mirrors an existing example with no novel logic)
    - Plan-faithful (no scope growth, no deferred questions resolved with surprising answers)
-
-   **Tier 2: Full review (default)** — Load the `ce:review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and surface residual work as todos. When the plan file path is known, pass it as `plan:<path>`. This is the default when working from a plan — use it unless all four Tier 1 criteria are met.
 
 3. **Final Validation**
    - All tasks marked completed
@@ -455,13 +455,13 @@ Before creating PR, verify:
 
 Every change gets reviewed. The tier determines depth, not whether review happens.
 
-**Tier 1 (inline self-review)** — all four must be true:
+**Tier 2 (full review)** — REQUIRED default. Invoke `ce:review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work surfaces as todos. Always use this tier unless all four Tier 1 criteria are explicitly confirmed.
+
+**Tier 1 (inline self-review)** — permitted only when all four are true (state each explicitly before choosing):
 - Purely additive (new files only, no existing behavior modified)
 - Single concern (one skill, one component — not cross-cutting)
 - Pattern-following (mirrors an existing example, no novel logic)
 - Plan-faithful (no scope growth, no surprising deferred-question resolutions)
-
-**Tier 2 (full review)** — the default when working from a plan. Invoke `ce:review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work surfaces as todos.
 
 ## Common Pitfalls to Avoid
 


### PR DESCRIPTION
## Summary

The Code Review step in ce:work's Phase 3 lacked enforcement parity with other required steps (like "Prepare Operational Validation Plan (REQUIRED)"), making it easy for agents to rationalize skipping `ce:review`. An agent reported this as a bug in its own execution — it should have run ce:review automatically but didn't.

Three changes fix the incentive structure:

1. **Added `(REQUIRED)` tag** to the Code Review header, matching other mandatory steps
2. **Reordered tiers** — Tier 2 (full review) now appears first as the default action; Tier 1 is presented as the exception requiring explicit opt-out
3. **Requires explicit justification** before choosing Tier 1 — agents must state which criteria apply and why, rather than silently skipping review

Propagated to `ce-work-beta` (shared bug fix, not experimental behavior).

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)