### PR TITLE
feat(ce-setup): check for ast-grep CLI and agent skill

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -1,0 +1,12 @@
+# Compound Engineering -- local config
+# Copy to .compound-engineering/config.local.yaml in your project root.
+# All settings are optional. Invalid values fall through to defaults.
+
+# --- Work delegation (Codex) ---
+
+# work_delegate: codex           # codex | false (default: false)
+# work_delegate_consent: true    # true | false (default: false)
+# work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
+# work_delegate_decision: auto   # auto | ask (default: auto)
+# work_delegate_model: gpt-5.4  # any valid codex model (default: gpt-5.4)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (default: high)

--- a/plugins/compound-engineering/skills/ce-setup/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-setup/SKILL.md
@@ -24,7 +24,7 @@ If a version is found, pass it to the check script via `--version`. Otherwise om
 
 Before running the script, display: "Compound Engineering -- checking your environment..."
 
-Run the bundled check script. Do not perform manual dependency checks -- the script handles all CLI tools, repo-local CE file checks, and `.gitignore` guidance in one pass.
+Run the bundled check script. Do not perform manual dependency checks -- the script handles all CLI tools, agent skills, repo-local CE file checks, and `.gitignore` guidance in one pass.
 
 ```bash
 bash scripts/check-health --version VERSION
@@ -48,17 +48,19 @@ If the line above resolved to `CLAUDE_CODE`, this is a Claude Code session and `
 
 After the diagnostic report, check whether:
 
-- any dependencies are missing (reported as yellow in the script output)
+- any CLI tools are missing (reported as yellow in the Tools section)
+- any agent skills are missing (reported as yellow in the Skills section)
 - `compound-engineering.local.md` is present and needs cleanup
 - `.compound-engineering/config.local.yaml` does not exist or is not safely gitignored
 - `.compound-engineering/config.local.example.yaml` is missing or outdated
 
-If everything is installed, no repo-local cleanup is needed, and `.compound-engineering/config.local.yaml` already exists and is gitignored, display the tool list and completion message. Parse the tool names from the script output and list each with a green circle:
+If everything is installed, no repo-local cleanup is needed, and `.compound-engineering/config.local.yaml` already exists and is gitignored, display the tool and skill list and completion message. Parse the tool and skill names from the script output and list each with a green circle. Omit the Skills line if the Skills section is absent from the script output:
 
 ```
  ✅ Compound Engineering setup complete
 
-    Tools: 🟢 agent-browser  🟢 gh  🟢 jq  🟢 vhs  🟢 silicon  🟢 ffmpeg
+    Tools:  🟢 agent-browser  🟢 gh  🟢 jq  🟢 vhs  🟢 silicon  🟢 ffmpeg  🟢 ast-grep
+    Skills: 🟢 ast-grep
     Config: ✅
 
     Run /ce-setup anytime to re-check.
@@ -103,22 +105,26 @@ If the local config already exists, check whether it is safely gitignored. If no
 
 ### Step 6: Offer Installation
 
-Present the missing dependencies using a multiSelect question with all items pre-selected. Use the install commands and URLs from the script's diagnostic output.
+Present the missing tools and skills using a multiSelect question with all items pre-selected. Use the install commands and URLs from the script's diagnostic output. Group items under `Tools:` and `Skills:` so the user can see which runtime each item targets; omit a group whose items are all installed.
 
 ```
-The following tools are missing. Select which to install:
+The following items are missing. Select which to install:
 (All items are pre-selected)
 
-Recommended:
+Tools:
   [x] agent-browser - Browser automation for testing and screenshots
   [x] gh - GitHub CLI for issues and PRs
   [x] jq - JSON processor
   [x] vhs (charmbracelet/vhs) - Create GIFs from CLI output
   [x] silicon (Aloxaf/silicon) - Generate code screenshots
   [x] ffmpeg - Video processing for feature demos
+  [x] ast-grep - Structural code search using AST patterns
+
+Skills:
+  [x] ast-grep - Agent skill for structural code search with ast-grep
 ```
 
-Only show dependencies that are actually missing. Omit installed ones.
+Only show items that are actually missing. Omit installed ones.
 
 ### Step 7: Install Selected Dependencies
 
@@ -134,7 +140,9 @@ For each selected dependency, in order:
    2. Skip - I'll install it manually
    ```
 
-2. **If approved:** Run the install command using a shell execution tool. After the command completes, verify installation by running the dependency's check command (e.g., `command -v agent-browser`).
+2. **If approved:** Run the install command using a shell execution tool. After the command completes, verify installation:
+   - For a CLI tool, run the dependency's check command (e.g., `command -v agent-browser`).
+   - For an agent skill, prefer `npx --yes skills list --global --json | jq -r '.[].name' | grep -qx <skill-name>` when `npx` is available; otherwise fall back to checking that `~/.claude/skills/<skill-name>` exists (file, directory, or symlink).
 
 3. **If verification succeeds:** Report success.
 

