### PR TITLE
feat(ce-strategy,ce-product-pulse): add PM skills for upstream anchor and outcome pulse

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -10,3 +10,22 @@
 # work_delegate_decision: auto   # auto | ask (default: auto)
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
 # work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
+
+# --- Product pulse ---
+# Settings written by /ce-product-pulse first-run interview. Re-run the skill with
+# argument `setup` or `reconfigure` to edit interactively.
+
+# pulse_product_name: "Spiral"                          # used in report titles (no default)
+# pulse_lookback_default: 24h                           # 1h | 24h | 7d | 30d (default: 24h)
+# pulse_primary_event: "session_started"                # the event that means "user showed up"
+# pulse_value_event: "task_completed"                   # the event that means "user got value"
+# pulse_completion_events: "onboarded,first_purchase"   # comma-separated, 0-3 events
+# pulse_quality_scoring: false                          # true | false (default: false; AI products only)
+# pulse_quality_dimension: "answer accuracy"            # dimension scored 1-5 when pulse_quality_scoring is true
+# pulse_analytics_source: posthog                       # posthog | mixpanel | custom (no default)
+# pulse_tracing_source: sentry                          # sentry | datadog | custom (no default)
+# pulse_payments_source: stripe                         # stripe | custom (no default)
+# pulse_db_enabled: false                               # true | false (default: false; read-only DB if true)
+# pulse_metric_sources: "retention_d7=posthog,nps=delighted"  # strategy-metric -> source overrides; comma-separated 'metric=source' pairs; unlisted metrics fall back to pulse_analytics_source
+# pulse_pending_metrics: "retention_d7,nps"             # comma-separated strategy metrics awaiting instrumentation; render as 'no data'
+# pulse_excluded_metrics: "north_star"                  # comma-separated strategy metrics intentionally not in pulse

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ The point is not ceremony. The point is leverage. A good brainstorm makes the pl
 
 ## Workflow
 
+`/ce-strategy` is upstream of the loop -- it captures the product's target problem, approach, persona, metrics, and tracks as a short durable anchor at `docs/strategy.md`. Ideate, brainstorm, and plan read it as grounding when present, so strategy choices flow into feature conception, prioritization, and spec.
+
 The core loop is: brainstorm the requirements, plan the implementation, work through the plan, review the result, compound the learning, then repeat with better context.
 
 Use `/ce-ideate` before the loop when you want the agent to generate and critique bigger ideas before choosing one to brainstorm. It produces a ranked ideation artifact, not requirements, plans, or code.
 
 | Skill | Purpose |
 |-------|---------|
+| `/ce-strategy` | Create or maintain `docs/strategy.md` -- the product's target problem, approach, persona, key metrics, and tracks. Read as grounding by ideate, brainstorm, and plan |
 | `/ce-ideate` | Optional big-picture ideation: generate and critically evaluate grounded ideas, then route the strongest one into brainstorming |
 | `/ce-brainstorm` | Interactive Q&A to think through a feature or problem and write a right-sized requirements doc before planning |
 | `/ce-plan` | Turn feature ideas into detailed implementation plans |
@@ -41,6 +44,9 @@ Use `/ce-ideate` before the loop when you want the agent to generate and critiqu
 | `/ce-debug` | Systematically reproduce failures, trace root cause, and implement fixes |
 | `/ce-code-review` | Multi-agent code review before merging |
 | `/ce-compound` | Document learnings to make future work easier |
+| `/ce-product-pulse` | Generate a single-page, time-windowed pulse report on usage, performance, errors, and followups. Saves to `docs/pulse-reports/` |
+
+`/ce-product-pulse` is the read-side companion -- a time-windowed report on what users actually experienced and how the product performed over a given window (24h, 7d, etc.), saved to `docs/pulse-reports/` so past pulses form a browseable timeline of user outcomes. The next strategy update and the next brainstorm get real signal to anchor to.
 
 Each cycle compounds: brainstorms sharpen plans, plans inform future plans, reviews catch more issues, patterns get documented.
 
@@ -68,7 +74,7 @@ For a focused bug investigation:
 
 After installing, run `/ce-setup` in any project. It checks your environment, installs missing tools, and bootstraps project config.
 
-The `compound-engineering` plugin currently ships 36 skills and 51 agents. See the [full component reference](plugins/compound-engineering/README.md) for the complete inventory.
+The `compound-engineering` plugin currently ships 37 skills and 51 agents. See the [full component reference](plugins/compound-engineering/README.md) for the complete inventory.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "compound-plugin",

--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -11,16 +11,17 @@ After installing, run `/ce-setup` in any project. It diagnoses your environment,
 | Component | Count |
 |-----------|-------|
 | Agents | 50+ |
-| Skills | 35+ |
+| Skills | 37+ |
 
 ## Skills
 
 ### Core Workflow
 
-The primary entry points for engineering work are skills invoked with slash syntax:
+The primary entry points for engineering work, invoked as slash commands. `ce-strategy` skill anchors the loop upstream; `ce-product-pulse` skill closes it with a read on user outcomes.
 
 | Skill | Description |
 |-------|-------------|
+| `/ce-strategy` | Create or maintain `docs/strategy.md` — the product's target problem, approach, persona, key metrics, and tracks. Re-runnable to update. Read as grounding by `/ce-ideate`, `/ce-brainstorm`, and `/ce-plan` when present |
 | `/ce-ideate` | Optional big-picture ideation: generate and critically evaluate grounded ideas, then route the strongest one into brainstorming |
 | `/ce-brainstorm` | Interactive Q&A to think through a feature or problem and write a right-sized requirements doc before planning |
 | `/ce-plan` | Create structured plans for any multi-step task -- software features, research workflows, events, study plans -- with automatic confidence checking |
@@ -30,6 +31,7 @@ The primary entry points for engineering work are skills invoked with slash synt
 | `/ce-compound` | Document solved problems to compound team knowledge |
 | `/ce-compound-refresh` | Refresh stale or drifting learnings and decide whether to keep, update, replace, or archive them |
 | `/ce-optimize` | Run iterative optimization loops with parallel experiments, measurement gates, and LLM-as-judge quality scoring |
+| `/ce-product-pulse` | Generate a single-page, time-windowed report on usage, performance, errors, and followups. Saves reports to `docs/pulse-reports/` as a browseable timeline of what users experienced |
 
 For `/ce-optimize`, see [`skills/ce-optimize/README.md`](./skills/ce-optimize/README.md) for usage guidance, example specs, and links to the schema and workflow docs.
 

--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -110,7 +110,7 @@ Scan the repo before substantive brainstorming. Match depth to scope:
 
 **Standard and Deep** — Two passes:
 
