### PR TITLE
fix(main): recover version drift, fix stale test, document learnings

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  ".": "3.0.3",
-  "plugins/compound-engineering": "3.0.3",
+  ".": "3.0.7",
+  "plugins/compound-engineering": "3.0.7",
   "plugins/coding-tutor": "1.3.0",
   ".claude-plugin": "1.0.2",
   ".cursor-plugin": "1.0.1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ bun run release:validate  # check plugin/marketplace consistency
 ## Working Agreement
 
 - **Branching:** Create a feature branch for any non-trivial change. If already on the correct branch for the task, keep using it; do not create additional branches or worktrees unless explicitly requested.
+- **Merge policy:** All changes to `main` go through pull requests. Direct pushes and direct merges are not allowed; branch protection on `main` enforces this by requiring the `test` status check to pass. The direct path bypasses `release:validate`, the test suite, and PR title validation — past direct merges have caused version drift requiring multi-PR recovery (see `docs/solutions/workflow/release-please-version-drift-recovery.md`).
 - **Safety:** Do not delete or overwrite user data. Avoid destructive commands.
 - **Testing:** Run `bun test` after changes that affect parsing, conversion, or output.
 - **Release versioning:** Releases are prepared by release automation, not normal feature PRs. The repo now has multiple release components (`cli`, `compound-engineering`, `coding-tutor`, `marketplace`). GitHub release PRs and GitHub Releases are the canonical release-notes surface for new releases; root `CHANGELOG.md` is only a pointer to that history. Use conventional titles such as `feat:` and `fix:` so release automation can classify change intent, but do not hand-bump release-owned versions or hand-author release notes in routine PRs.

