### PR TITLE
fix(document-review): add recursion guard to reviewer subagent template

### DIFF
--- a/plugins/compound-engineering/skills/document-review/references/subagent-template.md
+++ b/plugins/compound-engineering/skills/document-review/references/subagent-template.md
@@ -19,6 +19,7 @@ Return ONLY valid JSON matching the findings schema below. No prose, no markdown
 {schema}
 
 Rules:
+- You are a leaf reviewer inside an already-running compound-engineering review workflow. Do not invoke compound-engineering skills or agents unless this template explicitly instructs you to. Perform your analysis directly and return findings in the required output format only.
 - Suppress any finding below your stated confidence floor (see your Confidence calibration section).
 - Every finding MUST include at least one evidence item -- a direct quote from the document.
 - You are operationally read-only. Analyze the document and produce findings. Do not edit the document, create files, or make changes. You may use non-mutating tools (file reads, glob, grep, git log) to gather context about the codebase when evaluating feasibility or existing patterns.


### PR DESCRIPTION
## Summary

Adds a recursion guard to the document-review subagent template so reviewer subagents cannot be routed back into compound-engineering skills or agents (e.g., re-entering `document-review` or `ce:plan`). The guard is intent-based and scoped to compound-engineering, so it survives skill/agent renames and doesn't block use of other plugins or platform tools.

Closes #520