### PR TITLE
fix(resolve-pr-feedback): unblock /loop scheduling

### DIFF
--- a/plugins/compound-engineering/AGENTS.md
+++ b/plugins/compound-engineering/AGENTS.md
@@ -182,6 +182,8 @@ grep -E '^description:' skills/*/SKILL.md
 
 Beta skills use a `-beta` suffix and `disable-model-invocation: true` to prevent accidental auto-triggering. See `docs/solutions/skill-design/beta-skills-framework.md` for naming, validation, and promotion rules.
 
+**Caveat on non-beta use of `disable-model-invocation`:** The flag blocks all model-initiated invocations via the Skill tool, which includes scheduled re-entry from `/loop`. Only a user typing a slash command directly bypasses it. If a skill is intended to be schedulable (e.g., `resolve-pr-feedback`), do not set this flag — rely on description specificity and argument requirements to prevent accidental auto-fire instead.
+
 ### Stable/Beta Sync
 
 When modifying a skill that has a `-beta` counterpart (or vice versa), always check the other version and **state your sync decision explicitly** before committing — e.g., "Propagated to beta — shared test guidance" or "Not propagating — this is the experimental delegate mode beta exists to test." Syncing to both, stable-only, and beta-only are all valid outcomes. The goal is deliberate reasoning, not a default rule.

--- a/plugins/compound-engineering/skills/resolve-pr-feedback/SKILL.md
+++ b/plugins/compound-engineering/skills/resolve-pr-feedback/SKILL.md
@@ -2,7 +2,6 @@
 name: resolve-pr-feedback
 description: Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.
 argument-hint: "[PR number, comment URL, or blank for current branch's PR]"
-disable-model-invocation: true
 allowed-tools: Bash(gh *), Bash(git *), Read
 ---
 


### PR DESCRIPTION
`/loop` couldn't schedule `/resolve-pr-feedback` because `disable-model-invocation: true` blocks the Skill tool for every model-initiated invocation, not just semantic auto-fire. A scheduled wake-up is model-initiated, so the agent fell back to "follow the steps manually" and the skill never ran.

Remove the flag. The description is already intent-specific ("addressing PR review comments, resolving review threads"), and the skill body requires a PR context with `gh` auth, so accidental auto-fire stays bounded. Plugin `AGENTS.md` now documents the `/loop` tradeoff so non-beta skills don't reintroduce the flag.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7-D97757?logo=claude&logoColor=white)