### PR TITLE
fix(lfg): use platform-neutral skill references

### DIFF
--- a/plugins/compound-engineering/skills/lfg/SKILL.md
+++ b/plugins/compound-engineering/skills/lfg/SKILL.md
@@ -7,17 +7,19 @@ disable-model-invocation: true
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 2) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
-1. **Optional:** If the `ralph-loop` skill is available, run `/ralph-loop:ralph-loop "finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
+When invoking any skill referenced below, resolve its name against the available-skills list the host platform provides and use that exact entry. Some platforms list skills under a plugin namespace (e.g., `compound-engineering:ce-plan`); others list the bare name. Invoking a short-form guess that isn't in the list will fail — always match a listed entry verbatim before calling the Skill/Task tool.
 
-2. `/ce-plan $ARGUMENTS`
+1. **Optional:** If the `ralph-loop` skill is available, invoke it with `"finish all slash commands" --completion-promise "DONE"`. If not available or it fails, skip and continue to step 2 immediately.
 
-   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, run `/ce-plan $ARGUMENTS` again. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path** — it will be passed to ce-code-review in step 4.
+2. Invoke the `ce-plan` skill with `$ARGUMENTS`.
 
-3. `/ce-work`
+   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, invoke `ce-plan` again with `$ARGUMENTS`. Do NOT proceed to step 3 until a written plan exists. **Record the plan file path** — it will be passed to ce-code-review in step 4.
+
+3. Invoke the `ce-work` skill.
 
    GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 4 if no code changes were made.
 
-4. `/ce-code-review mode:autofix plan:<plan-path-from-step-2>`
+4. Invoke the `ce-code-review` skill with `mode:autofix plan:<plan-path-from-step-2>`.
 
    Pass the plan file path from step 2 so ce-code-review can verify requirements completeness. Read the Residual Actionable Work summary the skill emits.
 
@@ -51,7 +53,7 @@ CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required s
 
    Never block DONE on tracker filing failures once residuals have been durably recorded. A `no_sink` outcome is success only when the findings are present in the PR body or in the pushed fallback file.
 
-7. `/ce-test-browser`
+7. Invoke the `ce-test-browser` skill.
 
 8. Output `<promise>DONE</promise>` when complete
 

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -305,7 +305,7 @@ describe("ce-code-review contract", () => {
 
   test("orchestration callers pass explicit mode flags", async () => {
     const lfg = await readRepoFile("plugins/compound-engineering/skills/lfg/SKILL.md")
-    expect(lfg).toContain("/ce-code-review mode:autofix")
+    expect(lfg).toMatch(/ce-code-review[^\n]*mode:autofix/)
   })
 
   test("ce-work shipping-workflow enforces a residual-work gate after Tier 2 review", async () => {


### PR DESCRIPTION
## Summary

Fixes #574. The `lfg` skill previously used Claude-specific slash syntax (`/ce-plan $ARGUMENTS`, `/ce-work`, etc.) in its step list. When the agent invoked the Skill tool it would try the short name first (e.g., `Skill(ce-plan)`), fail because the host listed it as `compound-engineering:ce-plan`, then retry with the namespaced form — wasting a turn per step. This PR replaces the slash references with bare skill names and adds a platform-agnostic instruction to match the host's available-skills list verbatim, so the agent resolves the correct entry on the first try across Claude Code, Codex, OpenCode, and other targets.

## Test plan
- [x] Run `/lfg <small task>` in Claude Code and confirm the first skill invocation after lfg loads is `Skill(compound-engineering:ce-plan, ...)` with no prior failed `Skill(ce-plan)` attempt.