### PR TITLE
fix(ce-learnings-researcher): drop unreadable schema path reference

### DIFF
--- a/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
@@ -163,14 +163,14 @@ Fill `**Problem Type**` with the raw `problem_type` value from the frontmatter (
 
 ## Frontmatter Schema Reference
 
-The authoritative schema lives at `../../skills/ce-compound/references/yaml-schema.md`; read it on demand when you need the full contract, including `component` and `root_cause` enums (those are repo-specific and evolve — do not hard-code them here).
-
-The two `problem_type` tracks worth knowing in advance:
+The two `problem_type` tracks:
 
 - **Knowledge-track:** `architecture_pattern`, `design_pattern`, `tooling_decision`, `convention`, `workflow_issue`, `developer_experience`, `documentation_gap`, `best_practice` (fallback).
 - **Bug-track:** `build_error`, `test_failure`, `runtime_error`, `performance_issue`, `database_issue`, `security_issue`, `ui_bug`, `integration_issue`, `logic_error`.
 
-Subdirectory listings in the schema reference are illustrative, not exhaustive. Probe the live directory (Step 2) for what actually exists.
+Other frontmatter fields (`component`, `root_cause`, etc.) are repo-specific and evolve over time. Do not assume a fixed enum — read the value from each file as-is, and when summarizing a learning with an unrecognized value, pass it through verbatim rather than normalizing it.
+
+Probe the live `docs/solutions/` directory (Step 2) for what actually exists; do not hard-code subdirectory names.
 
 ## Output Format
 


### PR DESCRIPTION
The `ce-learnings-researcher` agent pointed at `../../skills/ce-compound/references/yaml-schema.md`, a path that cannot resolve at runtime: the agent's CWD is the user's project, and installed plugin paths are versioned under `~/.claude/plugins/cache/.../`. The markdown link rendered as a dead reference and no agent could ever follow it.

The agent doesn't actually need the schema to do its job. It reads existing `docs/solutions/` frontmatter to summarize matches; it doesn't write new entries, so it never needed the authoritative enum list. The two `problem_type` tracks it genuinely needs are already inline.

Replace the broken pointer with the behavioral rule the agent needs instead: for `component`, `root_cause`, and other evolving fields, pass unknown values through verbatim rather than normalizing against a hard-coded enum. This keeps the agent resilient as the schema grows without relying on a file it can't read.

Closes #625 (the community PR that surfaced this bug; its fix replaced the markdown link with a backtick path, which still can't resolve at runtime).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)