### PR TITLE
fix(ce-code-review): comment-gate previous-comments persona to skip empty PRs

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -220,15 +220,13 @@ Then check out the PR branch so persona agents can read the actual code (not the
 gh pr checkout <number-or-url>
 ```
 
-Then fetch PR metadata. Capture the base branch name and the PR base repository identity, not just the branch name. Also capture `reviews` and `comments` so Stage 3 can decide whether to spawn `previous-comments` without paying a subagent's startup cost just to discover the PR has no prior feedback yet:
+Then fetch PR metadata. Capture the base branch name and the PR base repository identity, not just the branch name. Project `reviews` and `comments` to a `hasPriorComments` boolean via `--jq` -- counting only, not materializing review or comment bodies into the orchestrator's context, which on PRs with long review history would offset the optimization this gate is meant to enable. Stage 3 uses `hasPriorComments` to decide whether to spawn `previous-comments`:
 
 ```
-gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url,reviews,comments
+gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url,reviews,comments --jq '{title, body, baseRefName, headRefName, url, hasPriorComments: ((.reviews | length) > 0 or (.comments | length) > 0)}'
 ```
 
 Use the repository portion of the returned PR URL as `<base-repo>` (for example, `EveryInc/compound-engineering-plugin` from `https://github.com/EveryInc/compound-engineering-plugin/pull/348`).
-
-Record whether the PR has any prior feedback: `HAS_PRIOR_COMMENTS=true` if either `reviews` or `comments` is non-empty, otherwise `false`. Stage 3 uses this flag.
 
 Then compute a local diff against the PR's base branch so re-reviews also include local fix commits and uncommitted edits. Substitute the PR base branch from metadata (shown here as `<base>`) and the PR base repository identity derived from the PR URL (shown here as `<base-repo>`). Resolve the base ref from the PR's actual base repository, not by assuming `origin` points at that repo:
 
@@ -290,7 +288,7 @@ On success, produce the diff:
 echo "BASE:$BASE" && echo "FILES:" && git diff --name-only $BASE && echo "DIFF:" && git diff -U10 $BASE && echo "UNTRACKED:" && git ls-files --others --exclude-standard
 ```
 
-You may still fetch additional PR metadata with `gh pr view` for title, body, linked issues, and `reviews,comments` (the latter so Stage 3 can comment-gate `previous-comments` consistently with PR mode); set `HAS_PRIOR_COMMENTS` from the result. Do not fail if no PR exists -- leave `HAS_PRIOR_COMMENTS=false`.
+You may still fetch additional PR metadata with `gh pr view` for title, body, linked issues, and a projected `hasPriorComments` boolean (use the same `--jq` shape from PR mode above so Stage 3 can comment-gate `previous-comments` consistently). Do not fail if no PR exists -- leave `hasPriorComments=false`.
 
 **If no argument (standalone on current branch):**
 
@@ -367,7 +365,7 @@ Read the diff and file list from Stage 1. The 4 always-on personas and 2 CE alwa
 **`previous-comments` is PR-only AND comment-gated.** Only select this persona when both conditions hold:
 
 1. Stage 1 gathered PR metadata (PR number or URL was provided as an argument, or `gh pr view` returned metadata for the current branch).
-2. `HAS_PRIOR_COMMENTS` from Stage 1 is true (the PR has at least one review submission or issue comment).
+2. `hasPriorComments` from Stage 1 is true (the PR has at least one review submission or issue comment).
 
 Skip it for standalone branch reviews with no associated PR, and skip it for PRs with no prior feedback yet -- there is nothing for the persona to verify, and a spawned subagent that returns empty findings still costs the full subagent startup overhead (persona spec, diff, schema, plus its own gh calls).
 

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -220,13 +220,15 @@ Then check out the PR branch so persona agents can read the actual code (not the
 gh pr checkout <number-or-url>
 ```
 
-Then fetch PR metadata. Capture the base branch name and the PR base repository identity, not just the branch name:
+Then fetch PR metadata. Capture the base branch name and the PR base repository identity, not just the branch name. Also capture `reviews` and `comments` so Stage 3 can decide whether to spawn `previous-comments` without paying a subagent's startup cost just to discover the PR has no prior feedback yet:
 
 ```
-gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url
+gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url,reviews,comments
 ```
 
 Use the repository portion of the returned PR URL as `<base-repo>` (for example, `EveryInc/compound-engineering-plugin` from `https://github.com/EveryInc/compound-engineering-plugin/pull/348`).
+
+Record whether the PR has any prior feedback: `HAS_PRIOR_COMMENTS=true` if either `reviews` or `comments` is non-empty, otherwise `false`. Stage 3 uses this flag.
 
 Then compute a local diff against the PR's base branch so re-reviews also include local fix commits and uncommitted edits. Substitute the PR base branch from metadata (shown here as `<base>`) and the PR base repository identity derived from the PR URL (shown here as `<base-repo>`). Resolve the base ref from the PR's actual base repository, not by assuming `origin` points at that repo:
 
@@ -288,7 +290,7 @@ On success, produce the diff:
 echo "BASE:$BASE" && echo "FILES:" && git diff --name-only $BASE && echo "DIFF:" && git diff -U10 $BASE && echo "UNTRACKED:" && git ls-files --others --exclude-standard
 ```
 
-You may still fetch additional PR metadata with `gh pr view` for title, body, and linked issues, but do not fail if no PR exists.
+You may still fetch additional PR metadata with `gh pr view` for title, body, linked issues, and `reviews,comments` (the latter so Stage 3 can comment-gate `previous-comments` consistently with PR mode); set `HAS_PRIOR_COMMENTS` from the result. Do not fail if no PR exists -- leave `HAS_PRIOR_COMMENTS=false`.
 
 **If no argument (standalone on current branch):**
 
@@ -362,7 +364,12 @@ Read the diff and file list from Stage 1. The 4 always-on personas and 2 CE alwa
 
 **File-type awareness for conditional selection:** Instruction-prose files (Markdown skill definitions, JSON schemas, config files) are product code but do not benefit from runtime-focused reviewers. The adversarial reviewer's techniques (race conditions, cascade failures, abuse cases) target executable code behavior. For diffs that only change instruction-prose files, skip adversarial unless the prose describes auth, payment, or data-mutation behavior. Count only executable code lines toward line-count thresholds.
 
-**`previous-comments` is PR-only.** Only select this persona when Stage 1 gathered PR metadata (PR number or URL was provided as an argument, or `gh pr view` returned metadata for the current branch). Skip it entirely for standalone branch reviews with no associated PR -- there are no prior comments to check.
+**`previous-comments` is PR-only AND comment-gated.** Only select this persona when both conditions hold:
+
+1. Stage 1 gathered PR metadata (PR number or URL was provided as an argument, or `gh pr view` returned metadata for the current branch).
+2. `HAS_PRIOR_COMMENTS` from Stage 1 is true (the PR has at least one review submission or issue comment).
+
+Skip it for standalone branch reviews with no associated PR, and skip it for PRs with no prior feedback yet -- there is nothing for the persona to verify, and a spawned subagent that returns empty findings still costs the full subagent startup overhead (persona spec, diff, schema, plus its own gh calls).
 
 Stack-specific personas are additive. A Rails UI change may warrant `kieran-rails` plus `julik-frontend-races`; a TypeScript API diff may warrant `kieran-typescript` plus `api-contract` and `reliability`.
 

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -220,10 +220,10 @@ Then check out the PR branch so persona agents can read the actual code (not the
 gh pr checkout <number-or-url>
 ```
 
-Then fetch PR metadata. Capture the base branch name and the PR base repository identity, not just the branch name. Project `reviews` and `comments` to a `hasPriorComments` boolean via `--jq` -- counting only, not materializing review or comment bodies into the orchestrator's context, which on PRs with long review history would offset the optimization this gate is meant to enable. Stage 3 uses `hasPriorComments` to decide whether to spawn `previous-comments`:
+Then fetch PR metadata. Capture the base branch name and the PR base repository identity, not just the branch name. Project `reviews` and `comments` to a `hasPriorComments` boolean via `--jq` -- counting only, not materializing review or comment bodies into the orchestrator's context. The reviews filter excludes approval-state submissions with empty bodies (approvals are not feedback to verify), so PRs with only approval clicks correctly fall through the gate. Stage 3 uses `hasPriorComments` to decide whether to spawn `previous-comments`:
 
 ```
-gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url,reviews,comments --jq '{title, body, baseRefName, headRefName, url, hasPriorComments: ((.reviews | length) > 0 or (.comments | length) > 0)}'
+gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url,reviews,comments --jq '{title, body, baseRefName, headRefName, url, hasPriorComments: ((.reviews | map(select(.state != "APPROVED" or .body != "")) | length) > 0 or (.comments | length) > 0)}'
 ```
 
 Use the repository portion of the returned PR URL as `<base-repo>` (for example, `EveryInc/compound-engineering-plugin` from `https://github.com/EveryInc/compound-engineering-plugin/pull/348`).
@@ -288,7 +288,7 @@ On success, produce the diff:
 echo "BASE:$BASE" && echo "FILES:" && git diff --name-only $BASE && echo "DIFF:" && git diff -U10 $BASE && echo "UNTRACKED:" && git ls-files --others --exclude-standard
 ```
 
-You may still fetch additional PR metadata with `gh pr view` for title, body, linked issues, and a projected `hasPriorComments` boolean (use the same `--jq` shape from PR mode above so Stage 3 can comment-gate `previous-comments` consistently). Do not fail if no PR exists -- leave `hasPriorComments=false`.
+You may still fetch additional PR metadata with `gh pr view` for title, body, linked issues, and a projected `hasPriorComments` boolean (use the same `--jq` shape from PR mode above so the gate ignores approval-only reviews and stays consistent across modes). Do not fail if no PR exists -- leave `hasPriorComments=false`.
 
 **If no argument (standalone on current branch):**
 

--- a/plugins/compound-engineering/skills/ce-code-review/references/persona-catalog.md
+++ b/plugins/compound-engineering/skills/ce-code-review/references/persona-catalog.md
@@ -35,7 +35,7 @@ Spawned when the orchestrator identifies relevant patterns in the diff. The orch
 | `reliability` | `ce-reliability-reviewer` | Error handling, retry logic, circuit breakers, timeouts, background jobs, async handlers, health checks |
 | `adversarial` | `ce-adversarial-reviewer` | Diff has >=50 changed non-test, non-generated, non-lockfile lines, OR touches auth, payments, data mutations, external API integrations, or other high-risk domains |
 | `cli-readiness` | `ce-cli-readiness-reviewer` | CLI command definitions, argument parsing, CLI framework usage, command handler implementations |
-| `previous-comments` | `ce-previous-comments-reviewer` | **PR-only AND comment-gated.** Reviewing a PR that has existing review comments or review threads from prior review rounds. Skip entirely when no PR metadata was gathered in Stage 1, OR when Stage 1's `HAS_PRIOR_COMMENTS` flag is false (no `reviews` and no `comments` on the PR). |
+| `previous-comments` | `ce-previous-comments-reviewer` | **PR-only AND comment-gated.** Reviewing a PR that has existing review comments or review threads from prior review rounds. Skip entirely when no PR metadata was gathered in Stage 1, OR when Stage 1's `hasPriorComments` flag is false (no `reviews` and no `comments` on the PR). |
 
 ## Stack-Specific Conditional (6 personas)
 

--- a/plugins/compound-engineering/skills/ce-code-review/references/persona-catalog.md
+++ b/plugins/compound-engineering/skills/ce-code-review/references/persona-catalog.md
@@ -35,7 +35,7 @@ Spawned when the orchestrator identifies relevant patterns in the diff. The orch
 | `reliability` | `ce-reliability-reviewer` | Error handling, retry logic, circuit breakers, timeouts, background jobs, async handlers, health checks |
 | `adversarial` | `ce-adversarial-reviewer` | Diff has >=50 changed non-test, non-generated, non-lockfile lines, OR touches auth, payments, data mutations, external API integrations, or other high-risk domains |
 | `cli-readiness` | `ce-cli-readiness-reviewer` | CLI command definitions, argument parsing, CLI framework usage, command handler implementations |
-| `previous-comments` | `ce-previous-comments-reviewer` | **PR-only.** Reviewing a PR that has existing review comments or review threads from prior review rounds. Skip entirely when no PR metadata was gathered in Stage 1. |
+| `previous-comments` | `ce-previous-comments-reviewer` | **PR-only AND comment-gated.** Reviewing a PR that has existing review comments or review threads from prior review rounds. Skip entirely when no PR metadata was gathered in Stage 1, OR when Stage 1's `HAS_PRIOR_COMMENTS` flag is false (no `reviews` and no `comments` on the PR). |
 
 ## Stack-Specific Conditional (6 personas)
 


### PR DESCRIPTION
The `previous-comments` reviewer was spawning on any PR that existed, even ones with zero prior reviews or comments. The agent then made its own `gh` calls only to return empty findings — roughly 25k tokens of subagent startup (persona spec, diff, schema, plus its own fetches) wasted per empty spawn.

Stage 1 already runs `gh pr view` for PR metadata, so this gate piggybacks on that call. Zero new API round-trips:

- Extended the PR-mode `gh pr view --json …` to also pull `reviews,comments`, and recorded `HAS_PRIOR_COMMENTS` from the result.
- Mirrored the addition in branch mode's optional PR fetch so the gate works consistently when reviewing a branch with an associated PR.
- Tightened the Stage 3 selection rule: `previous-comments` now requires both PR metadata gathered AND `HAS_PRIOR_COMMENTS` true. Updated the persona catalog to match.

The agent's own bail-on-empty guard remains as a safety net, but it should rarely fire now that the orchestrator handles the empty case before spawning.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)