### PR TITLE
fix(ce-plan): inline post-generation menu routing so option 1 actually starts /ce-work

### DIFF
--- a/docs/solutions/skill-design/post-menu-routing-belongs-inline-2026-04-28.md
+++ b/docs/solutions/skill-design/post-menu-routing-belongs-inline-2026-04-28.md
@@ -1,0 +1,58 @@
+---
+title: Always-on routing for interactive menus belongs inline in SKILL.md, not in references
+date: 2026-04-28
+category: skill-design
+module: compound-engineering
+problem_type: architecture_pattern
+component: ce-plan
+severity: medium
+applies_when:
+  - Authoring a skill that ends in an `AskUserQuestion`-style menu where the user picks the next action
+  - Deciding whether per-option routing belongs in SKILL.md or in a reference file
+  - Reviewing a skill where the agent renders a menu and stops at the user's selection without acting
+tags:
+  - skill-design
+  - menu-routing
+  - skill-md-vs-references
+  - ce-plan
+  - extraction-rule
+  - load-bearing-rules
+related_issue: https://github.com/EveryInc/compound-engineering-plugin/issues/714
+---
+
+## Problem
+
+`ce-plan` Phase 5.4 presented a four-option post-generation menu (`Start /ce-work`, `Create Issue`, `Open in Proof`, `Done for now`). The action that should fire when the user picked an option lived only in `references/plan-handoff.md`. The skill body said "Routing each selection ... lives in `references/plan-handoff.md` — follow it for every branch" plus a "Load `references/plan-handoff.md` now" instruction in 5.3.8.
+
+In practice, agents rendered the menu, captured the user's selection, and stopped without firing the routed action. The user picked "Start `/ce-work` (Recommended)" and watched the agent acknowledge the choice in prose ("User picked Start /ce-work. Handing off — invoke `/ce-work` next") instead of programmatically invoking `ce-work`.
+
+## Root Cause
+
+Two failure modes compounded:
+
+1. **The agent didn't load the reference.** SKILL.md content caches at session start; references load on demand. An agent that renders past the "Load `references/plan-handoff.md` now" instruction on the way to the menu has no per-option routing in its loaded context. The menu becomes a textual handoff with no associated action.
+2. **Even an agent that loaded the reference saw ambiguous language.** The reference said `**Start /ce-work** -> Call /ce-work with the plan path`. That doesn't name the platform's skill-invocation primitive. "Call /ce-work" can be read as "tell the user to type /ce-work in chat" rather than "fire the Skill tool now."
+
+The plugin's own `plugins/compound-engineering/AGENTS.md` "Conditional and Late-Sequence Extraction" section guides extraction: extract content that is *conditional or late-sequence and represents ~20%+ of the skill*. The bare per-option routing was late-sequence (only fires after Phase 5) but **not conditional** — option 1 always means "invoke ce-work," option 4 always means "end the turn." The always-on subset should not have been extracted.
+
+The same AGENTS.md, in "Skill Design Principles," already articulates the underlying rule: *"For load-bearing rules (those that MUST fire reliably), put strong language at the top of the relevant phase in SKILL.md, not just in the reference. References can be skipped; SKILL.md is always loaded."* The post-menu routing satisfies the load-bearing definition. Failing to apply this principle was the authoring mistake.
+
+## Fix
+
+1. Inline a `### Routing` block in SKILL.md Phase 5.4 with one explicit action per menu option. Use platform-explicit invocation language: "Invoke the `ce-work` skill via the platform's skill-invocation primitive (`Skill` in Claude Code, `Skill` in Codex, the equivalent on Gemini/Pi), passing the plan path as the skill argument. Do not merely tell the user to type `/ce-work` — fire the invocation now so the plan executes in this session."
+2. Mirror the same platform-explicit phrasing in `references/plan-handoff.md` so both surfaces converge. The reference still owns the elaborate sub-flows (Proof HITL state machine, Issue Creation tracker detection, post-HITL `ce-doc-review` resync, upload-failure fallback) — those are genuinely conditional and multi-step.
+3. Add a regression test (`tests/skills/ce-plan-handoff-routing.test.ts`) that fails if any of the four inline routing lines disappear, and specifically asserts that the `Start /ce-work` routing names the skill-invocation primitive and the plan path.
+
+## Authoring Checklist for Future Skills
+
+Before extracting a block to a reference file, ask:
+
+- **Is the block always executed when this phase is reached?** If yes, lean toward inlining. References are for branches the agent enters only sometimes.
+- **Does the block carry routing for an interactive menu the skill renders?** If yes, the bare per-option action belongs inline. The elaborate sub-flow for each option (multi-status state machines, retry logic, downstream skill dispatch) can stay in a reference.
+- **Could an agent that skips the reference still complete the skill correctly?** If no — if the agent without the reference would stop or guess — the missing content is load-bearing and belongs inline.
+- **Is the language platform-explicit?** When a routing line says "Call /ce-work," ask whether an agent could read it as "tell the user" rather than "fire the tool." Name the platform primitive (Skill tool, skill-invocation primitive) and the argument shape (plan path, file path).
+
+## Related Patterns
+
+- `docs/solutions/skill-design/git-workflow-skills-need-explicit-state-machines-2026-03-27.md` — same family: skills that render decision points need their state transitions to be deterministic in the loaded context, not one reference-load away.
+- `docs/solutions/skill-design/confidence-anchored-scoring-2026-04-21.md` — load-bearing scoring rubrics also belong inline in SKILL.md so they fire reliably across sessions.

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -884,7 +884,7 @@ When deepening is warranted, read `references/deepening-workflow.md` for confide
 
 ##### 5.3.8–5.4 Document Review, Final Checks, and Post-Generation Options
 
