### PR TITLE
fix(ce-work-beta): defer model and reasoning effort to Codex config

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -8,5 +8,5 @@
 # work_delegate_consent: true    # true | false (default: false)
 # work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
 # work_delegate_decision: auto   # auto | ask (default: auto)
-# work_delegate_model: gpt-5.4  # any valid codex model (default: gpt-5.4)
-# work_delegate_effort: high     # minimal | low | medium | high | xhigh (default: high)
+# work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)

--- a/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
+++ b/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
@@ -8,5 +8,5 @@
 # work_delegate_consent: true    # true | false (default: false)
 # work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
 # work_delegate_decision: auto   # auto | ask (default: auto)
-# work_delegate_model: gpt-5.4  # any valid codex model (default: gpt-5.4)
-# work_delegate_effort: high     # minimal | low | medium | high | xhigh (default: high)
+# work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -49,15 +49,15 @@ If the block above contains YAML key-value pairs, extract values for the keys li
 If it shows `__NO_CONFIG__`, the file does not exist — all settings fall through to defaults.
 If it shows an unresolved command string, read `.compound-engineering/config.local.yaml` from the repo root using the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the file does not exist, all settings fall through to defaults.
 
-If any setting has an unrecognized value, fall through to the hard default for that setting.
+If any setting has an unrecognized value, fall through to the hard default for that setting. For optional settings without a hard default (`work_delegate_model`, `work_delegate_effort`), an unrecognized or unparseable value resolves to **unset** — the corresponding flag is omitted from the `codex exec` invocation so Codex resolves from `~/.codex/config.toml`. Never substitute an invalid value into the CLI flags.
 
 Config keys:
 - `work_delegate` -- `codex` or default `false`
 - `work_delegate_consent` -- `true` or default `false`
 - `work_delegate_sandbox` -- `yolo` (default) or `full-auto`
 - `work_delegate_decision` -- `auto` (default) or `ask`
-- `work_delegate_model` -- Codex model to use. Optional — when unset, defers to the user's `~/.codex/config.toml` default. Passthrough — any valid model name accepted.
-- `work_delegate_effort` -- `minimal`, `low`, `medium`, `high`, or `xhigh`. Optional — when unset, defers to the user's `~/.codex/config.toml` default.
+- `work_delegate_model` -- Codex model to use. Optional — when unset or unparseable, defers to the user's `~/.codex/config.toml` default. Passthrough — any non-empty string is accepted as valid; only YAML parse failures or empty values resolve to unset.
+- `work_delegate_effort` -- one of `minimal`, `low`, `medium`, `high`, or `xhigh`. Optional — when unset or set to a value outside this enum, resolves to unset and defers to the user's `~/.codex/config.toml` default.
 
 Store the resolved state for downstream consumption:
 - `delegation_active` -- boolean, whether delegation mode is on

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -56,16 +56,16 @@ Config keys:
 - `work_delegate_consent` -- `true` or default `false`
 - `work_delegate_sandbox` -- `yolo` (default) or `full-auto`
 - `work_delegate_decision` -- `auto` (default) or `ask`
-- `work_delegate_model` -- Codex model to use (default `gpt-5.4`). Passthrough — any valid model name accepted.
-- `work_delegate_effort` -- `minimal`, `low`, `medium`, `high` (default), or `xhigh`
+- `work_delegate_model` -- Codex model to use. Optional — when unset, defers to the user's `~/.codex/config.toml` default. Passthrough — any valid model name accepted.
+- `work_delegate_effort` -- `minimal`, `low`, `medium`, `high`, or `xhigh`. Optional — when unset, defers to the user's `~/.codex/config.toml` default.
 
 Store the resolved state for downstream consumption:
 - `delegation_active` -- boolean, whether delegation mode is on
 - `delegation_source` -- `argument` or `config` or `default` -- how delegation was resolved (used by environment guard to decide notification verbosity)
 - `sandbox_mode` -- `yolo` or `full-auto` (from config or default `yolo`)
 - `consent_granted` -- boolean (from config `work_delegate_consent`)
