### PR TITLE
fix(ce-pr-description): mark return block as hand-off

### DIFF
--- a/plugins/compound-engineering/skills/ce-pr-description/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-pr-description/SKILL.md
@@ -370,6 +370,8 @@ Do not emit the body markdown in the return block — the caller reads it from `
 
 If Step 1 exited gracefully (closed/merged PR, invalid range, empty commit list), do not create a body file — just return the reason string.
 
+**The return block is a hand-off, not task completion.** When invoked by a parent skill (e.g., `git-commit-push-pr`), emit the return block and then continue executing the parent's remaining steps (typically `gh pr create` or `gh pr edit` with the returned title and body file). Do not stop after the return block unless invoked directly by the user with no parent workflow.
+
 ---
 
 ## Cross-platform notes


### PR DESCRIPTION
When `git-commit-push-pr` Step 6 delegates to `ce-pr-description`, the sub-skill's Step 9 emits a `=== TITLE === / === BODY_FILE ===` return block and ends. That return shape reads as a terminal output, so the caller exits the workflow instead of running `gh pr create` / `gh pr edit` from its own Step 7. Observed in practice while opening #591 — the caller stopped after the return block and the PR never got created.

One sentence at the end of `ce-pr-description` Step 9 names the return as a hand-off:

> **The return block is a hand-off, not task completion.** When invoked by a parent skill (e.g., `git-commit-push-pr`), emit the return block and then continue executing the parent's remaining steps (typically `gh pr create` or `gh pr edit` with the returned title and body file). Do not stop after the return block unless invoked directly by the user with no parent workflow.

Two lines added, no other changes. The apply command already exists in `git-commit-push-pr` Step 7 — the missing piece was a signal at the sub-skill's exit that the return is a hand-off, not a stop.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)