### PR TITLE
fix(ce-demo-reel): two-stage upload for reviewable approval gate

### DIFF
--- a/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
@@ -1,63 +1,60 @@
 # Upload and Approval
 
-Upload evidence to a public URL for preview, get user approval, and clean up rejected uploads.
+Upload a temporary preview for the user to review, then promote to permanent hosting on approval.
 
-## Step 1: Generate Userhash
+## Step 1: Preview Upload (Temporary)
 
-Generate a random userhash for this run so uploaded files can be deleted if the user rejects them:
-
-```bash
-python3 -c "import uuid; print(uuid.uuid4().hex)"
-```
-
-Store the output as `USERHASH` for use in upload and delete commands.
-
-## Step 2: Upload to catbox.moe
-
-Upload the evidence file (GIF or PNG) with the userhash. Set `ARTIFACT_PATH` to the GIF or PNG path:
+Upload the evidence file (GIF or PNG) to litterbox for a temporary 1-hour preview:
 
 ```bash
-python3 scripts/capture-demo.py upload --userhash [USERHASH] [ARTIFACT_PATH]
+python3 scripts/capture-demo.py preview [ARTIFACT_PATH]
 ```
 
-The script uploads to catbox.moe, validates the response starts with `https://`, and retries once on failure. The last line of output is the public URL (e.g., `https://files.catbox.moe/abc123.gif`).
+The last line of output is the preview URL (e.g., `https://litter.catbox.moe/abc123.gif`). This URL expires after 1 hour — no cleanup needed.
 
-For multiple files (static screenshots tier), upload each file separately with the same userhash.
+For multiple files (static screenshots tier), upload each file separately.
 
 **If upload fails** after retry, fall back to opening the local file with the platform file-opener (`open` on macOS, `xdg-open` on Linux) so the user can still review it. Include the local path in the approval question instead of a URL.
 
-## Step 3: Approval Gate
+## Step 2: Approval Gate
 
-Present the uploaded URL to the user for approval. Use the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini).
+Present the preview URL to the user for approval. Use the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini).
 
-**Question:** "Evidence uploaded: [CATBOX_URL]"
+**Question:** "Evidence preview (1h link): [PREVIEW_URL]"
 
 **Options:**
-1. **Use this in the PR** -- proceed with this URL
+1. **Use this in the PR** -- promote to permanent hosting
 2. **Recapture** -- provide instructions on what to change
 3. **Proceed without evidence** -- set evidence to null and proceed
 
 If the question tool is unavailable (headless/background mode), present the numbered options and wait for the user's reply before proceeding.
 
-### On "Recapture" or "Proceed without evidence"
+### On "Recapture"
 
-Delete the uploaded file before continuing:
+Return to the tier execution step. The user's instructions guide what to change in the next capture attempt. After recapture, upload a new preview and repeat the approval gate.
+
+### On "Proceed without evidence"
+
+Set evidence to null and proceed. The preview link expires on its own.
+
+## Step 3: Permanent Upload
+
+After the user approves, upload the same local artifact to permanent catbox hosting:
 
 ```bash
-python3 scripts/capture-demo.py delete --userhash [USERHASH] [CATBOX_URL]
+python3 scripts/capture-demo.py upload [ARTIFACT_PATH]
 ```
 
-The delete command accepts full URLs or bare filenames (e.g., `abc123.gif`).
+The last line of output is the permanent URL (e.g., `https://files.catbox.moe/abc123.gif`). Use this URL in the output, not the preview URL.
 
-- **Recapture:** Return to the tier execution step. The user's instructions guide what to change in the next capture attempt. Upload the new artifact with the same userhash.
-- **Proceed without evidence:** Set evidence to null and proceed.
+For multiple files, upload each file separately.
 
 ## Step 4: Return Output
 
-Return the structured output defined in the SKILL.md Output section: `Tier`, `Description`, and `URL`. The caller formats the evidence into the PR description. ce-demo-reel does not generate markdown.
+Return the structured output defined in the SKILL.md Output section: `Tier`, `Description`, and `URL` (the permanent catbox URL). The caller formats the evidence into the PR description. ce-demo-reel does not generate markdown.
 
 ## Step 5: Cleanup
 
