### PR TITLE
fix(document-review, review): restrict reviewer agents to read-only tools

### DIFF
--- a/plugins/compound-engineering/agents/document-review/adversarial-document-reviewer.md
+++ b/plugins/compound-engineering/agents/document-review/adversarial-document-reviewer.md
@@ -2,6 +2,7 @@
 name: adversarial-document-reviewer
 description: "Conditional document-review persona, selected when the document has >5 requirements or implementation units, makes significant architectural decisions, covers high-stakes domains, or proposes new abstractions. Challenges premises, surfaces unstated assumptions, and stress-tests decisions rather than evaluating document quality."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 # Adversarial Reviewer

--- a/plugins/compound-engineering/agents/document-review/coherence-reviewer.md
+++ b/plugins/compound-engineering/agents/document-review/coherence-reviewer.md
@@ -2,6 +2,7 @@
 name: coherence-reviewer
 description: "Reviews planning documents for internal consistency -- contradictions between sections, terminology drift, structural issues, and ambiguity where readers would diverge. Spawned by the document-review skill."
 model: haiku
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a technical editor reading for internal consistency. You don't evaluate whether the plan is good, feasible, or complete -- other reviewers handle that. You catch when the document disagrees with itself.

--- a/plugins/compound-engineering/agents/document-review/design-lens-reviewer.md
+++ b/plugins/compound-engineering/agents/document-review/design-lens-reviewer.md
@@ -2,6 +2,7 @@
 name: design-lens-reviewer
 description: "Reviews planning documents for missing design decisions -- information architecture, interaction states, user flows, and AI slop risk. Uses dimensional rating to identify gaps. Spawned by the document-review skill."
 model: sonnet
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a senior product designer reviewing plans for missing design decisions. Not visual design -- whether the plan accounts for decisions that will block or derail implementation. When plans skip these, implementers either block (waiting for answers) or guess (producing inconsistent UX).

--- a/plugins/compound-engineering/agents/document-review/feasibility-reviewer.md
+++ b/plugins/compound-engineering/agents/document-review/feasibility-reviewer.md
@@ -2,6 +2,7 @@
 name: feasibility-reviewer
 description: "Evaluates whether proposed technical approaches in planning documents will survive contact with reality -- architecture conflicts, dependency gaps, migration risks, and implementability. Spawned by the document-review skill."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a systems architect evaluating whether this plan can actually be built as described and whether an implementer could start working from it without making major architectural decisions the plan should have made.

--- a/plugins/compound-engineering/agents/document-review/product-lens-reviewer.md
+++ b/plugins/compound-engineering/agents/document-review/product-lens-reviewer.md
@@ -2,6 +2,7 @@
 name: product-lens-reviewer
 description: "Reviews planning documents as a senior product leader -- challenges premise claims, assesses strategic consequences (trajectory, identity, adoption, opportunity cost), and surfaces goal-work misalignment. Domain-agnostic: users may be end users, developers, operators, or any audience. Spawned by the document-review skill."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a senior product leader. The most common failure mode is building the wrong thing well. Challenge the premise before evaluating the execution.

--- a/plugins/compound-engineering/agents/document-review/scope-guardian-reviewer.md
+++ b/plugins/compound-engineering/agents/document-review/scope-guardian-reviewer.md
@@ -2,6 +2,7 @@
 name: scope-guardian-reviewer
 description: "Reviews planning documents for scope alignment and unjustified complexity -- challenges unnecessary abstractions, premature frameworks, and scope that exceeds stated goals. Spawned by the document-review skill."
 model: sonnet
+tools: Read, Grep, Glob, Bash
 ---
 
 You ask two questions about every plan: "Is this right-sized for its goals?" and "Does every abstraction earn its keep?" You are not reviewing whether the plan solves the right problem (product-lens) or is internally consistent (coherence-reviewer).

--- a/plugins/compound-engineering/agents/document-review/security-lens-reviewer.md
+++ b/plugins/compound-engineering/agents/document-review/security-lens-reviewer.md
@@ -2,6 +2,7 @@
 name: security-lens-reviewer
 description: "Evaluates planning documents for security gaps at the plan level -- auth/authz assumptions, data exposure risks, API surface vulnerabilities, and missing threat model elements. Spawned by the document-review skill."
 model: sonnet
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a security architect evaluating whether this plan accounts for security at the planning level. Distinct from code-level security review -- you examine whether the plan makes security-relevant decisions and identifies its attack surface before implementation begins.

--- a/plugins/compound-engineering/agents/review/architecture-strategist.md
+++ b/plugins/compound-engineering/agents/review/architecture-strategist.md
@@ -2,6 +2,7 @@
 name: architecture-strategist
 description: "Analyzes code changes from an architectural perspective for pattern compliance and design integrity. Use when reviewing PRs, adding services, or evaluating structural refactors."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a System Architecture Expert specializing in analyzing code changes and system design decisions. Your role is to ensure that all modifications align with established architectural patterns, maintain system integrity, and follow best practices for scalable, maintainable software systems.

--- a/plugins/compound-engineering/agents/review/cli-agent-readiness-reviewer.md
+++ b/plugins/compound-engineering/agents/review/cli-agent-readiness-reviewer.md
@@ -2,6 +2,7 @@
 name: cli-agent-readiness-reviewer
 description: "Reviews CLI source code, plans, or specs for AI agent readiness using a severity-based rubric focused on whether a CLI is merely usable by agents or genuinely optimized for them."
 model: inherit
+tools: Read, Grep, Glob, Bash
 color: yellow
 ---
 

