### PR TITLE
fix(release): remove stale release-as pin

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -14,7 +14,6 @@
     ".": {
       "release-type": "simple",
       "package-name": "cli",
-      "release-as": "3.0.2",
       "exclude-paths": [
         "AGENTS.md",
         "CLAUDE.md",
@@ -47,7 +46,6 @@
     "plugins/compound-engineering": {
       "release-type": "simple",
       "package-name": "compound-engineering",
-      "release-as": "3.0.2",
       "extra-files": [
         {
           "type": "json",

--- a/src/release/config.ts
+++ b/src/release/config.ts
@@ -3,6 +3,7 @@ import path from "path"
 type ReleasePleasePackageConfig = {
   "changelog-path"?: string
   "skip-changelog"?: boolean
+  "release-as"?: string
 }
 
 type ReleasePleaseConfig = {
@@ -13,6 +14,13 @@ export function validateReleasePleaseConfig(config: ReleasePleaseConfig): string
   const errors: string[] = []
 
   for (const [packagePath, packageConfig] of Object.entries(config.packages)) {
+    const releaseAs = packageConfig["release-as"]
+    if (releaseAs) {
+      errors.push(
+        `Package "${packagePath}" uses temporary release-as pin "${releaseAs}". Remove release-as after the pinned release ships so future releases can bump normally.`,
+      )
+    }
+
     const changelogPath = packageConfig["changelog-path"]
     if (!changelogPath) continue
 

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -36,4 +36,23 @@ describe("release-please config validation", () => {
 
     expect(errors).toEqual([])
   })
+
+  test("rejects checked-in release-as pins", () => {
+    const errors = validateReleasePleaseConfig({
+      packages: {
+        ".": {
+          "release-as": "3.0.2",
+        },
+        "plugins/compound-engineering": {
+          "release-as": "3.0.2",
+        },
+      },
+    })
+
+    expect(errors).toHaveLength(2)
+    expect(errors[0]).toContain('Package "."')
+    expect(errors[0]).toContain("release-as")
+    expect(errors[1]).toContain('Package "plugins/compound-engineering"')
+    expect(errors[1]).toContain("3.0.2")
+  })
 })


### PR DESCRIPTION
## Summary

Release-please can calculate the next `cli` and `compound-engineering` version again instead of staying pinned at `3.0.2`. This removes the temporary `release-as` override from the linked package configs and extends release validation to reject checked-in pins after an emergency pinned release ships.

## Testing

- `bun test`
- `bun run release:validate`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)