-Remove the `[RUN_DIR]` scratch directory and all temporary files. Preserve nothing -- the evidence lives at the public URL now.
+Remove the `[RUN_DIR]` scratch directory and all temporary files. Preserve nothing -- the evidence lives at the permanent URL now.
 
-If the upload failed and the user chose to proceed without evidence, clean up the scratch directory. If the user wants to retry the upload manually, preserve `[RUN_DIR]` so the artifact is still accessible.
+If the permanent upload failed, preserve `[RUN_DIR]` so the artifact is still accessible for manual upload.

--- a/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
@@ -4,9 +4,21 @@ Get user approval for the local artifact, upload evidence to a public URL, and g
 
 ## Step 1: Local Approval Gate
 
-Before uploading anywhere public, present the local artifact path to the user for approval. Use the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini).
+Before uploading anywhere public, open the artifact so the user can review it, then ask for approval.
 
-**Question:** "Evidence captured at [RUN_DIR]/[artifact]. Review it locally and decide:"
+**Open the file** using the platform file-opener before presenting the question:
+
+```bash
+open [RUN_DIR]/[artifact]
+```
+
+(`open` on macOS, `xdg-open` on Linux. Skip if running headless/in CI.)
+
+Then present the approval question via the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini).
+
+**Question:** "Evidence captured (`[artifact filename only]`). Review the file that just opened and decide:"
+
+Show only the artifact filename (e.g., `demo.gif`), not the full temp directory path.
 
 **Options:**
 1. **Looks good, upload for PR** -- proceed to upload

--- a/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
@@ -37,17 +37,17 @@ Return to the tier execution step. The user's instructions guide what to change 
 
 Set evidence to null and proceed. The preview link expires on its own.
 
-## Step 3: Permanent Upload
+## Step 3: Promote to Permanent Hosting
 
-After the user approves, upload the same local artifact to permanent catbox hosting:
+After the user approves, promote the preview URL to permanent catbox hosting:
 
 ```bash
-python3 scripts/capture-demo.py upload [ARTIFACT_PATH]
+python3 scripts/capture-demo.py upload [PREVIEW_URL]
 ```
 
-The last line of output is the permanent URL (e.g., `https://files.catbox.moe/abc123.gif`). Use this URL in the output, not the preview URL.
+This uses catbox's `urlupload` to copy directly from litterbox without re-uploading the local file. The last line of output is the permanent URL (e.g., `https://files.catbox.moe/abc123.gif`). Use this URL in the output, not the preview URL.
 
-For multiple files, upload each file separately.
+For multiple files, promote each preview URL separately.
 
 ## Step 4: Return Output
 
@@ -56,5 +56,3 @@ Return the structured output defined in the SKILL.md Output section: `Tier`, `De
 ## Step 5: Cleanup
 
 Remove the `[RUN_DIR]` scratch directory and all temporary files. Preserve nothing -- the evidence lives at the permanent URL now.
-
-If the permanent upload failed, preserve `[RUN_DIR]` so the artifact is still accessible for manual upload.

--- a/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
@@ -1,22 +1,32 @@
 # Upload and Approval
 
-Upload evidence to a public URL, get user approval, and return structured output for PR inclusion.
+Upload evidence to a public URL for preview, get user approval, and clean up rejected uploads.
 
-## Step 1: Upload to catbox.moe
+## Step 1: Generate Userhash
 
-Upload the evidence file (GIF or PNG) immediately after the tier produces it. Set `ARTIFACT_PATH` to the GIF or PNG path:
+Generate a random userhash for this run so uploaded files can be deleted if the user rejects them:
 
 ```bash
-python3 scripts/capture-demo.py upload [ARTIFACT_PATH]
+python3 -c "import uuid; print(uuid.uuid4().hex)"
+```
+
+Store the output as `USERHASH` for use in upload and delete commands.
+
+## Step 2: Upload to catbox.moe
+
+Upload the evidence file (GIF or PNG) with the userhash. Set `ARTIFACT_PATH` to the GIF or PNG path:
+
+```bash
+python3 scripts/capture-demo.py upload --userhash [USERHASH] [ARTIFACT_PATH]
 ```
 
 The script uploads to catbox.moe, validates the response starts with `https://`, and retries once on failure. The last line of output is the public URL (e.g., `https://files.catbox.moe/abc123.gif`).
 
