### PR TITLE
fix(ce-code-review): restate model override at dispatch point

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -402,7 +402,7 @@ Pass the resulting path list to the `project-standards` persona inside a `<stand
 
 Three reviewers inherit the session model with no override: `ce-correctness-reviewer`, `ce-security-reviewer`, and `ce-adversarial-reviewer`. These perform the highest-stakes analysis — logic bugs, security vulnerabilities, adversarial failure scenarios — and should run at whatever capability level the user has configured. If the user is on Opus, these get Opus.
 
-All other persona sub-agents and CE agents use the platform's mid-tier model to reduce cost and latency. In Claude Code, pass `model: "sonnet"` in the Agent tool call. On other platforms, use the equivalent mid-tier (e.g., `gpt-5.4-mini` in Codex as of April 2026). If the platform has no model override mechanism or the available model names are unknown, omit the model parameter and let agents inherit the default -- a working review on the parent model is better than a broken dispatch from an unrecognized model name.
+All other persona sub-agents and CE agents use the platform's mid-tier model to reduce cost and latency. See the Spawning subsection below for the exact dispatch-time override — the imperative lives there so it lands at the point of action when spawning many agents in parallel.
 
 The orchestrator (this skill) also inherits the session model; it handles intent discovery, reviewer selection, finding merge/dedup, and synthesis -- tasks that benefit from the same reasoning capability the user configured.
 
@@ -422,6 +422,8 @@ Pass `{run_id}` to every persona sub-agent so they can write their full analysis
 #### Spawning
 
 Omit the `mode` parameter when dispatching sub-agents so the user's configured permission settings apply. Do not pass `mode: "auto"`.
+
+**Model override at dispatch time.** Pass the platform's mid-tier model on every dispatch except `ce-correctness-reviewer`, `ce-security-reviewer`, and `ce-adversarial-reviewer`, which inherit the session model (per the Model tiering subsection above). In Claude Code, add `model: "sonnet"` to the `Agent` tool call. In Codex, pass the equivalent mid-tier on `spawn_agent` (e.g., `gpt-5.4-mini` as of April 2026). In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name. Check this on every Agent / `spawn_agent` / `subagent` call in the parallel dispatch; omitting it on Opus sessions silently 3-4x's the cost of a review.
 
 Spawn each selected persona reviewer as a parallel sub-agent using the subagent template included below. Each persona sub-agent receives:
 

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -283,6 +283,31 @@ describe("ce-code-review contract", () => {
     expect(template).toMatch(/Do not default to `gated_auto` when the fix is mechanical/i)
   })
 
+  test("Stage 4 spawning restates model-override imperative at point of action", async () => {
+    const content = await readRepoFile("plugins/compound-engineering/skills/ce-code-review/SKILL.md")
+
+    // Model tiering subsection still enumerates the three session-model exceptions
+    expect(content).toMatch(/ce-correctness-reviewer.*ce-security-reviewer.*ce-adversarial-reviewer/s)
+
+    // Imperative lives inside the Spawning subsection, not only in the rationale block.
+    // Extract the Spawning subsection and assert the model-override directive appears there
+    // with cross-platform dispatch primitives named at the call site.
+    const spawningMatch = content.match(/#### Spawning\n([\s\S]*?)(?=\n####|\n### )/)
+    expect(spawningMatch).not.toBeNull()
+    const spawning = spawningMatch![1]
+
+    expect(spawning).toMatch(/Model override at dispatch time/)
+    expect(spawning).toContain('model: "sonnet"')
+    expect(spawning).toContain("Agent")
+    expect(spawning).toContain("spawn_agent")
+    expect(spawning).toContain("subagent")
+    // Exceptions are restated at point of action so the agent does not have to recall them
+    // from the Model tiering subsection above during a 12-agent parallel dispatch.
+    expect(spawning).toContain("ce-correctness-reviewer")
+    expect(spawning).toContain("ce-security-reviewer")
+    expect(spawning).toContain("ce-adversarial-reviewer")
+  })
+
   test("Stage 5 synthesis uses anchor gate and one-anchor promotion", async () => {
     const content = await readRepoFile("plugins/compound-engineering/skills/ce-code-review/SKILL.md")
 


### PR DESCRIPTION
Reviewers were dispatching on the session model (Opus 4.7) instead of the mid-tier Sonnet the skill directs, burning through usage on persona reviewers that don't need frontier reasoning. The root cause was placement: the `model: "sonnet"` imperative lived only in a prose "Model tiering" rationale subsection, separated from the "Spawning" subsection that governs actual dispatch. Under 12-agent parallel dispatch, that upstream paragraph fell out of attention.

The fix restates the imperative inside Spawning alongside the existing `mode` paragraph. The 3 session-model exception reviewers (`ce-correctness-reviewer`, `ce-security-reviewer`, `ce-adversarial-reviewer`) are named inline, and the directive covers all cross-platform dispatch primitives (`Agent` in Claude Code, `spawn_agent` in Codex, `subagent` in Pi). The existing "omit if unknown" fallback is preserved for platforms without a model-override parameter. A contract test locks the imperative inside the Spawning subsection so it cannot drift back out to rationale.

Fixes #679

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)