### PR TITLE
fix(ce-gemini-imagegen): bump Pillow floor to 10.3.0 to clear 4 CVEs

### DIFF
--- a/plugins/compound-engineering/skills/ce-gemini-imagegen/requirements.txt
+++ b/plugins/compound-engineering/skills/ce-gemini-imagegen/requirements.txt
@@ -1,2 +1,5 @@
 google-genai>=1.0.0
-Pillow>=10.0.0
+# Pillow floor bumped above the last known RCE-class CVE affecting this skill.
+# 10.3.0 clears: PYSEC-2023-175, GHSA-j7hp-h8jx-5ppr (libwebp OOB),
+# GHSA-3f63-hfp8-52jq (arbitrary code execution), GHSA-44wm-f244-xhp3.
+Pillow>=10.3.0


### PR DESCRIPTION
## Summary

The `Pillow>=10.0.0` constraint in `plugins/compound-engineering/skills/ce-gemini-imagegen/requirements.txt` admits four CVEs that affect this skill's `PIL.Image` usage (imported in 5 of its scripts: `gemini_images.py`, `compose_images.py`, `multi_turn_chat.py`, `edit_image.py`, plus the README example).

| CVE | Severity | Summary | Pillow fix |
|-----|----------|---------|------------|
| [PYSEC-2023-175](https://osv.dev/vulnerability/PYSEC-2023-175) | critical | Pillow pre-10.0.1 | 10.0.1 |
| [GHSA-j7hp-h8jx-5ppr](https://osv.dev/vulnerability/GHSA-j7hp-h8jx-5ppr) | high | libwebp OOB write in `BuildHuffmanTable` (CVE-2023-4863) | 10.0.1 |
| [GHSA-3f63-hfp8-52jq](https://osv.dev/vulnerability/GHSA-3f63-hfp8-52jq) | critical | Arbitrary code execution in Pillow | 10.2.0 |
| [GHSA-44wm-f244-xhp3](https://osv.dev/vulnerability/GHSA-44wm-f244-xhp3) | high | Pillow buffer overflow | 10.3.0 |

Bumping the floor to `>=10.3.0` clears all four in a single hop. Added a comment above the pin so future contributors know why the floor was chosen and can bump again when the next Pillow CVE lands.

## Why the floor instead of an upper bound

Tightening only the lower bound (rather than pinning a narrow range) keeps the constraint additive — any user currently on a non-vulnerable version (10.3.0 through 11.x) is unaffected, and fresh `pip install` resolution still lands on the latest available.

The immediate exposure was narrow for fresh installs (pip resolves `>=10.0.0` to the latest available, which is currently past the CVE window), but the constraint itself documents intent — saying "this skill works with Pillow 10.0.0+" was a claim the CVE data falsified. Reproducible-build scenarios with pinned lockfiles, airgapped installs, or older pip resolvers could still land on vulnerable versions.

## How this was found

Surfaced by [Griffith](https://github.com/GruntworkAI/gruntwork-griffith), a Claude Code plugin static analyzer we're building. It's in Phase 1.5 preview (not yet stable; schema is still `0.1`), runs purely static analysis — no plugin code is executed — and delegates CVE data to Google's [osv-scanner](https://google.github.io/osv-scanner/) for the supply-chain tier.

**If you want to reproduce the finding yourself:**

```bash
# Install osv-scanner: brew install osv-scanner

# Clone Griffith and run from the Poetry venv (Phase 1.5 preview — no packaged install yet):
git clone https://github.com/GruntworkAI/gruntwork-griffith
cd gruntwork-griffith
poetry install
poetry run griffith analyze path/to/compound-engineering-plugin --sca
```

Expected output: the four CVEs above, grouped by severity, under a `## Dependencies` / `CVE scan` section.

Happy to share the full JSON report (`--json` flag), paste the wrapper's rendered markdown, or walk through anything else — just ask. Also genuinely interested in feedback on the tool itself if it comes up. One caveat I'll flag proactively: the `fixed_versions` list osv-scanner emits is cross-ecosystem (for the libwebp CVE it includes Rust / Electron / Go / NuGet versions), so I verified the Pillow-specific fix versions against OSV's `affected[]` array directly rather than trusting the raw aggregated list. We have a Griffith follow-up for per-ecosystem filtering.

## Test plan

- [x] Verified all four CVEs have Pillow fix versions ≤ 10.3.0 via OSV API (`api.osv.dev/v1/vulns/<id>`)
- [x] Confirmed `PIL.Image` is actively imported in the skill's scripts (grep)
- [x] Constraint change is additive — any user already on a non-vulnerable Pillow is unaffected