-**Load `references/plan-handoff.md` now.** It contains the full instructions for 5.3.8 (document review), 5.3.9 (final checks and cleanup), and 5.4 (post-generation handoff, including the Proof HITL flow, post-HITL re-review, and Issue Creation branching). Document review is mandatory — do not skip it even if the confidence check already ran.
+**STOP. Load `references/plan-handoff.md` now before continuing.** It carries the full instructions for 5.3.8 (document review), 5.3.9 (final checks and cleanup), and 5.4 (post-generation handoff, including the Proof HITL flow, post-HITL re-review, and Issue Creation branching). **This load is non-optional** — without it, the agent renders the post-generation menu, captures the user's selection, and stops without firing the routed action. Document review at 5.3.8 is also mandatory regardless of whether the confidence check already ran.
 
 After document review and final checks, present this menu using the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
 
@@ -896,7 +896,7 @@ After document review and final checks, present this menu using the platform's b
 3. **Open in Proof (web app) — review and comment to iterate with the agent** - Open the doc in Every's Proof editor, iterate with the agent via comments, or copy a link to share with others
 4. **Done for now** - Pause; the plan file is saved and can be resumed later
 
-**Routing — act on the user's selection, do not just announce it.** The action for each option is stated inline below so it cannot be missed. The elaborate sub-flows (Proof HITL state machine, Issue Creation tracker detection, post-HITL resync) live in `references/plan-handoff.md`; load that reference for those flows.
+**Routing.** Act on the user's selection — do not just announce it. Elaborate sub-flows (Proof HITL state machine, Issue Creation tracker detection, post-HITL resync) live in `references/plan-handoff.md`.
 
 - **Start `/ce-work`** — Invoke the `ce-work` skill via the platform's skill-invocation primitive (`Skill` in Claude Code, `Skill` in Codex, the equivalent on Gemini/Pi), passing the plan path as the skill argument. Do not merely tell the user to type `/ce-work` — fire the invocation now so the plan executes in this session.
 - **Create Issue** — Detect the project tracker (`gh` for GitHub, `linear` for Linear) and create the issue from the plan file as described under "Issue Creation" in `references/plan-handoff.md`. After creation, display the issue URL and ask whether to proceed to `/ce-work` via the platform's blocking question tool.

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -896,8 +896,15 @@ After document review and final checks, present this menu using the platform's b
 3. **Open in Proof (web app) — review and comment to iterate with the agent** - Open the doc in Every's Proof editor, iterate with the agent via comments, or copy a link to share with others
 4. **Done for now** - Pause; the plan file is saved and can be resumed later
 
