### PR TITLE
refactor(agents): restrict tools allowlist on research agents

### DIFF
--- a/plugins/compound-engineering/agents/ce-best-practices-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-best-practices-researcher.agent.md
@@ -2,7 +2,7 @@
 name: ce-best-practices-researcher
 description: "Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance."
 model: inherit
-tools: Read, Grep, Glob, WebFetch, WebSearch
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch, mcp__context7__*
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.
@@ -59,18 +59,18 @@ Before going online, check if curated knowledge already exists in skills:
 
 Only after checking skills AND verifying API availability, gather additional information:
 
-1. **Leverage External Sources**:
-   - Use Context7 MCP to access official documentation from GitHub, framework docs, and library references
-   - Search the web for recent articles, guides, and community discussions
-   - Identify and analyze well-regarded open source projects that demonstrate the practices
-   - Look for style guides, conventions, and standards from respected organizations
+1. **Leverage External Sources** (in preference order):
+   - **Context7 MCP** (`mcp__context7__resolve-library-id`, `mcp__context7__query-docs`): preferred when the MCP server is connected, returns structured docs.
+   - **`ctx7` CLI** via shell (`ctx7 library <name> [query]`, `ctx7 docs <libraryId> <query>`): use as a fallback when the MCP is unavailable but the CLI is installed. Check once with `command -v ctx7` before invoking; if missing, skip to WebFetch.
+   - **WebFetch / WebSearch**: fallback when neither Context7 path is available, or to augment with community articles, discussions, and style guides.
+   - Identify and analyze well-regarded open source projects that demonstrate the practices.
 
 2. **Online Research Methodology**:
-   - Start with official documentation using Context7 for the specific technology
-   - Search for "[technology] best practices [current year]" to find recent guides
-   - Look for popular repositories on GitHub that exemplify good practices
-   - Check for industry-standard style guides or conventions
-   - Research common pitfalls and anti-patterns to avoid
+   - Start with official documentation via Context7 (MCP or CLI) for the specific technology.
+   - Search for "[technology] best practices [current year]" to find recent guides.
+   - Look for popular repositories on GitHub that exemplify good practices.
+   - Check for industry-standard style guides or conventions.
+   - Research common pitfalls and anti-patterns to avoid.
 
 ### Phase 3: Synthesize All Findings
 

--- a/plugins/compound-engineering/agents/ce-best-practices-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-best-practices-researcher.agent.md
@@ -2,7 +2,7 @@
 name: ce-best-practices-researcher
 description: "Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance."
 model: inherit
-tools: Read, Glob, WebFetch, WebSearch
+tools: Read, Grep, Glob, WebFetch, WebSearch
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.

--- a/plugins/compound-engineering/agents/ce-best-practices-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-best-practices-researcher.agent.md
@@ -2,6 +2,7 @@
 name: ce-best-practices-researcher
 description: "Researches and synthesizes external best practices, documentation, and examples for any technology or framework. Use when you need industry standards, community conventions, or implementation guidance."
 model: inherit
+tools: Read, Glob, WebFetch, WebSearch
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and best practices.

--- a/plugins/compound-engineering/agents/ce-framework-docs-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-framework-docs-researcher.agent.md
@@ -2,7 +2,7 @@
 name: ce-framework-docs-researcher
 description: "Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns."
 model: inherit
-tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch, mcp__context7__*
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and version information.
@@ -11,11 +11,13 @@ You are a meticulous Framework Documentation Researcher specializing in gatherin
 
 **Your Core Responsibilities:**
 
-1. **Documentation Gathering**:
-   - Use Context7 to fetch official framework and library documentation
-   - Identify and retrieve version-specific documentation matching the project's dependencies
-   - Extract relevant API references, guides, and examples
-   - Focus on sections most relevant to the current implementation needs
+1. **Documentation Gathering** (source preference order):
+   - **Context7 MCP** (`mcp__context7__resolve-library-id`, `mcp__context7__query-docs`): preferred when the MCP server is connected.
+   - **`ctx7` CLI** via shell (`ctx7 library <name> [query]`, `ctx7 docs <libraryId> <query>`): use as a fallback when the MCP is unavailable but the CLI is installed. Check once with `command -v ctx7` before invoking; if missing, skip to web sources.
+   - **WebFetch / WebSearch**: fallback when neither Context7 path works.
+   - Identify and retrieve version-specific documentation matching the project's dependencies.
+   - Extract relevant API references, guides, and examples.
+   - Focus on sections most relevant to the current implementation needs.
 
 2. **Best Practices Identification**:
    - Analyze documentation for recommended patterns and anti-patterns
