### PR TITLE
fix(git-commit-push-pr): apply PR description after delegate hand-off

### DIFF
--- a/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
+++ b/plugins/compound-engineering/skills/git-commit-push-pr/SKILL.md
@@ -80,11 +80,14 @@ If `ce-pr-description` returns a "not open" or other graceful-exit message inste
 - If the user provided a focus, confirm it was addressed.
 - Ask the user to confirm before applying.
 
-If confirmed, apply with the returned title and body file:
+**If confirmed, perform these two actions in order.** They are separate steps with a hand-off boundary between them — do not stop after action 1.
 
-```bash
-gh pr edit --title "<returned title>" --body "$(cat "<returned body_file>")"
-```
+1. `ce-pr-description` has already returned its `=== TITLE ===` / `=== BODY_FILE ===` block and stopped; it does not apply on its own.
+2. Apply the returned title and body file yourself. This is this skill's responsibility, not the delegated skill's. Substitute `<TITLE>` and `<BODY_FILE>` verbatim from the return block; if `<TITLE>` contains `"`, `` ` ``, `$`, or `\`, escape them or switch to single quotes:
+
+   ```bash
+   gh pr edit --title "<TITLE>" --body "$(cat "<BODY_FILE>")"
+   ```
 
 Report the PR URL.
 
@@ -210,10 +213,10 @@ If `ce-pr-description` returns a graceful-exit message instead of `{title, body_
 
 #### New PR (no existing PR from Step 3)
 
-Using the `{title, body_file}` returned by `ce-pr-description`:
+Using the `=== TITLE ===` / `=== BODY_FILE ===` block returned by `ce-pr-description`, substitute `<TITLE>` and `<BODY_FILE>` verbatim. If `<TITLE>` contains `"`, `` ` ``, `$`, or `\`, escape them or switch to single quotes:
 
 ```bash
-gh pr create --title "<returned title>" --body "$(cat "<returned body_file>")"
+gh pr create --title "<TITLE>" --body "$(cat "<BODY_FILE>")"
 ```
 
 Keep the title under 72 characters; `ce-pr-description` already emits a conventional-commit title in that range.
@@ -222,13 +225,16 @@ Keep the title under 72 characters; `ce-pr-description` already emits a conventi
 
 The new commits are already on the PR from Step 5. Report the PR URL, then ask whether to rewrite the description.
 
-- If **yes**, run Step 6 now to generate `{title, body_file}` via `ce-pr-description` (passing the existing PR URL as `pr:`), then apply the returned title and body file:
-
-  ```bash
-  gh pr edit --title "<returned title>" --body "$(cat "<returned body_file>")"
-  ```
-
 - If **no** -- skip Step 6 entirely and finish. Do not run delegation or evidence capture when the user declined the rewrite.
+- If **yes**, perform these two actions in order. They are separate steps with a hand-off boundary between them -- do not stop after action 1.
+  1. Run Step 6 to generate via `ce-pr-description` (passing the existing PR URL as `pr:`). `ce-pr-description` explicitly does not apply on its own; it returns its `=== TITLE ===` / `=== BODY_FILE ===` block and stops.
+  2. Apply the returned title and body file yourself. This is this skill's responsibility, not the delegated skill's. Substitute `<TITLE>` and `<BODY_FILE>` verbatim from the return block; if `<TITLE>` contains `"`, `` ` ``, `$`, or `\`, escape them or switch to single quotes:
+
+     ```bash
+     gh pr edit --title "<TITLE>" --body "$(cat "<BODY_FILE>")"
+     ```
+
+  Then report the PR URL (Step 8).
 
 ### Step 8: Report
 


### PR DESCRIPTION
Fix a bug where `git-commit-push-pr` would generate a new PR description via `ce-pr-description` and then stop without applying it. Root cause: the apply step was phrased as a subordinate clause ("run step 6, then apply...") after the delegate's `=== TITLE ===` / `=== BODY_FILE ===` return block, and that return block reads as a natural stopping cue.

Promote "apply" to a first-class numbered sub-step with an explicit hand-off-boundary preamble at all three apply sites: Step 7 existing-PR, Step 7 new-PR, and DU-3 description-update. Also align placeholder tokens with `ce-pr-description`'s actual return labels (`<TITLE>` / `<BODY_FILE>`, previously `<returned title>` / `<returned body_file>`) and note the shell-escape hazard for titles containing `"`, `` ` ``, `$`, or `\`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)