### PR TITLE
feat(test-xcode): add triggering context to skill description

### DIFF
--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -46,7 +46,7 @@ The primary entry points for engineering work, invoked as slash commands:
 | `/resolve-pr-feedback` | Resolve PR review feedback in parallel |
 | `/sync` | Sync Claude Code config across machines |
 | `/test-browser` | Run browser tests on PR-affected pages |
-| `/test-xcode` | Build and test iOS apps on simulator |
+| `/test-xcode` | Build and test iOS apps on simulator using XcodeBuildMCP |
 | `/onboarding` | Generate `ONBOARDING.md` to help new contributors understand the codebase |
 | `/todo-resolve` | Resolve todos in parallel |
 | `/todo-triage` | Triage and prioritize pending todos |

--- a/plugins/compound-engineering/skills/test-xcode/SKILL.md
+++ b/plugins/compound-engineering/skills/test-xcode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-xcode
-description: Build and test iOS apps on simulator using XcodeBuildMCP
+description: "Build and test iOS apps on simulator using XcodeBuildMCP. Use after making iOS code changes, before creating a PR, or when verifying app behavior and checking for crashes on simulator."
 argument-hint: "[scheme name or 'current' to use default]"
 disable-model-invocation: true
 ---


### PR DESCRIPTION
Improves the `test-xcode` skill description to include usage context ("when to use it"), addressing both [#447](https://github.com/EveryInc/compound-engineering-plugin/issues/447) and the plugin's own skill compliance checklist which requires descriptions to cover what a skill does *and* when to use it.

**Before:** `Build and test iOS apps on simulator using XcodeBuildMCP`
**After:** `Build and test iOS apps on simulator using XcodeBuildMCP. Use after making iOS code changes, before creating a PR, or when verifying app behavior and checking for crashes on simulator.`

Also aligns the README table entry with the full skill name (adds XcodeBuildMCP mention).

Closes #447

---

[![Compound Engineering v2.59.0](https://img.shields.io/badge/Compound_Engineering-v2.59.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)