### PR TITLE
fix(cli): resolve repo-wide tsc --noEmit type errors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "compound-plugin",
@@ -11,6 +10,7 @@
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
+        "@types/js-yaml": "^4.0.9",
         "bun-types": "^1.0.0",
         "semantic-release": "^25.0.3",
       },
@@ -80,6 +80,8 @@
     "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/node": ["@types/node@25.0.9", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-/rpCXHlCWeqClNBwUhDcusJxXYDjZTyE8v5oTO7WbL8eij2nKhUeU89/6xgjU7N4/Vh3He0BtyhJdQbDyhiXAw=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
+    "@types/js-yaml": "^4.0.9",
     "bun-types": "^1.0.0",
     "semantic-release": "^25.0.3"
   }

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -3,7 +3,7 @@ import os from "os"
 import path from "path"
 import { loadClaudePlugin } from "../parsers/claude"
 import { targets, validateScope } from "../targets"
-import type { PermissionMode } from "../converters/claude-to-opencode"
+import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
 import { ensureCodexAgentsFile } from "../utils/codex-agents"
 import { expandHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveTargetOutputRoot } from "../utils/resolve-output"
@@ -92,7 +92,7 @@ export default defineCommand({
     const openclawHome = resolveTargetHome(args.openclawHome, path.join(os.homedir(), ".openclaw", "extensions"))
     const qwenHome = resolveTargetHome(args.qwenHome, path.join(os.homedir(), ".qwen", "extensions"))
 
-    const options = {
+    const options: ClaudeToOpenCodeOptions = {
       agentMode: String(args.agentMode) === "primary" ? "primary" : "subagent",
       inferTemperature: Boolean(args.inferTemperature),
       permissions: permissions as PermissionMode,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "url"
 import { loadClaudePlugin } from "../parsers/claude"
 import { targets, validateScope } from "../targets"
 import { pathExists } from "../utils/files"
-import type { PermissionMode } from "../converters/claude-to-opencode"
+import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
 import { ensureCodexAgentsFile } from "../utils/codex-agents"
 import { expandHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveTargetOutputRoot } from "../utils/resolve-output"
@@ -103,7 +103,7 @@ export default defineCommand({
       const openclawHome = resolveTargetHome(args.openclawHome, path.join(os.homedir(), ".openclaw", "extensions"))
       const qwenHome = resolveTargetHome(args.qwenHome, path.join(os.homedir(), ".qwen", "extensions"))
 
-      const options = {
+      const options: ClaudeToOpenCodeOptions = {
         agentMode: String(args.agentMode) === "primary" ? "primary" : "subagent",
         inferTemperature: Boolean(args.inferTemperature),
         permissions: permissions as PermissionMode,

--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -350,7 +350,7 @@ function applyPermissions(
     }
   }
 
-  const permission: Record<string, "allow" | "deny"> = {}
+  const permission: Record<string, "allow" | "deny" | Record<string, "allow" | "deny">> = {}
   const tools: Record<string, boolean> = {}
 
   for (const tool of sourceTools) {
@@ -369,7 +369,7 @@ function applyPermissions(
         for (const pattern of toolPatterns) {
           patternPermission[pattern] = "allow"
         }
-        ;(permission as Record<string, typeof patternPermission>)[tool] = patternPermission
+        ;(permission)[tool] = patternPermission
       } else {
         permission[tool] = enabled.has(tool) ? "allow" : "deny"
       }
@@ -383,7 +383,7 @@ function applyPermissions(
       for (const pattern of toolPatterns) {
         patternPermission[pattern] = "allow"
       }
-      ;(permission as Record<string, typeof patternPermission>)[tool] = patternPermission
+      ;(permission)[tool] = patternPermission
     }
   }
 
@@ -399,8 +399,8 @@ function applyPermissions(
     for (const pattern of combined) {
       combinedPermission[pattern] = "allow"
     }
-    ;(permission as Record<string, typeof combinedPermission>).edit = combinedPermission
-    ;(permission as Record<string, typeof combinedPermission>).write = combinedPermission
+    ;(permission).edit = combinedPermission
+    ;(permission).write = combinedPermission
   }
 
   config.permission = permission

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -1,14 +1,4 @@
 import type { ClaudePlugin } from "../types/claude"
-import type { OpenCodeBundle } from "../types/opencode"
-import type { CodexBundle } from "../types/codex"
-import type { DroidBundle } from "../types/droid"
-import type { PiBundle } from "../types/pi"
-import type { CopilotBundle } from "../types/copilot"
-import type { GeminiBundle } from "../types/gemini"
-import type { KiroBundle } from "../types/kiro"
-import type { WindsurfBundle } from "../types/windsurf"
-import type { OpenClawBundle } from "../types/openclaw"
-import type { QwenBundle } from "../types/qwen"
 import { convertClaudeToOpenCode, type ClaudeToOpenCodeOptions } from "../converters/claude-to-opencode"
 import { convertClaudeToCodex } from "../converters/claude-to-codex"
 import { convertClaudeToDroid } from "../converters/claude-to-droid"
@@ -72,62 +62,62 @@ export const targets: Record<string, TargetHandler> = {
     name: "opencode",
     implemented: true,
     convert: convertClaudeToOpenCode,
-    write: writeOpenCodeBundle,
+    write: writeOpenCodeBundle as TargetHandler["write"],
   },
   codex: {
     name: "codex",
     implemented: true,
-    convert: convertClaudeToCodex as TargetHandler<CodexBundle>["convert"],
-    write: writeCodexBundle as TargetHandler<CodexBundle>["write"],
+    convert: convertClaudeToCodex as TargetHandler["convert"],
+    write: writeCodexBundle as TargetHandler["write"],
   },
   droid: {
     name: "droid",
     implemented: true,
-    convert: convertClaudeToDroid as TargetHandler<DroidBundle>["convert"],
-    write: writeDroidBundle as TargetHandler<DroidBundle>["write"],
+    convert: convertClaudeToDroid as TargetHandler["convert"],
+    write: writeDroidBundle as TargetHandler["write"],
   },
   pi: {
     name: "pi",
     implemented: true,
-    convert: convertClaudeToPi as TargetHandler<PiBundle>["convert"],
-    write: writePiBundle as TargetHandler<PiBundle>["write"],
+    convert: convertClaudeToPi as TargetHandler["convert"],
+    write: writePiBundle as TargetHandler["write"],
   },
   copilot: {
     name: "copilot",
     implemented: true,
-    convert: convertClaudeToCopilot as TargetHandler<CopilotBundle>["convert"],
-    write: writeCopilotBundle as TargetHandler<CopilotBundle>["write"],
+    convert: convertClaudeToCopilot as TargetHandler["convert"],
+    write: writeCopilotBundle as TargetHandler["write"],
   },
   gemini: {
     name: "gemini",
     implemented: true,
-    convert: convertClaudeToGemini as TargetHandler<GeminiBundle>["convert"],
-    write: writeGeminiBundle as TargetHandler<GeminiBundle>["write"],
+    convert: convertClaudeToGemini as TargetHandler["convert"],
+    write: writeGeminiBundle as TargetHandler["write"],
   },
   kiro: {
     name: "kiro",
     implemented: true,
-    convert: convertClaudeToKiro as TargetHandler<KiroBundle>["convert"],
-    write: writeKiroBundle as TargetHandler<KiroBundle>["write"],
+    convert: convertClaudeToKiro as TargetHandler["convert"],
+    write: writeKiroBundle as TargetHandler["write"],
   },
   windsurf: {
     name: "windsurf",
     implemented: true,
     defaultScope: "global",
     supportedScopes: ["global", "workspace"],
-    convert: convertClaudeToWindsurf as TargetHandler<WindsurfBundle>["convert"],
-    write: writeWindsurfBundle as TargetHandler<WindsurfBundle>["write"],
+    convert: convertClaudeToWindsurf as TargetHandler["convert"],
+    write: writeWindsurfBundle as TargetHandler["write"],
   },
   openclaw: {
     name: "openclaw",
     implemented: true,
-    convert: convertClaudeToOpenClaw as TargetHandler<OpenClawBundle>["convert"],
-    write: writeOpenClawBundle as TargetHandler<OpenClawBundle>["write"],
+    convert: convertClaudeToOpenClaw as TargetHandler["convert"],
+    write: writeOpenClawBundle as TargetHandler["write"],
   },
   qwen: {
     name: "qwen",
     implemented: true,
-    convert: convertClaudeToQwen as TargetHandler<QwenBundle>["convert"],
-    write: writeQwenBundle as TargetHandler<QwenBundle>["write"],
+    convert: convertClaudeToQwen as TargetHandler["convert"],
+    write: writeQwenBundle as TargetHandler["write"],
   },
 }


### PR DESCRIPTION
## Summary

- **Missing types**: Added `@types/js-yaml` dev dependency
- **Narrowing**: Type-annotated `options` objects in `convert` and `install` commands so `agentMode` narrows from `string` to `"primary" | "subagent"`
- **Permission type**: Widened `permission` record value type in `claude-to-opencode.ts` to accept nested pattern records, removing four unsafe `as` casts
- **Target handler casts**: Changed `as TargetHandler<SpecificBundle>["write"]` to `as TargetHandler["write"]` across all targets — the previous casts were no-ops that didn't resolve the contravariance mismatch against the erased `Record<string, TargetHandler>` type

## Test plan

- [x] `bunx tsc --noEmit` passes (0 errors, was 21)
- [x] `bun test` passes (586/586)

🤖 Generated with [Claude Code](https://claude.com/claude-code)