### PR TITLE
fix(agents): remove self-referencing example blocks that cause recursive self-invocation

### DIFF
--- a/plugins/compound-engineering/agents/design/design-implementation-reviewer.md
+++ b/plugins/compound-engineering/agents/design/design-implementation-reviewer.md
@@ -4,21 +4,6 @@ description: "Visually compares live UI implementation against Figma designs and
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has just implemented a new component based on a Figma design.
-user: "I've finished implementing the hero section based on the Figma design"
-assistant: "I'll review how well your implementation matches the Figma design."
-<commentary>Since UI implementation has been completed, use the design-implementation-reviewer agent to compare the live version with Figma.</commentary>
-</example>
-<example>
-Context: After the general code agent has implemented design changes.
-user: "Update the button styles to match the new design system"
-assistant: "I've updated the button styles. Now let me verify the implementation matches the Figma specifications."
-<commentary>After implementing design changes, proactively use the design-implementation-reviewer to ensure accuracy.</commentary>
-</example>
-</examples>
-
 You are an expert UI/UX implementation reviewer specializing in ensuring pixel-perfect fidelity between Figma designs and live implementations. You have deep expertise in visual design principles, CSS, responsive design, and cross-browser compatibility.
 
 Your primary responsibility is to conduct thorough visual comparisons between implemented UI and Figma designs, providing actionable feedback on discrepancies.

--- a/plugins/compound-engineering/agents/design/design-iterator.md
+++ b/plugins/compound-engineering/agents/design/design-iterator.md
@@ -5,33 +5,6 @@ color: violet
 model: inherit
 ---
 
-<examples>
-<example>
-Context: User asks to change button color but result still looks off.
-user: "Change the button to blue"
-assistant: [makes change, takes screenshot] "The button is now blue, but I notice the overall color balance still feels off. Would you like me to use the design-iterator agent with 5 iterations to systematically improve the color harmony and visual balance?"
-<commentary>PROACTIVE USE: After a simple change doesn't fully resolve the design issue, suggest the design-iterator to do deeper work.</commentary>
-</example>
-<example>
-Context: User's design request leads to something that doesn't look right.
-user: "Make the hero section more modern"
-assistant: [makes initial changes] "I've added some modern elements, but the result isn't quite coming together. This looks like it needs iterative refinement. Let me use the design-iterator agent with 10 iterations to systematically improve typography, spacing, colors, and visual hierarchy until it feels polished."
-<commentary>PROACTIVE USE: When initial design work produces mediocre results, automatically suggest or use the design-iterator for comprehensive improvement.</commentary>
-</example>
-<example>
-Context: User wants explicit iterative refinement.
-user: "The features section looks boring, iterate on it 10 times"
-assistant: "I'll use the design-iterator agent to systematically refine your features section through 10 iterations of visual improvements"
-<commentary>User explicitly requests iteration, use design-iterator directly.</commentary>
-</example>
-<example>
-Context: Design task requires research and multiple passes.
-user: "Look at how Stripe does their pricing page and make mine better"
-assistant: "I'll launch the design-iterator agent with 8 iterations to research Stripe's design patterns and progressively apply those insights to your pricing page"
-<commentary>Competitor research combined with iterative refinement benefits from the systematic approach.</commentary>
-</example>
-</examples>
-
 You are an expert UI/UX design iterator specializing in systematic, progressive refinement of web components. Your methodology combines visual analysis, competitor research, and incremental improvements to transform ordinary interfaces into polished, professional designs.
 
 ## Core Methodology

--- a/plugins/compound-engineering/agents/design/figma-design-sync.md
+++ b/plugins/compound-engineering/agents/design/figma-design-sync.md
@@ -5,24 +5,6 @@ model: inherit
 color: purple
 ---
 
-<examples>
-<example>
-Context: User has just implemented a new component and wants to ensure it matches the Figma design.
-user: "I've just finished implementing the hero section component. Can you check if it matches the Figma design at https://figma.com/file/abc123/design?node-id=45:678"
-assistant: "I'll use the figma-design-sync agent to compare your implementation with the Figma design and fix any differences."
-</example>
-<example>
-Context: User is working on responsive design and wants to verify mobile breakpoint matches design.
-user: "The mobile view doesn't look quite right. Here's the Figma: https://figma.com/file/xyz789/mobile?node-id=12:34"
-assistant: "Let me use the figma-design-sync agent to identify the differences and fix them."
-</example>
-<example>
-Context: After initial fixes, user wants to verify the implementation now matches.
-user: "Can you check if the button component matches the design now?"
-assistant: "I'll run the figma-design-sync agent again to verify the implementation matches the Figma design."
-</example>
-</examples>
-
 You are an expert design-to-code synchronization specialist with deep expertise in visual design systems, web development, CSS/Tailwind styling, and automated quality assurance. Your mission is to ensure pixel-perfect alignment between Figma designs and their web implementations through systematic comparison, detailed analysis, and precise code adjustments.
 
 ## Your Core Responsibilities

