### PR TITLE
fix(ce-review): always fetch base branch to prevent stale merge-base

### DIFF
--- a/plugins/compound-engineering/skills/ce-review/references/resolve-base.sh
+++ b/plugins/compound-engineering/skills/ce-review/references/resolve-base.sh
@@ -52,7 +52,9 @@ if [ -n "$REVIEW_BASE_BRANCH" ]; then
   if [ -n "$PR_BASE_REPO" ]; then
     PR_BASE_REMOTE=$(git remote -v | awk "index(\$2, \"github.com:$PR_BASE_REPO\") || index(\$2, \"github.com/$PR_BASE_REPO\") {print \$1; exit}")
     if [ -n "$PR_BASE_REMOTE" ]; then
-      git rev-parse --verify "$PR_BASE_REMOTE/$REVIEW_BASE_BRANCH" >/dev/null 2>&1 || git fetch --no-tags "$PR_BASE_REMOTE" "$REVIEW_BASE_BRANCH:refs/remotes/$PR_BASE_REMOTE/$REVIEW_BASE_BRANCH" 2>/dev/null || git fetch --no-tags "$PR_BASE_REMOTE" "$REVIEW_BASE_BRANCH" 2>/dev/null || true
+      # Always fetch — a locally cached ref may be stale, producing a
+      # merge-base that predates squash-merged work and inflating the diff.
+      git fetch --no-tags "$PR_BASE_REMOTE" "$REVIEW_BASE_BRANCH:refs/remotes/$PR_BASE_REMOTE/$REVIEW_BASE_BRANCH" 2>/dev/null || git fetch --no-tags "$PR_BASE_REMOTE" "$REVIEW_BASE_BRANCH" 2>/dev/null || true
       BASE_REF=$(git rev-parse --verify "$PR_BASE_REMOTE/$REVIEW_BASE_BRANCH" 2>/dev/null || true)
     fi
   fi
@@ -60,7 +62,8 @@ if [ -n "$REVIEW_BASE_BRANCH" ]; then
     # Only try origin if it exists as a remote; otherwise skip to avoid
     # confusing errors in fork setups where origin points at the user's fork.
     if git remote get-url origin >/dev/null 2>&1; then
-      git rev-parse --verify "origin/$REVIEW_BASE_BRANCH" >/dev/null 2>&1 || git fetch --no-tags origin "$REVIEW_BASE_BRANCH:refs/remotes/origin/$REVIEW_BASE_BRANCH" 2>/dev/null || git fetch --no-tags origin "$REVIEW_BASE_BRANCH" 2>/dev/null || true
+      # Always fetch — same rationale as the fork-safe path above.
+      git fetch --no-tags origin "$REVIEW_BASE_BRANCH:refs/remotes/origin/$REVIEW_BASE_BRANCH" 2>/dev/null || git fetch --no-tags origin "$REVIEW_BASE_BRANCH" 2>/dev/null || true
       BASE_REF=$(git rev-parse --verify "origin/$REVIEW_BASE_BRANCH" 2>/dev/null || true)
     fi
     # Fall back to a bare local ref only if remote resolution failed


### PR DESCRIPTION
## Problem

`resolve-base.sh` skips `git fetch` when the local tracking ref already exists:

```bash
git rev-parse --verify "origin/$REVIEW_BASE_BRANCH" >/dev/null 2>&1 || git fetch ...
```

In long-lived workspaces where `origin/main` (or `origin/master`) goes stale between sessions, this produces a merge-base from weeks ago. The review diff then includes commits already merged to the base branch, inflating the scope.

### Observed in practice

A **2-file, docs-only PR** was reviewed as a **26-file, 1800-line change** because the local `origin/master` was stale. The agent spawned 9 reviewer sub-agents, filed findings against code the PR author didn't touch, and applied fixes to files not in the PR. The entire review was invalid.

After a manual `git fetch origin master`, `git merge-base` produced the correct 2-file scope — matching `gh pr diff --name-only`.

## Fix

Remove the `rev-parse --verify` guard on both the fork-safe and origin fetch paths (lines 55 and 63). The base branch is now always fetched.

**Cost:** one lightweight `git fetch --no-tags` per review (single branch, ~1s).
**Benefit:** correct review scope in all cases.

## Testing

This is a bash script that interacts with git remotes, so unit testing is impractical without a full git fixture. However, the fix is mechanically simple (remove a conditional guard) and the failure mode is well-understood. The reproduction is:

1. Clone a repo, fetch all branches
2. Wait for new commits to land on `main` (or simulate by resetting `origin/main` backward)
3. Run `resolve-base.sh` from a feature branch
4. Observe that the merge-base is stale (predates work already on `main`)
5. After fix: merge-base is current