-- `delegate_model` -- string (from config or default `gpt-5.4`)
-- `delegate_effort` -- string (from config or default `high`)
+- `delegate_model` -- string from config, or unset (defer to Codex config)
+- `delegate_effort` -- string from config, or unset (defer to Codex config)
 
 ---
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -231,19 +231,24 @@ else
 fi
 
 codex exec \
-  -m "<delegate_model>" \
-  -c 'model_reasoning_effort="<delegate_effort>"' \
   $SANDBOX_FLAG \
   --output-schema "<scratch-dir>/result-schema.json" \
   -o "<scratch-dir>/result-batch-<batch-num>.json" \
   - < "<scratch-dir>/prompt-batch-<batch-num>.md"
 ```
 
+**Conditional flags** — only include each line when the corresponding skill-state value is set:
+
+- If `delegate_model` is set, insert `  -m "<delegate_model>" \` as a line before `$SANDBOX_FLAG`.
+- If `delegate_effort` is set, insert `  -c 'model_reasoning_effort="<delegate_effort>"' \` as a line before `$SANDBOX_FLAG`.
+
+When either value is unset, omit its line entirely — Codex resolves the default from the user's `~/.codex/config.toml` (and ultimately the CLI's own built-in default). Do not substitute a placeholder string for unset values.
+
 Critical: `run_in_background: true` must be set as a **Bash tool parameter**, not as a shell `&` suffix. The tool parameter is what removes the timeout ceiling. A shell `&` inside a foreground Bash call still hits the 2-minute default timeout.
 
-Quoting is critical for the `-c` flag: use single quotes around the entire key=value and double quotes around the TOML string value inside. Example: `-c 'model_reasoning_effort="high"'`.
+Quoting is critical for the `-c` flag when present: use single quotes around the entire key=value and double quotes around the TOML string value inside. Example: `-c 'model_reasoning_effort="high"'`.
 
-Do not improvise CLI flags or modify this invocation template.
+Do not improvise CLI flags or modify this invocation template beyond the documented conditional insertions.
 
 **Step B — Poll (foreground, separate Bash calls):**
 


### PR DESCRIPTION
## Summary

- `work_delegate_model` and `work_delegate_effort` are now optional with no baked-in default. When unset, the skill omits `-m` and `-c 'model_reasoning_effort=...'` from `codex exec` so Codex resolves from `~/.codex/config.toml` (and ultimately the CLI's own default).
- Users can still pin a model or effort via `.compound-engineering/config.local.yaml` if they want to deviate from their global Codex config — that path is unchanged.
- Example configs and the ce-setup template now describe the keys as "omit to use ~/.codex/config.toml default" rather than advertising `gpt-5.4`/`high` as our defaults.

The previous behavior forced two ongoing problems: chasing new model names inside skill content as Codex evolves, and silently overriding whatever default the user already configured for Codex globally.

## Files changed

- `plugins/compound-engineering/skills/ce-work-beta/SKILL.md` — config keys reframed as optional; resolved state may be unset.
- `plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md` — `-m` and `-c` lines lifted out of the `codex exec` template into a "Conditional flags" block that inserts each line only when the corresponding skill-state value is set.
- `.compound-engineering/config.local.example.yaml`, `plugins/compound-engineering/skills/ce-setup/references/config-template.yaml` — comments updated.

Stable/beta sync: not propagating to `ce-work` — codex delegation only exists in beta.

## Test plan

- [ ] With no `work_delegate_model`/`work_delegate_effort` in config: confirm `codex exec` invocation has neither `-m` nor `-c 'model_reasoning_effort=...'` (Codex picks up `~/.codex/config.toml`).
- [ ] With `work_delegate_model: gpt-5.4` set: confirm `-m "gpt-5.4"` is included.
- [ ] With `work_delegate_effort: medium` set: confirm `-c 'model_reasoning_effort="medium"'` is included.
- [ ] `bun run release:validate` passes (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)