-For multiple files (static screenshots tier), upload each file separately.
+For multiple files (static screenshots tier), upload each file separately with the same userhash.
 
 **If upload fails** after retry, fall back to opening the local file with the platform file-opener (`open` on macOS, `xdg-open` on Linux) so the user can still review it. Include the local path in the approval question instead of a URL.
 
-## Step 2: Approval Gate
+## Step 3: Approval Gate
 
 Present the uploaded URL to the user for approval. Use the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini).
 
@@ -24,16 +34,29 @@ Present the uploaded URL to the user for approval. Use the platform's blocking q
 
 **Options:**
 1. **Use this in the PR** -- proceed with this URL
-2. **Recapture** -- return to the tier execution step; the user should provide instructions on what to change
+2. **Recapture** -- provide instructions on what to change
 3. **Proceed without evidence** -- set evidence to null and proceed
 
 If the question tool is unavailable (headless/background mode), present the numbered options and wait for the user's reply before proceeding.
 
-## Step 3: Return Output
+### On "Recapture" or "Proceed without evidence"
+
+Delete the uploaded file before continuing:
+
+```bash
+python3 scripts/capture-demo.py delete --userhash [USERHASH] [CATBOX_URL]
+```
+
+The delete command accepts full URLs or bare filenames (e.g., `abc123.gif`).
+
+- **Recapture:** Return to the tier execution step. The user's instructions guide what to change in the next capture attempt. Upload the new artifact with the same userhash.
+- **Proceed without evidence:** Set evidence to null and proceed.
+
+## Step 4: Return Output
 
 Return the structured output defined in the SKILL.md Output section: `Tier`, `Description`, and `URL`. The caller formats the evidence into the PR description. ce-demo-reel does not generate markdown.
 
-## Step 4: Cleanup
+## Step 5: Cleanup
 
 Remove the `[RUN_DIR]` scratch directory and all temporary files. Preserve nothing -- the evidence lives at the public URL now.
 

--- a/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
@@ -1,35 +1,10 @@
 # Upload and Approval
 
-Get user approval for the local artifact, upload evidence to a public URL, and generate markdown for PR inclusion.
+Upload evidence to a public URL, get user approval, and return structured output for PR inclusion.
 
-## Step 1: Local Approval Gate
+## Step 1: Upload to catbox.moe
 
-Before uploading anywhere public, open the artifact so the user can review it, then ask for approval.
-
-**Open the file** using the platform file-opener before presenting the question:
-
-```bash
-open [RUN_DIR]/[artifact]
-```
-
-(`open` on macOS, `xdg-open` on Linux. Skip if running headless/in CI.)
-
-Then present the approval question via the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini).
-
-**Question:** "Evidence captured (`[artifact filename only]`). Review the file that just opened and decide:"
-
-Show only the artifact filename (e.g., `demo.gif`), not the full temp directory path.
-
-**Options:**
-1. **Looks good, upload for PR** -- proceed to upload
-2. **Not good enough, try again** -- return to the tier execution step and re-capture
-3. **Skip evidence for this PR** -- set evidence to null and proceed
-
-If the question tool is unavailable (headless/background mode), present the numbered options and wait for the user's reply before proceeding.
-
-## Step 2: Upload to catbox.moe
-
-After the user approves the local artifact, upload the evidence file (GIF or PNG) using the capture pipeline script. Set `ARTIFACT_PATH` to the approved GIF or PNG path:
+Upload the evidence file (GIF or PNG) immediately after the tier produces it. Set `ARTIFACT_PATH` to the GIF or PNG path:
 
 ```bash
 python3 scripts/capture-demo.py upload [ARTIFACT_PATH]
@@ -37,9 +12,22 @@ python3 scripts/capture-demo.py upload [ARTIFACT_PATH]
 
 The script uploads to catbox.moe, validates the response starts with `https://`, and retries once on failure. The last line of output is the public URL (e.g., `https://files.catbox.moe/abc123.gif`).
 
