### PR TITLE
docs(openclaw): document native CE workflow commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Each cycle compounds: brainstorms sharpen plans, plans inform future plans, revi
 
 This repo includes a Bun/TypeScript CLI that converts Claude Code plugins to OpenCode, Codex, Factory Droid, Pi, Gemini CLI, GitHub Copilot, Kiro CLI, Windsurf, OpenClaw, and Qwen Code.
 
+OpenClaw note: native skill commands are sanitized by OpenClaw, so CE workflow skills show up as `/ce_plan`, `/ce_work`, `/ce_review`, `/ce_brainstorm`, etc. today.
+
 ```bash
 # convert the compound-engineering plugin into OpenCode format
 bunx @every-env/compound-plugin install compound-engineering --to opencode
@@ -117,7 +119,7 @@ bunx @every-env/compound-plugin install compound-engineering --to all
 | `gemini` | `.gemini/` | Skills from agents; commands as `.toml`; namespaced commands become directories (`workflows:plan` -> `commands/workflows/plan.toml`) |
 | `copilot` | `.github/` | Agents as `.agent.md` with Copilot frontmatter; MCP env vars prefixed with `COPILOT_MCP_` |
 | `kiro` | `.kiro/` | Agents as JSON configs + prompt `.md` files; only stdio MCP servers supported |
-| `openclaw` | `~/.openclaw/extensions/<plugin>/` | Entry-point TypeScript skill file; `openclaw-extension.json` for MCP servers |
+| `openclaw` | `~/.openclaw/extensions/<plugin>/` | Native plugin entry point plus copied skills; `openclaw.json` for MCP servers. OpenClaw native skill commands currently normalize `ce:plan`-style names to `/ce_plan` rather than `/ce-plan`. |
 | `windsurf` | `~/.codeium/windsurf/` (global) or `.windsurf/` (workspace) | Agents become skills; commands become flat workflows; `mcp_config.json` merged |
 | `qwen` | `~/.qwen/extensions/<plugin>/` | Agents as `.yaml`; env vars with placeholders extracted as settings; colon separator for nested commands |
 

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -13,7 +13,9 @@ AI-powered development tools that get smarter with every use. Make each unit of 
 
 ### Core Workflow
 
-The primary entry points for engineering work, invoked as slash commands:
+The primary entry points for engineering work, invoked as slash commands.
+
+OpenClaw note: converted installs currently expose these workflow skills as underscore-normalized native commands such as `/ce_plan`, `/ce_work`, `/ce_review`, and `/ce_brainstorm`.
 
 | Skill | Description |
 |-------|-------------|
@@ -24,6 +26,13 @@ The primary entry points for engineering work, invoked as slash commands:
 | `/ce:work` | Execute work items systematically |
 | `/ce:compound` | Document solved problems to compound team knowledge |
 | `/ce:compound-refresh` | Refresh stale or drifting learnings and decide whether to keep, update, replace, or archive them |
+
+OpenClaw native command mapping today:
+- `/ce_plan` -> `ce:plan`
+- `/ce_work` -> `ce:work`
+- `/ce_review` -> `ce:review`
+- `/ce_brainstorm` -> `ce:brainstorm`
+- `/ce_compound` -> `ce:compound`
 
 ### Git Workflow
 


### PR DESCRIPTION
## What
- document the current OpenClaw-native CE workflow command surface
- clarify that OpenClaw currently exposes CE workflow skills as underscore-normalized commands like `/ce_plan`
- fix the root README OpenClaw target note to reference `openclaw.json` and the actual native command behavior

## Why
- the current docs imply CE workflow commands remain `/ce:plan`-style in OpenClaw installs
- in practice, OpenClaw native skill command sanitization currently exposes them as `/ce_plan`, `/ce_work`, `/ce_review`, and related forms
- this PR makes the docs match reality while any future OpenClaw naming improvement is handled upstream

## Tests
- docs only

## AI Assistance
- Used: yes
- Testing: manual diff review
- I understand this code.