### PR TITLE
fix(ce-update): use correct marketplace name in cache path

### DIFF
--- a/plugins/compound-engineering/skills/ce-update/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-update/SKILL.md
@@ -28,10 +28,10 @@ below handles those cases.
 !`echo "${CLAUDE_PLUGIN_ROOT}" 2>/dev/null || echo '__CE_UPDATE_ROOT_FAILED__'`
 
 **Latest released version:**
-!`gh release list --repo Everyinc/compound-engineering-plugin --limit 30 --json tagName --jq '[.[] | select(.tagName | startswith("compound-engineering-v"))][0].tagName | sub("compound-engineering-v";"")' 2>/dev/null || echo '__CE_UPDATE_VERSION_FAILED__'`
+!`gh release list --repo EveryInc/compound-engineering-plugin --limit 30 --json tagName --jq '[.[] | select(.tagName | startswith("compound-engineering-v"))][0].tagName | sub("compound-engineering-v";"")' 2>/dev/null || echo '__CE_UPDATE_VERSION_FAILED__'`
 
 **Cached version folder(s):**
-!`ls "${CLAUDE_PLUGIN_ROOT}/cache/every-marketplace/compound-engineering/" 2>/dev/null || echo '__CE_UPDATE_CACHE_FAILED__'`
+!`ls "${CLAUDE_PLUGIN_ROOT}/cache/compound-engineering-plugin/compound-engineering/" 2>/dev/null || echo '__CE_UPDATE_CACHE_FAILED__'`
 
 ## Decision logic
 
@@ -61,7 +61,7 @@ construct the delete path.
 
 **Clear the stale cache:**
 ```bash
-rm -rf "<plugin-root-path>/cache/every-marketplace/compound-engineering"
+rm -rf "<plugin-root-path>/cache/compound-engineering-plugin/compound-engineering"
 ```
 
 Tell the user:


### PR DESCRIPTION
The ce-update skill was looking at `${CLAUDE_PLUGIN_ROOT}/cache/every-marketplace/compound-engineering/`
for the cached plugin version, but the actual marketplace name registered in
`.claude-plugin/marketplace.json` is `compound-engineering-plugin`. Claude Code
caches marketplaces under their registered name, so the skill never found the
cache and always reported "no marketplace cache found".

Also align the `gh release list --repo` casing (`EveryInc`) with the canonical
owner casing used elsewhere in the repo.

Fixes EveryInc/compound-engineering-plugin#556