--- a/plugins/compound-engineering/agents/docs/ankane-readme-writer.md
+++ b/plugins/compound-engineering/agents/docs/ankane-readme-writer.md
@@ -5,21 +5,6 @@ color: cyan
 model: inherit
 ---
 
-<examples>
-<example>
-Context: User is creating documentation for a new Ruby gem.
-user: "I need to write a README for my new search gem called 'turbo-search'"
-assistant: "I'll use the ankane-readme-writer agent to create a properly formatted README following the Ankane style guide"
-<commentary>Since the user needs a README for a Ruby gem and wants to follow best practices, use the ankane-readme-writer agent to ensure it follows the Ankane template structure.</commentary>
-</example>
-<example>
-Context: User has an existing README that needs to be reformatted.
-user: "Can you update my gem's README to follow the Ankane style?"
-assistant: "Let me use the ankane-readme-writer agent to reformat your README according to the Ankane template"
-<commentary>The user explicitly wants to follow Ankane style, so use the specialized agent for this formatting standard.</commentary>
-</example>
-</examples>
-
 You are an expert Ruby gem documentation writer specializing in the Ankane-style README format. You have deep knowledge of Ruby ecosystem conventions and excel at creating clear, concise documentation that follows Andrew Kane's proven template structure.
 
 Your core responsibilities:

--- a/plugins/compound-engineering/agents/research/best-practices-researcher.md
+++ b/plugins/compound-engineering/agents/research/best-practices-researcher.md
@@ -4,21 +4,6 @@ description: "Researches and synthesizes external best practices, documentation,
 model: inherit
 ---
 
-<examples>
-<example>
-Context: User wants to know the best way to structure GitHub issues for their Rails project.
-user: "I need to create some GitHub issues for our project. Can you research best practices for writing good issues?"
-assistant: "I'll use the best-practices-researcher agent to gather comprehensive information about GitHub issue best practices, including examples from successful projects and Rails-specific conventions."
-<commentary>Since the user is asking for research on best practices, use the best-practices-researcher agent to gather external documentation and examples.</commentary>
-</example>
-<example>
-Context: User is implementing a new authentication system and wants to follow security best practices.
-user: "We're adding JWT authentication to our Rails API. What are the current best practices?"
-assistant: "Let me use the best-practices-researcher agent to research current JWT authentication best practices, security considerations, and Rails-specific implementation patterns."
-<commentary>The user needs research on best practices for a specific technology implementation, so the best-practices-researcher agent is appropriate.</commentary>
-</example>
-</examples>
-
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.
 
 You are an expert technology researcher specializing in discovering, analyzing, and synthesizing best practices from authoritative sources. Your mission is to provide comprehensive, actionable guidance based on current industry standards and successful real-world implementations.

--- a/plugins/compound-engineering/agents/research/framework-docs-researcher.md
+++ b/plugins/compound-engineering/agents/research/framework-docs-researcher.md
@@ -4,21 +4,6 @@ description: "Gathers comprehensive documentation and best practices for framewo
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user needs to understand how to properly implement a new feature using a specific library.
-user: "I need to implement file uploads using Active Storage"
-assistant: "I'll use the framework-docs-researcher agent to gather comprehensive documentation about Active Storage"
-<commentary>Since the user needs to understand a framework/library feature, use the framework-docs-researcher agent to collect all relevant documentation and best practices.</commentary>
-</example>
-<example>
-Context: The user is troubleshooting an issue with a gem.
-user: "Why is the turbo-rails gem not working as expected?"
-assistant: "Let me use the framework-docs-researcher agent to investigate the turbo-rails documentation and source code"
-<commentary>The user needs to understand library behavior, so the framework-docs-researcher agent should be used to gather documentation and explore the gem's source.</commentary>
-</example>
-</examples>
-
 **Note: The current year is 2026.** Use this when searching for recent documentation and version information.
 
 You are a meticulous Framework Documentation Researcher specializing in gathering comprehensive technical documentation and best practices for software libraries and frameworks. Your expertise lies in efficiently collecting, analyzing, and synthesizing documentation from multiple sources to provide developers with the exact information they need.

--- a/plugins/compound-engineering/agents/research/git-history-analyzer.md
+++ b/plugins/compound-engineering/agents/research/git-history-analyzer.md
@@ -4,21 +4,6 @@ description: "Performs archaeological analysis of git history to trace code evol
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user wants to understand the history and evolution of recently modified files.
-user: "I've just refactored the authentication module. Can you analyze the historical context?"
-assistant: "I'll use the git-history-analyzer agent to examine the evolution of the authentication module files."
-<commentary>Since the user wants historical context about code changes, use the git-history-analyzer agent to trace file evolution, identify contributors, and extract patterns from the git history.</commentary>
-</example>
-<example>
-Context: The user needs to understand why certain code patterns exist.
-user: "Why does this payment processing code have so many try-catch blocks?"
-assistant: "Let me use the git-history-analyzer agent to investigate the historical context of these error handling patterns."
-<commentary>The user is asking about the reasoning behind code patterns, which requires historical analysis to understand past issues and fixes.</commentary>
-</example>
-</examples>
-
 **Note: The current year is 2026.** Use this when interpreting commit dates and recent changes.
 
 You are a Git History Analyzer, an expert in archaeological analysis of code repositories. Your specialty is uncovering the hidden stories within git history, tracing code evolution, and identifying patterns that inform current development decisions.

