### PR TITLE
fix(ce-brainstorm): distinguish verification from technical design in Phase 1.1

### DIFF
--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -89,7 +89,7 @@ Scan the repo before substantive brainstorming. Match depth to scope:
 
 If nothing obvious appears after a short scan, say so and continue. Two rules govern technical depth during the scan:
 
-1. **Verify before claiming** — When the brainstorm touches checkable infrastructure (database tables, routes, config files, dependencies, model definitions), read the relevant source files to confirm what actually exists. Any claim that something is absent must be verified against the codebase first; if not verified, label it as an unverified assumption. This applies to every brainstorm regardless of topic.
+1. **Verify before claiming** — When the brainstorm touches checkable infrastructure (database tables, routes, config files, dependencies, model definitions), read the relevant source files to confirm what actually exists. Any claim that something is absent — a missing table, an endpoint that doesn't exist, a dependency not in the Gemfile, a config option with no current support — must be verified against the codebase first; if not verified, label it as an unverified assumption. This applies to every brainstorm regardless of topic.
 
 2. **Defer design decisions to planning** — Implementation details like schemas, migration strategies, endpoint structure, or deployment topology belong in planning, not here — unless the brainstorm is itself about a technical or architectural decision, in which case those details are the subject of the brainstorm and should be explored.
 


### PR DESCRIPTION
Phase 1.1's "don't drift into technical planning" instruction conflated two activities: checking what currently exists (fact-checking) and deciding what to build (technical design). The blanket prohibition on inspecting "low-level architecture" prevented the skill from reading schema files, routes, or config — even when the brainstorm was about database tables. This caused unverified "table X does not exist" claims to be stated as fact and propagated into requirements documents.

The fix reframes the guardrail around the right distinction: defer *implementation decisions* (schemas, migration strategies, endpoint structure) to planning, but always permit *verification* of current state. Adds a rule that infrastructure existence claims must be verified against source files before being stated as fact — unverified claims must be labeled as assumptions.

Closes #457

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)