--- a/plugins/compound-engineering/agents/review/code-simplicity-reviewer.md
+++ b/plugins/compound-engineering/agents/review/code-simplicity-reviewer.md
@@ -2,6 +2,7 @@
 name: code-simplicity-reviewer
 description: "Final review pass to ensure code is as simple and minimal as possible. Use after implementation is complete to identify YAGNI violations and simplification opportunities."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a code simplicity expert specializing in minimalism and the YAGNI (You Aren't Gonna Need It) principle. Your mission is to ruthlessly simplify code while maintaining functionality and clarity.

--- a/plugins/compound-engineering/agents/review/data-integrity-guardian.md
+++ b/plugins/compound-engineering/agents/review/data-integrity-guardian.md
@@ -2,6 +2,7 @@
 name: data-integrity-guardian
 description: "Reviews database migrations, data models, and persistent data code for safety. Use when checking migration safety, data constraints, transaction boundaries, or privacy compliance."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a Data Integrity Guardian, an expert in database design, data migration safety, and data governance. Your deep expertise spans relational database theory, ACID properties, data privacy regulations (GDPR, CCPA), and production database management.

--- a/plugins/compound-engineering/agents/review/data-migration-expert.md
+++ b/plugins/compound-engineering/agents/review/data-migration-expert.md
@@ -2,6 +2,7 @@
 name: data-migration-expert
 description: "Validates data migrations, backfills, and production data transformations against reality. Use when PRs involve ID mappings, column renames, enum conversions, or schema changes."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a Data Migration Expert. Your mission is to prevent data corruption by validating that migrations match production reality, not fixture or assumed values.

--- a/plugins/compound-engineering/agents/review/deployment-verification-agent.md
+++ b/plugins/compound-engineering/agents/review/deployment-verification-agent.md
@@ -2,6 +2,7 @@
 name: deployment-verification-agent
 description: "Produces Go/No-Go deployment checklists with SQL verification queries, rollback procedures, and monitoring plans. Use when PRs touch production data, migrations, or risky data changes."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a Deployment Verification Agent. Your mission is to produce concrete, executable checklists for risky data deployments so engineers aren't guessing at launch time.

--- a/plugins/compound-engineering/agents/review/pattern-recognition-specialist.md
+++ b/plugins/compound-engineering/agents/review/pattern-recognition-specialist.md
@@ -2,6 +2,7 @@
 name: pattern-recognition-specialist
 description: "Analyzes code for design patterns, anti-patterns, naming conventions, and duplication. Use when checking codebase consistency or verifying new code follows established patterns."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a Code Pattern Analysis Expert specializing in identifying design patterns, anti-patterns, and code quality issues across codebases. Your expertise spans multiple programming languages with deep knowledge of software architecture principles and best practices.

--- a/plugins/compound-engineering/agents/review/performance-oracle.md
+++ b/plugins/compound-engineering/agents/review/performance-oracle.md
@@ -2,6 +2,7 @@
 name: performance-oracle
 description: "Analyzes code for performance bottlenecks, algorithmic complexity, database queries, memory usage, and scalability. Use after implementing features or when performance concerns arise."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are the Performance Oracle, an elite performance optimization expert specializing in identifying and resolving performance bottlenecks in software systems. Your deep expertise spans algorithmic complexity analysis, database optimization, memory management, caching strategies, and system scalability.

--- a/plugins/compound-engineering/agents/review/schema-drift-detector.md
+++ b/plugins/compound-engineering/agents/review/schema-drift-detector.md
@@ -2,6 +2,7 @@
 name: schema-drift-detector
 description: "Detects unrelated schema.rb changes in PRs by cross-referencing against included migrations. Use when reviewing PRs with database schema changes."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a Schema Drift Detector. Your mission is to prevent accidental inclusion of unrelated schema.rb changes in PRs - a common issue when developers run migrations from other branches.

--- a/plugins/compound-engineering/agents/review/security-sentinel.md
+++ b/plugins/compound-engineering/agents/review/security-sentinel.md
@@ -2,6 +2,7 @@
 name: security-sentinel
 description: "Performs security audits for vulnerabilities, input validation, auth/authz, hardcoded secrets, and OWASP compliance. Use when reviewing code for security issues or before deployment."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 You are an elite Application Security Specialist with deep expertise in identifying and mitigating security vulnerabilities. You think like an attacker, constantly asking: Where are the vulnerabilities? What could go wrong? How could this be exploited?


### PR DESCRIPTION
## Summary

The `coherence-reviewer` sub-agent (the only reviewer using `model: haiku`) consistently failed with "Prompt is too long" in user environments with many MCP servers or plugins installed. Haiku's 200K context window is 5x smaller than Sonnet/Opus's 1M, and without an explicit `tools` field, sub-agents inherit every tool definition from the parent session. Those inherited definitions (MCP tools, Agent catalog, Skill catalog) consumed enough context to push past the limit before the task prompt was even loaded.

All 17 reviewer agents that were missing the field now have `tools: Read, Grep, Glob, Bash`, matching the read-only contract they already follow and the pattern 20 other code-review agents already had.

## Why `tools` and not `model`

Haiku is intentionally chosen for coherence-review because the task is simple pattern-matching (terminology drift, broken cross-references) that doesn't need Sonnet-level reasoning. The root cause isn't the model. It's unbounded tool inheritance inflating the sub-agent's context in proportion to whatever the user has installed. Restricting tools makes the context deterministic regardless of environment.

## Test plan

- Dispatched `coherence-reviewer` with `model: haiku` against a 505-line plan document in the dev environment. Succeeded at 46K total tokens with room to spare.
- Verified all 35 reviewer agents (28 review + 7 document-review) now have the `tools` field.
- `bun run release:validate` passes.

Closes #551

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.6_(1M,_Extended_Thinking)-D97757?logo=claude&logoColor=white)