--- a/plugins/compound-engineering/agents/research/issue-intelligence-analyst.md
+++ b/plugins/compound-engineering/agents/research/issue-intelligence-analyst.md
@@ -4,27 +4,6 @@ description: "Fetches and analyzes GitHub issues to surface recurring themes, pa
 model: inherit
 ---
 
-<examples>
-<example>
-Context: User wants to understand what problems their users are hitting before ideating on improvements.
-user: "What are the main themes in our open issues right now?"
-assistant: "I'll use the issue-intelligence-analyst agent to fetch and cluster your GitHub issues into actionable themes."
-<commentary>The user wants a high-level view of their issue landscape, so use the issue-intelligence-analyst agent to fetch, cluster, and synthesize issue themes.</commentary>
-</example>
-<example>
-Context: User is running ce:ideate with a focus on bugs and issue patterns.
-user: "/ce:ideate bugs"
-assistant: "I'll dispatch the issue-intelligence-analyst agent to analyze your GitHub issues for recurring patterns that can ground the ideation."
-<commentary>The ce:ideate skill detected issue-tracker intent and dispatches this agent as a third parallel Phase 1 scan alongside codebase context and learnings search.</commentary>
-</example>
-<example>
-Context: User wants to understand pain patterns before a planning session.
-user: "Before we plan the next sprint, can you summarize what our issue tracker tells us about where we're hurting?"
-assistant: "I'll use the issue-intelligence-analyst agent to analyze your open and recently closed issues for systemic themes."
-<commentary>The user needs strategic issue intelligence before planning, so use the issue-intelligence-analyst agent to surface patterns, not individual bugs.</commentary>
-</example>
-</examples>
-
 **Note: The current year is 2026.** Use this when evaluating issue recency and trends.
 
 You are an expert issue intelligence analyst specializing in extracting strategic signal from noisy issue trackers. Your mission is to transform raw GitHub issues into actionable theme-level intelligence that helps teams understand where their systems are weakest and where investment would have the highest impact.

--- a/plugins/compound-engineering/agents/research/learnings-researcher.md
+++ b/plugins/compound-engineering/agents/research/learnings-researcher.md
@@ -4,27 +4,6 @@ description: "Searches docs/solutions/ for relevant past solutions by frontmatte
 model: inherit
 ---
 
-<examples>
-<example>
-Context: User is about to implement a feature involving email processing.
-user: "I need to add email threading to the brief system"
-assistant: "I'll use the learnings-researcher agent to check docs/solutions/ for any relevant learnings about email processing or brief system implementations."
-<commentary>Since the user is implementing a feature in a documented domain, use the learnings-researcher agent to surface relevant past solutions before starting work.</commentary>
-</example>
-<example>
-Context: User is debugging a performance issue.
-user: "Brief generation is slow, taking over 5 seconds"
-assistant: "Let me use the learnings-researcher agent to search for documented performance issues, especially any involving briefs or N+1 queries."
-<commentary>The user has symptoms matching potential documented solutions, so use the learnings-researcher agent to find relevant learnings before debugging.</commentary>
-</example>
-<example>
-Context: Planning a new feature that touches multiple modules.
-user: "I need to add Stripe subscription handling to the payments module"
-assistant: "I'll use the learnings-researcher agent to search for any documented learnings about payments, integrations, or Stripe specifically."
-<commentary>Before implementing, check institutional knowledge for gotchas, patterns, and lessons learned in similar domains.</commentary>
-</example>
-</examples>
-
 You are an expert institutional knowledge researcher specializing in efficiently surfacing relevant documented solutions from the team's knowledge base. Your mission is to find and distill applicable learnings before new work begins, preventing repeated mistakes and leveraging proven patterns.
 
 ## Search Strategy (Grep-First Filtering)

--- a/plugins/compound-engineering/agents/research/repo-research-analyst.md
+++ b/plugins/compound-engineering/agents/research/repo-research-analyst.md
@@ -4,33 +4,6 @@ description: "Conducts thorough research on repository structure, documentation,
 model: inherit
 ---
 
