### PR TITLE
fix(openclaw): use sync plugin registration

### DIFF
--- a/src/converters/claude-to-openclaw.ts
+++ b/src/converters/claude-to-openclaw.ts
@@ -175,17 +175,16 @@ function buildOpenClawConfig(
 function generateEntryPoint(commands: OpenClawCommandRegistration[]): string {
   const commandRegistrations = commands
     .map((cmd) => {
-      // JSON.stringify produces a fully-escaped string literal safe for JS/TS source embedding
       const safeName = JSON.stringify(cmd.name)
       const safeDesc = JSON.stringify(cmd.description ?? "")
-      const safeNotFound = JSON.stringify(`Command ${cmd.name} not found. Check skills directory.`)
+      const safeBody = JSON.stringify(cmd.body)
       return `  api.registerCommand({
     name: ${safeName},
     description: ${safeDesc},
     acceptsArgs: ${cmd.acceptsArgs},
     requireAuth: false,
-    handler: (ctx) => ({
-      text: skills[${safeName}] ?? ${safeNotFound},
+    handler: () => ({
+      text: ${safeBody},
     }),
   });`
     })
@@ -193,39 +192,7 @@ function generateEntryPoint(commands: OpenClawCommandRegistration[]): string {
 
   return `// Auto-generated OpenClaw plugin entry point
 // Converted from Claude Code plugin format by compound-plugin CLI
-import { promises as fs } from "fs";
-import path from "path";
-import { fileURLToPath } from "url";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-// Pre-load skill bodies for command responses
-const skills: Record<string, string> = {};
-
-async function loadSkills() {
-  const skillsDir = path.join(__dirname, "skills");
-  try {
-    const entries = await fs.readdir(skillsDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-      const skillPath = path.join(skillsDir, entry.name, "SKILL.md");
-      try {
-        const content = await fs.readFile(skillPath, "utf8");
-        // Strip frontmatter
-        const body = content.replace(/^---[\\s\\S]*?---\\n*/, "");
-        skills[entry.name.replace(/^cmd-/, "")] = body.trim();
-      } catch {
-        // Skill file not found, skip
-      }
-    }
-  } catch {
-    // Skills directory not found
-  }
-}
-
-export default async function register(api) {
-  await loadSkills();
-
+export default function register(api) {
 ${commandRegistrations}
 }
 `

--- a/tests/openclaw-converter.test.ts
+++ b/tests/openclaw-converter.test.ts
@@ -231,9 +231,11 @@ describe("convertClaudeToOpenClaw", () => {
     expect(nameLine).toBeDefined()
   })
 
-  test("generateEntryPoint emits typed skills record", () => {
+  test("generateEntryPoint inlines command bodies for sync registration", () => {
     const bundle = convertClaudeToOpenClaw(fixturePlugin, defaultOptions)
-    expect(bundle.entryPoint).toContain("const skills: Record<string, string> = {}")
+    expect(bundle.entryPoint).not.toContain("const skills: Record<string, string> = {}")
+    expect(bundle.entryPoint).toContain('text: "Plan the work. See ~/.openclaw/settings for config."')
+    expect(bundle.entryPoint).toContain("export default function register(api)")
   })
 
   test("plugin without MCP servers has no openclawConfig", () => {


### PR DESCRIPTION
## What
- make the generated OpenClaw plugin entrypoint export a synchronous `register(api)` function
- inline converted command bodies into the generated command handlers
- remove async skill preloading from the generated OpenClaw entrypoint

## Why
- OpenClaw ignores plugin registrations that return a promise
- the generated async entrypoint causes the runtime to report: `plugin register returned a promise; async registration is ignored`
- switching to fire-and-forget skill loading fixes the warning but introduces a startup race where commands can return not found before skill files finish loading
- inlining the converted command body removes both issues and keeps registration synchronous

## Tests
- `bun test tests/openclaw-converter.test.ts`

## AI Assistance
- Used: yes
- Testing: targeted automated test (`bun test tests/openclaw-converter.test.ts`) plus local OpenClaw plugin inspection after reinstall