### PR TITLE
docs(ce-setup): add getting started sections to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Brainstorm -> Plan -> Work -> Review -> Compound -> Repeat
 
 Each cycle compounds: brainstorms sharpen plans, plans inform future plans, reviews catch more issues, patterns get documented.
 
+### Getting started
+
+After installing, run `/ce-setup` in any project. It checks your environment, installs missing tools (agent-browser, gh, jq, vhs, silicon, ffmpeg), and bootstraps project config.
+
 ---
 
 ## Install

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -2,6 +2,10 @@
 
 AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last.
 
+## Getting Started
+
+After installing, run `/ce-setup` in any project. It diagnoses your environment, installs missing tools, and bootstraps project config in one interactive flow.
+
 ## Components
 
 | Component | Count |
@@ -53,6 +57,7 @@ The primary entry points for engineering work, invoked as slash commands:
 | `/test-browser` | Run browser tests on PR-affected pages |
 | `/test-xcode` | Build and test iOS apps on simulator using XcodeBuildMCP |
 | `/onboarding` | Generate `ONBOARDING.md` to help new contributors understand the codebase |
+| `/ce-setup` | Diagnose environment, install missing tools, and bootstrap project config |
 | `/ce-update` | Check compound-engineering plugin version and fix stale cache (Claude Code only) |
 | `/todo-resolve` | Resolve todos in parallel |
 | `/todo-triage` | Triage and prioritize pending todos |
@@ -73,7 +78,6 @@ The primary entry points for engineering work, invoked as slash commands:
 |-------|-------------|
 | `claude-permissions-optimizer` | Optimize Claude Code permissions from session history |
 | `document-review` | Review documents using parallel persona agents for role-specific feedback |
-| `ce-setup` | Diagnose and configure environment: checks CLI deps, MCP servers, env vars, plugin version, and repo-local config; offers guided installation for missing tools |
 
 ### Content & Collaboration
 
@@ -182,6 +186,8 @@ Agents are specialized subagents invoked by skills — you typically don't call 
 ```bash
 claude /plugin install compound-engineering
 ```
+
+Then run `/ce-setup` to check your environment and install recommended tools.
 
 ## Version History
 


### PR DESCRIPTION
## Summary

New users now see `/ce-setup` as the first step after installation. Both READMEs point to it so the onboarding path is: install -> `/ce-setup` -> start working.

- Root README: added "Getting started" section after the workflow table
- Plugin README: added "Getting Started" section at the top, moved `ce-setup` to Workflow Utilities, removed the standalone Browser Automation section (redundant now that `/ce-setup` handles tool installation), added post-install note

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)