-**If upload fails** after retry, report the failure and the local artifact path. Do not commit evidence files to the repo — they are ephemeral artifacts, not source material. Tell the user: "Upload failed. Local artifact preserved at [ARTIFACT_PATH]. You can upload it manually or retry later."
-
 For multiple files (static screenshots tier), upload each file separately.
+
+**If upload fails** after retry, fall back to opening the local file with the platform file-opener (`open` on macOS, `xdg-open` on Linux) so the user can still review it. Include the local path in the approval question instead of a URL.
+
+## Step 2: Approval Gate
+
+Present the uploaded URL to the user for approval. Use the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini).
+
+**Question:** "Evidence uploaded: [CATBOX_URL]"
+
+**Options:**
+1. **Use this in the PR** -- proceed with this URL
+2. **Recapture** -- return to the tier execution step; the user should provide instructions on what to change
+3. **Proceed without evidence** -- set evidence to null and proceed
+
+If the question tool is unavailable (headless/background mode), present the numbered options and wait for the user's reply before proceeding.
 
 ## Step 3: Return Output
 
@@ -49,4 +37,4 @@ Return the structured output defined in the SKILL.md Output section: `Tier`, `De
 
 Remove the `[RUN_DIR]` scratch directory and all temporary files. Preserve nothing -- the evidence lives at the public URL now.
 
-If the upload failed and the user has not yet manually uploaded, preserve `[RUN_DIR]` so the artifact is still accessible.
+If the upload failed and the user chose to proceed without evidence, clean up the scratch directory. If the user wants to retry the upload manually, preserve `[RUN_DIR]` so the artifact is still accessible.

--- a/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/references/upload-and-approval.md
@@ -39,15 +39,17 @@ Set evidence to null and proceed. The preview link expires on its own.
 
 ## Step 3: Promote to Permanent Hosting
 
-After the user approves, promote the preview URL to permanent catbox hosting:
+After the user approves, upload to permanent catbox hosting. The command accepts either the preview URL (preferred) or the local file path (fallback):
 
 ```bash
-python3 scripts/capture-demo.py upload [PREVIEW_URL]
+python3 scripts/capture-demo.py upload [PREVIEW_URL or ARTIFACT_PATH]
 ```
 
-This uses catbox's `urlupload` to copy directly from litterbox without re-uploading the local file. The last line of output is the permanent URL (e.g., `https://files.catbox.moe/abc123.gif`). Use this URL in the output, not the preview URL.
+If Step 1 produced a preview URL, pass it here -- catbox copies directly from litterbox without re-uploading. If Step 1 fell back to local review (no preview URL), pass the local artifact path instead.
 
-For multiple files, promote each preview URL separately.
+The last line of output is the permanent URL (e.g., `https://files.catbox.moe/abc123.gif`). Use this URL in the output, not the preview URL.
+
+For multiple files, promote each separately.
 
 ## Step 4: Return Output
 

--- a/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
+++ b/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
@@ -9,8 +9,8 @@ Subcommands:
   stitch [--duration N] OUTPUT FRAME [FRAME ...]            Stitch frames into animated GIF
   screenshot-reel --output OUT [--duration N] [--lang L] [--theme T] --text F [F ...]   Render text frames via silicon + stitch
   terminal-recording --output OUT --tape TAPE               Run VHS tape file
