### PR TITLE
fix(ce-demo-reel): wait for network idle and reject blank frames

### DIFF
--- a/plugins/compound-engineering/skills/ce-demo-reel/references/tier-browser-reel.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/references/tier-browser-reel.md
@@ -72,7 +72,11 @@ agent-browser open [URL]
 ```
 
 ```bash
-agent-browser wait 2000
+agent-browser wait --load networkidle
+```
+
+```bash
+agent-browser wait 1000
 ```
 
 ```bash
@@ -81,7 +85,8 @@ agent-browser screenshot [RUN_DIR]/frame-01-initial.png
 
 **Capture tips:**
 - Use URL navigation (`agent-browser open URL`) rather than clicking SPA elements (clicks often fail on React/Vue/Svelte SPAs)
-- Wait 2-3 seconds after navigation for the page to settle
+- Wait for `--load networkidle` after navigation, then a short fixed buffer for any post-fetch render. A fixed `wait 2000` alone is not enough on SPAs that fetch data after paint -- screenshots will capture the empty shell.
+- For pages that keep network activity open (websockets, long-polling), use `agent-browser wait --text "<known content>"` to wait for a specific string from the populated UI, or `agent-browser wait --fn "<expression>"` for a custom readiness condition.
 - Capture the full viewport (sidebar, header give reviewers context)
 
 **Keep secrets out of frame:**

--- a/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
+++ b/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
@@ -325,9 +325,12 @@ def _stitch_frames(output, frames, duration=3.0, min_frame_bytes=DEFAULT_MIN_FRA
             if size < min_frame_bytes:
                 die(
                     f"Frame {f} is {size} bytes, below the {min_frame_bytes}-byte minimum. "
-                    f"This usually means the page had not finished loading when the screenshot was taken. "
-                    f"Re-capture after `agent-browser wait --load networkidle`, or pass --min-frame-bytes "
-                    f"to lower the threshold if the small frame is intentional."
+                    f"PNG size is dominated by entropy, so this is usually -- but not always -- "
+                    f"a page that had not finished loading when the screenshot was taken. "
+                    f"If the page is genuinely loaded but compresses small (flat-color UI, "
+                    f"sparse empty state, small viewport), pass --min-frame-bytes 0 to disable "
+                    f"the check, or a smaller positive value to lower the threshold. "
+                    f"Otherwise, re-capture after `agent-browser wait --load networkidle`."
                 )
 
     if not check_tool("ffmpeg"):

--- a/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
+++ b/plugins/compound-engineering/skills/ce-demo-reel/scripts/capture-demo.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 MAX_GIF_SIZE = 10 * 1024 * 1024   # 10 MB — GitHub inline render limit
 TARGET_GIF_SIZE = 5 * 1024 * 1024  # 5 MB — preferred target
+DEFAULT_MIN_FRAME_BYTES = 20 * 1024  # Below this a screenshot is almost certainly blank
 CATBOX_API = "https://catbox.moe/user/api.php"
 LITTERBOX_API = "https://litterbox.catbox.moe/resources/internals/api.php"
 
@@ -312,13 +313,22 @@ def _get_frame_dimensions(path):
     return int(parts[0]), int(parts[1])
 
 
-def _stitch_frames(output, frames, duration=3.0):
+def _stitch_frames(output, frames, duration=3.0, min_frame_bytes=DEFAULT_MIN_FRAME_BYTES):
     if not frames:
         die("No input frames provided")
 
     for f in frames:
         if not Path(f).exists():
             die(f"Frame not found: {f}")
+        if min_frame_bytes > 0:
+            size = Path(f).stat().st_size
+            if size < min_frame_bytes:
+                die(
+                    f"Frame {f} is {size} bytes, below the {min_frame_bytes}-byte minimum. "
+                    f"This usually means the page had not finished loading when the screenshot was taken. "
+                    f"Re-capture after `agent-browser wait --load networkidle`, or pass --min-frame-bytes "
+                    f"to lower the threshold if the small frame is intentional."
+                )
 
     if not check_tool("ffmpeg"):
         die("ffmpeg is not installed. Install with: brew install ffmpeg")
@@ -413,7 +423,7 @@ def _stitch_frames(output, frames, duration=3.0):
                 if len(reduced) < len(frames):
                     print(f"  Reduced from {len(frames)} to {len(reduced)} frames")
                     shutil.rmtree(tmpdir, ignore_errors=True)
-                    _stitch_frames(output, reduced, duration)
+                    _stitch_frames(output, reduced, duration, min_frame_bytes)
                     return
             print("  WARNING: Could not reduce below 10 MB. GIF may not render inline on GitHub.")
         elif size > TARGET_GIF_SIZE:
@@ -424,7 +434,7 @@ def _stitch_frames(output, frames, duration=3.0):
 
 
 def cmd_stitch(args):
-    _stitch_frames(args.output, args.frames, args.duration)
+    _stitch_frames(args.output, args.frames, args.duration, args.min_frame_bytes)
 
 
 # --- Screenshot Reel ---
@@ -459,7 +469,9 @@ def cmd_screenshot_reel(args):
             frame_pngs.append(out_png)
 
         print(f"Rendered {len(frame_pngs)} frames via silicon")
-        _stitch_frames(args.output, frame_pngs, args.duration)
+        # silicon-rendered code frames are predictably small; the blank-screenshot
+        # guard does not apply to this tier.
+        _stitch_frames(args.output, frame_pngs, args.duration, min_frame_bytes=0)
 
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
@@ -710,6 +722,13 @@ Commands:
     # stitch
     p_stitch = sub.add_parser("stitch", help="Stitch frames into animated GIF")
     p_stitch.add_argument("--duration", type=float, default=3.0, help="Seconds per frame")
+    p_stitch.add_argument(
+        "--min-frame-bytes", type=int, default=DEFAULT_MIN_FRAME_BYTES,
+        help=(
+            "Minimum bytes per frame; smaller frames almost always mean a blank screenshot. "
+            "Set to 0 to disable the check."
+        ),
+    )
     p_stitch.add_argument("output", help="Output GIF path")
     p_stitch.add_argument("frames", nargs="+", help="Input frame PNGs")
 

--- a/tests/ce-demo-reel.test.ts
+++ b/tests/ce-demo-reel.test.ts
@@ -305,6 +305,27 @@ describe("capture-evidence.py", () => {
       expect(exitCode).toBe(1)
       expect(stderr).toContain("File not found")
     })
+
+    test("stitch fails fast when a frame is below the minimum size", async () => {
+      // Regression: blank screenshots from SPAs were stitched and uploaded silently.
+      // _stitch_frames must reject frames smaller than --min-frame-bytes (default 20480)
+      // before invoking ffmpeg, naming the offending file.
+      const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "evidence-blank-"))
+      try {
+        const tinyPng = createTestPng([10, 10, 10])
+        const tinyPath = path.join(tmp, "blank.png")
+        await fs.writeFile(tinyPath, tinyPng)
+
+        const out = path.join(tmp, "out.gif")
+        const { exitCode, stderr } = await run("stitch", out, tinyPath)
+
+        expect(exitCode).toBe(1)
+        expect(stderr).toContain("blank.png")
+        expect(stderr.toLowerCase()).toContain("min")
+      } finally {
+        await fs.rm(tmp, { recursive: true, force: true })
+      }
+    })
   })
 
   // --- Stitch integration (requires ffmpeg) ---