-Routing each selection, contextual surfacing of residual document-review findings, and the post-HITL resync logic all live in `references/plan-handoff.md` — follow it for every branch.
+**Routing — act on the user's selection, do not just announce it.** The action for each option is stated inline below so it cannot be missed. The elaborate sub-flows (Proof HITL state machine, Issue Creation tracker detection, post-HITL resync) live in `references/plan-handoff.md`; load that reference for those flows.
 
-**Completion check:** This skill is not complete until the post-generation menu above has been presented and the user has selected an action. If you have written the plan file and have not yet presented the menu, you are not done — go to the load instruction above and continue.
+- **Start `/ce-work`** — Invoke the `ce-work` skill via the platform's skill-invocation primitive (`Skill` in Claude Code, `Skill` in Codex, the equivalent on Gemini/Pi), passing the plan path as the skill argument. Do not merely tell the user to type `/ce-work` — fire the invocation now so the plan executes in this session.
+- **Create Issue** — Detect the project tracker (`gh` for GitHub, `linear` for Linear) and create the issue from the plan file as described under "Issue Creation" in `references/plan-handoff.md`. After creation, display the issue URL and ask whether to proceed to `/ce-work` via the platform's blocking question tool.
+- **Open in Proof (web app) — review and comment to iterate with the agent** — Load the `ce-proof` skill in HITL-review mode with the plan file as `source file`, the plan title as `doc title`, identity `ai:compound-engineering` / `Compound Engineering`, and recommended next step `/ce-work`. Then follow the post-HITL resync logic in `references/plan-handoff.md`, which handles the four `ce-proof` return statuses, re-runs `ce-doc-review` after material edits, and falls back gracefully on upload failure.
+- **Done for now** — Display a brief confirmation that the plan file is saved and end the turn. Do not start follow-up work without an explicit further user prompt.
+
+If the user asks for another document review (either from a contextual prompt about residual findings or via free-form request), load the `ce-doc-review` skill with the plan path for another pass and then return to this menu. For free-text revisions outside the four options, accept the input and loop back to this menu after applying the revision.
+
+**Completion check:** This skill is not complete until the post-generation menu above has been presented, the user has selected an action, and the inline routing for that selection has been executed. Presenting the menu and stopping at the user's selection is not completion — fire the routed action.
 
 **Pipeline mode exception:** In LFG or any `disable-model-invocation` context, skip the interactive menu and return control to the caller after the plan file is written, confidence check has run, and `ce-doc-review` has run in headless mode (per `references/plan-handoff.md`).

--- a/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
@@ -45,8 +45,8 @@ After document-review completes, present the options using the platform's blocki
 
 **Surface additional document review contextually, not as a menu fixture:** When the prior document-review pass surfaced residual P0/P1 findings that the user has not addressed, mention them adjacent to the menu and offer another review pass in prose (e.g., "Document review flagged 2 P1 findings you may want to address — want me to run another pass before you pick?"). Do not add it to the option list.
 