-  upload [--userhash H] FILE         Upload to catbox.moe (retries once)
-  delete --userhash H FILE [FILE ...] Delete files from catbox.moe
+  preview FILE                       Upload to litterbox (1h expiry) for preview
+  upload FILE                        Upload to catbox.moe (permanent)
 """
 import argparse
 import json
@@ -28,6 +28,7 @@ from pathlib import Path
 MAX_GIF_SIZE = 10 * 1024 * 1024   # 10 MB — GitHub inline render limit
 TARGET_GIF_SIZE = 5 * 1024 * 1024  # 5 MB — preferred target
 CATBOX_API = "https://catbox.moe/user/api.php"
+LITTERBOX_API = "https://litterbox.catbox.moe/resources/internals/api.php"
 
 
 # --- Helpers ---
@@ -528,92 +529,72 @@ def cmd_terminal_recording(args):
 
 # --- Upload ---
 
+def _upload_to(api_url, file_path, extra_fields=None):
+    """Upload a file to a catbox-family API. Returns the URL or empty string."""
+    if not check_tool("curl"):
+        die("curl is not installed")
+
+    cmd = [
+        "curl", "-s", "--connect-timeout", "10",
+        "-F", "reqtype=fileupload",
+        "-F", f"fileToUpload=@{file_path}",
+    ]
+    for field in (extra_fields or []):
+        cmd += ["-F", field]
+    cmd.append(api_url)
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=30, check=False,
+        )
+        return result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        print("ERROR: Upload timed out after 30s", file=sys.stderr)
+        return ""
+
+
+def _upload_with_retry(api_url, file_path, label, extra_fields=None):
+    """Upload with one retry. Prints and returns the URL, or exits on failure."""
+    size_mb = file_size_mb(file_path)
+    print(f"Uploading {file_path} ({size_mb:.1f} MB) to {label}...")
+
+    url = _upload_to(api_url, file_path, extra_fields)
+    if url.startswith("https://"):
+        print(f"Uploaded: {url}")
+        print(url)
+        return url
+
+    print(f"ERROR: Upload failed. Response: {url[:200]}", file=sys.stderr)
+    print(f"Local file preserved at: {file_path}", file=sys.stderr)
+    print("Retrying in 2 seconds...", file=sys.stderr)
+    time.sleep(2)
+
+    url = _upload_to(api_url, file_path, extra_fields)
+    if url.startswith("https://"):
+        print(f"Uploaded (retry): {url}")
+        print(url)
+        return url
+
+    print("ERROR: Retry also failed.", file=sys.stderr)
+    sys.exit(1)
+
+
+# --- Preview (litterbox — temporary, 1h expiry) ---
+
+def cmd_preview(args):
+    file_path = args.file
+    if not Path(file_path).exists():
+        die(f"File not found: {file_path}")
+    _upload_with_retry(LITTERBOX_API, file_path, "litterbox (1h expiry)", ["time=1h"])
+
+
+# --- Upload (catbox — permanent) ---
+
 def cmd_upload(args):
     file_path = args.file
     if not Path(file_path).exists():
         die(f"File not found: {file_path}")
-
-    if not check_tool("curl"):
-        die("curl is not installed")
-
-    userhash = args.userhash
-    size_mb = file_size_mb(file_path)
-    print(f"Uploading {file_path} ({size_mb:.1f} MB) to catbox.moe...")
-
-    def _try_upload():
-        cmd = [
-            "curl", "-s", "--connect-timeout", "10",
-            "-F", "reqtype=fileupload",
-            "-F", f"fileToUpload=@{file_path}",
-        ]
-        if userhash:
-            cmd += ["-F", f"userhash={userhash}"]
-        cmd.append(CATBOX_API)
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=30, check=False,
-            )
-            return result.stdout.strip()
-        except subprocess.TimeoutExpired:
-            print("ERROR: Upload timed out after 30s", file=sys.stderr)
-            return ""
-
-    url = _try_upload()
-
-    if url.startswith("https://"):
-        print(f"Uploaded: {url}")
-        print(url)
-        return
-
-    print(f"ERROR: Upload failed. Response: {url[:200]}", file=sys.stderr)
-    print(f"Local file preserved at: {file_path}", file=sys.stderr)
-
-    # Retry once
-    print("Retrying in 2 seconds...", file=sys.stderr)
-    time.sleep(2)
-    url = _try_upload()
-
-    if url.startswith("https://"):
-        print(f"Uploaded (retry): {url}")
-        print(url)
-    else:
-        print("ERROR: Retry also failed. Upload manually or commit to branch.", file=sys.stderr)
-        sys.exit(1)
-
-
-# --- Delete ---
-
-def cmd_delete(args):
-    if not check_tool("curl"):
-        die("curl is not installed")
-
-    # Extract just the filename from full URLs or bare filenames
-    filenames = []
-    for f in args.files:
-        if f.startswith("https://"):
-            filenames.append(f.rsplit("/", 1)[-1])
-        else:
-            filenames.append(f)
-
-    files_str = " ".join(filenames)
-    print(f"Deleting from catbox.moe: {files_str}")
-
-    try:
-        result = subprocess.run(
-            ["curl", "-s", "--connect-timeout", "10",
-             "-d", f"reqtype=deletefiles&userhash={args.userhash}&files={files_str}",
-             CATBOX_API],
-            capture_output=True, text=True, timeout=30, check=False,
-        )
-        response = result.stdout.strip()
-        if result.returncode == 0:
-            print(f"Delete response: {response}")
-        else:
-            print(f"ERROR: Delete failed (exit {result.returncode})", file=sys.stderr)
-            if response:
-                print(response, file=sys.stderr)
-    except subprocess.TimeoutExpired:
-        print("ERROR: Delete timed out after 30s", file=sys.stderr)
+    _upload_with_retry(CATBOX_API, file_path, "catbox.moe")
 
 
 # --- Main ---
@@ -630,8 +611,8 @@ Commands:
   stitch [--duration N] OUTPUT FRAMES    Stitch frames into animated GIF
   screenshot-reel --output O --text F    Render text via silicon + stitch
   terminal-recording --output O --tape T Run VHS tape
-  upload [--userhash H] FILE             Upload to catbox.moe
-  delete --userhash H FILE [FILE ...]    Delete files from catbox.moe
+  preview FILE                           Upload to litterbox (1h expiry)
+  upload FILE                            Upload to catbox.moe (permanent)
 """,
     )
     sub = parser.add_subparsers(dest="command")
