### PR TITLE
chore(release): pin cli + compound-engineering to 3.0.2 via per-package release-as

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -14,6 +14,7 @@
     ".": {
       "release-type": "simple",
       "package-name": "cli",
+      "release-as": "3.0.2",
       "exclude-paths": [
         "AGENTS.md",
         "CLAUDE.md",
@@ -46,6 +47,7 @@
     "plugins/compound-engineering": {
       "release-type": "simple",
       "package-name": "compound-engineering",
+      "release-as": "3.0.2",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

Fixes the incorrect version scoping in PR #661 by (1) reverting the empty pin commit 7a6c84d3 and (2) pinning only `cli` + `compound-engineering` to 3.0.2 via per-package `release-as` config — the actual supported mechanism in release-please.

### Background

PR #665 tried to re-pin the pending release from 3.1.0 back to 3.0.2 using an empty commit with `Release-As: cli@3.0.2` / `Release-As: compound-engineering@3.0.2` footers. This had two unsupported assumptions:

1. **`<component>@<version>` is not real syntax.** release-please's parser (`src/commit.ts`) ignores the `component@` prefix and reads the whole value as a version. Both footers effectively became `Release-As: 3.0.2`.
2. **Empty commits fan out to every package bucket.** `src/util/commit-split.ts` with `includeEmpty: true` pushes file-less commits into every package. Combined with (1), this caused release PR #661 to propose bumping **all five** packages to 3.0.2:
   - cli 3.0.1 → 3.0.2 ✓ (intended)
   - compound-engineering 3.0.1 → 3.0.2 ✓ (intended)
   - coding-tutor 1.3.0 → 3.0.2 ✗ (unintended)
   - marketplace 1.0.2 → 3.0.2 ✗ (unintended)
   - cursor-marketplace 1.0.1 → 3.0.2 ✗ (unintended)

### What this PR does

- **Revert `7a6c84d3`** (empty commit). Because the reverted commit is empty, the revert is also empty — this exists as an intent signal in git history. Note: a revert commit does NOT remove the ancestor commit's `Release-As` footers from release-please's view. That is handled separately (see below).

- **Add `"release-as": "3.0.2"` to the `.` and `plugins/compound-engineering` blocks in `release-please-config.json`.** This is the supported mechanism — `strategies/base.ts#buildNewVersion` short-circuits the bump calculation only for packages that have config-level `release-as`, leaving the other three packages' buckets untouched.

- **(Already applied) Edited PR #665's description** to include a `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` block. This tells release-please to treat commit `7a6c84d3` as `chore: no-op` on every future run, which neutralizes the fanned-out `RELEASE AS` note that would otherwise still bump the other three packages.

### Expected effect after merge

On the release-please workflow run triggered by this merge:

- PR #661 regenerates with:
  - cli 3.0.1 → 3.0.2
  - compound-engineering 3.0.1 → 3.0.2
  - No changes to coding-tutor, marketplace, or cursor-marketplace.
- Changelog entries only appear for `cli` and `compound-engineering`.

### Follow-up (required)

After PR #661 merges and the 3.0.2 release ships, open a cleanup PR that removes the two `"release-as": "3.0.2"` entries from `release-please-config.json`. Otherwise every subsequent release will stay pinned at 3.0.2.

## Test plan

- [ ] After this PR merges, confirm release-please workflow runs and PR #661 regenerates.
- [ ] Confirm the regenerated PR #661 diff ONLY touches:
  - `package.json` (cli)
  - `.github/.release-please-manifest.json` (only `.` and `plugins/compound-engineering` lines change)
  - `CHANGELOG.md`, `plugins/compound-engineering/CHANGELOG.md`
  - `plugins/compound-engineering/.claude-plugin/plugin.json`
  - `plugins/compound-engineering/.codex-plugin/plugin.json`
  - `plugins/compound-engineering/.cursor-plugin/plugin.json`
- [ ] Confirm the regenerated PR #661 does NOT touch:
  - `plugins/coding-tutor/**`
  - `.claude-plugin/marketplace.json`, `.claude-plugin/CHANGELOG.md`
  - `.cursor-plugin/marketplace.json`, `.cursor-plugin/CHANGELOG.md`
- [ ] If regeneration looks wrong, DO NOT MERGE #661 — investigate.
- [ ] After #661 merges and releases ship, open cleanup PR to remove the two `release-as` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
