### PR TITLE
fix(document-review): show contextual next-step in Phase 5 menu

### DIFF
--- a/plugins/compound-engineering/skills/document-review/SKILL.md
+++ b/plugins/compound-engineering/skills/document-review/SKILL.md
@@ -26,6 +26,7 @@ Callers invoke headless mode by including `mode:headless` in the skill arguments
 Skill("compound-engineering:document-review", "mode:headless docs/plans/my-plan.md")
 ```
 
+
 If `mode:headless` is not present, the skill runs in its default interactive mode with no behavior change.
 
 ## Phase 1: Get and Analyze Document
@@ -254,10 +255,12 @@ These are pipeline artifacts and must not be flagged for removal.
 - Gemini: `ask_user`
 - Fallback (no question tool available): present numbered options and stop; wait for the user's next message
 
-Offer:
+Offer these two options. Use the document type from Phase 1 to set the "Review complete" description:
 
-1. **Refine again** -- another review pass
-2. **Review complete** -- document is ready
+1. **Refine again** -- Address the findings above, then re-review
+2. **Review complete** -- description based on document type:
+   - requirements document: "Create technical plan with ce:plan"
+   - plan document: "Implement with ce:work"
 
 After 2 refinement passes, recommend completion -- diminishing returns are likely. But if the user wants to continue, allow it.
 


### PR DESCRIPTION
## Summary

The "Review complete" option in document-review's interactive Phase 5 menu described itself as "document is ready", which was vague enough that the model would embellish it with incorrect caller context — e.g., "proceed to brainstorm handoff" when running inside ce:brainstorm, where the actual next step is planning.

Now uses the document type classification that Phase 1 already performs to show the concrete next workflow step: requirements docs get "Create technical plan with ce:plan", plan docs get "Implement with ce:work". No new flags or caller coordination needed — document-review already knows the document type.

## Test plan

- [ ] Run ce:brainstorm through to document-review and verify the "Review complete" option says "Create technical plan with ce:plan"
- [ ] Run ce:plan through to document-review and verify the "Review complete" option says "Implement with ce:work"
- [ ] Run document-review standalone on a requirements doc and verify the same contextual description appears

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)