--- a/plugins/compound-engineering/skills/ce-setup/scripts/check-health
+++ b/plugins/compound-engineering/skills/ce-setup/scripts/check-health
@@ -18,6 +18,17 @@ deps=(
   "vhs|recommended|NONINTERACTIVE=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install -q vhs|https://github.com/charmbracelet/vhs"
   "silicon|recommended|NONINTERACTIVE=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install -q silicon|https://github.com/Aloxaf/silicon"
   "ffmpeg|recommended|NONINTERACTIVE=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install -q ffmpeg|https://ffmpeg.org/download.html"
+  "ast-grep|recommended|NONINTERACTIVE=1 HOMEBREW_NO_AUTO_UPDATE=1 brew install -q ast-grep|https://ast-grep.github.io"
+)
+
+# Agent skills installed via the `skills` CLI (vercel-labs/skills).
+# Format: name|tier|install_cmd|url
+# Presence is resolved authoritatively via `npx --yes skills list --global --json`
+# when npx and jq are available; otherwise falls back to a Claude Code path
+# probe at ~/.claude/skills/<name>.
+
+skills=(
+  "ast-grep|recommended|npx skills add ast-grep/agent-skill -g -y|https://github.com/ast-grep/agent-skill"
 )
 
 # =====================================================
@@ -62,6 +73,44 @@ for entry in "${deps[@]}"; do
     results+=("$name|$tier|ok|$install_cmd|$url")
   else
     results+=("$name|$tier|missing|$install_cmd|$url")
+  fi
+done
+
+# =====================================================
+#  Check skills
+# =====================================================
+
+has_npx="no"
+has_jq="no"
+command -v npx >/dev/null 2>&1 && has_npx="yes"
+command -v jq >/dev/null 2>&1 && has_jq="yes"
+
+installed_skill_names=""
+if [ "$has_npx" = "yes" ] && [ "$has_jq" = "yes" ]; then
+  installed_skill_names=$(npx --yes skills list --global --json 2>/dev/null | jq -r '.[].name' 2>/dev/null)
+fi
+
+skill_ok=0; skill_total=0
+skill_results=()
+skills_root="$HOME/.claude/skills"
+for entry in "${skills[@]}"; do
+  IFS='|' read -r name tier install_cmd url <<< "$entry"
+  skill_total=$((skill_total + 1))
+
+  is_installed="no"
+  if [ -n "$installed_skill_names" ]; then
+    if printf '%s\n' "$installed_skill_names" | grep -qx "$name"; then
+      is_installed="yes"
+    fi
+  elif [ -e "$skills_root/$name" ]; then
+    is_installed="yes"
+  fi
+
+  if [ "$is_installed" = "yes" ]; then
+    skill_ok=$((skill_ok + 1))
+    skill_results+=("$name|$tier|ok|$install_cmd|$url")
+  else
+    skill_results+=("$name|$tier|missing|$install_cmd|$url")
   fi
 done
 
@@ -129,6 +178,24 @@ for result in "${results[@]}"; do
   fi
 done
 
+# --- Skills ---
+
+if [ "${#skills[@]}" -gt 0 ]; then
+  section "Skills  ${skill_ok}/${skill_total}"
+
+  for result in "${skill_results[@]}"; do
+    IFS='|' read -r name tier status install_cmd url <<< "$result"
+    if [ "$status" = "ok" ]; then
+      ok "$name"
+    else
+      warn "$name"
+      issues=$((issues + 1))
+      detail "$install_cmd"
+      detail "$url"
+    fi
+  done
+fi
+
 # --- Project ---
 
 if [ "$in_repo" = "yes" ]; then
@@ -171,9 +238,9 @@ fi
 
 echo ""
 if [ "$issues" -eq 0 ]; then
-  echo " ✅  All clear  ${cli_ok}/${cli_total} tools"
+  echo " ✅  All clear  ${cli_ok}/${cli_total} tools  ${skill_ok}/${skill_total} skills"
 else
-  echo " ⚠️   ${issues} issue(s) found  ${cli_ok}/${cli_total} tools"
+  echo " ⚠️   ${issues} issue(s) found  ${cli_ok}/${cli_total} tools  ${skill_ok}/${skill_total} skills"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

`/ce-setup` now checks the `ast-grep` CLI and the ast-grep agent skill, adding both to the existing tools list and introducing a parallel **Skills** section in the diagnostic output. Previously the script only knew about the original CLI deps, so devs wanting structural code search had to install `ast-grep` and register its skill by hand.

## What changed

- **`Skills` check** — new section parallel to Tools. Resolves skill presence via `npx --yes skills list --global --json`, falling back to the `~/.claude/skills/<name>` path probe when `npx` or `jq` is unavailable.
- **`ast-grep` CLI** — added to the Tools dependency list with `brew install ast-grep` and the upstream URL.
- **ast-grep agent skill** — added to the new skills array with the canonical `npx skills add ast-grep/agent-skill -g -y` install command.
- **`SKILL.md`** — Step 6's install menu now groups missing items under `Tools:` and `Skills:`; Step 7 teaches how to verify skill installs via the `skills` CLI or the path fallback.
- **Example config committed** — `.compound-engineering/config.local.example.yaml` now exists at the repo root. The plugin's own checkout had never had it, so `/ce-setup` always flagged "Example config missing" for plugin contributors. Bundled here so the new Skills output is not buried behind an unrelated false-positive when dogfooding.

## Screenshots

![ce-setup output with Skills section](https://files.catbox.moe/5ktwxv.png)

The screenshot shows the new `Skills 0/1` row pending the ast-grep install, with `npx skills add ast-grep/agent-skill -g -y` surfaced beneath it.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)