-*Constraint Check* — Check project instruction files (`AGENTS.md`, and `CLAUDE.md` only if retained as compatibility context) for workflow, product, or scope constraints that affect the brainstorm. If these add nothing, move on.
+*Constraint Check* — Check project instruction files (`AGENTS.md`, and `CLAUDE.md` only if retained as compatibility context) for workflow, product, or scope constraints that affect the brainstorm. Also read `docs/strategy.md` if it exists — the product's target problem, approach, persona, and active tracks are direct input to what this brainstorm should deliver and should shape scope, success criteria, and which approaches are aligned vs out-of-scope. If these add nothing, move on.
 
 *Topic Scan* — Search for relevant terms. Read the most relevant existing artifact if one exists (brainstorm, plan, spec, skill, feature doc). Skim adjacent examples covering similar behavior.
 

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -234,13 +234,14 @@ Run grounding agents in parallel in the **foreground** (do not background — re
 
 1. **Quick context scan** — dispatch a general-purpose sub-agent using the platform's cheapest capable model (e.g., `model: "haiku"` in Claude Code) with this prompt:
 
-   > Read the project's AGENTS.md (or CLAUDE.md only as compatibility fallback, then README.md if neither exists), then discover the top-level directory layout using the native file-search/glob tool (e.g., `Glob` with pattern `*` or `*/*` in Claude Code). Return a concise summary (under 30 lines) covering:
+   > Read the project's AGENTS.md (or CLAUDE.md only as compatibility fallback, then README.md if neither exists), then discover the top-level directory layout using the native file-search/glob tool (e.g., `Glob` with pattern `*` or `*/*` in Claude Code). Also read `docs/strategy.md` if it exists — it captures the product's target problem, approach, persona, metrics, and tracks. Return a concise summary (under 30 lines) covering:
    > - project shape (language, framework, top-level directory layout)
    > - notable patterns or conventions
    > - obvious pain points or gaps
    > - likely leverage points for improvement
+   > - product strategy summary, if `docs/strategy.md` was present — include the approach and active tracks verbatim so ideation can weight toward strategy-aligned directions
    >
-   > Keep the scan shallow — read only top-level documentation and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
+   > Keep the scan shallow — read only top-level documentation, `docs/strategy.md` if present, and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
    >
    > Focus hint: {focus_hint}
 

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -194,6 +194,7 @@ Fires **only in solo invocation** — when Phase 0.2 found no upstream brainstor
 Prepare a concise planning context summary (a paragraph or two) to pass as input to the research agents:
 - If an origin document exists, summarize the problem frame, requirements, and key decisions from that document
 - Otherwise use the feature description directly
+- If `docs/strategy.md` exists, read it and include the relevant pieces (target problem, approach, active tracks) in the summary so downstream research and planning decisions are anchored to product strategy
 
 Run these agents in parallel:
 
@@ -205,6 +206,7 @@ Collect:
 - Implementation patterns, relevant files, modules, and tests
 - AGENTS.md guidance that materially affects the plan, with CLAUDE.md used only as compatibility fallback when present
 - Institutional learnings from `docs/solutions/`
+- Product strategy context when `docs/strategy.md` is present — flag any plan decisions that pull away from the active tracks or the stated approach
 
 **Slack context** (opt-in) — never auto-dispatch. Route by condition:
 

--- a/plugins/compound-engineering/skills/ce-product-pulse/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-product-pulse/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: ce-product-pulse
+description: "Generate a time-windowed pulse report on what users experienced and how the product performed - usage, quality, errors, signals worth investigating. Use when the user says 'run a pulse', 'show me the pulse', 'how are we doing', 'weekly recap', 'launch-day check', or passes a time window like '24h' or '7d'. Configures via .compound-engineering/config.local.yaml and saves reports to docs/pulse-reports/."
+argument-hint: "[lookback window, e.g. '24h', '7d', '1h'; default 24h]"
+allowed-tools:
+  - Read
+  - Write
+  - Glob
+  - Grep
+  - Bash
+  - AskUserQuestion
+---
+
+# Product Pulse
+
+`ce-product-pulse` queries the product's data sources for a given time window and produces a compact, single-page report covering usage, performance, errors, and followups. The report is saved to `docs/pulse-reports/` and the key points are surfaced in chat.
+
+The skill does not mutate the product, the database, or any external system. Its only writes are pulse settings appended to `.compound-engineering/config.local.yaml` (the unified CE local config, gitignored, machine-local) and the report file (`docs/pulse-reports/...`). MCP and other data-source tools are invoked read-only; if a tool offers write modes, do not use them.
+
+## Interaction Method
+
+Default to the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
+
+Ask one question at a time. Reserve multi-select for first-run configuration only.
+
+## Lookback Window
+
+<lookback> #$ARGUMENTS </lookback>
+
+Interpret the argument as a time window. Common forms:
+
+- `24h`, `48h`, `72h` - trailing hours
+- `7d`, `30d` - trailing days
+- `1h` - short-window (useful during launches)
+
+If the argument is empty, default to `pulse_lookback_default` from config (resolved in Phase 0); if that is also unset, fall through to the hard default of `24h`. If the argument is unparseable, ask the user to clarify.
+
+Apply a **15-minute trailing buffer** to the window's upper bound. Many analytics and tracing tools have ingestion lag; querying right up to `now` under-reports the most recent events. For a `24h` window, query `[now - 24h - 15m, now - 15m]`.
+
+## Core Principles
+
+1. **Read it like a founder.** No hardcoded thresholds. Do not label things "bad" or "good" by default - present the numbers and let the reader judge.
+2. **Single page.** Target 30-40 lines of terminal output. If the report is getting long, cut.
+3. **No PII in saved reports.** Do not include user emails, account IDs, or message content in the report written to disk.
+4. **Parallel where safe, serial where it matters.** Analytics and tracing queries run in parallel. Database queries run serially to avoid load.
+5. **Memory through saved reports.** Every run writes to `docs/pulse-reports/` so past pulses are browseable as a timeline.
+6. **Read-only database access only.** If a database is used as a data source, the connection must be read-only. The interview refuses to accept read-write credentials. Database access is optional - many products complete the pulse with analytics and tracing alone.
+7. **Strategy-seeded when available.** If `docs/strategy.md` exists, the interview reads it before asking questions and carries forward the product name and key metrics as seeds. The goal of data-source setup is to wire up whatever connections are needed to actually measure those metrics.
+
+## Execution Flow
+
+### Phase 0: Route by Config State
+
+**Config (pre-resolved):**
+!`(top=$(git rev-parse --show-toplevel 2>/dev/null); [ -n "$top" ] && cat "$top/.compound-engineering/config.local.yaml" 2>/dev/null) || (common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); main="${common%/.git}"; [ -n "$main" ] && cat "$main/.compound-engineering/config.local.yaml" 2>/dev/null) || echo '__NO_CONFIG__'`
+
+If the block above contains YAML key-value pairs, extract values for the `pulse_*` keys listed under "Config keys" below.
+If it shows `__NO_CONFIG__`, the file does not exist — treat this as a first run.
+If it shows an unresolved command string, read `.compound-engineering/config.local.yaml` from the repo root using the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the file does not exist, treat as first run.
+
+**Config keys:**
+- `pulse_product_name` -- string, used in report titles. Required for routing: if unset, skill is unconfigured.
+- `pulse_lookback_default` -- one of `1h`, `24h`, `7d`, `30d` (default: `24h`)
+- `pulse_primary_event` -- string, the engagement event name
+- `pulse_value_event` -- string, the value-realization event name
+- `pulse_completion_events` -- comma-separated string of 0-3 event names
+- `pulse_quality_scoring` -- `true` or default `false` (AI products only)
+- `pulse_quality_dimension` -- string scored 1-5 when `pulse_quality_scoring` is true; ignored otherwise
+- `pulse_analytics_source` -- string identifying analytics provider (e.g., `posthog`, `mixpanel`, `custom`)
+- `pulse_tracing_source` -- string identifying tracing provider (e.g., `sentry`, `datadog`, `custom`)
+- `pulse_payments_source` -- string identifying payments provider (e.g., `stripe`, `custom`); omit if not used
+- `pulse_db_enabled` -- `true` or default `false`; when `true`, read-only DB access is part of the pulse
+- `pulse_metric_sources` -- comma-separated `metric=source` pairs giving per-strategy-metric source overrides (e.g., `retention_d7=posthog,nps=delighted`). Strategy metrics not listed fall back to `pulse_analytics_source` and are rendered with a `(default source)` marker so the implicit routing is visible.
+- `pulse_pending_metrics` -- comma-separated string of strategy-doc metric names awaiting instrumentation; rendered as `no data` in each pulse report until instrumentation lands
+- `pulse_excluded_metrics` -- comma-separated string of strategy-doc metric names intentionally excluded from the pulse; the metric stays in `docs/strategy.md` but is not surfaced in pulse reports
+
+**Routing:**
+
+- **`pulse_product_name` is unset (or config file missing)** -> First run. Go to Phase 1 (interview), then Phase 2.
+- **`pulse_product_name` is set** -> Skip to Phase 2.
+
+If the argument was `setup`, `reconfigure`, or `edit config`, go to Phase 1 regardless of config state.
+
+### Phase 1: First-Run Interview
+
+#### 1.0 Seed from strategy (if available)
+
+Before asking any questions, read `docs/strategy.md` using the native file-read tool. If the file exists, extract:
+
+- The product name from the H1 title, stripping the trailing ` Strategy` suffix (e.g., `# Spiral Strategy` -> `Spiral`)
+- The list of key metrics from the `## Key metrics` section, one per line
+
+Open the interview by surfacing what was extracted: announce that a strategy doc was found, show the seeded product name and the list of key metrics that will be carried into event/data setup, and invite the user to correct any of it before continuing.
+
+If `docs/strategy.md` does not exist, note that explicitly in chat: no strategy doc on file, running setup from scratch, and mention that `ce-strategy` can seed pulse later if run first.
+
+#### 1.1 Interview
+
+Read `references/interview.md`. This load is non-optional - the pushback rules, anti-pattern examples, and metric-to-source mapping logic live there.
+
+Run the interview in this order:
+
+1. Product name (confirm or edit the seeded value)
+2. Primary engagement event
+3. Value-realization event
+4. Completions or conversions (0-3)
+5. Quality scoring (opt-in, AI products only)
+6. Data sources - wire up connections for each agreed metric and event. Nudge toward MCP. Reject read-write database access. DB entirely optional.
+7. System performance - a short recommended setup for top errors and latency. Users rarely have strong opinions here; present defaults and accept.
+8. Default lookback window
+
+Apply the pushback rules in `references/interview.md` for each section. Treat every metric, event, and signal the user proposes against the **SMART bar** (specific, measurable, actionable, relevant, timely) spelled out in `references/interview.md` under "Overall Rules" - push back on anything vague, vanity, or unactionable.
+
+If the user offers read-write database access, refuse and offer the alternatives documented in `references/interview.md` section 6.
+
+Write the captured config to `<repo-root>/.compound-engineering/config.local.yaml` as flat `pulse_*` keys, using the schema in `references/interview.md` under "Config file shape". Resolve the repo root with `git rev-parse --show-toplevel`. To write: (1) if the file or directory does not exist, create `.compound-engineering/` and write the YAML file; (2) if the file exists, merge new keys into the existing YAML, preserving any non-pulse keys (e.g., `work_delegate_*`) untouched. If `.compound-engineering/config.local.yaml` is not already covered by the repo's `.gitignore`, offer to add the entry before writing. Show the resulting pulse block to the user in chat and offer one round of edits.
+
+After the config is written, run the **scheduling recommendation** from `references/interview.md` section 9: offer to set up a recurring run so the user gets the pulse on a cadence instead of having to remember to run it. Accept yes/no/later. If yes, hand off to whichever scheduling primitive the current harness exposes — the in-plugin `schedule` skill if it is installed, otherwise note that scheduling is platform-specific (cron, GitHub Actions, the host's own automation) and emit a brief hint covering what would need to run. Do not schedule inline. Then proceed to Phase 2.
+
+### Phase 2: Run the Pulse
+
+If Phase 1 ran (first run, or `setup`/`reconfigure` argument), re-read `.compound-engineering/config.local.yaml` from the repo root using the native file-read tool to pick up any edits accepted during the Phase 1 review step. Otherwise, use the `pulse_*` values already extracted in Phase 0. Apply hard defaults for any unset settings (see Phase 0 "Config keys").
+
+#### 2.1 Dispatch Queries
+
+Run these in **parallel** (different tools, no shared load):
+
+- Product analytics query (primary event count, value-realization count, completions, conversion ratios) over the window
+- Application tracing query (error counts by category, latency distribution, top error signatures) over the window
+- Payments query, if configured (new customers, churn, revenue delta) over the window
+
+Run these **serially**, after the parallel batch:
+
+- Read-only database queries. One at a time. Tight, scoped queries only. Never full-table scans on large tables. If a DB query would be expensive, skip it and note "DB query skipped (estimated cost too high)".
+
+#### 2.2 Optional: Sample Quality Scoring
+
+If `pulse_quality_scoring` is `true` (AI products only), sample up to 10 sessions or conversations from the window and score each 1-5 on the dimension recorded in `pulse_quality_dimension`.
+
+**Scoring discipline:** Default to 4 or 5 when the session looks normal. Reserve 1-3 for sessions with a clear failure mode (product gave wrong answer, user got stuck, error surfaced). If every session is scoring 3, the bar is too strict; if every session is scoring 5, the bar is too loose.
+
+**No PII in the score summary.** Capture a count distribution (e.g., "8x 5, 1x 4, 1x 2") and a short anonymized note on any session scored below 4. Do not include message content or user identifiers in the saved report.
+
+#### 2.3 Assemble the Report
+
+Read `references/report-template.md`. Fill in the template using the query results. Four sections, in order:
+
+1. **Headlines** - 2-3 lines summarizing the window
+2. **Usage** - primary engagement, value realization, completions, quality sample
+3. **System performance** - latency (p50/p95/p99) and top 5 errors by count with one-line explanation each
+4. **Followups** - 1-5 things worth investigating
+
+Keep the total to 30-40 lines. If a section is thin, leave it thin; do not pad.
+
+#### 2.4 Write the Report
+
+Save to `docs/pulse-reports/YYYY-MM-DD_HH-MM.md` using the local time of the run. Create `docs/pulse-reports/` if it does not exist.
+
+Surface the Headlines and top Followup in chat. Provide the full file path so the user can open the saved report.
+
+### Phase 3: Routine Hook
+
+First-run setup already offered scheduling (see Phase 1.1 end). Phase 3 is a lighter re-surface for ad-hoc runs:
+
+- If the argument was a known schedule keyword (`daily`, `hourly`, `weekly`), note that this run is ad-hoc and suggest scheduling via the harness's available primitive (the in-plugin `schedule` skill where present; otherwise a platform-native option) for recurring runs.
+- If no schedule is on file and this is the third or later pulse run the user has done, mention once that scheduling is available. Don't nag on every run.
+
+Never schedule automatically. Any scheduling handoff requires explicit confirmation.
+
+## What This Skill Does Not Do
+
+- Does not report "what shipped." Shipped work lives in the issue tracker and commit history, not here. Pulse is strictly about user experience and system performance.
+- Does not set thresholds or alert the user. The reader interprets.
+- Does not persist PII in saved reports.
+- Does not mutate the database or any external system. All queries are read-only.
+- Does not replace tracing dashboards or analytics tools. It consolidates a single-page read; deep investigation still uses the native tools.
+
+## Learn More
+
+The "read like a founder" posture and the single-page constraint are deliberate. Dashboards with 40 metrics produce attention sprawl; one page with the right four sections forces the reader to notice what matters. The saved-reports folder is designed to be a team's working memory, not a data warehouse - past pulses are grepable, diffable, and disposable.

--- a/plugins/compound-engineering/skills/ce-product-pulse/references/interview.md
+++ b/plugins/compound-engineering/skills/ce-product-pulse/references/interview.md
@@ -1,0 +1,260 @@
+# Product Pulse First-Run Interview
+
+Loaded by `SKILL.md` at the start of Phase 1. Captures the configuration that will be merged into `.compound-engineering/config.local.yaml` (the unified CE local config, gitignored, machine-local) as `pulse_*` keys and re-read on every subsequent run.
+
+For each section: ask the opening question, evaluate the answer against the quality bar, push back when it falls into a named anti-pattern, and capture the final answer in the user's own language.
+
+## Overall Rules
+
+1. **Push back, but don't spiral.** One round of pushback per section max. If the second answer still isn't usable, capture what the user gave, flag it in the config as `needs-review`, and move on.
+2. **Name events in the user's own words.** The config will be readable by the whole team - use the terms they actually use, not a generic template.
+3. **Ask about tools, not credentials.** The interview captures *which* tool and *what shape of query*. It does not collect API keys, tokens, or database passwords. Those stay in the user's environment.
+4. **Honor strategy seeds.** If `SKILL.md` Phase 1.0 surfaced a product name or a list of key metrics from `docs/strategy.md`, start with those as defaults and let the user edit. Do not re-ask questions that the strategy doc already answered unambiguously.
+5. **Evaluate metrics against the SMART bar.** Every event, metric, and signal the user proposes should be:
+   - **Specific** - a named event or a named metric, not a category. `message_sent` passes; "engagement" does not.
+   - **Measurable** - you can point to the tool and query that returns a number. "Users like it" does not pass; "NPS score from Delighted" does.
+   - **Actionable** - if the number moves, the team knows what to do next. "Daily active users" alone usually fails this - pair it with a conversion or retention signal that surfaces a decision.
+   - **Relevant** - ties to the product's target problem and persona (from the strategy doc if seeded). Generic funnel metrics that don't connect to the strategy are suspect.
+   - **Timely** - reads in the pulse window (24h, 7d, etc.) and reflects the current state. Lagging metrics that only move quarterly don't belong in a daily pulse.
+
+   When a user proposes a metric that fails one of these, push back by naming the specific dimension: "That sounds more like a vanity metric than an actionable one - if it moves, what do we do? Is there a tighter signal that would drive a decision?" Do not use the word "SMART" with the user; use the plain-English question.
+
+---
+
+## 1. Product Name
+
+**Opening question:**
+
+- If seeded from strategy: "Product name from strategy is `{{name}}`. Keep it or edit?"
+- Otherwise: "What's the product called?"
+
+No pushback needed. Capture verbatim.
+
+---
+
+## 2. Primary Engagement Event
+
+**Opening question:** "When someone is using your product, what single event fires? The one that tells you a user is active right now."
+
+This is the heartbeat of the pulse. Pick one event - the one that represents a user actually using the product, not opening a page.
+
+**Apply the SMART bar** (see Overall Rules). The event must be specific (a named event), measurable (the analytics tool returns a count), actionable (if it moves, the team notices), relevant (ties to the product's job), and timely (reads cleanly in short windows).
+
+**Engagement vs value test.** After the user names an event, ask yourself: does this event fire when the user is *using* the product, or when the user has *gotten value* from it? Engagement is earlier (they're in it). Value is later (it worked). If the candidate is really value-realization, push back: "That sounds like the moment the product *worked* for them. What event happens earlier - when they're in the middle of using it? The value event belongs in section 3." Common slips: `agent_accepted_draft` (value) vs `agent_received_draft` (engagement); `ride_completed` (value) vs `ride_started` (engagement); `question_answered_correctly` (value) vs `question_asked` (engagement).
+
+**Anti-patterns and pushback:**
+
+- **Page view or visit** ("pageview", "app opened", "login") -> "Those tell you someone showed up. I'm looking for the event that says they actually *used* the product. What fires when a user is doing the thing the product is for?"
+- **Multiple events with no clear primary** ("well, it could be X or Y or Z depending on the flow") -> "For the pulse, pick the one that's closest to 'a user is active using the core product.' If two candidates are genuinely tied, pick the one that happens *when the user spends time in exchange for value* - for async products that's usually 'contributed content' over 'opened app'."
+- **Too deep in the funnel** ("purchase_completed") -> "That's a conversion event - we'll capture that separately. For the primary engagement event, what happens earlier - when they're using the product, not when they've already converted?"
+- **Vague** ("interaction", "activity") -> "Is there a specific event name in your analytics tool? I want to write down the literal event name so this is repeatable."
+
+**Capture:** Event name verbatim (e.g., `message_sent`, `document_edited`, `ride_started`). Plus a one-line description of what it means.
+
+---
+
+## 3. Value-Realization Event
+
+**Opening question:** "What event fires when a user actually gets value - when the product delivered what they came for?"
+
+Different from engagement. Engagement says "they're using it"; value-realization says "they got what they wanted." Some products have a clear distinction (engagement: `typed_in_box`; value: `got_useful_answer`); for others it's the same event (engagement: `ride_requested`; value: `ride_completed`).
+
+**Apply the SMART bar.** The bar here is the same - specific, measurable, actionable, relevant, timely - and the proxy test is especially important because value-realization is often felt, not fired.
+
+**Anti-patterns and pushback:**
+
+- **Same as engagement event, accidentally** -> "Is that the same as the engagement event you gave me? If so, that's fine - some products have one event that covers both. Want to confirm, or is there a later signal that says 'this user got the thing they came for'?"
+- **Revenue event** ("purchase") -> "Purchase is a conversion event - we'll capture that separately. For value-realization, I'm looking for the moment a user knows the product worked for them, which is usually before or separate from payment."
+- **Value is a feeling, not an event** ("they feel like the team aligned", "they trust the output") -> "That's real, but we can't measure a feeling directly in the pulse. What's a proxy event that correlates? Common patterns: a completion event (workflow finished), a time-to-first-X metric (seconds from open to output), a short-window return rate (came back the next day), or a copy/share/export event (took the output into their actual work). Pick the one closest to the feeling."
+- **Can't name one** -> "That's useful to know. If there's no discrete event, is there a session or workflow *completion* that stands in? Something like 'they finished the task they opened the product to do.' If not, we'll treat engagement as the value proxy and note it in the config."
+
+**Capture:** Event name verbatim, or `same-as-engagement` with a note, or `not-defined` with a note.
+
+---
+
+## 4. Completion or Conversion Events
+
+**Opening question:** "Any conversion or completion events worth tracking - signups, upgrades, trial starts, purchases?"
+
+Optional section. 0-3 events is typical.
+
+**Apply the SMART bar** (see Overall Rules). Each conversion event should tie to a decision: if `trial_started` moves ±20%, what would the team do? If the answer is "nothing", the event is a vanity metric and shouldn't be in the pulse.
+
+**Anti-patterns and pushback:**
+
+- **Long list** ("we have 12 of them") -> "Pick the top 3 that move the business. The others can be queried ad-hoc when you want; the pulse keeps the top 3."
+- **Non-actionable conversion** ("email_opens", "logo_impressions") -> "If that number swings, what do we do? If the answer is 'nothing,' it's a vanity metric. What's a tighter signal further down the funnel?"
+
+**Capture:** List of 0-3 event names with one-line descriptions each.
+
+---
+
+## 5. Quality Scoring (optional, AI products)
+
+**Opening question:** "Is this an AI product where a conversation or session could be rated for quality? If yes, I'll sample up to 10 sessions per run and score each 1-5 on a dimension you define. Say no if this isn't applicable."
+
+If the user opts in, ask: "What dimension should sessions be scored on? (e.g., 'got to a useful answer', 'response was accurate', 'no hallucinations')."
+
+**Pushback:**
+
+- **Vague dimension** ("quality", "goodness", "helpful", "good response") -> "Quality on what axis specifically? The dimension should be something a human could look at a transcript and judge consistently."
+- **Multiple dimensions** ("accurate AND actionable") -> "Start with one. You can add dimensions by editing the config later. Keeping it at one keeps the scores comparable across runs. Which matters more right now?"
+- **Reviewability test** - after the user names a dimension, apply this check silently: could two separate reviewers look at the same session and agree on the score? If no, push back once: "Let's tighten this - what would make a reviewer score this a 5 vs a 3? If you can name the distinction in one sentence, the dimension is tight enough." If the user can answer, capture it as a scoring note alongside the dimension. If they can't, flag the dimension `needs-review` and move on.
+
+**Capture:** opt-in (yes/no), dimension (if opted in), scoring note (1 sentence distinguishing 5 from 3), scoring discipline reminder ("default to 4-5; reserve 1-3 for clear failures").
+
+---
+
+## 6. Data Sources
+
+**Opening framing:** "Now we wire up the connections needed to actually report on the events and metrics you've named. The goal is the smallest set of sources that covers everything above - one source can be enough. Let's walk through each metric."
+
+### 6.0 Build the metric-to-source list
+
+Compile the full list of signals that need a source:
+
+- The primary engagement event (section 2)
+- The value-realization event (section 3), if different from engagement
+- Each completion/conversion event (section 4)
+- Each key metric carried from the strategy doc, if strategy was seeded
+
+For each entry, ask one question: "Where does `{{event or metric}}` live? Name the tool (e.g. Mixpanel, PostHog, Amplitude, Stripe, internal DB) and how the agent would query it."
+
+The answer produces (tool name, query shape). If multiple entries land in the same tool, consolidate them into one source entry.
+
+**Persist per-strategy-metric source mapping.** For each strategy metric whose source differs from the default (`pulse_analytics_source` for analytics-class metrics, `pulse_payments_source` for revenue/payments-class metrics, etc.), record the override in `pulse_metric_sources` as a `metric=source` pair. Example: if `pulse_analytics_source` is `posthog` but `nps` is captured in Delighted, write `pulse_metric_sources: "nps=delighted"`. Strategy metrics whose source matches the class default do not need an entry. Without this mapping, multi-source setups silently lose the per-metric routing between runs.
+
+**Dual-source arbitration.** If a single signal could be answered from two different sources (e.g., both PostHog and a read-only DB replica have the search events), pick one as canonical and name it in the config. Ask: "Both `{{source A}}` and `{{source B}}` can cover this - which is the source of truth? The pulse queries one per signal so numbers stay consistent across runs." Capture the canonical source. The other tool may still be used for ad-hoc investigation but is not wired into the pulse.
+
+**If the user says "we don't have that instrumented yet"** (common for strategy-seeded metrics like retention or NPS): offer two off-ramps and let them pick.
+
+- **Defer** - append the metric name to `pulse_pending_metrics` (CSV). The metric renders as `no data` in each pulse report until instrumentation lands. Right call when the metric matters and the team will instrument it.
+- **Drop from pulse** - append the metric name to `pulse_excluded_metrics` (CSV). The metric stays in `docs/strategy.md` but the pulse skips it entirely. Right call when the metric is aspirational and won't have data any time soon.
+
+Do not silently skip. Every un-instrumented strategy metric must land in exactly one of `pulse_pending_metrics` (visible as `no data`) or `pulse_excluded_metrics` (omitted from the report).
+
+### 6.1 MCP nudge
+
+After each unique source is named, check MCP coverage:
+
+1. Call `search_mcp_registry` with the tool name to see if an official or community MCP exists. Do not guess from memory.
+2. If one exists and the user already has it connected (ask: "Is the `{{tool}}` MCP already connected?"), note `using MCP for {{tool}}` in the config.
+3. If one exists but the user hasn't connected it, suggest: "There's an MCP for `{{tool}}`. Connecting it is the fastest way to let the agent query on each run - I can call `suggest_connectors` to walk you through it, or we can skip and I'll note the source as `manual - agent will need credentials or another path`."
+4. If no MCP exists, capture `manual` and note what shape of query the agent should use (CLI, API, etc.).
+
+Do not set up MCP connections inside this interview - that's a separate flow. Just record which tools have MCP coverage and which do not.
+
+### 6.2 Database access (optional, read-only only)
+
+Ask explicitly: "Do you have a read-only database connection you'd like the agent to use for any signals that live in the DB? Read-only only - I will refuse a read-write connection."
+
+**Handling the answer:**
+
+- **"No" or "skip"** -> capture `database: not used` and move on. DB is entirely optional; many products report the pulse from analytics and tracing alone.
+- **"Yes, read-only"** (read replica, read-only user, row-level-security enforced) -> capture connection shape and which tables are available. Ask about cost: "For pulse queries, scans need to be cheap - what indexed columns are available, and are there any tables to avoid?"
+- **"Yes, but it's my prod credential"** or any indication the connection has write access -> refuse: "For safety the pulse will not query a database with write access, even read-only in intent. The options are: (a) set up a read-only replica or a read-only user, (b) skip the DB entirely - analytics usually covers the pulse. Which do you want?" Do not proceed until the user picks (a) with verified read-only scope or (b) skip. Do not capture a read-write connection under any framing.
+
+### 6.3 Consolidated source list
+
+When every signal has a source (or is marked "covered by analytics above"), summarize the source list back to the user: "Here's what we'll wire up: {{sources}}. Any source missing for a signal you care about?"
+
+Capture the final list in the config. A minimum of one source is acceptable.
+
+**Source-count check** - judge by ratio, not absolute count:
+
+- If the config has 3-4 metrics and every source covers a distinct one, 3-4 sources is the floor and not a warning. Accept without flagging.
+- If the config has 1-2 metrics spread across 4+ sources, the setup is over-instrumented - flag for review and ask: "We have {{N}} sources but only {{M}} metrics. Is there a single tool that could cover most of this?"
+- Above 5 sources regardless of metric count, flag for review. Lots of sources means lots of auth, latency, and failure modes on every run.
+
+---
+
+## 7. System Performance
+
+**Opening framing:** "The system performance portion of the pulse is pretty standard - most teams want the same thing: top errors with context, and latency percentiles. Unless you have strong opinions, I'll set up the recommended default."
+
+**Recommended default (confirm or override):**
+
+- **Top errors:** top 5 error signatures from the tracing tool, by count, descending. Each entry includes the signature and a one-line explanation of what it likely means.
+- **Latency:** p50, p95, p99 over the window, compared to the prior equal-length window.
+- **Tracing tool:** {{capture tool name if not already named in section 6}}
+
+Ask one confirmation question: "Keep the recommended setup, or customize?"
+
+- **Keep** -> capture defaults.
+- **Customize** -> ask what they want to change. Common adjustments: "top 3 instead of 5", "skip latency", "add a specific error signature to always surface". Accept and record.
+
+If no tracing tool was named in section 6, ask: "What tool do you use for application tracing and errors? (e.g., Datadog, Sentry, Honeycomb, New Relic.) Skip if you don't have one - I'll omit the system performance section from the report." Skipping is fine - the pulse will just report usage and followups in that case.
+
+**Capture:** tool name (or "none"), top-error count (default 5), latency opt (default on).
+
+---
+
+## 8. Default Lookback Window
+
+**Opening question:** "What should the default lookback window be when no time window is specified? Common: 24h for daily ops, 7d for weekly review, 1h for launches."
+
+Capture: single default (e.g., `24h`).
+
+---
+
+## 9. Scheduling Recommendation
+
+After the config is written and shown to the user, make a scheduling offer before handing back to Phase 2.
+
+**Opening framing:** "Pulses are most useful on a cadence - a report once a day (or once a week) catches drift you'd miss otherwise. Want me to set up a recurring run?"
+
+**Ask one question:**
+
+- "Yes, daily" - at a time they pick
+- "Yes, weekly" - day + time they pick
+- "Not now - I'll run it manually"
+- "Later - remind me after a few manual runs"
+
+**Handling the answer:**
+
+- **Yes (daily or weekly)** -> "I'll hand this to the `schedule` skill. Confirm the time/day and it'll set up the recurring job." Do not schedule inline - hand off to the `schedule` skill explicitly, which is the single source of truth for recurring tasks. On Claude Code, this uses the Routines feature.
+- **Not now** -> capture `schedule: manual` in the config. No nag.
+- **Later** -> capture `schedule: ask-again-after-3-runs` in the config. The SKILL.md Phase 3 logic re-surfaces the offer after 3 manual runs.
+
+Skipping this entirely is fine - the skill does not require a schedule to function. But recommending one is the right default because the value of pulse compounds through the saved-reports timeline; one-off runs lose most of that value.
+
+**Capture:** `schedule: daily | weekly | manual | ask-again-after-3-runs` plus time/day if applicable.
+
+---
+
+## Config File Shape
+
+After the interview completes, merge a `pulse_*` block into `<repo-root>/.compound-engineering/config.local.yaml`. Resolve the repo root with `git rev-parse --show-toplevel`. Preserve any non-pulse keys that already exist in the file (e.g., `work_delegate_*`); only add or update `pulse_*` keys.
+
+If the file does not yet exist, create the directory and file. If `.compound-engineering/config.local.yaml` is not already covered by `.gitignore`, offer to add the entry before writing.
+
+The pulse block uses these flat keys (matches the `work_delegate_*` precedent for consistency):
+
+~~~yaml
+# --- Product pulse ---
+
+pulse_product_name: "{{product_name}}"
+pulse_lookback_default: {{24h | 7d | 1h | other}}    # default 24h if omitted
+pulse_primary_event: "{{event_name}}"
+pulse_value_event: "{{event_name}}"                  # may equal pulse_primary_event; omit if not defined
+pulse_completion_events: "{{event,event,event}}"     # comma-separated, 0-3 events; omit if none
+pulse_quality_scoring: {{true | false}}              # AI products only; default false
+pulse_quality_dimension: "{{dimension}}"             # only meaningful when pulse_quality_scoring is true
+pulse_analytics_source: {{posthog | mixpanel | custom | omit}}
+pulse_tracing_source: {{sentry | datadog | custom | omit}}
+pulse_payments_source: {{stripe | custom | omit}}    # omit if not used
+pulse_db_enabled: {{true | false}}                   # default false; read-only DB access only
+pulse_metric_sources: "{{metric=source,metric=source}}"  # strategy-metric -> source overrides; omit metrics that use the class default (pulse_analytics_source for analytics-class, pulse_payments_source for revenue, etc.)
+pulse_pending_metrics: "{{metric,metric}}"           # strategy metrics deferred for instrumentation; render as 'no data'; omit if none
+pulse_excluded_metrics: "{{metric,metric}}"          # strategy metrics intentionally not in pulse; omit if none
+~~~
+
+**Notes on what is NOT persisted in config:**
+
+- **Strategy metrics carried forward**: surfaced in the report, not stored as config — they live in `docs/strategy.md` and are re-read each run from there.
+- **Per-source connection details** (URLs, API keys, query specifics): live with the user's MCP configuration, not in this config.
+- **Hardcoded operational settings** (15-minute trailing buffer, top-N error count, p50/p95/p99 latencies, "no PII in reports", "parallel analytics + tracing, serial DB"): these are skill behavior, not user config; they live in `SKILL.md` and stay constant.
+- **Schedule cadence**: handled by the `schedule` skill (or platform-native cron), not pulse config. The pulse skill only hands off; it does not own the cadence record.
+- **Tracing top-N count and latency on/off**: not configurable in this version. The report always includes top 5 errors and full p50/p95/p99 latency. Add config keys later if a real need surfaces.
+
+After writing, surface the resulting `pulse_*` block to the user in chat. Offer one round of edits. Then return to SKILL.md Phase 2.

--- a/plugins/compound-engineering/skills/ce-product-pulse/references/report-template.md
+++ b/plugins/compound-engineering/skills/ce-product-pulse/references/report-template.md
@@ -1,0 +1,89 @@
+# Pulse Report Template
+
+Loaded by `SKILL.md` at Phase 2.3 after queries have returned. Fill the template using the query results. Target total length: 30-40 lines.
+
+## Rules for filling in
+
+- Use real numbers, not ranges or hedges. If a number is uncertain, note the source inline.
+- Percent deltas compare the current window to the previous equal-length window (e.g., for `24h`, compare to the prior `24h`). If no comparison is possible, omit the delta rather than inventing one.
+- No hardcoded thresholds. Do not label things "high" or "low" or color anything red unless the reader asked for threshold-based annotation at setup.
+- No PII. No emails, no account IDs, no message content.
+- Headlines are the top of the page. If a reader only reads the first 3 lines, they should know the most important thing that happened.
+- If `docs/strategy.md` exists, re-read its `## Key metrics` section before assembling the report. For each strategy metric, decide what to render:
+  - If the metric name appears in `pulse_excluded_metrics`, omit it from the report.
+  - If the metric name appears in `pulse_pending_metrics`, include it in the Usage section marked `no data (instrumentation pending)`.
+  - Otherwise, resolve the source for this metric: look it up in `pulse_metric_sources` (CSV of `metric=source` pairs); if present, use that source. If absent, fall back to `pulse_analytics_source` and append `(default source)` to the metric line so the implicit routing is visible. Then query and render the metric with its current value and delta. If the query returns no value, include it anyway and mark it `no data`.
+
+## Template
+
+The block below is the literal content to write. Replace every `{{placeholder}}` with query output. Delete lines whose data isn't available for this run.
+
+~~~markdown
+# {{product_name}} Pulse - {{window}} - {{YYYY-MM-DD HH:MM}} {{TZ}}
+
+## Headlines
+
+- {{one-line headline capturing the most notable thing in the window}}
+- {{optional second headline}}
+- {{optional third headline}}
+
+## Usage
+
+- **Primary engagement:** {{N events}} ({{delta vs prior window}})
+- **Value realization:** {{N events}} ({{delta}}) - {{ratio vs engagement}}
+- **Completions / conversions:**
+  - {{conversion event 1}}: {{N}} ({{delta}})
+  - {{conversion event 2}}: {{N}} ({{delta}})
+- **Strategy metrics (if carried forward):**
+  - {{metric name}}: {{value}} ({{delta}})
+- **Quality sample (if configured):** {{distribution e.g. "8x 5, 1x 4, 1x 2"}}
+
+## System performance
+
+- **Latency:** p50 {{ms}}, p95 {{ms}}, p99 {{ms}} ({{delta vs prior window}})
+- **Top errors** (top 5 by count, descending):
+  1. **{{error signature}}** - {{N occurrences}} - {{one-line context, no PII}}
+  2. **{{error signature}}** - {{N occurrences}} - {{one-line context}}
+  3. **{{error signature}}** - {{N occurrences}} - {{one-line context}}
+  4. **{{error signature}}** - {{N occurrences}} - {{one-line context}}
+  5. **{{error signature}}** - {{N occurrences}} - {{one-line context}}
+
+## Followups
+
+- {{One thing worth investigating next - specific enough to act on}}
+- {{Another thing worth investigating}}
+- {{3-5 items max; trim if thin}}
+
+---
+_Source windows: analytics [{{start}} -> {{end}}], tracing [{{start}} -> {{end}}], payments [{{start}} -> {{end}}]. Trailing buffer: 15m. Saved to `docs/pulse-reports/{{YYYY-MM-DD}}_{{HH-MM}}.md`._
+~~~
+
+## Variations
+
+- **No system performance tool configured:** omit the entire `## System performance` section. The report stays Headlines / Usage / Followups.
+- **Quality scoring not opted in:** omit the quality sample line.
+- **Single-source setup (analytics only):** omit the tracing and payments source windows from the footer.
+- **Error count customized at setup** (e.g., top 3 instead of top 5): follow the configured count. Do not pad or trim beyond what the query returned.
+
+## Post-write checklist
+
+Before saving and surfacing to chat:
+
+- [ ] Total length is 30-40 lines (give or take 5).
+- [ ] Headlines exist and lead with the most notable item.
+- [ ] No hardcoded thresholds ("high error rate", "low conversion").
+- [ ] No PII. Scan error signatures and followups for user emails, IDs, or message snippets.
+- [ ] Top 5 errors (or the configured count), not top 10. Trim if the query returned more.
+- [ ] Strategy metrics carried forward from config are rendered in Usage, or marked `no data`.
+- [ ] Followups are specific - each one should be actionable as a sentence.
+- [ ] Filename and in-file timestamp use the same wall-clock time.
+
+## What to surface in chat
+
+After writing the file, post back:
+
+- The Headlines section verbatim
+- The top Followup, if action looks urgent
+- The saved file path so the user can open the full report
+
+Do not paste the full report into chat - the file is the artifact.

--- a/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
+++ b/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
@@ -10,3 +10,22 @@
 # work_delegate_decision: auto   # auto | ask (default: auto)
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
 # work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
+
+# --- Product pulse ---
+# Settings written by /ce-product-pulse first-run interview. Re-run the skill with
+# argument `setup` or `reconfigure` to edit interactively.
+
+# pulse_product_name: "Spiral"                          # used in report titles (no default)
+# pulse_lookback_default: 24h                           # 1h | 24h | 7d | 30d (default: 24h)
+# pulse_primary_event: "session_started"                # the event that means "user showed up"
+# pulse_value_event: "task_completed"                   # the event that means "user got value"
+# pulse_completion_events: "onboarded,first_purchase"   # comma-separated, 0-3 events
+# pulse_quality_scoring: false                          # true | false (default: false; AI products only)
+# pulse_quality_dimension: "answer accuracy"            # dimension scored 1-5 when pulse_quality_scoring is true
+# pulse_analytics_source: posthog                       # posthog | mixpanel | custom (no default)
+# pulse_tracing_source: sentry                          # sentry | datadog | custom (no default)
+# pulse_payments_source: stripe                         # stripe | custom (no default)
+# pulse_db_enabled: false                               # true | false (default: false; read-only DB if true)
+# pulse_metric_sources: "retention_d7=posthog,nps=delighted"  # strategy-metric -> source overrides; comma-separated 'metric=source' pairs; unlisted metrics fall back to pulse_analytics_source
+# pulse_pending_metrics: "retention_d7,nps"             # comma-separated strategy metrics awaiting instrumentation; render as 'no data'
+# pulse_excluded_metrics: "north_star"                  # comma-separated strategy metrics intentionally not in pulse

--- a/plugins/compound-engineering/skills/ce-strategy/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-strategy/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: ce-strategy
+description: "Create or maintain docs/strategy.md - the product's target problem, approach, users, key metrics, and tracks of work. Use when starting a new product, updating direction, or when prompts like 'write our strategy', 'update the roadmap', 'what are we working on', or 'set up the strategy doc' come up. Also triggers when ce-ideate, ce-brainstorm, or ce-plan need upstream grounding and no strategy doc exists yet."
+argument-hint: "[optional: section to revisit, e.g. 'metrics' or 'approach']"
+---
+
+# Product Strategy
+
+**Note: The current year is 2026.** Use this when dating the strategy document.
+
+`ce-strategy` produces and maintains `docs/strategy.md` - a short, durable anchor document that captures what the product is, who it serves, how it succeeds, and where the team is investing. Downstream skills (`ce-ideate`, `ce-brainstorm`, `ce-plan`) read it as grounding when it exists.
+
+The document is short and structured on purpose. Good answers to a handful of sharp questions produce a better strategy than any amount of prose. This skill asks those questions, pushes back on weak answers, and writes the doc.
+
+## Interaction Method
+
+Default to the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
+
+Ask one question at a time. Prefer free-form responses for the substantive sections (problem, approach, persona); reserve single-select for routing decisions (which section to revisit). Each option label must be self-contained.
+
+## Focus Hint
+
+<focus_hint> #$ARGUMENTS </focus_hint>
+
+Interpret any argument as an optional focus: a section name to revisit (`metrics`, `approach`, `tracks`) or a scope hint. With no argument, proceed open-ended and let the file state decide the path.
+
+## Core Principles
+
+1. **Anchor, not plan.** Strategy is what the product is and why. Features belong in `ce-brainstorm`; schedules belong in the issue tracker. Do not let either creep into the doc.
+2. **Rigor in the questions, not the headings.** The section headers are plain English. The interview questions enforce strategy discipline.
+3. **Short is a feature.** The template is constrained. Adding sections costs more than it looks like. Push back on expansion.
+4. **Durable across runs.** This skill is rerunnable. On a second run it updates in place, preserves what is working, and only challenges sections that look stale or weak.
+
+## Execution Flow
+
+### Phase 0: Route by File State
+
+Read `docs/strategy.md` using the native file-read tool.
+
+- **File does not exist** -> First run. Go to Phase 1.
+- **File exists and argument names a specific section** -> Targeted update. Go to Phase 2.
+- **File exists, no argument** -> Ask which section(s) to revisit, then Phase 2.
+
+Announce the path in one line: "Strategy doc not found - let's write it." or "Found existing strategy - let's review and update."
+
+### Phase 1: First-Run Interview
+
+Read `references/interview.md`. This load is non-optional - the pushback rules, anti-pattern examples, and quality bar for each section live there. Improvising from memory produces a passive transcription instead of a strategy doc.
+
+Run the interview in the section order of the final document:
+
+1. Target problem
+2. Our approach
+3. Who it's for
+4. Key metrics
+5. Tracks
+6. Milestones (optional)
+7. Not working on (optional)
+8. Marketing (optional)
+
+For each section, ask the opening question, apply the pushback rules, and capture the final answer in the user's own language. Do not skip the pushback step - it is the core of the skill. Two rounds of pushback per section maximum; capture what the user has given after that and note the section is worth revisiting on the next run.
+
+When all required sections (1-5) are captured, read `references/strategy-template.md`, fill it in, and present the full draft in chat before writing. Offer one round of edits. Then write to `docs/strategy.md`.
+
+### Phase 2: Update Run
+
+Read the existing `docs/strategy.md` thoroughly. Summarize current state in 3-5 lines so the user sees what is on file.
+
+If the argument named a specific section, jump to that section in `references/interview.md`. Preserve all other sections exactly. Apply pushback as if this were a first run - do not rubber-stamp existing weak content just because it is already written.
+
+If no specific target, ask the user which section to revisit using the blocking question tool. Options:
+
+- "Target problem"
+- "Our approach"
+- "Who it's for"
+- "Metrics, tracks, or other"
+
+For each revisited section, re-interview with full pushback. For sections the user confirms are still accurate, leave them untouched. Update the `Last updated` date.
+
+Write the updated doc back to `docs/strategy.md`.
+
+### Phase 3: Downstream Handoff
+
+After writing, note in one line where the file lives and that `ce-ideate`, `ce-brainstorm`, and `ce-plan` will pick it up as grounding on their next run.
+
+If no downstream skill has run yet on this repo, suggest `ce-ideate` or `ce-brainstorm` skills as a next step.
+
+## What This Skill Does Not Do
+
+- Does not update the issue tracker or reconcile in-flight work. Strategy is the doc; execution lives elsewhere.
+- Does not prioritize the backlog. Prioritization is a separate workflow.
+- Does not write product requirements or implementation plans - those are `ce-brainstorm` and `ce-plan`.
+- Does not compute metric values. It records which metrics matter and where they live, not what they read today.
+
+## Learn More
+
+The "Target problem / Our approach / Tracks" structure is informed by Richard Rumelt's *Good Strategy Bad Strategy* - specifically his kernel of diagnosis, guiding policy, and coherent action. The interview questions in `references/interview.md` are designed to push past the patterns he calls "bad strategy": fluff, goals dressed up as strategy, and feature lists in place of a guiding choice. The book is the recommended follow-up reading if the distinction between a slogan and a strategy is not yet sharp.

--- a/plugins/compound-engineering/skills/ce-strategy/references/interview.md
+++ b/plugins/compound-engineering/skills/ce-strategy/references/interview.md
@@ -1,0 +1,143 @@
+# Strategy Interview
+
+Loaded by `SKILL.md` at the start of Phase 1 and revisited per-section in Phase 2. Every section below maps one-to-one to a section in `strategy-template.md`.
+
+For each section: ask the opening question, evaluate the answer against the quality bar, push back when it falls into a named anti-pattern, and capture the final answer in the user's own language.
+
+## Overall Rules
+
+1. **Ask, don't prescribe.** Do not offer menu options for open answers (problem, approach, persona). Use free-form responses. Reserve multi-select for routing decisions.
+2. **Push back once, maybe twice.** If the first answer is weak, name the specific issue and ask a sharper question. If the second answer is still weak, capture what the user has given and note in the draft that the section is worth revisiting. Do not let the interview spiral.
+3. **Quote the user back at them.** When challenging an answer, use the user's own words verbatim. Paraphrasing softens the challenge and is easier to dismiss.
+4. **Keep each answer to 1-3 sentences.** Longer answers are usually hiding something vague. If the user writes a paragraph, ask them to pick the sentence that matters most.
+5. **Don't leak the anti-pattern names.** The user does not need to hear "that's a vanity metric" - just ask the sharper question that follows.
+
+---
+
+## 1. Target Problem
+
+**Opening question:** "What's the core problem this product solves - and what makes that problem hard?"
+
+Strong answers name a specific situation the target user is in, identify what makes the situation hard *right now* (a crux, a constraint, something that isn't easy to route around), and are falsifiable - you could imagine the problem being absent and know the difference.
+
+**Anti-patterns and pushback:**
+
+- **Goal stated as problem** ("the problem is we need to grow revenue") -> "That's a goal, not a problem. What's in the world that's making that goal hard to achieve? Whose situation are you changing?"
+- **Vague wish** ("people need better tools for X") -> "Whose situation specifically? Doing what? What do they try today, and why doesn't it work?"
+- **Symptom, not cause** ("users churn after 30 days") -> "That's a symptom. What's happening in their world that makes them stop caring? What's the underlying condition?"
+- **Too broad** ("communication at work is broken") -> "That's a civilization-scale problem. Narrow it to a situation you can actually affect - which users, doing what, when does it hurt most?"
+- **Feature-shaped** ("there's no good way to do [specific workflow] with AI") -> "That's a missing feature, not the underlying problem. What outcome do users want that the feature would give them?"
+
+**Capture:** One or two sentences naming the user's situation and the crux. No solution language.
+
+---
+
+## 2. Our Approach
+
+**Opening question:** "Given that problem, what's your approach - the commitment or principle that makes it tractable?"
+
+This is the guiding choice: how the product competes or operates, so that many downstream decisions become easier. It is not the product and it is not a feature list.
+
+Strong answers are a choice (implying alternatives explicitly *not* pursued), are general enough to direct many decisions but specific enough to rule things out, and sound more like "we win by [doing X differently]" than "we do [a list of things]".
+
+**Anti-patterns and pushback:**
+
+- **Fluff / values** ("we're customer-obsessed and move fast") -> "Those are values, not an approach. What are you doing *differently* from the other products users could pick? If the answer applies to any company, it's not your approach."
+- **Feature list** ("we're building AI-powered X, Y, and Z") -> "That's a feature list. What's the underlying bet that makes you pick those features over others? What principle is guiding what you ship?"
+- **Product description as approach** ("we use AI to draft replies") -> "That's what the product does, but what's the *choice* inside it? Every competitor will say the same thing. Your approach should name what you're doing that the obvious alternative isn't - is it a grounding choice, a trust-building commitment, a workflow bet? What are you betting on that they're not?"
+- **Goal restated** ("our approach is to be the market leader") -> "That's still the goal. How does the product win? What choice are you making that competitors aren't?"
+- **Multiple approaches at once** ("we're going deep on enterprise, self-serve, and a consumer app") -> "Pick one as the guiding approach. The others may still get work, but one of them organizes the rest. Which is it?"
+- **Doesn't connect to the problem** (problem: "users can't trust AI output"; approach: "build a fast, beautiful UI") -> "How does that approach solve the problem you named? If there's no line between them, one of the two is wrong."
+
+**Capture:** One or two sentences. Ideally ends with or implies "...so that [outcome tied to the problem]".
+
+---
+
+## 3. Who It's For
+
+**Opening question:** "Who is the primary user, and what job are they hiring this product to do?"
+
+Jobs-to-be-done framing - the user isn't a demographic, they're someone in a situation trying to make progress.
+
+Strong answers name one primary persona (additional personas allowed but secondary), identify them by role or situation rather than demographic, and state a concrete job as a verb phrase.
+
+**Anti-patterns and pushback:**
+
+- **Too many primary personas** ("it's for founders, PMs, engineers, and designers") -> "If it's for everyone, it's for no one. Who matters most? The others can still benefit, but one of them drives the product decisions."
+- **Demographic framing** ("25-45 year old professionals") -> "That's a demographic, not a user. What are they trying to do that makes them pick up this product?"
+- **Role without situation** ("PMs") -> "PMs doing what? Running a roadmap review? Writing a spec at midnight? Convincing a skeptical eng lead? The situation is where the product matters."
+- **Generic job** ("they want to be more productive") -> "Productive at what specifically? They're hiring this product to do *what*? The more specific, the better the product decisions downstream."
+
+**Capture:** Persona name plus JTBD sentence. Example: "Solo founders running their own roadmap. They're hiring the product to keep strategy and execution aligned without a PM on staff."
+
+---
+
+## 4. Key Metrics
+
+**Opening question:** "What 3-5 metrics will tell you whether the approach is working?"
+
+Metrics are the feedback loop. Bad metrics create the illusion of progress while the product gets worse.
+
+Strong answers stay at 3-5 (not 10), mix leading and lagging (something that moves weekly and something that moves quarterly), and could plausibly regress if the product got worse.
+
+**Anti-patterns and pushback:**
+
+- **Vanity metrics** ("total signups, total pageviews, cumulative users") -> "Those can all go up while the product gets worse. What moves when users actually get value?"
+- **Too many** ("here are 12 metrics we watch") -> "A dashboard isn't a strategy. Pick the 3-5 you'd stake the quarter on. What are the others telling you that those don't?"
+- **Outputs, not outcomes** ("ship velocity, deploys per week") -> "Those measure the team, not the product. If the team doubled velocity but users didn't care, would you call it a win?"
+- **Can only go up** ("cumulative hours saved") -> "A metric that can only go up doesn't tell you much. What's the rate, the ratio, or the thing that can regress?"
+- **Unmeasurable** ("user delight") -> "How specifically? If you can't define how you'd check it on a Tuesday, it's aspirational, not a metric."
+
+**Capture:** A list of 3-5. Each with a one-line definition. Note where each is measured (analytics, DB, qualitative, etc.) if known. If measurement is undefined, ask: "Where does this metric live today? If nowhere, is this something you can start measuring?"
+
+---
+
+## 5. Tracks
+
+**Opening question:** "What are the 2-4 tracks of work you're investing in to execute the approach?"
+
+Tracks are the coherent-actions half of the strategy kernel - concrete areas of investment that flow from the approach. They are not feature lists and not personal todo items. Each track is a named *domain of work*.
+
+Strong answers stay at 2-4 (not 8, not 1), connect clearly back to the approach, and are broad enough that multiple features live inside each one.
+
+**Anti-patterns and pushback:**
+
+- **Feature list in disguise** ("track 1: Slack integration; track 2: mobile app; track 3: dark mode") -> "Those are features. What's the *investment area* each one lives inside? 'Integrations' might be one track, with Slack, Teams, and Discord as candidates inside it."
+- **Too many tracks** ("we have 7 tracks this quarter") -> "With 7 tracks, every track is starved for attention. Which 3 are load-bearing? The others either fold in or drop."
+- **Doesn't connect to approach** (approach: "win by being the easiest to onboard"; track: "enterprise SSO") -> "How does that track serve the approach? If it's a separate bet, name it as one. If it's load-bearing for onboarding, explain the link."
+- **Too vague** ("improve the product") -> "Every track is 'improve the product.' What's the specific investment area that's different from the others?"
+- **One track only** -> "With one track, there's no real choice being made. What are the 2-3 things the product needs to be good at, and how are they different?"
+
+**Capture:** 2-4 tracks. For each: a name, a one-line purpose, and a short note on why this serves the approach.
+
+---
+
+## 6. Milestones (optional)
+
+**Opening question:** "Are there any dated milestones worth anchoring - a launch, a fundraise, a conference, a renewal? Skip if none apply."
+
+Only capture externally visible, real milestones. Avoid turning this into an internal schedule.
+
+Default is to skip. Do not push the user to invent milestones. If they name some, capture them verbatim with dates.
+
+---
+
+## 7. Not Working On (optional)
+
+**Opening question:** "Is there anything you've explicitly decided *not* to do right now that's worth naming? This is for things the team keeps being tempted by."
+
+Clarity tool, not a blocker list. Skip by default. If the user names items, one sentence each. Do not encourage a long list.
+
+---
+
+## 8. Marketing (optional)
+
+**Opening question:** "Any positioning or narrative language you want the doc to carry - a one-liner, a tagline, a key message? Skip if not yet."
+
+Skip by default. Keep to 2-3 lines if present.
+
+---
+
+## After the Interview
+
+Once sections 1-5 are captured (and any optional sections the user engaged with), read `strategy-template.md` and fill it in. Present the full draft in chat before writing. Offer one edit round. Then write to `docs/strategy.md`.

--- a/plugins/compound-engineering/skills/ce-strategy/references/strategy-template.md
+++ b/plugins/compound-engineering/skills/ce-strategy/references/strategy-template.md
@@ -1,0 +1,84 @@
+# Strategy Template
+
+Loaded by `SKILL.md` after the interview is complete. Fill it in using the captured answers and write to `docs/strategy.md`.
+
+## Rules for filling in
+
+- Use the user's own language where possible. Do not paraphrase into generic PM-speak.
+- Each section stays compact. The whole doc should read in under 5 minutes.
+- Section order is locked. Do not add new top-level sections.
+- Optional sections: delete entirely if unused. Do not leave empty headers.
+- Write the `_Last updated_` line with today's ISO date (YYYY-MM-DD).
+
+## Template
+
+The block below is the literal file to write (minus this line and the fences). Replace every `{{placeholder}}` with the captured answer. Delete any optional section whose placeholder wasn't answered.
+
+~~~markdown
+# {{product_name}} Strategy
+
+_Last updated: {{YYYY-MM-DD}}. Re-run `/ce-strategy` to update._
+
+## Target problem
+
+{{1-2 sentence diagnosis. Names the user situation and the crux that makes it hard. No solution language.}}
+
+## Our approach
+
+{{1-2 sentence guiding policy. What this product commits to, so that the target problem becomes tractable.}}
+
+## Who it's for
+
+**Primary:** {{Persona name}} - {{one-sentence JTBD, e.g. "They're hiring {{product_name}} to..."}}
+
+<!-- Duplicate the block above for additional personas only if truly necessary. Fewer is better. -->
+
+## Key metrics
+
+- **{{metric 1 name}}** - {{one-line definition; where it's measured}}
+- **{{metric 2 name}}** - {{...}}
+- **{{metric 3 name}}** - {{...}}
+
+<!-- 3-5 total. Stop at 5. -->
+
+## Tracks
+
+### {{Track 1 name}}
+
+{{One line: what this track is - the investment area, not a feature list.}}
+
+_Why it serves the approach:_ {{one line}}
+
+<!-- Duplicate the block above for 2-4 tracks total. If you can't keep it to 4, something is wrong - fold related tracks together. -->
+
+## Milestones
+
+- **{{YYYY-MM-DD}}** - {{milestone}}
+
+<!-- Optional. Delete the section if unused. Only externally visible milestones: launches, fundraises, conferences, renewals. -->
+
+## Not working on
+
+- {{one line per item}}
+
+<!-- Optional. Delete the section if unused. Use only for things the team keeps being tempted by. -->
+
+## Marketing
+
+**One-liner:** {{single-sentence pitch}}
+
+**Key message:** {{2-3 lines if useful}}
+
+<!-- Optional. Delete the section if unused. -->
+~~~
+
+## Post-write checklist
+
+Before confirming the write, scan the draft for:
+
+- [ ] No section has more than 4 sentences except Tracks (where each track has its own short block).
+- [ ] No placeholders remain (`{{...}}`).
+- [ ] Optional sections with no content have been deleted, not left empty.
+- [ ] Metric count is between 3 and 5. Track count is between 2 and 4.
+- [ ] Target problem and Our approach are connected - one clearly responds to the other.
+- [ ] `_Last updated_` line carries today's date in ISO format.


### PR DESCRIPTION
## Summary

Adds PM skills `ce-strategy` and `ce-product-pulse`:

- **`/ce-strategy`** — Interviews the user to produce `docs/strategy.md`: a Rumeltian problem/approach statement, persona(s), key metrics, and work tracks. Short and structured on purpose; re-runnable to update individual sections. `ce:ideate`, `ce:brainstorm`, and `ce:plan` read it as grounding when present.
- **`/ce-product-pulse`** — Generates a single-page, time-windowed report (usage, performance, errors, followups) saved to `~/pulse-reports/` as a browseable timeline. First-time run interviews the user to define metrics and wire data sources (MCP-preferred, read-only DB only). Adapted from Spiral's "pulse" command.

Both skills use the dash-form `ce-*` naming convention going forward; existing `ce:*` skills can be renamed in a separate sweep.

## Upstream/downstream wiring

The two skills bookend the existing loop — strategy anchors it, pulse closes it:

```
        Strategy (docs/strategy.md)
           |
           v
Brainstorm -> Plan -> Work -> Review -> Compound -> Pulse -> Repeat
                                                      |
                                                      v
                                        (~/pulse-reports/ signal for
                                         next strategy + brainstorm)
```

Three existing skills now read `docs/strategy.md` when present:
- `ce:brainstorm` — Constraint Check pulls in strategy alongside `AGENTS.md`.
- `ce:ideate` — quick-context sub-agent summarizes strategy and returns approach + active tracks so ideation weights toward strategy-aligned directions.
- `ce:plan` — planning context summary includes target problem/approach/tracks; research flags plan decisions that pull away from active tracks.

`ce-product-pulse` also seeds from strategy when available: product name and key metrics are carried into data-source setup so the interview wires up connections to actually measure the metrics strategy defined.

## What this does not do

- No backlog prioritization, no issue-tracker updates, no scheduling (product-pulse hands off to the `schedule` skill with explicit confirmation).
- Pulse is read-only: refuses read-write DB credentials, persists no PII in saved reports.
- Strategy is an anchor doc, not a plan — features belong in `ce:brainstorm`, schedules in the tracker.

## Files changed

- `plugins/compound-engineering/skills/ce-strategy/` (new) — `SKILL.md` + `references/interview.md` + `references/strategy-template.md`
- `plugins/compound-engineering/skills/ce-product-pulse/` (new) — `SKILL.md` + `references/interview.md` + `references/report-template.md`
- `plugins/compound-engineering/skills/ce-{brainstorm,ideate,plan}/SKILL.md` — strategy-as-grounding integration
- `README.md`, `plugins/compound-engineering/README.md` — workflow diagram, command tables, skill count 42→44

## Test plan

- [x] `bun run release:validate` passes (45 skills, 50 agents)
- [ ] `bun test` passes
- [ ] `/ce-strategy` first-run flow produces a valid `docs/strategy.md` and re-runs update a single section without clobbering the rest
- [ ] `/ce-product-pulse` first-run interview writes `docs/product-pulse.md` and refuses read-write DB creds; subsequent run produces a 30-40-line report at `~/pulse-reports/YYYY-MM-DD_HH-MM.md`
- [ ] `/ce:brainstorm`, `/ce:ideate`, `/ce:plan` all read `docs/strategy.md` when present and run cleanly when it is absent
- [ ] Converter output is clean: `bun run convert` for opencode/codex targets with a test plugin including both skills