### PR TITLE
fix: replace broken relative path in learnings-researcher agent

### DIFF
--- a/plugins/compound-engineering/agents/research/learnings-researcher.md
+++ b/plugins/compound-engineering/agents/research/learnings-researcher.md
@@ -132,7 +132,7 @@ For each relevant document, return a summary in this format:
 
 ## Frontmatter Schema Reference
 
-Reference the [yaml-schema.md](../../skills/compound-docs/references/yaml-schema.md) for the complete schema. Key enum values:
+See the `compound-docs` skill (`skills/compound-docs/references/yaml-schema.md`) for the complete schema. Key enum values:
 
 **problem_type values:**
 - build_error, test_failure, runtime_error, performance_issue


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugins/compound-engineering/agents/research/learnings-researcher.md` contains a markdown link with a relative path to the YAML schema file:

```markdown
Reference the [yaml-schema.md](../../skills/compound-docs/references/yaml-schema.md) for the complete schema.
```

This relative path cannot resolve at runtime for two reasons:

1. **CWD is never the agent file's directory** — when an agent runs, its working directory is the project root (or wherever Claude Code was invoked), not `agents/research/`. The `../..` traversal resolves to the wrong location.
2. **Breaks after install** — the plugin marketplace installs files into a versioned cache path. Relative paths between agent files and skill files break completely in that context.

The referenced file is therefore inaccessible to the agent, and the markdown link renders as a broken hyperlink.

## Fix

Replace the relative markdown link with a plain text skill reference that names the skill and documents the path without attempting a relative resolution:

```markdown
See the `compound-docs` skill (`skills/compound-docs/references/yaml-schema.md`) for the complete schema.
```

The inline enum values already documented below this line are unaffected — they provide the full schema for agent use and are the primary reference.

## Impact

The agent silently lacked access to the schema file via the documented link. No behavioral change is expected since the inline enum values below are complete; this fix removes the broken link and documents the correct skill reference.