### PR TITLE
fix(ce-compound-refresh): restore ce:compound hand-off

### DIFF
--- a/plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: ce:compound-refresh
-description: Refresh stale or drifting learnings and pattern docs in docs/solutions/ by reviewing, updating, consolidating, replacing, or deleting them against the current codebase. Use after refactors, migrations, dependency upgrades, or when a retrieved learning feels outdated or wrong. Also use when reviewing docs/solutions/ for accuracy, when a recently solved problem contradicts an existing learning, when pattern docs no longer reflect current code, or when multiple docs seem to cover the same topic and might benefit from consolidation.
-disable-model-invocation: true
+description: Refresh stale learning docs and pattern docs under docs/solutions/ by reviewing them against the current codebase, then updating, consolidating, replacing, or deleting the drifted ones. Trigger this skill when the user asks to refresh, audit, sweep, clean up, or consolidate stale docs in docs/solutions/ (phrases like "refresh my learnings", "audit docs/solutions/", "clean up stale learnings", "consolidate overlapping docs", "compound refresh", "/ce:compound-refresh"), or when ce:compound has just captured a new learning and flagged a specific older doc in docs/solutions/ as now inaccurate or superseded — invoke with the narrow scope hint ce:compound provides. Also trigger when the user points at a specific learning or pattern doc under docs/solutions/ and calls it stale, outdated, overlapping, or drifted. Do not trigger for general refactor, migration, debugging, or code-review work unless the user has explicitly directed attention to docs/solutions/ itself.
 ---
 
 # Compound Refresh


### PR DESCRIPTION
`ce:compound` recommends running `ce:compound-refresh` when a newly captured learning contradicts an older doc in `docs/solutions/`. That hand-off never fired — `disable-model-invocation: true` silently blocks every model-initiated Skill tool call, and only a user typing `/ce:compound-refresh` bypasses it.

Remove the flag and rely on description specificity to prevent accidental auto-fire, matching the guidance in `plugins/compound-engineering/AGENTS.md` for schedulable skills. The new description narrows positive triggers to explicit asks about `docs/solutions/` (refresh, audit, sweep, clean up, consolidate) or an in-session `ce:compound` hand-off with a scope hint, and adds one negative clause excluding general refactor, migration, debug, or review work unless the user has pointed attention at `docs/solutions/`.

Verified by direct `claude -p` invocation with the new description installed under a fresh name: the positive phrase "refresh my compound learnings please" triggers the Skill tool with the scoped skill. Negative phrasing (README updates, Rails upgrades, flaky-test debugging, general code review) does not.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)