### PR TITLE
feat(git-commit-push-pr): pre-resolve context to reduce bash calls

### DIFF
--- a/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
+++ b/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
@@ -68,7 +68,7 @@ Interpret the result this way:
 Run this single command to gather all context:
 
 ```bash
-printf '=== STATUS ===\n' && git status && printf '\n=== DIFF ===\n' && git diff HEAD && printf '\n=== BRANCH ===\n' && git branch --show-current && printf '\n=== LOG ===\n' && git log --oneline -10; printf '\n=== DEFAULT_BRANCH ===\n'; git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo '__DEFAULT_BRANCH_UNRESOLVED__'; printf '\n=== PR_CHECK ===\n'; PR_OUT=$(gh pr view --json url,title,state 2>&1); PR_EXIT=$?; printf '%s\n__GH_PR_VIEW_EXIT__=%s\n' "$PR_OUT" "$PR_EXIT"
+printf '=== STATUS ===\n'; git status; printf '\n=== DIFF ===\n'; git diff HEAD; printf '\n=== BRANCH ===\n'; git branch --show-current; printf '\n=== LOG ===\n'; git log --oneline -10; printf '\n=== DEFAULT_BRANCH ===\n'; git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo '__DEFAULT_BRANCH_UNRESOLVED__'; printf '\n=== PR_CHECK ===\n'; PR_OUT=$(gh pr view --json url,title,state 2>&1); PR_EXIT=$?; printf '%s\n__GH_PR_VIEW_EXIT__=%s\n' "$PR_OUT" "$PR_EXIT"
 ```
 
 Interpret the PR check result using the Reusable PR probe rules above.

--- a/plugins/compound-engineering/skills/git-commit/SKILL.md
+++ b/plugins/compound-engineering/skills/git-commit/SKILL.md
@@ -35,7 +35,7 @@ Create a single, well-crafted git commit from the current working tree changes.
 Run this single command to gather all context:
 
 ```bash
-printf '=== STATUS ===\n' && git status && printf '\n=== DIFF ===\n' && git diff HEAD && printf '\n=== BRANCH ===\n' && git branch --show-current && printf '\n=== LOG ===\n' && git log --oneline -10; printf '\n=== DEFAULT_BRANCH ===\n'; git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo '__DEFAULT_BRANCH_UNRESOLVED__'
+printf '=== STATUS ===\n'; git status; printf '\n=== DIFF ===\n'; git diff HEAD; printf '\n=== BRANCH ===\n'; git branch --show-current; printf '\n=== LOG ===\n'; git log --oneline -10; printf '\n=== DEFAULT_BRANCH ===\n'; git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo '__DEFAULT_BRANCH_UNRESOLVED__'
 ```
 
 ---


### PR DESCRIPTION
## Summary

Reduces the number of individual bash calls in the `git-commit-push-pr` and `git-commit` skills by pre-resolving read-only context on Claude Code and chaining commands elsewhere.

The screenshot that motivated this: a typical "ship this" invocation was producing 9 separate bash tool calls — the first 4-5 were pure info-gathering (git status, diff, branch, log, default branch, PR check) that could be eliminated or consolidated.

## Approach

**Claude Code path:** A new `## Context` section uses `!` backtick pre-resolution to populate git status, working tree diff, current branch, recent commits, remote default branch, and (for git-commit-push-pr) existing PR check before the skill body executes. The model sees populated data and uses it directly — zero bash calls for context gathering.

**Non-CC path:** The same section gates with "If you are not Claude Code, skip to Context fallback" at the top, directing to a single combined command that gathers all context in one bash call. The fallback section has a reciprocal gate ("If you are Claude Code, skip this section") so CC doesn't redundantly run it.

**Action-phase optimizations (all platforms):**
- Stage + commit chained into one call per commit group (`git add && git commit`)
- Step 6 scope gathering in git-commit-push-pr (verify ref, merge-base, log, diff) consolidated from 4 separate code blocks to 2

| Phase | Before | After (CC) | After (non-CC) |
|-------|--------|------------|-----------------|
| Context gathering | 5-6 calls | 0 | 1 |
| Stage + commit | 2 calls | 1 | 1 |
| Scope gathering (PR skill only) | 4-5 calls | 2 | 2 |

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)