### PR TITLE
fix: add platform requirement guard for CLAUDE_PLUGIN_ROOT in coding-tutor skill

### DIFF
--- a/plugins/coding-tutor/skills/coding-tutor/SKILL.md
+++ b/plugins/coding-tutor/skills/coding-tutor/SKILL.md
@@ -21,6 +21,11 @@ Then proceed with setup and onboarding.
 
 **Before doing anything else**, run the setup script to ensure the central tutorials repository exists:
 
+> **Platform requirement**: `CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code. On other platforms (Codex, Gemini CLI, etc.) it is unset and all script invocations below will fail. Verify it is set before proceeding:
+> ```bash
+> : "${CLAUDE_PLUGIN_ROOT:?'CLAUDE_PLUGIN_ROOT is not set — this skill requires Claude Code or a manual export of the plugin path'}"
+> ```
+
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/skills/coding-tutor/scripts/setup_tutorials.py
 ```


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugins/coding-tutor/skills/coding-tutor/SKILL.md` uses `${CLAUDE_PLUGIN_ROOT}` in all four script invocations without any fallback or guard:

- `python3 ${CLAUDE_PLUGIN_ROOT}/skills/coding-tutor/scripts/setup_tutorials.py`
- `python3 ${CLAUDE_PLUGIN_ROOT}/skills/coding-tutor/scripts/index_tutorials.py`
- `python3 ${CLAUDE_PLUGIN_ROOT}/skills/coding-tutor/scripts/create_tutorial.py`
- `python3 ${CLAUDE_PLUGIN_ROOT}/skills/coding-tutor/scripts/quiz_priority.py`

`CLAUDE_PLUGIN_ROOT` is set automatically by Claude Code but is **unset on other platforms** (Codex, Gemini CLI, etc.). When unset, these commands silently expand to invalid paths like `python3 /skills/coding-tutor/scripts/setup_tutorials.py`, failing with cryptic errors rather than a clear explanation.

## Fix

Add an explicit platform requirement note with a guard command at the top of the "Setup" section. Uses bash `:?` parameter expansion to fail immediately with an actionable error message if `CLAUDE_PLUGIN_ROOT` is unset:

```bash
: "${CLAUDE_PLUGIN_ROOT:?'CLAUDE_PLUGIN_ROOT is not set — this skill requires Claude Code or a manual export of the plugin path'}"
```

This is a single targeted addition that converts silent failure to explicit failure with a clear error.

## Impact

On non-Claude-Code platforms, users now receive a clear error pointing to the root cause instead of mysterious Python import or path errors.