--- a/docs/solutions/workflow/release-please-version-drift-recovery.md
+++ b/docs/solutions/workflow/release-please-version-drift-recovery.md
@@ -1,0 +1,207 @@
+---
+title: "Release-please version drift recovery"
+category: workflow
+date: 2026-04-24
+created: 2026-04-24
+severity: high
+component: release-automation
+problem_type: workflow_issue
+tags:
+  - release-please
+  - version-drift
+  - plugin-versioning
+  - recovery-playbook
+  - linked-versions
+  - extra-files
+---
+
+# Release-please version drift recovery
+
+## Problem
+
+Manual edits to a release-managed version field (any `plugin.json` listed in `extra-files`, `package.json`, or the release-please manifest) cause drift that:
+
+- Breaks `bun run release:validate` on every PR's CI
+- Can cause version regression on the next release-please run if left uncorrected
+- Is easy to introduce accidentally — a one-line edit during a feature commit
+- Has at least three valid recovery paths, each with different user-impact trade-offs
+
+This doc is the playbook when drift is detected. It exists because investigating from scratch takes significant effort and the wrong choice can make things worse.
+
+## File relationship map
+
+The repo has five release components. Each owns one or more files. Release-please reads the manifest and writes the extra-files.
+
+```
+.github/.release-please-manifest.json       (release-please memory: last released per component)
+├── "."                                     → cli component              (v = X.Y.Z)
+├── "plugins/compound-engineering"          → compound-engineering       (v = X.Y.Z)
+├── "plugins/coding-tutor"                  → coding-tutor               (v = A.B.C)
+├── ".claude-plugin"                        → marketplace                (v = M.N.O)
+└── ".cursor-plugin"                        → cursor-marketplace         (v = P.Q.R)
+
+.github/release-please-config.json          (component config: extra-files, plugins)
+└── "plugins": [{ type: "linked-versions", components: ["cli", "compound-engineering"] }]
+    ← forces cli and compound-engineering to bump together
+
+Each component's extra-files get rewritten by release-please when a release is cut:
+
+  cli (".")                               compound-engineering
+  ├── package.json ($.version)            ├── .claude-plugin/plugin.json  ($.version)
+                                          ├── .cursor-plugin/plugin.json  ($.version)
+                                          └── .codex-plugin/plugin.json   ($.version)
+
+  coding-tutor                            marketplace / cursor-marketplace
+  ├── .claude-plugin/plugin.json          ├── marketplace.json ($.metadata.version)
+  ├── .cursor-plugin/plugin.json
+  └── .codex-plugin/plugin.json
+```
+
+**Key invariants:**
+
+- Every file in a component's `extra-files` list must share the same version.
+- Because of `linked-versions`, **`cli` and `compound-engineering` must always be at the same version.** That means `package.json` (cli) and all three `compound-engineering/*/plugin.json` files move together.
+- Marketplace components (`.claude-plugin`, `.cursor-plugin`) are **independent** — they have their own versions and don't move with plugin bumps.
+- `bun run release:validate` enforces these invariants. Its error message names the file(s) that drifted.
+
+## How release-please tracks versions
+
+Release-please treats the **manifest as the source of truth** for "last released version per component." Extra-files are outputs that release-please writes to during a release. The flow is:
+
+1. Push to `main` triggers the `release-pr` workflow
+2. Release-please reads the manifest to know what was last released
+3. Release-please walks conventional commits since the last release tag
+4. Release-please computes the next version (`feat:` → minor, `fix:` → patch, etc.)
+5. Release-please opens or updates a "chore: release main" PR that:
+   - Bumps the manifest to the new version
+   - Bumps every `extra-file` to the new version
+6. When the release PR merges, the release is cut (git tag, optional npm publish)
+
+Under normal operation, **humans never touch the manifest or the extra-files**. Both are updated together by release-please during a release PR. Drift is the state where this guarantee has been violated.
+
+## Drift detection
+
+`bun run release:validate` runs on every PR and on every push to `main` via `.github/workflows/ci.yml`. It fails when:
+
+- Any two `extra-files` within the same component have different versions
+- A marketplace plugin-list is asymmetric across `.claude-plugin`, `.cursor-plugin`, and `.agents/plugins`
+- A Codex manifest is missing required fields or its `skills` directory
+- A description has drifted across Claude/Cursor/Codex plugin.json files (auto-corrected with `write: true`)
+
+**Important:** the manifest's memory of last-released version is **not** directly validated against extra-files. This means a state where all extra-files agree at X.Y.Z but the manifest thinks the last release was W.X.Y (W<X) will pass `release:validate` today. It will fail the NEXT release-please run when release-please tries to bump back down from W.X.Y.
+
+## Recovery decision tree
+
+When drift is detected, choose the recovery path before editing anything.
+
+```
+release:validate reports drift
+    ↓
+1. Identify which component(s) have drifted. Check:
+    - extra-files vs each other within the component
+    - extra-files vs the manifest entry for that component
+    - linked-versions: is cli in sync with compound-engineering?
+    ↓
+2. Is anyone installed at the drifted (higher) version?
+    ├── YES (or unknown — developers using `/plugin install --dev` from main)
+    │       → Forward-sync: update all lower files UP to match the drifted high
+    │
+    └── NO (can verify no git tag, no npm publish, no marketplace cache entry)
+            → Backward-revert: revert the drifted file DOWN to match the rest
+```
+
+### Path A: Forward-sync
+
+Use when any user may have installed the drifted version locally (most common case — developers running `/plugin install` from a main checkout will have whatever version `.claude-plugin/plugin.json` says).
+
+**Scope of changes:**
+
+- All extra-files within the affected component(s) → bump up to the drifted version
+- `.github/.release-please-manifest.json` entry for the affected component → bump to match
+- **If the affected component is `compound-engineering` or `cli`:** because of `linked-versions`, bump BOTH:
+  - manifest's `plugins/compound-engineering` and `.` entries together
+  - `package.json` (cli's extra-file) and all three compound-engineering plugin.json files together
+
+**Why the manifest edit is necessary:** without it, the next release-please run reads "last released was W.X.Y" (the stale manifest value), computes next version as W.X.(Y+1), and writes W.X.(Y+1) to extra-files — regressing any user at the forward-synced version.
+
+**This is release-please's documented recovery pattern for out-of-band releases.** The manifest file is in git precisely so it can be manually corrected when a release happened outside release-please's normal flow.
+
+### Path B: Backward-revert
+
+Use when you can verify no user is installed at the drifted version. Requires:
+
+- No git tag exists for the drifted version (e.g., `git tag -l | grep <version>`)
+- No npm publish exists (e.g., `npm view @every-env/compound-plugin versions`)
+- No marketplace release exists for the drifted version
+- No team member has pulled main since the drift was introduced (hard to verify; assume YES if drift has existed longer than ~an hour)
+
+**Scope of changes:**
+
+- The drifted extra-file(s) → revert DOWN to the manifest's value
+- Manifest and `package.json` (cli) unchanged — they were already correct
+
+**This is simpler** (fewer files changed, no manifest edit) **but risks user regression** if anyone was installed at the drifted high version. Their local cache dir (e.g., `~/.claude/plugins/cache/.../compound-engineering/<drifted>/`) becomes orphaned, and tooling that treats the version field as monotonic may refuse to downgrade or emit warnings.
+
+### Path C: `release-as` pin
+
+Use when you want release-please itself to perform the sync via a normal release PR, instead of manually editing the manifest.
+
+**Scope of changes:**
+
+- Forward-sync all extra-files UP to the drifted version (same as Path A)
+- Add `"release-as": "<drifted+1>"` to each affected component in `.github/release-please-config.json`
+- Do NOT edit the manifest
+- Next release-please run produces a release PR bumping everything to `<drifted+1>`, which is above the drifted version and avoids regression
+
+**Caveat:** after the release PR merges, the `release-as` pin must be removed — otherwise every subsequent release will be pinned to that same version. The repo has been bitten by stale `release-as` pins before (see `ab44d89b`), so Path C is usually more overhead than Path A. Prefer Path A unless there's a specific reason release-please should drive the bump.
+
+### Summary
+
+| Path | Files changed | When to use | Risk |
+|---|---|---|---|
+| A — forward-sync | 3–5 (extras + manifest + linked) | Anyone might be at drifted version (default) | None if execution is correct |
+| B — backward-revert | 1–2 (just the drifted extras) | Verified no one is at drifted version | User regression if verification was wrong |
+| C — `release-as` pin | 3–5 + config change + cleanup after | Want release-please to drive the bump | Requires remembering to remove pin |
+
+## Manifest manual edits
+
+**Release-please normally maintains `.github/.release-please-manifest.json`.** It's updated inside release PRs alongside the extra-files. Humans don't touch it under normal operation.
+
+**Manual edits are legitimate** in exactly one case: recovery from out-of-band releases or version changes, as in Path A above. Release-please's own documentation calls this out — the manifest is tracked in git precisely so it can be corrected when reality diverges from what release-please remembers.
+
+If you find yourself editing the manifest for any reason other than Path A recovery, stop and reconsider. You're probably doing something release-please is meant to own.
+
+## Worked example: 2026-04-24 incident
+
+Between `chore: release main (#675)` (which cut 3.0.3) and PR #677, four direct-to-main merges (`1f20c384`, `f8720da3`, `22d493b1`, `47350c3e`) each bumped `.claude-plugin/plugin.json` by one patch version — 3.0.3 → 3.0.4 → 3.0.5 → 3.0.6 → 3.0.7 — without touching `.cursor-plugin`, `.codex-plugin`, the manifest, or `package.json`. The bumps were added inline with feature work, bypassing PR CI because they landed via direct merge to `main`.
+
+The drift was invisible until PR #677 opened. That PR's CI ran `release:validate` on its merge commit, which inherited main's drifted state (`.claude-plugin` at 3.0.7, everything else at 3.0.3). The validator failed on `.cursor-plugin/plugin.json` and `.codex-plugin/plugin.json` for not matching `.claude-plugin`.
+
+Recovery used Path A (forward-sync to 3.0.7) because:
+
+- Developers installing `compound-engineering` from a local main checkout would have 3.0.7 in their plugin cache by then
+- Path B would have orphaned those caches and triggered version-regression warnings
+- Path C would have reintroduced a `release-as` pin that had just been cleaned up
+
+PR #678 applied the full Path A fix across five fields in four files and updated a stale test assertion that was also hiding behind the release-validate failure (commit `1f20c384` renumbered steps in `lfg/SKILL.md` but didn't update `tests/review-skill-contract.test.ts`). See PR #678's commits for the exact diff.
+
+## Prevention
+
+Direct-to-main merges are the root cause. They bypass the PR CI that runs `release:validate`, test suites, and semantic title validation.
+
+**Branch protection on `main`** is the enforcement. The `test` status check must be required before merge, and admin bypass should be off (or used only for true emergencies). Without branch protection, the AGENTS.md "don't manually bump" rule is honor-system only — which this incident showed is insufficient.
+
+Optional complementary guards:
+
+- **Dedicated CI job** detecting manual version bumps on non-release-please PR authors. Attacks the cause rather than the symptom, with a clearer error message pointing at AGENTS.md.
+- **Pre-commit hook** running `release:validate` locally via `core.hooksPath`. Catches accidents before push. Bypassable with `--no-verify`, so it's a speed-bump, not a lock.
+
+These are nice-to-haves. Branch protection is the real fix.
+
+## Related docs
+
+- `docs/solutions/workflow/manual-release-please-github-releases.md` — big-picture release model
+- `docs/solutions/plugin-versioning-requirements.md` — plugin-scoped contributor rules
+- `plugins/compound-engineering/AGENTS.md` — "Versioning Requirements" section with the don't-manually-bump rules
+- `.github/release-please-config.json` — the extra-files and linked-versions configuration this doc references
+- `src/release/metadata.ts` — the `syncReleaseMetadata` function that `release:validate` runs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@every-env/compound-plugin",
-  "version": "3.0.3",
+  "version": "3.0.7",
   "description": "Official Compound Engineering plugin for Claude Code, Codex, and more",
   "type": "module",
   "private": false,

--- a/plugins/compound-engineering/.codex-plugin/plugin.json
+++ b/plugins/compound-engineering/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "compound-engineering",
-  "version": "3.0.3",
+  "version": "3.0.7",
   "description": "AI-powered development tools for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",

--- a/plugins/compound-engineering/.cursor-plugin/plugin.json
+++ b/plugins/compound-engineering/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
   "displayName": "Compound Engineering",
-  "version": "3.0.3",
+  "version": "3.0.7",
   "description": "AI-powered development tools for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",

--- a/plugins/compound-engineering/AGENTS.md
+++ b/plugins/compound-engineering/AGENTS.md
@@ -23,6 +23,8 @@ This is easy to miss because authoring feels like using: you edit the plugin whi
 
 The repo uses an automated release process to prepare plugin releases, including version selection and changelog generation. Because multiple PRs may merge before the next release, contributors cannot know the final released version from within an individual PR.
 
+**If `bun run release:validate` reports drift, see `docs/solutions/workflow/release-please-version-drift-recovery.md`** for the file-relationship map, the recovery decision tree (forward-sync vs. backward-revert vs. `release-as` pin), and worked examples. That doc answers questions the rules below don't: *why these files are release-managed, how they sync via `extra-files` and `linked-versions`, and what to do when the rules below were violated.*
+
 ### Contributor Rules
 
 - Do **not** manually bump `.claude-plugin/plugin.json` version in a normal feature PR.

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -553,7 +553,7 @@ describe("ce-code-review contract", () => {
     // Autonomous residual handoff step exists between code review and test-browser.
     expect(lfg).toContain("Persist review autofixes")
     expect(lfg).toContain("fix(review): apply autofix feedback")
-    expect(lfg).toContain("Do not proceed to step 6, run browser tests, or output DONE while review autofix edits remain only in the working tree.")
+    expect(lfg).toContain("Do not proceed to step 5, run browser tests, or output DONE while review autofix edits remain only in the working tree.")
     expect(lfg).toContain("there were no review autofixes to persist")
     expect(lfg).toContain("Autonomous residual handoff")
     expect(lfg).toMatch(/Do not prompt the user/)
@@ -569,8 +569,11 @@ describe("ce-code-review contract", () => {
     expect(lfg).toMatch(/no_sink/)
 
     // PR description update path is non-interactive and does not route through
-    // confirmation-driven PR update skills.
-    expect(lfg).not.toContain("ce-commit-push-pr")
+    // confirmation-driven PR update skills. The positive assertion on
+    // `gh pr edit` below is the actual check; a broad `not.toContain` would
+    // falsely trip on step 7's legitimate use of ce-commit-push-pr for the
+    // post-work commit/PR-open step.
+    expect(lfg).toContain("do not load any confirmation-driven PR update skill")
     expect(lfg).toContain("gh pr edit PR_NUMBER --body-file BODY_FILE")
     expect(lfg).toContain("## Residual Review Findings")
     expect(lfg).toContain("docs/residual-review-findings/<branch-or-head-sha>.md")


### PR DESCRIPTION
## Summary

`main`'s CI has been red since four direct-to-main merges bumped `plugins/compound-engineering/.claude-plugin/plugin.json` past the other plugin manifests (3.0.3 to 3.0.7) without syncing the cursor, codex, release-please manifest, or linked cli files. This PR unblocks CI by forward-syncing everything to 3.0.7, repairs a stale test assertion that was hiding behind the release-validate failure, and ships a recovery playbook so this class of drift doesn't eat hours of investigation next time.

## Drift recovery

Forward-sync rather than revert because anyone running `compound-engineering` from a local `main` checkout already has 3.0.7 in their plugin cache. Reverting to 3.0.3 would orphan those caches and trip version-regression warnings in tooling that treats the version field as monotonic. Forward-sync preserves semver monotonicity with zero regression for any current install.

The 5 version fields now agree at 3.0.7:

| File | Field |
|---|---|
| `plugins/compound-engineering/.cursor-plugin/plugin.json` | `$.version` |
| `plugins/compound-engineering/.codex-plugin/plugin.json` | `$.version` |
| `.github/.release-please-manifest.json` | `plugins/compound-engineering` |
| `.github/.release-please-manifest.json` | `.` (cli, via `linked-versions`) |
| `package.json` | `$.version` (cli extra-file) |

The release-please manifest edit is intentional. Release-please's own docs call out manual manifest edits as the correct recovery pattern for out-of-band releases. Without it, the next release-please run would compute the next version from 3.0.3 and overwrite extra-files downward, regressing any user on 3.0.7.

## Stale test fix

Commit `1f20c384 feat(lfg): add ce-commit-push-pr step and remove ralph-loop` renumbered steps in `lfg/SKILL.md` but did not update two assertions in `tests/review-skill-contract.test.ts`. Fix: `"step 6"` becomes `"step 5"` (residual handoff is the chronologically-next step after persisting autofixes), and the now-over-broad `not.toContain("ce-commit-push-pr")` becomes a positive assertion on step 5's `"do not load any confirmation-driven PR update skill"` phrase. The intent the broad check was trying to express is preserved; step 7's legitimate use of `ce-commit-push-pr` no longer trips it.

## Recovery playbook

New doc at `docs/solutions/workflow/release-please-version-drift-recovery.md` captures:

- The file-relationship map (extra-files + manifest + `linked-versions`)
- How release-please reads the manifest and writes extra-files
- The recovery decision tree: forward-sync vs. backward-revert vs. `release-as` pin, with user-install impact as the tiebreaker
- When manifest manual edits are legitimate (out-of-band recovery only)
- The 2026-04-24 incident as a worked example

Root `AGENTS.md` gains a `Merge policy` bullet making the "all changes via PR" rule explicit. Plugin `AGENTS.md` "Versioning Requirements" gets a one-line pointer to the new playbook so anyone hitting `release:validate` drift lands on the recovery doc first.

## Verification

`bun run release:validate`: in sync. `bun test`: 906 / 906.

## Follow-up

Kieran: please enable branch protection on `main` requiring the `test` status check before merge, with admin bypass off or reserved for emergencies. The new `Merge policy` rule is honor-system without branch protection, which this incident showed is not enough. The drift crept in across `1f20c384`, `f8720da3`, `22d493b1`, and `47350c3e`, all direct merges.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)
