### PR TITLE
fix(ce-release-notes): backtick-wrap `<skill-name>` token in description

### DIFF
--- a/plugins/compound-engineering/AGENTS.md
+++ b/plugins/compound-engineering/AGENTS.md
@@ -83,6 +83,7 @@ When adding or modifying skills, verify compliance with the skill spec:
 - [ ] `name:` present and matches directory name (lowercase-with-hyphens)
 - [ ] `description:` present and describes **what it does and when to use it** (per official spec: "Explains code with diagrams. Use when exploring how code works.")
 - [ ] `description:` value is quoted (single or double) if it contains colons -- unquoted colons break `js-yaml` strict parsing and crash `install --to opencode/codex`. Run `bun test tests/frontmatter.test.ts` to verify.
+- [ ] `description:` value does not contain raw angle-bracket tokens like `<skill-name>`, `<tag>`, or `<placeholder>` -- Cowork's plugin validator parses descriptions as HTML and rejects unknown tags with a generic "Plugin validation failed" banner (see issue #602). Claude Code tolerates them, so the bug only surfaces downstream. Backtick-wrap the token (`` `<skill-name>` ``) or rephrase. Enforced by `tests/frontmatter.test.ts`.
 
 ### Reference File Inclusion (Required if references/ exists)
 

--- a/plugins/compound-engineering/skills/ce-release-notes/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-release-notes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-release-notes
-description: Summarize recent compound-engineering plugin releases, or answer a specific question about a past release with a version citation. Use when the user types `/ce-release-notes` or asks "what changed in compound-engineering recently?" or "what happened to <skill-name>?".
+description: Summarize recent compound-engineering plugin releases, or answer a specific question about a past release with a version citation. Use when the user types `/ce-release-notes` or asks "what changed in compound-engineering recently?" or "what happened to `<skill-name>`?".
 argument-hint: "[optional: question about a past release]"
 disable-model-invocation: true
 ---

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -72,6 +72,17 @@ describe("frontmatter YAML validity", () => {
       test(`${pluginRoot}/${rel} has valid strict YAML frontmatter`, () => {
         expect(() => load(yaml)).not.toThrow()
       })
+
+      test(`${pluginRoot}/${rel} description has no unwrapped angle-bracket tokens`, () => {
+        const parsed = load(yaml) as Record<string, unknown> | null
+        const description = parsed && typeof parsed.description === "string" ? parsed.description : ""
+        // Strip backtick-delimited spans; what remains must not contain a bare <tag>.
+        // Cowork's plugin validator parses descriptions as HTML and rejects
+        // unknown tags with a silent "Plugin validation failed" banner. See issue #602.
+        const stripped = description.replace(/`[^`]*`/g, "")
+        const bareTag = stripped.match(/<[A-Za-z][\w-]*>/)
+        expect(bareTag, `Backtick-wrap or rephrase: ${bareTag?.[0] ?? ""}`).toBeNull()
+      })
     }
   }
 })


### PR DESCRIPTION
Cowork's plugin validator parses description frontmatter as HTML and rejects raw angle-bracket tokens that look like unknown tags, failing
installation with a generic "Plugin validation failed" banner. Claude Code accepts the raw token, so the bug only surfaces on Cowork.

Fixes #602