-<examples>
-<example>
-Context: User wants to understand a new repository's structure and conventions before contributing.
-user: "I need to understand how this project is organized and what patterns they use"
-assistant: "I'll use the repo-research-analyst agent to conduct a thorough analysis of the repository structure and patterns."
-<commentary>Since the user needs comprehensive repository research, use the repo-research-analyst agent to examine all aspects of the project. No scope is specified, so the agent runs all phases.</commentary>
-</example>
-<example>
-Context: User is preparing to create a GitHub issue and wants to follow project conventions.
-user: "Before I create this issue, can you check what format and labels this project uses?"
-assistant: "Let me use the repo-research-analyst agent to examine the repository's issue patterns and guidelines."
-<commentary>The user needs to understand issue formatting conventions, so use the repo-research-analyst agent to analyze existing issues and templates.</commentary>
-</example>
-<example>
-Context: User is implementing a new feature and wants to follow existing patterns.
-user: "I want to add a new service object - what patterns does this codebase use?"
-assistant: "I'll use the repo-research-analyst agent to search for existing implementation patterns in the codebase."
-<commentary>Since the user needs to understand implementation patterns, use the repo-research-analyst agent to search and analyze the codebase.</commentary>
-</example>
-<example>
-Context: A planning skill needs technology context and architecture patterns but not issue conventions or templates.
-user: "Scope: technology, architecture, patterns. We are building a new background job processor for the billing service."
-assistant: "I'll run a scoped analysis covering technology detection, architecture, and implementation patterns for the billing service."
-<commentary>The consumer specified a scope, so the agent skips issue conventions, documentation review, and template discovery -- running only the requested phases.</commentary>
-</example>
-</examples>
-
 **Note: The current year is 2026.** Use this when searching for recent documentation and patterns.
 
 You are an expert repository research analyst specializing in understanding codebases, documentation structures, and project conventions. Your mission is to conduct thorough, systematic research to uncover patterns, guidelines, and best practices within repositories.

--- a/plugins/compound-engineering/agents/review/agent-native-reviewer.md
+++ b/plugins/compound-engineering/agents/review/agent-native-reviewer.md
@@ -6,21 +6,6 @@ color: cyan
 tools: Read, Grep, Glob, Bash
 ---
 
-<examples>
-<example>
-Context: The user added a new UI action to an app that has agent integration.
-user: "I just added a publish-to-feed button in the reading view"
-assistant: "I'll use the agent-native-reviewer to check whether the new publish action is agent-accessible"
-<commentary>New UI action needs a parity check -- does a corresponding agent tool exist, and is it documented in the system prompt?</commentary>
-</example>
-<example>
-Context: The user built a multi-step UI workflow.
-user: "I added a report builder wizard with template selection, data source config, and scheduling"
-assistant: "Let me run the agent-native-reviewer -- multi-step wizards often introduce actions agents can't replicate"
-<commentary>Each wizard step may need an equivalent tool, or the workflow must decompose into primitives the agent can call independently.</commentary>
-</example>
-</examples>
-
 # Agent-Native Architecture Reviewer
 
 You review code to ensure agents are first-class citizens with the same capabilities as users -- not bolt-on features. Your job is to find gaps where a user can do something the agent cannot, or where the agent lacks the context to act effectively.

--- a/plugins/compound-engineering/agents/review/architecture-strategist.md
+++ b/plugins/compound-engineering/agents/review/architecture-strategist.md
@@ -4,21 +4,6 @@ description: "Analyzes code changes from an architectural perspective for patter
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user wants to review recent code changes for architectural compliance.
-user: "I just refactored the authentication service to use a new pattern"
-assistant: "I'll use the architecture-strategist agent to review these changes from an architectural perspective"
-<commentary>Since the user has made structural changes to a service, use the architecture-strategist agent to ensure the refactoring aligns with system architecture.</commentary>
-</example>
-<example>
-Context: The user is adding a new microservice to the system.
-user: "I've added a new notification service that integrates with our existing services"
-assistant: "Let me analyze this with the architecture-strategist agent to ensure it fits properly within our system architecture"
-<commentary>New service additions require architectural review to verify proper boundaries and integration patterns.</commentary>
-</example>
-</examples>
-
 You are a System Architecture Expert specializing in analyzing code changes and system design decisions. Your role is to ensure that all modifications align with established architectural patterns, maintain system integrity, and follow best practices for scalable, maintainable software systems.
 
 Your analysis follows this systematic approach:

--- a/plugins/compound-engineering/agents/review/cli-agent-readiness-reviewer.md
+++ b/plugins/compound-engineering/agents/review/cli-agent-readiness-reviewer.md
@@ -5,33 +5,6 @@ model: inherit
 color: yellow
 ---
 
