### PR TITLE
fix(ce-plan): run ambiguity gate before the non-software catch-all

### DIFF
--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -82,9 +82,9 @@ If the plan already has a `deepened: YYYY-MM-DD` frontmatter field and there is 
 
 If the task involves building, modifying, or architecting software (references code, repos, APIs, databases, or asks to build/modify/deploy), continue to Phase 0.2.
 
-Otherwise, read `references/universal-planning.md` and follow that workflow instead. Skip all subsequent phases. Named tools or source links don't change this routing — they're inputs, handled per Core Principle 8.
-
 If the domain is genuinely ambiguous (e.g., "plan a migration" with no other context), ask the user before routing.
+
+Otherwise, read `references/universal-planning.md` and follow that workflow instead. Skip all subsequent phases. Named tools or source links don't change this routing — they're inputs, handled per Core Principle 8.
 
 #### 0.2 Find Upstream Requirements Document
 


### PR DESCRIPTION
## Summary

Follow-up to #597. Codex flagged that the reordered Phase 0.1b put the `Otherwise, read universal-planning...` catch-all before the ambiguity check. Because that branch also says to skip subsequent phases, the ambiguity gate became unreachable — a prompt like "plan a migration" with no other context would route straight to non-software planning instead of asking the user first.

## Fix

Move the ambiguity check above the catch-all:

1. Software → Phase 0.2.
2. Genuinely ambiguous → ask before routing.
3. Otherwise → `universal-planning.md`.

Now software-adjacent or under-specified requests still get intercepted.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)