-Based on selection:
-- **Start `/ce-work`** -> Call `/ce-work` with the plan path
+Based on selection (the bare per-option routing is also stated inline in the SKILL.md so it cannot be missed when this reference is not loaded; the elaborate sub-flows below are the reason this reference still exists):
+- **Start `/ce-work`** -> Invoke the `ce-work` skill via the platform's skill-invocation primitive (`Skill` in Claude Code, `Skill` in Codex, the equivalent on Gemini/Pi), passing the plan path as the skill argument. Do not merely tell the user to type `/ce-work` — fire the invocation now so the plan executes in this session.
 - **Create Issue** -> Follow the Issue Creation section below
 - **Open in Proof (web app) — review and comment to iterate with the agent** -> Load the `ce-proof` skill in HITL-review mode with:
   - source file: `docs/plans/<plan_filename>.md`
@@ -63,7 +63,7 @@ Based on selection:
   - `status: aborted` -> fall back to the options without changes.
 
   If the initial upload fails (network error, Proof API down), retry once after a short wait. If it still fails, tell the user the upload didn't succeed and briefly explain why, then return to the options — don't leave them wondering why the option did nothing.
-- **Done for now** -> Display a brief confirmation that the plan file is saved and end the turn
+- **Done for now** -> Display a brief confirmation that the plan file is saved and end the turn. Do not start follow-up work without an explicit further user prompt.
 - **If the user asks for another document review** (either from the contextual prompt when P0/P1 findings remain, or by free-form request) -> Load the `ce-doc-review` skill with the plan path for another pass, then return to the options
 - **Other** -> Accept free text for revisions and loop back to options
 

