### PR TITLE
fix: add platform requirement guard for CLAUDE_PLUGIN_ROOT in git-worktree skill

### DIFF
--- a/plugins/compound-engineering/skills/git-worktree/SKILL.md
+++ b/plugins/compound-engineering/skills/git-worktree/SKILL.md
@@ -21,6 +21,11 @@ This skill provides a unified interface for managing Git worktrees across your d
 
 **NEVER call `git worktree add` directly.** Always use the `worktree-manager.sh` script.
 
+> **Platform requirement**: `CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code. On other platforms (Codex, Gemini CLI, etc.) it is unset and all script paths below will fail. Before running any command, verify the variable is set:
+> ```bash
+> : "${CLAUDE_PLUGIN_ROOT:?'CLAUDE_PLUGIN_ROOT is not set — this skill requires Claude Code or a manual export of the plugin path'}"
+> ```
+
 The script handles critical setup that raw git commands don't:
 1. Copies `.env`, `.env.local`, `.env.test`, etc. from main repo
 2. Ensures `.worktrees` is in `.gitignore`


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugins/compound-engineering/skills/git-worktree/SKILL.md` uses `${CLAUDE_PLUGIN_ROOT}` in all 20 script invocations without any fallback or guard. `CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code but is **unset on other platforms** (Codex, Gemini CLI, etc.).

When unset, every invocation silently expands to a broken path:

```bash
# What the agent runs on non-Claude-Code platforms:
bash /skills/git-worktree/scripts/worktree-manager.sh create feature-name
#    ^ leading slash, resolves to filesystem root — fails silently or with a cryptic error
```

This makes the skill silently broken on any platform other than Claude Code, with no indication to the user of why.

## Fix

Add an explicit platform requirement note with a guard command at the top of the CRITICAL section. The guard uses bash's `:?` parameter expansion to fail immediately with a clear, actionable error message if `CLAUDE_PLUGIN_ROOT` is unset, rather than running with a broken path:

```bash
: "${CLAUDE_PLUGIN_ROOT:?'CLAUDE_PLUGIN_ROOT is not set — this skill requires Claude Code or a manual export of the plugin path'}"
```

This is a single targeted addition rather than modifying all 20 occurrences, preserving the existing examples while converting silent failure to explicit failure.

## Impact

On non-Claude-Code platforms, users now receive a clear error pointing to the root cause instead of cryptic bash errors from invalid paths.