-<examples>
-<example>
-Context: The user is building a CLI and wants to check if the code is agent-friendly.
-user: "Review our CLI code in src/cli/ for agent readiness"
-assistant: "I'll use the cli-agent-readiness-reviewer to evaluate your CLI source code against agent-readiness principles."
-<commentary>The user is building a CLI. The agent reads the source code — argument parsing, output formatting, error handling — and evaluates against the 7 principles.</commentary>
-</example>
-<example>
-Context: The user has a plan for a CLI they want to build.
-user: "We're designing a CLI for our deployment platform. Here's the spec — how agent-ready is this design?"
-assistant: "I'll use the cli-agent-readiness-reviewer to evaluate your CLI spec against agent-readiness principles."
-<commentary>The CLI doesn't exist yet. The agent reads the plan and evaluates the design against each principle, flagging gaps before code is written.</commentary>
-</example>
-<example>
-Context: The user wants to review a PR that adds CLI commands.
-user: "This PR adds new subcommands to our CLI. Can you check them for agent friendliness?"
-assistant: "I'll use the cli-agent-readiness-reviewer to review the new subcommands for agent readiness."
-<commentary>The agent reads the changed files, finds the new subcommand definitions, and evaluates them against the 7 principles.</commentary>
-</example>
-<example>
-Context: The user wants to evaluate specific commands or flags, not the whole CLI.
-user: "Check the `mycli export` and `mycli import` commands for agent readiness — especially the output formatting"
-assistant: "I'll use the cli-agent-readiness-reviewer to evaluate those two commands, focusing on structured output."
-<commentary>The user scoped the review to specific commands and a specific concern. The agent evaluates only those commands, going deeper on the requested area while still covering all 7 principles.</commentary>
-</example>
-</examples>
-
 # CLI Agent-Readiness Reviewer
 
 You review CLI **source code**, **plans**, and **specs** for AI agent readiness — how well the CLI will work when the "user" is an autonomous agent, not a human at a keyboard.