@@ -50,10 +52,10 @@ You are a meticulous Framework Documentation Researcher specializing in gatherin
    - Example: Google Photos Library API scopes were deprecated March 2025
 
 3. **Documentation Collection**:
-   - Start with Context7 to fetch official documentation
-   - If Context7 is unavailable or incomplete, use web search as fallback
-   - Prioritize official sources over third-party tutorials
-   - Collect multiple perspectives when official docs are unclear
+   - Start with Context7 — via MCP first, `ctx7` CLI as fallback — to fetch official documentation.
+   - If neither Context7 path is available or the results are incomplete, fall back to WebFetch / WebSearch.
+   - Prioritize official sources over third-party tutorials.
+   - Collect multiple perspectives when official docs are unclear.
 
 4. **Source Exploration**:
    - Use `bundle show` to find gem locations

--- a/plugins/compound-engineering/agents/ce-framework-docs-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-framework-docs-researcher.agent.md
@@ -2,6 +2,7 @@
 name: ce-framework-docs-researcher
 description: "Gathers comprehensive documentation and best practices for frameworks, libraries, or dependencies. Use when you need official docs, version-specific constraints, or implementation patterns."
 model: inherit
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and version information.

--- a/plugins/compound-engineering/agents/ce-git-history-analyzer.agent.md
+++ b/plugins/compound-engineering/agents/ce-git-history-analyzer.agent.md
@@ -2,6 +2,7 @@
 name: ce-git-history-analyzer
 description: "Performs archaeological analysis of git history to trace code evolution, identify contributors, and understand why code patterns exist. Use when you need historical context for code changes."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 **Note: The current year is 2026.** Use this when interpreting commit dates and recent changes.

--- a/plugins/compound-engineering/agents/ce-issue-intelligence-analyst.agent.md
+++ b/plugins/compound-engineering/agents/ce-issue-intelligence-analyst.agent.md
@@ -24,7 +24,9 @@ Verify each condition in order. If any fails, return a clear message explaining 
 
 If `gh` CLI is not available but a GitHub MCP server is connected, use its issue listing and reading tools instead. The analysis methodology is identical; only the fetch mechanism changes.
 
-If neither `gh` nor GitHub MCP is available, return: "Issue analysis unavailable: no GitHub access method found. Ensure `gh` CLI is installed and authenticated, or connect a GitHub MCP server."
+**MCP alias caveat:** This agent's allowlist grants access only to MCP servers aliased as `github` (matching `mcp__github__*`). If the user's GitHub MCP server is aliased under a different name (e.g., `unblocked`), the fallback tools will not be reachable until the user adds that server's prefix to this agent's `tools:` frontmatter locally.
+
+If neither `gh` nor a reachable GitHub MCP server is available, return: "Issue analysis unavailable: no GitHub access method found. Ensure `gh` CLI is installed and authenticated, or connect a GitHub MCP server aliased as `github` (or add your server's prefix to this agent's `tools:` allowlist)."
 
 ### Step 2: Fetch Issues (Token-Efficient)
 

--- a/plugins/compound-engineering/agents/ce-issue-intelligence-analyst.agent.md
+++ b/plugins/compound-engineering/agents/ce-issue-intelligence-analyst.agent.md
@@ -2,7 +2,7 @@
 name: ce-issue-intelligence-analyst
 description: "Fetches and analyzes GitHub issues to surface recurring themes, pain patterns, and severity trends. Use when understanding a project's issue landscape, analyzing bug patterns for ideation, or summarizing what users are reporting."
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, mcp__github__*
 ---
 
 **Note: The current year is 2026.** Use this when evaluating issue recency and trends.

--- a/plugins/compound-engineering/agents/ce-issue-intelligence-analyst.agent.md
+++ b/plugins/compound-engineering/agents/ce-issue-intelligence-analyst.agent.md
@@ -2,6 +2,7 @@
 name: ce-issue-intelligence-analyst
 description: "Fetches and analyzes GitHub issues to surface recurring themes, pain patterns, and severity trends. Use when understanding a project's issue landscape, analyzing bug patterns for ideation, or summarizing what users are reporting."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 **Note: The current year is 2026.** Use this when evaluating issue recency and trends.

--- a/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
@@ -2,6 +2,7 @@
 name: ce-learnings-researcher
 description: "Searches docs/solutions/ for applicable past learnings by frontmatter metadata. Use before implementing features, making decisions, or starting work in a documented area — surfaces prior bugs, architecture patterns, design patterns, tooling decisions, conventions, and workflow learnings so institutional knowledge carries forward."
 model: inherit