@@ -670,15 +651,13 @@ Commands:
     p_term.add_argument("--output", help="Output GIF path (overrides tape Output directive)")
     p_term.add_argument("--tape", required=True, help="VHS tape file path")
 
-    # upload
-    p_upload = sub.add_parser("upload", help="Upload to catbox.moe")
-    p_upload.add_argument("--userhash", help="Catbox userhash for file management")
-    p_upload.add_argument("file", help="File to upload")
+    # preview
+    p_preview = sub.add_parser("preview", help="Upload to litterbox (1h expiry) for preview")
+    p_preview.add_argument("file", help="File to upload")
 
-    # delete
-    p_delete = sub.add_parser("delete", help="Delete files from catbox.moe")
-    p_delete.add_argument("--userhash", required=True, help="Catbox userhash used during upload")
-    p_delete.add_argument("files", nargs="+", help="Filenames or URLs to delete")
+    # upload
+    p_upload = sub.add_parser("upload", help="Upload to catbox.moe (permanent)")
+    p_upload.add_argument("file", help="File to upload")
 
     args = parser.parse_args()
 
@@ -693,8 +672,8 @@ Commands:
         "stitch": cmd_stitch,
         "screenshot-reel": cmd_screenshot_reel,
         "terminal-recording": cmd_terminal_recording,
+        "preview": cmd_preview,
         "upload": cmd_upload,
-        "delete": cmd_delete,
     }
     dispatch[args.command](args)
 

--- a/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
+++ b/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
@@ -10,7 +10,7 @@ Subcommands:
   screenshot-reel --output OUT [--duration N] [--lang L] [--theme T] --text F [F ...]   Render text frames via silicon + stitch
   terminal-recording --output OUT --tape TAPE               Run VHS tape file
   preview FILE                       Upload to litterbox (1h expiry) for preview