--- a/tests/skills/ce-plan-handoff-routing.test.ts
+++ b/tests/skills/ce-plan-handoff-routing.test.ts
@@ -57,9 +57,14 @@ describe("ce-plan post-generation menu routing", () => {
 
     for (const { name, fragment } of optionFragments) {
       const escaped = fragment.replace(/[.*+?^${}()|[\]\\`]/g, "\\$&")
-      // Bullet form: `- **...<fragment>...**` followed by separator + action.
+      // Bullet form: `- **...<fragment>...**` followed by separator + action,
+      // ALL on the same line. Use `[ \t]*` for the inter-token gaps instead of
+      // `\s*` so a bullet with no action text cannot match by spilling into the
+      // next bullet's leading `-` (Codex P2 catch on PR #715: `\s*` consumed
+      // newlines, letting an empty-action bullet pass the regex). The trailing
+      // `[^\n]+` requires at least one non-newline character of action text.
       const inlineRoutingPattern = new RegExp(
-        `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*\\s*(?:[—\\-]+>?|->)\\s*\\S`,
+        `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*[ \\t]*(?:[—\\-]+>?|->)[ \\t]*[^\\n]+`,
         "m",
       )
       const found = inlineRoutingPattern.test(phaseRegion)
@@ -120,5 +125,36 @@ describe("ce-plan post-generation menu routing", () => {
       /skill[\s-]?invocation|Skill tool|skill primitive/i.test(ceWorkLine![0]),
       `references/plan-handoff.md 'Start /ce-work' routing must use platform-explicit invocation language matching SKILL.md (e.g., 'invoke the ce-work skill via the platform's skill-invocation primitive'). The bare 'Call /ce-work with the plan path' phrasing was the regression. Found: ${JSON.stringify(ceWorkLine![0])}`,
     ).toBe(true)
+  })
+
+  test("inline-routing regex rejects empty-action bullets even when followed by another bullet", () => {
+    // Regression guard for Codex P2 finding on PR #715: the previous
+    // `\s*(?:...)\s*` shape allowed newline consumption, so a bullet with no
+    // action text on its own line could still match by spilling into the next
+    // bullet's leading `-`. The first test in this file would silently pass
+    // on a real regression. This test recreates the failure mode and asserts
+    // the regex now refuses it.
+    //
+    // Construct the same regex shape used above and exercise it directly
+    // against a hand-rolled fixture — no live SKILL.md needed.
+    const fragment = "Start `/ce-work`"
+    const escaped = fragment.replace(/[.*+?^${}()|[\]\\`]/g, "\\$&")
+    const fixedRegex = new RegExp(
+      `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*[ \\t]*(?:[—\\-]+>?|->)[ \\t]*[^\\n]+`,
+      "m",
+    )
+    const broken = [
+      "- **Start `/ce-work`**",
+      "- **Done for now** — End the turn.",
+    ].join("\n")
+    expect(
+      fixedRegex.test(broken),
+      "Routing regex must NOT match a bullet with no action text on its own line, even when the next bullet's `-` could be misread as the separator. If this assertion fires, the regex regressed back to consuming newlines (Codex P2 on PR #715).",
+    ).toBe(false)
+
+    // And confirm the regex still matches the legitimate same-line shape so
+    // the negative case isn't masking a positive-case breakage.
+    const valid = "- **Start `/ce-work`** — Invoke the ce-work skill, passing the plan path."
+    expect(fixedRegex.test(valid)).toBe(true)
   })
 })

--- a/tests/skills/ce-plan-handoff-routing.test.ts
+++ b/tests/skills/ce-plan-handoff-routing.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const SKILL_PATH = path.join(
+  process.cwd(),
+  "plugins/compound-engineering/skills/ce-plan/SKILL.md",
+)
+const SKILL_BODY = readFileSync(SKILL_PATH, "utf8")
+
+const HANDOFF_PATH = path.join(
+  process.cwd(),
+  "plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md",
+)
+const HANDOFF_BODY = readFileSync(HANDOFF_PATH, "utf8")
+
+// Regression guard for https://github.com/EveryInc/compound-engineering-plugin/issues/714.
+//
+// ce-plan Phase 5.4 presents a 4-option post-generation menu. Because SKILL.md
+// content caches at session start while reference files load on demand, the
+// per-option routing (what action fires when the user picks an option) MUST
+// live in SKILL.md itself — not solely in references/plan-handoff.md. The
+// reference may still hold elaborate sub-flows (HITL state machine, Issue
+// Creation tracker detection); only the bare per-option action must be inline.
+//
+// Symptom when this regresses: the agent renders the menu, the user picks
+// "Start `/ce-work` (Recommended)", and the agent stops in prose without
+// invoking the ce-work skill.
+describe("ce-plan post-generation menu routing", () => {
+  test("SKILL.md contains inline routing for all four menu options", () => {
+    // Anchor on the Phase 5.4 region so a stray match elsewhere in the file
+    // doesn't satisfy these assertions.
+    const phaseStart = SKILL_BODY.indexOf("##### 5.3.8")
+    expect(
+      phaseStart,
+      "ce-plan SKILL.md no longer contains the '##### 5.3.8' phase heading — the test anchor needs updating, or Phase 5.4 was removed.",
+    ).toBeGreaterThan(-1)
+    const phaseRegion = SKILL_BODY.slice(phaseStart)
+
+    // Each menu option must have a routing bullet in the phase region that
+    // pairs the label with an action statement. The routing bullet shape is
+    // `- **<label-or-label-fragment>** — <action sentence>`. We accept "—",
+    // "->", or "-" as the separator so legitimate phrasing tweaks don't break
+    // the test, but require:
+    //   - the line starts with `- **` (a bullet, not the numbered menu list)
+    //   - the bold span contains a fragment unique to the option label
+    //   - the bold span is followed by a separator and at least one action verb
+    // Testing for a label fragment (not the full label) tolerates the long
+    // "Open in Proof (web app) — review and comment to iterate with the agent"
+    // label without the assertion becoming brittle.
+    const optionFragments: { name: string; fragment: string }[] = [
+      { name: "Start /ce-work", fragment: "Start `/ce-work`" },
+      { name: "Create Issue", fragment: "Create Issue" },
+      { name: "Open in Proof", fragment: "Open in Proof" },
+      { name: "Done for now", fragment: "Done for now" },
+    ]
+
+    for (const { name, fragment } of optionFragments) {
+      const escaped = fragment.replace(/[.*+?^${}()|[\]\\`]/g, "\\$&")
+      // Bullet form: `- **...<fragment>...**` followed by separator + action.
+      const inlineRoutingPattern = new RegExp(
+        `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*\\s*(?:[—\\-]+>?|->)\\s*\\S`,
+        "m",
+      )
+      const found = inlineRoutingPattern.test(phaseRegion)
+      expect(
+        found,
+        `ce-plan SKILL.md Phase 5.4 is missing inline routing for menu option "${name}". The bare per-option action MUST live in SKILL.md (not solely in references/plan-handoff.md) so an agent that doesn't load the reference still routes correctly. See https://github.com/EveryInc/compound-engineering-plugin/issues/714 and docs/solutions/skill-design/post-menu-routing-belongs-inline-2026-04-28.md.`,
+      ).toBe(true)
+    }
+  })
+
+  test("Start /ce-work routing names skill-invocation primitive and plan path", () => {
+    const phaseStart = SKILL_BODY.indexOf("##### 5.3.8")
+    const phaseRegion = SKILL_BODY.slice(phaseStart)
+
+    // The Start /ce-work routing line must be platform-explicit. We require
+    // that the routing BULLET (not the menu list entry) names both
+    // (a) the skill-invocation primitive (Skill tool / skill-invocation /
+    // skill primitive) and (b) the plan path being passed as the argument.
+    // This is what makes the difference between "tell the user to type
+    // /ce-work" and "fire the Skill tool now."
+    //
+    // Anchor on the bullet form `- **Start \`/ce-work\`**` to avoid matching
+    // the numbered menu list entry `1. **Start \`/ce-work\`** (recommended) -`,
+    // which legitimately doesn't carry the routing language.
+    const ceWorkRoutingMatch = phaseRegion.match(
+      /^- \*\*Start `\/ce-work`\*\*[\s\S]{0,500}/m,
+    )
+    expect(
+      ceWorkRoutingMatch,
+      "ce-plan SKILL.md Phase 5.4 is missing the inline '- **Start `/ce-work`** ...' routing bullet (distinct from the numbered menu list entry).",
+    ).not.toBeNull()
+    const block = ceWorkRoutingMatch![0]
+
+    expect(
+      /skill[\s-]?invocation|Skill tool|skill primitive/i.test(block),
+      "ce-plan SKILL.md 'Start /ce-work' routing must name the skill-invocation primitive (e.g., 'Skill tool in Claude Code', 'platform's skill-invocation primitive') so the agent fires the invocation rather than announcing a handoff in prose. See issue #714.",
+    ).toBe(true)
+
+    expect(
+      /plan path|plan file path|plan as the (?:skill )?argument|passing the plan/i.test(block),
+      "ce-plan SKILL.md 'Start /ce-work' routing must name the plan path as the argument so the agent passes it correctly to ce-work. See issue #714.",
+    ).toBe(true)
+  })
+
+  test("plan-handoff.md routing for Start /ce-work matches the inline platform-explicit phrasing", () => {
+    // Both surfaces must converge: the reference file's routing line should
+    // also use platform-explicit invocation language so that an agent which
+    // does load the reference sees compatible (not contradictory) guidance.
+    const ceWorkLine = HANDOFF_BODY.match(
+      /\*\*Start `\/ce-work`\*\*[^\n]*->[^\n]+/,
+    )
+    expect(
+      ceWorkLine,
+      "references/plan-handoff.md is missing the routing line for 'Start /ce-work'.",
+    ).not.toBeNull()
+
+    expect(
+      /skill[\s-]?invocation|Skill tool|skill primitive/i.test(ceWorkLine![0]),
+      `references/plan-handoff.md 'Start /ce-work' routing must use platform-explicit invocation language matching SKILL.md (e.g., 'invoke the ce-work skill via the platform's skill-invocation primitive'). The bare 'Call /ce-work with the plan path' phrasing was the regression. Found: ${JSON.stringify(ceWorkLine![0])}`,
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Closes #714.

## Summary

`ce-plan` Phase 5.4 presents a 4-option post-generation menu where option 1 is "Start \`/ce-work\` (Recommended)". The per-option routing lived only in \`references/plan-handoff.md\`. Two failure modes followed:

1. An agent that didn't load the reference saw the menu as a textual handoff with no associated action and stopped after the user's selection.
2. An agent that did load the reference saw ambiguous language (\`**Start /ce-work** -> Call /ce-work with the plan path\`) that could be read as "tell the user to type /ce-work" rather than "fire the Skill tool now."

Reproduced live on 2026-04-28: user picked option 1, agent acknowledged the choice in prose, and stopped without invoking \`ce-work\`.

## Changes

- **\`plugins/compound-engineering/skills/ce-plan/SKILL.md\`** — Inline \`Routing\` block in Phase 5.4 with one explicit action per menu option, using platform-explicit invocation language ("Invoke the \`ce-work\` skill via the platform's skill-invocation primitive — \`Skill\` in Claude Code, equivalent on Codex/Gemini/Pi — passing the plan path as the skill argument. Do not merely tell the user to type \`/ce-work\` — fire the invocation now.")
- **\`plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md\`** — Mirror the same platform-explicit phrasing in the routing block so the inline and reference language converge. Elaborate sub-flows (Proof HITL state machine, Issue Creation tracker detection, post-HITL \`ce-doc-review\` resync) remain in the reference where they belong.
- **\`tests/skills/ce-plan-handoff-routing.test.ts\`** — Regression test asserting all four inline routing lines are present and that the \`Start /ce-work\` routing specifically names both the skill-invocation primitive and the plan path.
- **\`docs/solutions/skill-design/post-menu-routing-belongs-inline-2026-04-28.md\`** — Authoring principle: always-on routing for interactive menus belongs inline in SKILL.md; only conditional, multi-step sub-flows belong in references. References the existing \"Skill Design Principles\" rule about load-bearing rules in plugin AGENTS.md.

## Why scope this way

The plugin's \`AGENTS.md\` "Conditional and Late-Sequence Extraction" rule says to extract conditional or late-sequence content. The bare per-option routing is late-sequence but **not conditional** — option 1 always means "invoke ce-work." The same AGENTS.md, in "Skill Design Principles," already says: *"For load-bearing rules (those that MUST fire reliably), put strong language at the top of the relevant phase in SKILL.md, not just in the reference."* This PR applies that principle to Phase 5.4 routing while keeping genuinely conditional flows (HITL, Issue Creation) in the reference.

## Verification

- \`bun test tests/skills/ce-plan-handoff-routing.test.ts\` — 3 pass, 0 fail (10 expect calls)
- \`bun test tests/frontmatter.test.ts\` — passes (sanity)
- \`bun run release:validate\` — clean ("Release metadata is in sync. compound-engineering currently has 51 agents, 35 skills, and 0 MCP servers.")
- No version files modified (\`.claude-plugin/plugin.json\`, \`.cursor-plugin/plugin.json\`, \`.codex-plugin/plugin.json\`, \`.claude-plugin/marketplace.json\`, root \`CHANGELOG.md\` — all untouched per AGENTS.md rules)
- Pre-existing failures in \`tests/skills/ce-polish-beta-project-type.test.ts\` (9 fails) confirmed present on \`upstream/main\` before any of this work; unrelated to this PR

## Test plan

- [x] Regression test passes on the fix
- [x] Regression test fails on the regression (verified during authoring — initial regex bugs caught a real "Open in Proof" missing-routing case and a Start /ce-work language-not-platform-explicit case)
- [x] Full \`bun test\` run shows no new failures vs. \`upstream/main\`
- [x] \`bun run release:validate\` passes
- [x] No release-owned files modified