### PR TITLE
fix(ce-brainstorm): enforce Interaction Rules in universal flow

### DIFF
--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -27,10 +27,13 @@ This skill does not implement code. It explores, clarifies, and documents decisi
 
 ## Interaction Rules
 
-1. **Ask one question at a time** - Do not batch several unrelated questions into one message.
+These rules apply to every brainstorm, including the universal (non-software) flow routed to `references/universal-brainstorming.md`.
+
+1. **Ask one question at a time** - One question per turn, even when sub-questions feel related. Stacking several questions in a single message produces diluted answers; pick the single most useful one and ask it.
 2. **Prefer single-select multiple choice** - Use single-select when choosing one direction, one priority, or one next step.
 3. **Use multi-select rarely and intentionally** - Use it only for compatible sets such as goals, constraints, non-goals, or success criteria that can all coexist. If prioritization matters, follow up by asking which selected item is primary.
-4. **Use the platform's blocking question tool** - `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
+4. **Default to the platform's blocking question tool** - Use `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). These tools include a free-text fallback (e.g., "Other" in Claude Code), so options scaffold the answer without confining it — well-chosen options surface dimensions the user may not have separated, and pick-plus-optional-note is lower activation energy than composing prose from scratch. This default holds for opening and elicitation questions too, not only narrowing. Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
+5. **Use prose only when the question is genuinely open** - Drop the blocking tool only when (a) the answer is inherently narrative ("walk me through how you got here"), (b) the question is diagnostic or introspective and presented options would leak your priors and bias the answer (e.g., "what concerns you most?" where a 4-option menu signals which axes matter), or (c) you cannot write 3-4 genuinely distinct, plausibly-correct options that cover the space without padding or strawmen. The test: if you'd be straining to fill the option slots, the question is open — use prose. Rule 1 still applies: still one question per turn.
 
 ## Output Guidance
 
@@ -68,7 +71,7 @@ Before proceeding to Phase 0.2, classify whether this is a software task. The ke
 
 **Neither** (respond directly, skip all brainstorming phases) -- the input is a quick-help request, error message, factual question, or single-step task that doesn't need a brainstorm.
 
-**If non-software brainstorming is detected:** Read `references/universal-brainstorming.md` and use those facilitation principles to brainstorm with the user naturally. Do not follow the software brainstorming phases below.
+**If non-software brainstorming is detected:** Read `references/universal-brainstorming.md` and use those facilitation principles. Skip Phases 0.2–4 below — the **Core Principles and Interaction Rules above still apply unchanged**, including one-question-per-turn and the default to the platform's blocking question tool.
 
 #### 0.2 Assess Whether Brainstorming Is Needed
 

--- a/plugins/compound-engineering/skills/ce-brainstorm/references/universal-brainstorming.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/universal-brainstorming.md
@@ -1,6 +1,6 @@
 # Universal Brainstorming Facilitator
 
-This file is loaded when ce-brainstorm detects a non-software task (Phase 0). It replaces the software-specific brainstorming phases with facilitation principles for any domain. Do not follow the software brainstorming workflow (Phases 0.2 through 4). Instead, absorb these principles and facilitate the brainstorm naturally.
+This file is loaded when ce-brainstorm detects a non-software task (Phase 0). It replaces the software-specific brainstorming phases (Phases 0.2 through 4) with facilitation principles for any domain. The Core Principles and **Interaction Rules** in the parent `ce-brainstorm/SKILL.md` still apply unchanged — including one-question-per-turn and the default to the platform's blocking question tool. This file extends those rules with universal-domain facilitation guidance; it does not relax them.
 
 ---
 
@@ -9,6 +9,14 @@ This file is loaded when ce-brainstorm detects a non-software task (Phase 0). It
 Be a thinking partner, not an answer machine. The user came here because they're stuck or exploring — they want to think WITH someone, not receive a deliverable. Resist the urge to generate a complete solution immediately. A premature answer anchors the conversation and kills exploration.
 
 **Match the tone to the stakes.** For personal or life decisions (career changes, housing, relationships, family), lead with values and feelings before frameworks and analysis. Ask what matters to them, not just what the options are. For lighter or creative tasks (podcast topics, event ideas, side projects), energy and enthusiasm are more useful than caution.
+
+## Asking questions
+
+"Thinking partner" framing does not mean "conversational prose." The parent skill's Interaction Rules apply in full: one question per turn, and default to the platform's blocking question tool (with its free-text fallback) even for opening and elicitation.
+
+"What's prompting this?", "what matters most here?", and "what have you ruled out?" feel open-ended and conversational, but that's not a reason to skip the tool. The free-text option preserves flexibility while a well-crafted option set teaches the user the dimensions they might not have separated. Pick-plus-optional-note is lower activation energy than composing prose from scratch — especially for emotional or values-laden topics where prose can feel like an essay prompt.
+
+Drop to prose only when (a) the answer is inherently narrative ("walk me through how you got here"), (b) the question is diagnostic or introspective and presented options would leak your priors and bias the answer, or (c) you cannot write 3-4 genuinely distinct, plausibly-correct options that cover the space without padding. If you'd be straining to fill the option slots, the question is open — use prose.
 
 ## How to start
 


### PR DESCRIPTION
## Summary

`ce-brainstorm`'s universal (non-software) flow was silently dropping the parent skill's Interaction Rules. Phase 0.1b said "do not follow the software brainstorming phases below," which was ambiguous about whether the Core Principles and Interaction Rules (which sit above the phases) still applied. Combined with "facilitate the brainstorm naturally" inside `universal-brainstorming.md`, this let the agent skip the blocking question tool (`AskUserQuestion`) and stack multiple questions per turn during universal brainstorms.

The fix binds one Interaction Rule set to both flows, tightens the rules where the loopholes were, and adds a concrete test for when prose is justified over the blocking tool.

## What changed

- **Phase 0.1b** now reads: "Skip Phases 0.2-4 below; Core Principles and Interaction Rules above still apply unchanged."
- **Rule 1** (one question per turn) closes the "several *unrelated* questions" loophole. Sub-questions that feel related still count as stacking.
- **Rule 4** becomes a default-to-tool rule. The free-text fallback (e.g., "Other" in Claude Code) means options scaffold the answer rather than confine it, so the default holds for opening and elicitation, not only narrowing.
- **New Rule 5** defines the prose exceptions and a runtime test: drop to prose only when the answer is inherently narrative, when the question is diagnostic or introspective and presented options would leak priors, or when you cannot write 3-4 genuinely distinct, plausibly-correct options without padding. If you're straining to fill option slots, the question is open.
- **`universal-brainstorming.md`** drops the biasing "facilitate naturally" phrase and adds an `## Asking questions` section that restates the discipline at the point of effect.

## Why not a separate rule set for the universal flow

Conversational tone is a content property; it does not require conversational prose as the *question mechanism*. The free-text escape valve in `AskUserQuestion` lets one discipline cover both flows without forcing the universal agent into a picklist feel. A separate, softer rule set for universal brainstorms was exactly what let this bug happen in the first place.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)