-  upload FILE                        Upload to catbox.moe (permanent)
+  upload FILE_OR_URL                 Upload/promote to catbox.moe (permanent)
 """
 import argparse
 import json
@@ -590,11 +590,54 @@ def cmd_preview(args):
 
 # --- Upload (catbox — permanent) ---
 
+def _promote_url(source_url):
+    """Promote a URL (e.g., litterbox preview) to permanent catbox hosting."""
+    if not check_tool("curl"):
+        die("curl is not installed")
+
+    print(f"Promoting {source_url} to catbox.moe...")
+
+    def _try():
+        try:
+            result = subprocess.run(
+                ["curl", "-s", "--connect-timeout", "10",
+                 "-F", "reqtype=urlupload",
+                 "-F", f"url={source_url}", CATBOX_API],
+                capture_output=True, text=True, timeout=30, check=False,
+            )
+            return result.stdout.strip()
+        except subprocess.TimeoutExpired:
+            print("ERROR: Upload timed out after 30s", file=sys.stderr)
+            return ""
+
+    url = _try()
+    if url.startswith("https://"):
+        print(f"Promoted: {url}")
+        print(url)
+        return url
+
+    print(f"ERROR: Promote failed. Response: {url[:200]}", file=sys.stderr)
+    print("Retrying in 2 seconds...", file=sys.stderr)
+    time.sleep(2)
+
+    url = _try()
+    if url.startswith("https://"):
+        print(f"Promoted (retry): {url}")
+        print(url)
+        return url
+
+    print("ERROR: Retry also failed.", file=sys.stderr)
+    sys.exit(1)
+
+
 def cmd_upload(args):
-    file_path = args.file
-    if not Path(file_path).exists():
-        die(f"File not found: {file_path}")
-    _upload_with_retry(CATBOX_API, file_path, "catbox.moe")
+    source = args.source
+    if source.startswith("https://"):
+        _promote_url(source)
+    else:
+        if not Path(source).exists():
+            die(f"File not found: {source}")
+        _upload_with_retry(CATBOX_API, source, "catbox.moe")
 
 
 # --- Main ---
@@ -612,7 +655,7 @@ Commands:
   screenshot-reel --output O --text F    Render text via silicon + stitch
   terminal-recording --output O --tape T Run VHS tape
   preview FILE                           Upload to litterbox (1h expiry)
-  upload FILE                            Upload to catbox.moe (permanent)
+  upload FILE_OR_URL                     Upload/promote to catbox.moe (permanent)
 """,
     )
     sub = parser.add_subparsers(dest="command")
@@ -656,8 +699,8 @@ Commands:
     p_preview.add_argument("file", help="File to upload")
 
     # upload
-    p_upload = sub.add_parser("upload", help="Upload to catbox.moe (permanent)")
-    p_upload.add_argument("file", help="File to upload")
+    p_upload = sub.add_parser("upload", help="Upload or promote to catbox.moe (permanent)")
+    p_upload.add_argument("source", help="Local file path or URL to promote")
 
     args = parser.parse_args()
 

--- a/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
+++ b/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
@@ -9,7 +9,8 @@ Subcommands:
   stitch [--duration N] OUTPUT FRAME [FRAME ...]            Stitch frames into animated GIF
   screenshot-reel --output OUT [--duration N] [--lang L] [--theme T] --text F [F ...]   Render text frames via silicon + stitch
   terminal-recording --output OUT --tape TAPE               Run VHS tape file
