### PR TITLE
fix(ce-resolve-pr-feedback): add declined verdict for harmful suggestions

### DIFF
--- a/plugins/compound-engineering/agents/ce-pr-comment-resolver.agent.md
+++ b/plugins/compound-engineering/agents/ce-pr-comment-resolver.agent.md
@@ -39,9 +39,10 @@ Before touching any code, read the referenced file and classify the feedback:
 
 4. **Would fixing improve the code?**
    - YES -> verdict: `fixed` (or `fixed-differently` if using a better approach than suggested)
+   - NO, the suggested fix would actively make the code worse (violates a project rule in CLAUDE.md/AGENTS.md, adds dead defensive code, suppresses errors that should propagate, premature abstraction, restates code in comments) -> verdict: `declined` with the specific harm cited
    - UNCERTAIN -> default to fixing. Agent time is cheap.
 
-**Default to fixing.** The bar for skipping is "the reviewer is factually wrong about the code." Not "this is low priority." If we're looking at it, fix it.
+**Default to fixing.** The bar for skipping is "the reviewer is factually wrong about the code" (`not-addressing`) or "the suggested fix would actively make the code worse" (`declined`). Not "this is low priority." When in doubt, fix it.
 
 **Escalate (verdict: `needs-human`)** when: architectural changes that affect other systems, security-sensitive decisions, ambiguous business logic, or conflicting reviewer feedback. This should be rare -- most feedback has a clear right answer.
 
@@ -82,6 +83,13 @@ For not-addressing:
 Not addressing: [reason with evidence, e.g., "null check already exists at line 85"]
 ```
 
+For declined:
+```markdown
+> [quote the relevant part of the reviewer's comment]
+
+Declined: [specific harm cited, e.g., "this would add a defensive null check the type system already guarantees" or "violates the no-premature-abstraction guidance in CLAUDE.md"]
+```
+
 For needs-human -- do the investigation work before escalating. Don't punt with "this is complex." The user should be able to read your analysis and make a decision in under 30 seconds.
 
 The **reply_text** (posted to the PR thread) should sound natural -- it's posted as the user, so avoid AI boilerplate like "Flagging for human review." Write it as the PR author would:
@@ -118,7 +126,7 @@ recommend, say so and explain what additional context would tip the decision.]
 5. **Return the summary** -- this is your final output to the parent:
 
 ```
-verdict: [fixed | fixed-differently | replied | not-addressing | needs-human]
+verdict: [fixed | fixed-differently | replied | not-addressing | declined | needs-human]
 feedback_id: [the thread ID or comment ID]
 feedback_type: [review_thread | pr_comment | review_body]
 reply_text: [the full markdown reply to post]

--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash(gh *), Bash(git *), Read
 Evaluate and fix PR review feedback, then reply and resolve threads. Spawns parallel agents for each thread.
 
 > **Agent time is cheap. Tech debt is expensive.**
-> Fix everything valid -- including nitpicks and low-priority items. If we're already in the code, fix it rather than punt it.
+> Fix everything valid -- including nitpicks and low-priority items. If we're already in the code, fix it rather than punt it. Narrow exception: when implementing the suggested fix would actively make the code worse (violates a project rule in CLAUDE.md/AGENTS.md, adds dead defensive code, suppresses errors that should propagate, premature abstraction, restates code in comments), use the `declined` verdict and cite the specific harm. When in doubt, fix it.
 
 ## Security
 
@@ -168,7 +168,7 @@ The cluster agent reads the broader area before making targeted fixes. It return
 #### Agent return format
 
 Each agent returns a short summary:
-- **verdict**: `fixed`, `fixed-differently`, `replied`, `not-addressing`, or `needs-human`
+- **verdict**: `fixed`, `fixed-differently`, `replied`, `not-addressing`, `declined`, or `needs-human`
 - **feedback_id**: the thread ID or comment ID it handled
 - **feedback_type**: `review_thread`, `pr_comment`, or `review_body`
 - **reply_text**: the markdown reply to post (quoting the relevant part of the original feedback)
@@ -183,6 +183,7 @@ Verdict meanings:
 - `fixed-differently` -- code change made, but with a better approach than suggested
 - `replied` -- no code change needed; answered a question, acknowledged feedback, or explained a design decision
 - `not-addressing` -- feedback is factually wrong about the code; skip with evidence
+- `declined` -- observation may be valid, but implementing the suggested fix would actively make the code worse; reply cites the specific harm
 - `needs-human` -- cannot determine the right action; needs user decision
 
 #### Batching and conflict avoidance
@@ -197,7 +198,7 @@ Fixes can occasionally expand beyond their referenced file (e.g., renaming a met
 
 ### 6. Validate Combined State
 
-After all agents complete, aggregate `files_changed` across every returned summary (individual and cluster alike). If it's empty -- all verdicts are `replied`, `not-addressing`, or `needs-human` -- skip steps 6 and 7 entirely and proceed to step 8.
+After all agents complete, aggregate `files_changed` across every returned summary (individual and cluster alike). If it's empty -- all verdicts are `replied`, `not-addressing`, `declined`, or `needs-human` -- skip steps 6 and 7 entirely and proceed to step 8.
 
 Resolvers run only targeted tests on their own changes. This step runs the project's full validation **once** against the combined diff to catch cross-agent interactions that targeted runs can't see.
 
@@ -247,6 +248,13 @@ For items not addressed:
 > [quoted relevant part of original feedback]
 
 Not addressing: [reason with evidence, e.g., "null check already exists at line 85"]
+```
+
+For declined items:
+```markdown
+> [quoted relevant part of original feedback]
+
+Declined: [specific harm cited, e.g., "this would add a defensive null check the type system already guarantees" or "violates the no-premature-abstraction guidance in CLAUDE.md"]
 ```
 
 For `needs-human` verdicts, post the reply but do NOT resolve the thread. Leave it open for human input.
@@ -304,6 +312,7 @@ Fixed (count): [brief description of each fix]
 Fixed differently (count): [what was changed and why the approach differed]
 Replied (count): [what questions were answered]
 Not addressing (count): [what was skipped and why]
+Declined (count): [what was declined and the harm cited]
 
 Validation: [one line -- e.g., "bun test passed (893/893)" or "bun test passed with pre-existing failure in X noted"; omit when no code changes were committed]
 ```


### PR DESCRIPTION
PR review agents previously had only one skip path: `not-addressing`, defined as "feedback is factually wrong about the code." That left no exit when a reviewer's observation was valid but the suggested fix would actively make the code worse: defensive checks the type system already guarantees, suppressed errors, premature abstraction, comments that restate code.

This adds a `declined` verdict alongside `not-addressing`, scoped to cases where the agent can cite a concrete harm or a project rule in CLAUDE.md/AGENTS.md the fix would violate. The reply on the PR thread cites the specific harm so the reviewer can push back if the call was wrong.

Default behavior is unchanged. The skill still fixes every valid comment, including nitpicks. There is no new evaluation gate and no per-fix overhead. `declined` is one more option in the verdict list the agent already chooses from, firing only when the agent can name the concrete harm.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)