### PR TITLE
fix(cli): exclude non-CLI paths from release-please

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -30,7 +30,10 @@
         ".agents/",
         ".gemini/",
         ".cursor/",
-        ".windsurf/"
+        ".windsurf/",
+        ".claude-plugin/",
+        ".cursor-plugin/",
+        "plugins/"
       ],
       "extra-files": [
         {


### PR DESCRIPTION
## Summary

- Adds `exclude-paths` to the CLI (`"."`) package in release-please config so root-level docs (`AGENTS.md`, `README.md`, etc.), CI config (`.github/`), release scripts (`scripts/`), and agent platform config dirs (`.claude/`, `.codex/`, `.gemini/`, `.cursor/`, `.windsurf/`, `.agents/`) are not misattributed as CLI changes
- Prevents phantom CLI releases and unnecessary version synchronization when only docs or repo config change
- `linked-versions` is unchanged — real CLI or plugin changes still bump both components to the same version

## Context

PR #470 (generated by release-please) incorrectly showed CLI release notes for commit `feat(skill-design): document skill file isolation...` which only touched `AGENTS.md`. Because `linked-versions` then synchronized compound-engineering to match, both components got a phantom bump. This fix prevents that class of error.

After merging, close PR #470 so release-please regenerates a clean release PR on the next real change.

## Test plan

- [ ] Verify `bun run release:validate` passes
- [ ] After merge, confirm next release-please PR excludes doc-only commits from CLI changelog
- [ ] Confirm `linked-versions` still synchronizes versions on real CLI+plugin changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)