-  upload FILE                        Upload to catbox.moe (retries once)
+  upload [--userhash H] FILE         Upload to catbox.moe (retries once)
+  delete --userhash H FILE [FILE ...] Delete files from catbox.moe
 """
 import argparse
 import json
@@ -535,16 +536,22 @@ def cmd_upload(args):
     if not check_tool("curl"):
         die("curl is not installed")
 
+    userhash = args.userhash
     size_mb = file_size_mb(file_path)
     print(f"Uploading {file_path} ({size_mb:.1f} MB) to catbox.moe...")
 
     def _try_upload():
+        cmd = [
+            "curl", "-s", "--connect-timeout", "10",
+            "-F", "reqtype=fileupload",
+            "-F", f"fileToUpload=@{file_path}",
+        ]
+        if userhash:
+            cmd += ["-F", f"userhash={userhash}"]
+        cmd.append(CATBOX_API)
         try:
             result = subprocess.run(
-                ["curl", "-s", "--connect-timeout", "10",
-                 "-F", "reqtype=fileupload",
-                 "-F", f"fileToUpload=@{file_path}", CATBOX_API],
-                capture_output=True, text=True, timeout=30, check=False,
+                cmd, capture_output=True, text=True, timeout=30, check=False,
             )
             return result.stdout.strip()
         except subprocess.TimeoutExpired:
@@ -574,6 +581,41 @@ def cmd_upload(args):
         sys.exit(1)
 
 
+# --- Delete ---
+
+def cmd_delete(args):
+    if not check_tool("curl"):
+        die("curl is not installed")
+
+    # Extract just the filename from full URLs or bare filenames
+    filenames = []
+    for f in args.files:
+        if f.startswith("https://"):
+            filenames.append(f.rsplit("/", 1)[-1])
+        else:
+            filenames.append(f)
+
+    files_str = " ".join(filenames)
+    print(f"Deleting from catbox.moe: {files_str}")
+
+    try:
+        result = subprocess.run(
+            ["curl", "-s", "--connect-timeout", "10",
+             "-d", f"reqtype=deletefiles&userhash={args.userhash}&files={files_str}",
+             CATBOX_API],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+        response = result.stdout.strip()
+        if result.returncode == 0:
+            print(f"Delete response: {response}")
+        else:
+            print(f"ERROR: Delete failed (exit {result.returncode})", file=sys.stderr)
+            if response:
+                print(response, file=sys.stderr)
+    except subprocess.TimeoutExpired:
+        print("ERROR: Delete timed out after 30s", file=sys.stderr)
+
+
 # --- Main ---
 
 def main():
@@ -588,7 +630,8 @@ Commands:
   stitch [--duration N] OUTPUT FRAMES    Stitch frames into animated GIF
   screenshot-reel --output O --text F    Render text via silicon + stitch
   terminal-recording --output O --tape T Run VHS tape
-  upload FILE                            Upload to catbox.moe
+  upload [--userhash H] FILE             Upload to catbox.moe
+  delete --userhash H FILE [FILE ...]    Delete files from catbox.moe
 """,
     )
     sub = parser.add_subparsers(dest="command")
@@ -629,7 +672,13 @@ Commands:
 
     # upload
     p_upload = sub.add_parser("upload", help="Upload to catbox.moe")
+    p_upload.add_argument("--userhash", help="Catbox userhash for file management")
     p_upload.add_argument("file", help="File to upload")
+
+    # delete
+    p_delete = sub.add_parser("delete", help="Delete files from catbox.moe")
+    p_delete.add_argument("--userhash", required=True, help="Catbox userhash used during upload")
+    p_delete.add_argument("files", nargs="+", help="Filenames or URLs to delete")
 
     args = parser.parse_args()
 
@@ -645,6 +694,7 @@ Commands:
         "screenshot-reel": cmd_screenshot_reel,
         "terminal-recording": cmd_terminal_recording,
         "upload": cmd_upload,
+        "delete": cmd_delete,
     }
     dispatch[args.command](args)
 


### PR DESCRIPTION
## Summary

The demo-reel approval gate showed the full OS temp path (`/var/folders/64/.../demo-reel-XXXXXX/demo.gif`) as the only way to review the captured artifact. Nobody is going to copy-paste that.

Now the approval gate uploads a 1-hour preview to litterbox first, giving the user a clickable URL to review. If approved, the same local file gets promoted to permanent catbox hosting for the PR. Rejected previews expire on their own.

## Changes

**Approval flow** (`upload-and-approval.md`): Restructured from a single upload step to a three-phase flow: preview upload (litterbox.catbox.moe, 1h expiry) → approval gate with clickable URL → permanent upload (catbox) on approval.

**Capture script** (`capture-demo.py`): Added `preview` subcommand targeting the litterbox API. Refactored upload internals into `_upload_to` and `_upload_with_retry` shared by both `preview` and `upload` commands.

## Test plan

- [ ] Run `python3 scripts/capture-demo.py preview <file>` and confirm a `litter.catbox.moe` URL is returned
- [ ] Run `python3 scripts/capture-demo.py upload <file>` and confirm a `files.catbox.moe` URL is returned
- [ ] Run `/ce-demo-reel` end-to-end: confirm the approval gate shows a clickable preview link, and approving produces a permanent URL

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)