### PR TITLE
feat(model): add MiniMax provider prefix for cross-platform model normalization

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -34,6 +34,7 @@ export function resolveClaudeFamilyAlias(model: string): string {
  * "claude-sonnet-4-6" -> "anthropic/claude-sonnet-4-6"
  * "gpt-5.4"           -> "openai/gpt-5.4"
  * "gemini-2.0"        -> "google/gemini-2.0"
+ * "minimax-m2.7"      -> "minimax/minimax-m2.7"
  * "anthropic/foo"     -> "anthropic/foo" (unchanged)
  */
 export function addProviderPrefix(model: string): string {
@@ -42,6 +43,7 @@ export function addProviderPrefix(model: string): string {
   if (/^(gpt-|o1-|o3-)/.test(model)) return `openai/${model}`
   if (/^gemini-/.test(model)) return `google/${model}`
   if (/^qwen-/.test(model)) return `qwen/${model}`
+  if (/^minimax-/i.test(model)) return `minimax/${model}`
   return `anthropic/${model}`
 }
 

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -40,6 +40,12 @@ describe("addProviderPrefix", () => {
     expect(addProviderPrefix("qwen-3.5-plus")).toBe("qwen/qwen-3.5-plus")
   })
 
+  test("prefixes MiniMax models with minimax/", () => {
+    expect(addProviderPrefix("minimax-m2.7")).toBe("minimax/minimax-m2.7")
+    expect(addProviderPrefix("minimax-m2.5-highspeed")).toBe("minimax/minimax-m2.5-highspeed")
+    expect(addProviderPrefix("MiniMax-M2.7")).toBe("minimax/MiniMax-M2.7")
+  })
+
   test("defaults unknown models to anthropic/ prefix", () => {
     expect(addProviderPrefix("some-model")).toBe("anthropic/some-model")
   })

--- a/tests/openclaw-converter.test.ts
+++ b/tests/openclaw-converter.test.ts
@@ -91,6 +91,26 @@ describe("convertClaudeToOpenClaw", () => {
     expect(parsed.data.model).toBe("anthropic/claude-sonnet-4-6")
   })
 
+  test("prefixes minimax models with minimax/ provider", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [
+        {
+          name: "minimax-agent",
+          description: "MiniMax agent",
+          model: "minimax-m2.7",
+          body: "Use MiniMax model.",
+          sourcePath: "/tmp/plugin/agents/minimax.md",
+        },
+      ],
+    }
+
+    const bundle = convertClaudeToOpenClaw(plugin, defaultOptions)
+    const skill = bundle.skills.find((s) => s.name === "minimax-agent")
+    const parsed = parseFrontmatter(skill!.content)
+    expect(parsed.data.model).toBe("minimax/minimax-m2.7")
+  })
+
   test("converts commands to skill files (excluding disableModelInvocation)", () => {
     const bundle = convertClaudeToOpenClaw(fixturePlugin, defaultOptions)
 

--- a/tests/qwen-converter.test.ts
+++ b/tests/qwen-converter.test.ts
@@ -246,6 +246,16 @@ describe("convertClaudeToQwen", () => {
     expect(parsed.data.model).toBe("qwen/qwen-max")
   })
 
+  test("prefixes minimax models with minimax/ provider", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [{ name: "a", description: "d", model: "minimax-m2.7", body: "b", sourcePath: "/tmp/a.md" }],
+    }
+    const bundle = convertClaudeToQwen(plugin, defaultOptions)
+    const parsed = parseFrontmatter(bundle.agents[0].content)
+    expect(parsed.data.model).toBe("minimax/minimax-m2.7")
+  })
+
   test("passes through already-namespaced models unchanged", () => {
     const plugin: ClaudePlugin = {
       ...fixturePlugin,


### PR DESCRIPTION
## Summary

Adds MiniMax model recognition to the `addProviderPrefix()` function in `src/utils/model.ts`, so that MiniMax models (e.g. `minimax-m2.7`, `MiniMax-M2.5-highspeed`) are correctly namespaced as `minimax/` when converting plugins for multi-provider target platforms.

### Changes

- **`src/utils/model.ts`**: Add `minimax-` pattern (case-insensitive) to `addProviderPrefix()`, mapping MiniMax model IDs to the `minimax/` provider prefix
- **`tests/model-utils.test.ts`**: Add unit tests for MiniMax model prefixing (lowercase, highspeed variant, PascalCase)
- **`tests/qwen-converter.test.ts`**: Add converter test verifying MiniMax models get `minimax/` prefix in Qwen output
- **`tests/openclaw-converter.test.ts`**: Add converter test verifying MiniMax models get `minimax/` prefix in OpenClaw output

### How it works

MiniMax is a cloud LLM provider with models like `MiniMax-M2.7` and `MiniMax-M2.5-highspeed` (204K context). Multi-provider target platforms (OpenCode, Qwen, OpenClaw) need provider-prefixed model IDs to route requests correctly. This change ensures:

| Input | Output |
|-------|--------|
| `minimax-m2.7` | `minimax/minimax-m2.7` |
| `minimax-m2.5-highspeed` | `minimax/minimax-m2.5-highspeed` |
| `MiniMax-M2.7` | `minimax/MiniMax-M2.7` |

Case-insensitive matching handles both `minimax-` and `MiniMax-` conventions used in the wild.

## Test plan

- [x] `bun test tests/model-utils.test.ts` - unit tests for MiniMax prefix
- [x] `bun test tests/qwen-converter.test.ts` - Qwen converter integration
- [x] `bun test tests/openclaw-converter.test.ts` - OpenClaw converter integration
- [x] `bun test` - full suite (532 pass, 1 pre-existing failure in resolve-base-script.test.ts)
