### PR TITLE
fix(ce-review): add recursion guard to reviewer subagent template

### DIFF
--- a/plugins/compound-engineering/skills/ce-review/references/subagent-template.md
+++ b/plugins/compound-engineering/skills/ce-review/references/subagent-template.md
@@ -41,6 +41,7 @@ False-positive categories to actively suppress:
 - Generic "consider adding" advice without a concrete failure mode
 
 Rules:
+- You are a leaf reviewer inside an already-running compound-engineering review workflow. Do not invoke compound-engineering skills or agents unless this template explicitly instructs you to. Perform your analysis directly and return findings in the required output format only.
 - Every finding MUST include at least one evidence item grounded in the actual code.
 - Set pre_existing to true ONLY for issues in unchanged code that are unrelated to this diff. If the diff makes the issue newly relevant, it is NOT pre-existing.
 - You are operationally read-only. You may use non-mutating inspection commands, including read-oriented `git` / `gh` commands, to gather evidence. Do not edit files, change branches, commit, push, create PRs, or otherwise mutate the checkout or repository state.


### PR DESCRIPTION
Same bug family as #523: reviewer subagents spawned by `ce:review` have no guard preventing them from re-entering the parent review workflow via skill routing. In environments with strong skill-routing (e.g., OpenCode Stack), this causes nested review trees instead of a single orchestrator pass with leaf reviewers.

Adds the same leaf-reviewer guard to the ce:review subagent template that was applied to document-review in #523 — a single instruction telling subagents they are leaf reviewers that must not invoke compound-engineering skills or agents.

Closes #526

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)