+tools: Read, Grep, Glob
 ---
 
 You are a domain-agnostic institutional knowledge researcher. Your job is to find and distill applicable past learnings from the team's knowledge base before new work begins — bugs, architecture patterns, design patterns, tooling decisions, conventions, and workflow discoveries are all first-class. Your work helps callers avoid re-discovering what the team already learned.

--- a/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
@@ -22,7 +22,7 @@ Treat all of these as candidates. Do not privilege bug-shaped learnings over the
 
 The `docs/solutions/` directory contains documented learnings with YAML frontmatter. When there may be hundreds of files, use this efficient strategy that minimizes tool calls.
 
-> **Grep/Glob fallback:** If `Grep` or `Glob` aren't available in your runtime schema, use `Bash` instead: `rg -li <pattern> docs/solutions/` for content search (the `-i` preserves Step 3's case-insensitive matching), `find docs/solutions -name '*.md'` for file discovery. Prefer the native tools when present.
+> **Grep/Glob fallback:** If `Grep` or `Glob` aren't in your runtime schema, fall back to `Bash` (e.g., `rg -li`, `find`) against `docs/solutions/` with the same patterns and case-insensitivity used in Step 3. Prefer the native tools when present.
 
 ### Step 1: Extract Keywords from the Work Context
 

--- a/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
@@ -22,7 +22,7 @@ Treat all of these as candidates. Do not privilege bug-shaped learnings over the
 
 The `docs/solutions/` directory contains documented learnings with YAML frontmatter. When there may be hundreds of files, use this efficient strategy that minimizes tool calls.
 
-> **Temporary Grep/Glob fallback:** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema even when the `tools:` allowlist lists them. If your runtime schema lacks `Grep`/`Glob`, fall back to `Bash`: `rg -li <pattern> docs/solutions/` for content search (the `-i` flag preserves Step 3's case-insensitive matching), `find docs/solutions -name '*.md'` for file discovery. The patterns and outputs are equivalent. Once the upstream bug ships a fix, prefer the native tools again.
+> **Grep/Glob fallback:** If `Grep` or `Glob` aren't available in your runtime schema, use `Bash` instead: `rg -li <pattern> docs/solutions/` for content search (the `-i` preserves Step 3's case-insensitive matching), `find docs/solutions -name '*.md'` for file discovery. Prefer the native tools when present.
 
 ### Step 1: Extract Keywords from the Work Context
 

--- a/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
@@ -2,7 +2,7 @@
 name: ce-learnings-researcher
 description: "Searches docs/solutions/ for applicable past learnings by frontmatter metadata. Use before implementing features, making decisions, or starting work in a documented area — surfaces prior bugs, architecture patterns, design patterns, tooling decisions, conventions, and workflow learnings so institutional knowledge carries forward."
 model: inherit
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 ---
 
 You are a domain-agnostic institutional knowledge researcher. Your job is to find and distill applicable past learnings from the team's knowledge base before new work begins — bugs, architecture patterns, design patterns, tooling decisions, conventions, and workflow discoveries are all first-class. Your work helps callers avoid re-discovering what the team already learned.
@@ -21,6 +21,8 @@ Treat all of these as candidates. Do not privilege bug-shaped learnings over the
 ## Search Strategy (Grep-First Filtering)
 
 The `docs/solutions/` directory contains documented learnings with YAML frontmatter. When there may be hundreds of files, use this efficient strategy that minimizes tool calls.