@@ -345,7 +366,7 @@ describe("capture-evidence.py", () => {
 
       const output = path.join(tmpDir, "output.gif")
       const { exitCode, stdout } = await run(
-        "stitch", "--duration", "0.5", output,
+        "stitch", "--duration", "0.5", "--min-frame-bytes", "0", output,
         path.join(tmpDir, "frame1.png"),
         path.join(tmpDir, "frame2.png"),
       )
@@ -372,7 +393,7 @@ describe("capture-evidence.py", () => {
 
       const output = path.join(tmpDir, "output3.gif")
       const { exitCode, stdout } = await run(
-        "stitch", "--duration", "0.5", output,
+        "stitch", "--duration", "0.5", "--min-frame-bytes", "0", output,
         path.join(tmpDir, "frame1.png"),
         path.join(tmpDir, "frame2.png"),
         path.join(tmpDir, "frame3.png"),
@@ -390,7 +411,7 @@ describe("capture-evidence.py", () => {
 
       const output = path.join(tmpDir, "output-default-dur.gif")
       const { exitCode, stdout } = await run(
-        "stitch", output,
+        "stitch", "--min-frame-bytes", "0", output,
         path.join(tmpDir, "frame1.png"),
         path.join(tmpDir, "frame2.png"),
       )


### PR DESCRIPTION
## Summary

`/ce-demo-reel` previously uploaded blank GIFs to catbox without warning when run against React or Next.js apps that fetch data after initial paint. The fixed `agent-browser wait 2000` returned before the data arrived, so screenshots captured an empty shell, and the stitch pipeline checked only that frame files existed, not that they had real content. The end result was a "successful" run reporting a public URL pointing at a near-empty GIF.

## Fix

Two layers, so a regression in either still fails safely:

- **Wait for network idle, not a fixed timer.** `tier-browser-reel.md` now uses `agent-browser wait --load networkidle` followed by a short fixed buffer for any post-fetch render. Capture tips also recommend `--text "<known content>"` and `--fn "<expression>"` for sites with persistent network activity (websockets, long-polling) where `networkidle` would never fire.
- **Reject suspiciously small frames before stitching.** `capture-demo.py:_stitch_frames` now enforces a 20 KB minimum per frame, configurable via `--min-frame-bytes` (set to `0` to disable). The error names the offending file, its actual size, and points at the network-idle wait. The silicon `screenshot-reel` caller passes `0` because rendered code frames are legitimately small.

A regression test in `tests/ce-demo-reel.test.ts` creates a tiny synthetic PNG and asserts the stitch command exits non-zero with a message identifying the file. Existing happy-path stitch tests pass `--min-frame-bytes 0` since their 1x1 fixtures are not real screenshots.

Closes #689.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)