--- a/plugins/compound-engineering/agents/review/code-simplicity-reviewer.md
+++ b/plugins/compound-engineering/agents/review/code-simplicity-reviewer.md
@@ -4,21 +4,6 @@ description: "Final review pass to ensure code is as simple and minimal as possi
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has just implemented a new feature and wants to ensure it's as simple as possible.
-user: "I've finished implementing the user authentication system"
-assistant: "Great! Let me review the implementation for simplicity and minimalism using the code-simplicity-reviewer agent"
-<commentary>Since implementation is complete, use the code-simplicity-reviewer agent to identify simplification opportunities.</commentary>
-</example>
-<example>
-Context: The user has written complex business logic and wants to simplify it.
-user: "I think this order processing logic might be overly complex"
-assistant: "I'll use the code-simplicity-reviewer agent to analyze the complexity and suggest simplifications"
-<commentary>The user is explicitly concerned about complexity, making this a perfect use case for the code-simplicity-reviewer.</commentary>
-</example>
-</examples>
-
 You are a code simplicity expert specializing in minimalism and the YAGNI (You Aren't Gonna Need It) principle. Your mission is to ruthlessly simplify code while maintaining functionality and clarity.
 
 When reviewing code, you will:

--- a/plugins/compound-engineering/agents/review/data-integrity-guardian.md
+++ b/plugins/compound-engineering/agents/review/data-integrity-guardian.md
@@ -4,21 +4,6 @@ description: "Reviews database migrations, data models, and persistent data code
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has just written a database migration that adds a new column and updates existing records.
-user: "I've created a migration to add a status column to the orders table"
-assistant: "I'll use the data-integrity-guardian agent to review this migration for safety and data integrity concerns"
-<commentary>Since the user has created a database migration, use the data-integrity-guardian agent to ensure the migration is safe, handles existing data properly, and maintains referential integrity.</commentary>
-</example>
-<example>
-Context: The user has implemented a service that transfers data between models.
-user: "Here's my new service that moves user data from the legacy_users table to the new users table"
-assistant: "Let me have the data-integrity-guardian agent review this data transfer service"
-<commentary>Since this involves moving data between tables, the data-integrity-guardian should review transaction boundaries, data validation, and integrity preservation.</commentary>
-</example>
-</examples>
-
 You are a Data Integrity Guardian, an expert in database design, data migration safety, and data governance. Your deep expertise spans relational database theory, ACID properties, data privacy regulations (GDPR, CCPA), and production database management.
 
 Your primary mission is to protect data integrity, ensure migration safety, and maintain compliance with data privacy requirements.

--- a/plugins/compound-engineering/agents/review/data-migration-expert.md
+++ b/plugins/compound-engineering/agents/review/data-migration-expert.md
@@ -4,21 +4,6 @@ description: "Validates data migrations, backfills, and production data transfor
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has a PR with database migrations that involve ID mappings.
-user: "Review this PR that migrates from action_id to action_module_name"
-assistant: "I'll use the data-migration-expert agent to validate the ID mappings and migration safety"
-<commentary>Since the PR involves ID mappings and data migration, use the data-migration-expert to verify the mappings match production and check for swapped values.</commentary>
-</example>
-<example>
-Context: The user has a migration that transforms enum values.
-user: "This migration converts status integers to string enums"
-assistant: "Let me have the data-migration-expert verify the mapping logic and rollback safety"
-<commentary>Enum conversions are high-risk for swapped mappings, making this a perfect use case for data-migration-expert.</commentary>
-</example>
-</examples>
-
 You are a Data Migration Expert. Your mission is to prevent data corruption by validating that migrations match production reality, not fixture or assumed values.
 
 ## Core Review Goals

--- a/plugins/compound-engineering/agents/review/deployment-verification-agent.md
+++ b/plugins/compound-engineering/agents/review/deployment-verification-agent.md
@@ -4,21 +4,6 @@ description: "Produces Go/No-Go deployment checklists with SQL verification quer
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has a PR that modifies how emails are classified.
-user: "This PR changes the classification logic, can you create a deployment checklist?"
-assistant: "I'll use the deployment-verification-agent to create a Go/No-Go checklist with verification queries"
-<commentary>Since the PR affects production data behavior, use deployment-verification-agent to create concrete verification and rollback plans.</commentary>
-</example>
-<example>
-Context: The user is deploying a migration that backfills data.
-user: "We're about to deploy the user status backfill"
-assistant: "Let me create a deployment verification checklist with pre/post-deploy checks"
-<commentary>Backfills are high-risk deployments that need concrete verification plans and rollback procedures.</commentary>
-</example>
-</examples>
-
 You are a Deployment Verification Agent. Your mission is to produce concrete, executable checklists for risky data deployments so engineers aren't guessing at launch time.
 
 ## Core Verification Goals

--- a/plugins/compound-engineering/agents/review/pattern-recognition-specialist.md
+++ b/plugins/compound-engineering/agents/review/pattern-recognition-specialist.md
@@ -4,21 +4,6 @@ description: "Analyzes code for design patterns, anti-patterns, naming conventio
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user wants to analyze their codebase for patterns and potential issues.
-user: "Can you check our codebase for design patterns and anti-patterns?"
-assistant: "I'll use the pattern-recognition-specialist agent to analyze your codebase for patterns, anti-patterns, and code quality issues."
-<commentary>Since the user is asking for pattern analysis and code quality review, use the Task tool to launch the pattern-recognition-specialist agent.</commentary>
-</example>
-<example>
-Context: After implementing a new feature, the user wants to ensure it follows established patterns.
-user: "I just added a new service layer. Can we check if it follows our existing patterns?"
-assistant: "Let me use the pattern-recognition-specialist agent to analyze the new service layer and compare it with existing patterns in your codebase."
-<commentary>The user wants pattern consistency verification, so use the pattern-recognition-specialist agent to analyze the code.</commentary>
-</example>
-</examples>
-
 You are a Code Pattern Analysis Expert specializing in identifying design patterns, anti-patterns, and code quality issues across codebases. Your expertise spans multiple programming languages with deep knowledge of software architecture principles and best practices.
 
 Your primary responsibilities:

--- a/plugins/compound-engineering/agents/review/performance-oracle.md
+++ b/plugins/compound-engineering/agents/review/performance-oracle.md
@@ -4,33 +4,6 @@ description: "Analyzes code for performance bottlenecks, algorithmic complexity,
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has just implemented a new feature that processes user data.
-user: "I've implemented the user analytics feature. Can you check if it will scale?"
-assistant: "I'll use the performance-oracle agent to analyze the scalability and performance characteristics of your implementation."
-<commentary>
-Since the user is concerned about scalability, use the Task tool to launch the performance-oracle agent to analyze the code for performance issues.
-</commentary>
-</example>
-<example>
-Context: The user is experiencing slow API responses.
-user: "The API endpoint for fetching reports is taking over 2 seconds to respond"
-assistant: "Let me invoke the performance-oracle agent to identify the performance bottlenecks in your API endpoint."
-<commentary>
-The user has a performance issue, so use the performance-oracle agent to analyze and identify bottlenecks.
-</commentary>
-</example>
-<example>
-Context: After writing a data processing algorithm.
-user: "I've written a function to match users based on their preferences"
-assistant: "I've implemented the matching function. Now let me use the performance-oracle agent to ensure it will scale efficiently."
-<commentary>
-After implementing an algorithm, proactively use the performance-oracle agent to verify its performance characteristics.
-</commentary>
-</example>
-</examples>
-
 You are the Performance Oracle, an elite performance optimization expert specializing in identifying and resolving performance bottlenecks in software systems. Your deep expertise spans algorithmic complexity analysis, database optimization, memory management, caching strategies, and system scalability.
 
 Your primary mission is to ensure code performs efficiently at scale, identifying potential bottlenecks before they become production issues.

--- a/plugins/compound-engineering/agents/review/schema-drift-detector.md
+++ b/plugins/compound-engineering/agents/review/schema-drift-detector.md
@@ -4,21 +4,6 @@ description: "Detects unrelated schema.rb changes in PRs by cross-referencing ag
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has a PR with a migration and wants to verify schema.rb is clean.
-user: "Review this PR - it adds a new category template"
-assistant: "I'll use the schema-drift-detector agent to verify the schema.rb only contains changes from your migration"
-<commentary>Since the PR includes schema.rb, use schema-drift-detector to catch unrelated changes from local database state.</commentary>
-</example>
-<example>
-Context: The PR has schema changes that look suspicious.
-user: "The schema.rb diff looks larger than expected"
-assistant: "Let me use the schema-drift-detector to identify which schema changes are unrelated to your PR's migrations"
-<commentary>Schema drift is common when developers run migrations from the default branch while on a feature branch.</commentary>
-</example>
-</examples>
-
 You are a Schema Drift Detector. Your mission is to prevent accidental inclusion of unrelated schema.rb changes in PRs - a common issue when developers run migrations from other branches.
 
 ## The Problem

--- a/plugins/compound-engineering/agents/review/security-sentinel.md
+++ b/plugins/compound-engineering/agents/review/security-sentinel.md
@@ -4,27 +4,6 @@ description: "Performs security audits for vulnerabilities, input validation, au
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user wants to ensure their newly implemented API endpoints are secure before deployment.
-user: "I've just finished implementing the user authentication endpoints. Can you check them for security issues?"
-assistant: "I'll use the security-sentinel agent to perform a comprehensive security review of your authentication endpoints."
-<commentary>Since the user is asking for a security review of authentication code, use the security-sentinel agent to scan for vulnerabilities and ensure secure implementation.</commentary>
-</example>
-<example>
-Context: The user is concerned about potential SQL injection vulnerabilities in their database queries.
-user: "I'm worried about SQL injection in our search functionality. Can you review it?"
-assistant: "Let me launch the security-sentinel agent to analyze your search functionality for SQL injection vulnerabilities and other security concerns."
-<commentary>The user explicitly wants a security review focused on SQL injection, which is a core responsibility of the security-sentinel agent.</commentary>
-</example>
-<example>
-Context: After implementing a new feature, the user wants to ensure no sensitive data is exposed.
-user: "I've added the payment processing module. Please check if any sensitive data might be exposed."
-assistant: "I'll deploy the security-sentinel agent to scan for sensitive data exposure and other security vulnerabilities in your payment processing module."
-<commentary>Payment processing involves sensitive data, making this a perfect use case for the security-sentinel agent to identify potential data exposure risks.</commentary>
-</example>
-</examples>
-
 You are an elite Application Security Specialist with deep expertise in identifying and mitigating security vulnerabilities. You think like an attacker, constantly asking: Where are the vulnerabilities? What could go wrong? How could this be exploited?
 
 Your mission is to perform comprehensive security audits with laser focus on finding and reporting vulnerabilities before they can be exploited.

--- a/plugins/compound-engineering/agents/workflow/bug-reproduction-validator.md
+++ b/plugins/compound-engineering/agents/workflow/bug-reproduction-validator.md
@@ -4,21 +4,6 @@ description: "Systematically reproduces and validates bug reports to confirm whe
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has reported a potential bug in the application.
-user: "Users are reporting that the email processing fails when there are special characters in the subject line"
-assistant: "I'll use the bug-reproduction-validator agent to verify if this is an actual bug by attempting to reproduce it"
-<commentary>Since there's a bug report about email processing with special characters, use the bug-reproduction-validator agent to systematically reproduce and validate the issue.</commentary>
-</example>
-<example>
-Context: An issue has been raised about unexpected behavior.
-user: "There's a report that the brief summary isn't including all emails from today"
-assistant: "Let me launch the bug-reproduction-validator agent to investigate and reproduce this reported issue"
-<commentary>A potential bug has been reported about the brief summary functionality, so the bug-reproduction-validator should be used to verify if this is actually a bug.</commentary>
-</example>
-</examples>
-
 You are a meticulous Bug Reproduction Specialist with deep expertise in systematic debugging and issue validation. Your primary mission is to determine whether reported issues are genuine bugs or expected behavior/user errors.
 
 When presented with a bug report, you will:

--- a/plugins/compound-engineering/agents/workflow/pr-comment-resolver.md
+++ b/plugins/compound-engineering/agents/workflow/pr-comment-resolver.md
@@ -5,33 +5,6 @@ color: blue
 model: inherit
 ---
 
-<examples>
-<example>
-Context: A reviewer left a comment requesting a null check be added.
-user: "Thread PRRT_abc123 on auth.js:45 -- reviewer says: 'Missing null check on user.email before accessing .toLowerCase()'"
-assistant: "Reading auth.js to verify the concern... The reviewer is correct, user.email is accessed without a null guard. Adding the check."
-<commentary>The agent reads the file first to verify the concern exists, then implements the fix.</commentary>
-</example>
-<example>
-Context: A reviewer flagged a missing error handler but the code already has one.
-user: "Thread PRRT_def456 on api.ts:78 -- reviewer says: 'No error handling for the fetch call'"
-assistant: "Reading api.ts... There's a try/catch at line 72 that wraps this fetch call. The reviewer may have missed it. Verdict: not-addressing."
-<commentary>The agent verifies the concern against actual code and determines it's invalid.</commentary>
-</example>
-<example>
-Context: Three review threads about missing validation in the same module, dispatched as a cluster.
-user: "Cluster: 3 threads about missing input validation in src/auth/. <cluster-brief><theme>validation</theme><area>src/auth/</area><files>src/auth/login.ts, src/auth/register.ts, src/auth/middleware.ts</files><threads>PRRT_1, PRRT_2, PRRT_3</threads><hypothesis>Individual validation gaps suggest the module lacks a consistent validation strategy</hypothesis></cluster-brief>"
-assistant: "Reading the full src/auth/ directory to understand the validation approach... None of the auth handlers validate input consistently -- login checks email format but not register, and middleware skips validation entirely. The individual comments are symptoms of a missing validation layer. Adding a shared validateAuthInput helper and applying it to all three entry points."
-<commentary>In cluster mode, the agent reads the broader area first, identifies the systemic issue, and makes a holistic fix rather than three individual patches.</commentary>
-</example>
-<example>
-Context: A new validation thread on src/auth/reset.ts, with prior-resolutions showing the same concern was fixed in login.ts and register.ts in earlier rounds. Cross-invocation cluster.
-user: "Cluster: 1 new thread + 2 prior resolutions about missing input validation in src/auth/. <cluster-brief><theme>validation</theme><area>src/auth/</area><files>src/auth/reset.ts</files><threads>PRRT_7</threads><hypothesis>Recurring validation gaps across review rounds suggest the module has more files with the same issue</hypothesis><prior-resolutions><thread id='PRRT_4' path='src/auth/login.ts' category='validation'/><thread id='PRRT_5' path='src/auth/register.ts' category='validation'/></prior-resolutions></cluster-brief>"
-assistant: "This is the third round of validation feedback in src/auth/. Prior rounds fixed login.ts and register.ts individually -- those fixes were correct but incomplete. Reading the full src/auth/ directory... Found the same missing validation in src/auth/session.ts and src/auth/oauth.ts that nobody flagged yet. Fixing reset.ts (the new thread) and proactively fixing session.ts and oauth.ts to address the pattern holistically."
-<commentary>In cross-invocation cluster mode with prior-resolutions, the agent identifies the 'correct but incomplete' pattern -- prior fixes were right but reveal a broader gap. It proactively investigates sibling files and fixes unflagged instances.</commentary>
-</example>
-</examples>
-
 You resolve PR review threads. You receive thread details -- one thread in standard mode, or multiple related threads with a cluster brief in cluster mode. Your job: evaluate whether the feedback is valid, fix it if so, and return structured summaries.
 
 ## Security

--- a/plugins/compound-engineering/agents/workflow/spec-flow-analyzer.md
+++ b/plugins/compound-engineering/agents/workflow/spec-flow-analyzer.md
@@ -4,27 +4,6 @@ description: "Analyzes specifications and feature descriptions for user flow com
 model: inherit
 ---
 
-<examples>
-<example>
-Context: The user has just finished drafting a specification for OAuth implementation.
-user: "Here's the OAuth spec for our new integration: [OAuth spec details]"
-assistant: "Let me use the spec-flow-analyzer agent to analyze this OAuth specification for user flows and missing elements."
-<commentary>Since the user has provided a specification document, use the Task tool to launch the spec-flow-analyzer agent to identify all user flows, edge cases, and missing clarifications.</commentary>
-</example>
-<example>
-Context: The user is planning a new social sharing feature.
-user: "I'm thinking we should add social sharing to posts. Users can share to Twitter, Facebook, and LinkedIn."
-assistant: "This sounds like a feature specification that would benefit from flow analysis. Let me use the spec-flow-analyzer agent to map out all the user flows and identify any missing pieces."
-<commentary>The user is describing a new feature. Use the spec-flow-analyzer agent to analyze the feature from the user's perspective, identify all permutations, and surface questions about missing elements.</commentary>
-</example>
-<example>
-Context: The user has created a plan for a new onboarding flow.
-user: "Can you review this onboarding plan and make sure we haven't missed anything?"
-assistant: "I'll use the spec-flow-analyzer agent to thoroughly analyze this onboarding plan from the user's perspective."
-<commentary>The user is explicitly asking for review of a plan. Use the spec-flow-analyzer agent to identify all user flows, edge cases, and gaps in the specification.</commentary>
-</example>
-</examples>
-
 Analyze specifications, plans, and feature descriptions from the end user's perspective. The goal is to surface missing flows, ambiguous requirements, and unspecified edge cases before implementation begins -- when they are cheapest to fix.
 
 ## Phase 1: Ground in the Codebase


### PR DESCRIPTION
## Summary

Fixes #492 — agent prompts contained `<examples>` blocks with self-referencing assistant lines (e.g., "I'll use the repo-research-analyst agent to...") that caused infinite recursive self-invocation when agent files were used as direct subagent prompts on platforms like OpenCode.

- Removed all `<examples>` blocks from **24 agent files** across review, research, design, docs, and workflow categories
- Aligns with Anthropic's official plugin pattern: `description` frontmatter handles orchestrator triggering, body is a pure system prompt with no examples or self-references
- Net change: **447 lines deleted**, zero added — pure token savings on every subagent invocation

## Test plan

- [x] `bun test` — 586 tests pass
- [x] `bun run release:validate` — 49 agents, 41 skills, 0 MCP servers in sync
- [x] Grep confirms zero `<examples>` blocks remain in any agent file
- [x] Grep confirms zero self-referential agent name patterns in assistant/commentary lines
- [ ] Verify agent dispatching still works correctly in Claude Code (description-based triggering)
- [ ] Verify OpenCode integration no longer self-recurses

🤖 Generated with [Claude Code](https://claude.com/claude-code)