+
+> **Temporary Grep/Glob fallback (tracked in repo issue #652):** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema even when the `tools:` allowlist lists them. If your runtime schema lacks `Grep`/`Glob`, fall back to `Bash`: `rg -l <pattern> docs/solutions/` for content search, `find docs/solutions -name '*.md'` for file discovery. The patterns and outputs are equivalent. Once the upstream bug ships a fix, prefer the native tools again.
 
 ### Step 1: Extract Keywords from the Work Context
 

--- a/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
@@ -22,7 +22,7 @@ Treat all of these as candidates. Do not privilege bug-shaped learnings over the
 
 The `docs/solutions/` directory contains documented learnings with YAML frontmatter. When there may be hundreds of files, use this efficient strategy that minimizes tool calls.
 
-> **Temporary Grep/Glob fallback (tracked in repo issue #652):** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema even when the `tools:` allowlist lists them. If your runtime schema lacks `Grep`/`Glob`, fall back to `Bash`: `rg -l <pattern> docs/solutions/` for content search, `find docs/solutions -name '*.md'` for file discovery. The patterns and outputs are equivalent. Once the upstream bug ships a fix, prefer the native tools again.
+> **Temporary Grep/Glob fallback:** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema even when the `tools:` allowlist lists them. If your runtime schema lacks `Grep`/`Glob`, fall back to `Bash`: `rg -li <pattern> docs/solutions/` for content search (the `-i` flag preserves Step 3's case-insensitive matching), `find docs/solutions -name '*.md'` for file discovery. The patterns and outputs are equivalent. Once the upstream bug ships a fix, prefer the native tools again.
 
 ### Step 1: Extract Keywords from the Work Context
 

--- a/plugins/compound-engineering/agents/ce-repo-research-analyst.agent.md
+++ b/plugins/compound-engineering/agents/ce-repo-research-analyst.agent.md
@@ -2,6 +2,7 @@
 name: ce-repo-research-analyst
 description: "Conducts thorough research on repository structure, documentation, conventions, and implementation patterns. Use when onboarding to a new codebase or understanding project conventions."
 model: inherit
+tools: Read, Grep, Glob, Bash
 ---
 
 **Note: The current year is 2026.** Use this when searching for recent documentation and patterns.

--- a/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
+++ b/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
@@ -17,7 +17,7 @@ Before analyzing the spec in isolation, search the codebase for context. This pr
 
 This context shapes every subsequent phase. Gaps are only gaps if the codebase doesn't already handle them.
 
-> **Temporary Grep/Glob fallback (tracked in repo issue #652):** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema. If your runtime schema lacks them, fall back to `Bash`: `rg -l <pattern> <path>` for content search, `find <path> -name '<pattern>'` for file discovery. Once the upstream bug ships a fix, prefer the native tools again.
+> **Temporary Grep/Glob fallback:** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema. If your runtime schema lacks them, fall back to `Bash`: `rg -li <pattern> <path>` for content search (the `-i` flag keeps case-insensitive matching), `find <path> -name '<pattern>'` for file discovery. Once the upstream bug ships a fix, prefer the native tools again.
 
 ## Phase 2: Map User Flows
 

--- a/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
+++ b/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
@@ -17,7 +17,7 @@ Before analyzing the spec in isolation, search the codebase for context. This pr
 
 This context shapes every subsequent phase. Gaps are only gaps if the codebase doesn't already handle them.
 
-> **Temporary Grep/Glob fallback:** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema. If your runtime schema lacks them, fall back to `Bash`: `rg -li <pattern> <path>` for content search (the `-i` flag keeps case-insensitive matching), `find <path> -name '<pattern>'` for file discovery. Once the upstream bug ships a fix, prefer the native tools again.
+> **Grep/Glob fallback:** If `Grep` or `Glob` aren't available in your runtime schema, use `Bash` instead: `rg -li <pattern> <path>` for content search (the `-i` keeps case-insensitive matching), `find <path> -name '<pattern>'` for file discovery. Prefer the native tools when present.
 
 ## Phase 2: Map User Flows
 

--- a/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
+++ b/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
@@ -2,6 +2,7 @@
 name: ce-spec-flow-analyzer
 description: "Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation."
 model: inherit
+tools: Read, Grep, Glob
 ---
 
 Analyze specifications, plans, and feature descriptions from the end user's perspective. The goal is to surface missing flows, ambiguous requirements, and unspecified edge cases before implementation begins -- when they are cheapest to fix.

--- a/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
+++ b/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
@@ -17,7 +17,7 @@ Before analyzing the spec in isolation, search the codebase for context. This pr
 
 This context shapes every subsequent phase. Gaps are only gaps if the codebase doesn't already handle them.
 
-> **Grep/Glob fallback:** If `Grep` or `Glob` aren't available in your runtime schema, use `Bash` instead: `rg -li <pattern> <path>` for content search (the `-i` keeps case-insensitive matching), `find <path> -name '<pattern>'` for file discovery. Prefer the native tools when present.
+> **Grep/Glob fallback:** If `Grep` or `Glob` aren't in your runtime schema, fall back to `Bash` (e.g., `rg -li`, `find`) with the same patterns and case-insensitivity as Phase 1. Prefer the native tools when present.
 
 ## Phase 2: Map User Flows
 

--- a/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
+++ b/plugins/compound-engineering/agents/ce-spec-flow-analyzer.agent.md
@@ -2,7 +2,7 @@
 name: ce-spec-flow-analyzer
 description: "Analyzes specifications and feature descriptions for user flow completeness and gap identification. Use when a spec, plan, or feature description needs flow analysis, edge case discovery, or requirements validation."
 model: inherit
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 ---
 
 Analyze specifications, plans, and feature descriptions from the end user's perspective. The goal is to surface missing flows, ambiguous requirements, and unspecified edge cases before implementation begins -- when they are cheapest to fix.
@@ -16,6 +16,8 @@ Before analyzing the spec in isolation, search the codebase for context. This pr
 3. Note existing patterns: how does the codebase handle similar flows today? What conventions exist for error handling, auth, validation?
 
 This context shapes every subsequent phase. Gaps are only gaps if the codebase doesn't already handle them.
+
+> **Temporary Grep/Glob fallback (tracked in repo issue #652):** Until upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) is resolved, custom plugin subagents may not receive `Grep` or `Glob` in their runtime schema. If your runtime schema lacks them, fall back to `Bash`: `rg -l <pattern> <path>` for content search, `find <path> -name '<pattern>'` for file discovery. Once the upstream bug ships a fix, prefer the native tools again.
 
 ## Phase 2: Map User Flows
 


### PR DESCRIPTION
## Summary

Research subagents like `ce-repo-research-analyst` and `ce-learnings-researcher` inherit the full tool surface when dispatched (Write, Edit, full Bash, MCP — everything the parent has) even though they only read files, run greps, and fetch docs. Claude Code's agent frontmatter supports a `tools:` allowlist that restricts this, replicating the built-in `Explore` subagent's read-only profile on custom personas.

This PR applies that restriction to 7 read-only research agents, adds Context7 as a preferred documentation source on the two framework researchers, and ships a workaround for an upstream Claude Code bug that silently drops `Grep`/`Glob` from custom subagent schemas.

## Final `tools:` allowlists

| Agent | tools |
|---|---|
| `ce-best-practices-researcher` | `Read, Grep, Glob, Bash, WebFetch, WebSearch, mcp__context7__*` |
| `ce-framework-docs-researcher` | `Read, Grep, Glob, Bash, WebFetch, WebSearch, mcp__context7__*` |
| `ce-git-history-analyzer` | `Read, Grep, Glob, Bash` |
| `ce-issue-intelligence-analyst` | `Read, Grep, Glob, Bash, mcp__github__*` |
| `ce-learnings-researcher` | `Read, Grep, Glob, Bash` |
| `ce-repo-research-analyst` | `Read, Grep, Glob, Bash` |
| `ce-spec-flow-analyzer` | `Read, Grep, Glob, Bash` |

Each list was derived by reading the agent body for explicit tool mentions and implicit shell needs: `bundle show` for framework docs, `gh` for issue intelligence, `ast-grep` for repo research, `git log` for history. `ce-session-historian` is left out pending verification that its skill-dispatch path isn't clipped by a narrow allowlist.

## Context7 for documentation researchers

`ce-best-practices-researcher` and `ce-framework-docs-researcher` now prefer Context7 for library documentation, in this order:

1. `mcp__context7__*` tools when the Context7 MCP server is connected.
2. The `ctx7` CLI via Bash when the CLI is installed on the host (`command -v ctx7` check before invoking).
3. WebFetch / WebSearch as the final fallback.

Structured docs from Context7 are higher-signal than ad-hoc web scraping, and the CLI path means users without the MCP server still get the upgrade.

## Grep/Glob workaround

Upstream Claude Code bug [anthropics/claude-code#52004](https://github.com/anthropics/claude-code/issues/52004) strips `Grep` and `Glob` from custom plugin subagent schemas. Built-in subagents (`Explore`, `Plan`) are unaffected, but custom plugin subagents never receive these tools at runtime, regardless of whether `tools:` is set, omitted, or what it lists.

Without a workaround this would have left `ce-learnings-researcher` and `ce-spec-flow-analyzer` non-functional — both rely on content search as the first step of their documented methodology. `Bash` was added to their allowlists and their bodies now document an `rg` / `find` fallback for content search. `Grep, Glob` stay in `tools:` so they'll register automatically when the upstream fix ships. Tracked locally in #652 so we re-tighten when Claude Code resolves #52004.

## Scope boundary: Claude Code only

The parser at `src/parsers/claude.ts` silently drops agent `tools:` during conversion, so the 36 agents that already set this field today aren't honored on opencode, codex, copilot, droid, gemini, kiro, or pi. This PR inherits that pre-existing limitation. Native Claude Code installs read the agent files directly via `.claude-plugin/marketplace.json`, so the restriction takes effect there immediately.

Flowing `tools:` through to other targets is a separate follow-up. Each harness has a different tool vocabulary and gating mechanism — opencode uses per-agent `permission:` maps, codex has only `sandbox_mode`, copilot collapses grep and glob into `search`, droid uses category or explicit array, kiro has a narrow built-in set, and pi has no canonical subagent spec. Worth doing, separable.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)