### PR TITLE
fix: add missing YAML frontmatter to coding-tutor commands

### DIFF
--- a/plugins/coding-tutor/commands/quiz-me.md
+++ b/plugins/coding-tutor/commands/quiz-me.md
@@ -1,1 +1,6 @@
+---
+name: quiz-me
+description: Quiz yourself on previously learned coding concepts using spaced repetition
+---
+
 Quiz me using the coding-tutor skill

--- a/plugins/coding-tutor/commands/sync-tutorials.md
+++ b/plugins/coding-tutor/commands/sync-tutorials.md
@@ -1,3 +1,8 @@
+---
+name: sync-tutorials
+description: Commit and push your coding tutorials to GitHub for backup and mobile reading
+---
+
 # Sync Coding Tutor Tutorials
 
 Commit and push your tutorials to the GitHub repository for backup and mobile reading.

--- a/plugins/coding-tutor/commands/teach-me.md
+++ b/plugins/coding-tutor/commands/teach-me.md
@@ -1,1 +1,6 @@
+---
+name: teach-me
+description: Teach a coding concept using personalized tutorials built from your existing knowledge and codebase
+---
+
 Teach me something using the coding-tutor skill


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Three commands in the `coding-tutor` plugin (`teach-me.md`, `quiz-me.md`, `sync-tutorials.md`) are missing required YAML frontmatter. Without a `name` and `description` field, the Claude Code plugin registry cannot resolve these commands — invoking `/teach-me`, `/quiz-me`, or `/sync-tutorials` will fail with a "command not found" error.

## Fix

Added the minimum required frontmatter block to each file, matching the format used by all other commands in the repo (e.g. `changelog.md`, `deploy-docs.md`):

```yaml
---
name: <command-name>
description: <one-line description>
---
```

No existing content was changed.

## Impact

Without this fix, the three `coding-tutor` commands are effectively unregistered and unusable via the plugin system.