### PR TITLE
fix(review): default to harness-native code review, escalate on risk

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -42,10 +42,10 @@ Programmatic callers (when `mode:autofix`, `mode:report-only`, or `mode:headless
 
 Sequence:
 
-1. **Run the harness's built-in code review.**
-   - If you are Claude Code, run the `/review` tool.
-   - If you are Gemini, run a quick code review.
-   - For all other coding harnesses, run your built-in code review tool.
+1. **Run the harness's built-in code review.** If `$ARGUMENTS` contained a review target (PR number, GitHub URL, or branch name) after stripping recognized tokens, forward that target to the built-in. If no target was provided, run the bare command and let the built-in default to the current branch.
+   - If you are Claude Code, run the `/review` tool, passing the target if present (e.g., `/review 123`, `/review <PR-URL>`, `/review <branch>`); otherwise run bare `/review`.
+   - If you are Gemini, run a quick code review against the resolved target (or the current branch when none was provided).
+   - For all other coding harnesses, run your built-in code review tool, forwarding the target when its syntax accepts one.
 
    Then stop. Do not dispatch the multi-agent reviewer pipeline.
 

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -32,6 +32,27 @@ All tokens are optional. Each one present means one less thing to infer. When ab
 
 **Conflicting mode flags:** If multiple mode tokens appear in arguments, stop and do not dispatch agents. If `mode:headless` is one of the conflicting tokens, emit the headless error envelope: `Review failed (headless mode). Reason: conflicting mode flags — <mode_a> and <mode_b> cannot be combined.` Otherwise emit the generic form: `Review failed. Reason: conflicting mode flags — <mode_a> and <mode_b> cannot be combined.`
 
+## Quick Review Short-Circuit
+
+If `$ARGUMENTS` indicates the user wants a quick, fast, or light code review, do not dispatch the multi-agent flow.
+
+**Announce the chosen path** before any other work (Quick review vs Multi-agent review).
+
+Programmatic callers (when `mode:autofix`, `mode:report-only`, or `mode:headless` is present) skip this announcement -- the orchestrator owns user-facing messaging.
+
+Sequence:
+
+1. **Run the harness's built-in code review.**
+   - If you are Claude Code, run the `/review` tool.
+   - If you are Gemini, run a quick code review.
+   - For all other coding harnesses, run your built-in code review tool.
+
+   Then stop. Do not dispatch the multi-agent reviewer pipeline.
+
+2. **Exemption -- no built-in code review exists.** If the current harness has no built-in code review command or skill, do not short-circuit. Continue into the full multi-agent review described in the rest of this skill (Tier 2).
+
+3. **Programmatic callers bypass this short-circuit.** When `mode:autofix`, `mode:report-only`, or `mode:headless` is present, ignore quick intent and run the full multi-agent review. Skill-to-skill callers that want the lightweight pass should invoke `/review` (or the harness equivalent) directly rather than route through this short-circuit.
+
 ## Mode Detection
 
 | Mode | When | Behavior |

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -384,7 +384,7 @@ Determine how to proceed based on what was provided in `<input_document>`.
    - Keep user informed of major milestones
    - When the plan defines U-IDs for Implementation Units, or the plan or origin document carries stable R-IDs (and optionally A/F/AE IDs), reference them in blockers, deferred-work notes, task summaries, and final verification — not routine status updates. U-IDs anchor units across plan edits; R/A/F/AE anchor product intent across the brainstorm-plan handoff. Use the IDs the plan supplies and do not invent ones it does not. This preserves traceability without burying signal under noise.
 
-### Phase 3-4: Quality Check and Ship It
+### Phase 3-4: Quality Check and Finishing Work
 
 When all Phase 2 tasks are complete and execution transitions to quality check, read `references/shipping-workflow.md` for the full shipping workflow: quality checks, code review, final validation, PR creation, and notification.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/shipping-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/shipping-workflow.md
@@ -20,7 +20,7 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
    Every change gets reviewed before shipping. Default to Tier 1 and escalate to Tier 2 only when a concrete signal calls for it. Tier 2 is materially more expensive in time and tokens -- pay that cost when a signal justifies it, not as a default.
 
-   **Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline before Final Validation. Skip the Residual Work Gate.
+   **Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline before Final Validation. Skip the Residual Work Gate. If the current harness has no built-in code review command or skill, escalate to Tier 2 -- Tier 1 cannot run, and "Every change gets reviewed" still applies.
 
    **Tier 2 -- `ce-code-review` (escalation).** Invoke the `ce-code-review` skill with `mode:autofix`, passing `plan:<path>` when known. Then proceed to the Residual Work Gate.
 
@@ -125,7 +125,7 @@ Before creating PR, verify:
 
 Every change gets reviewed. Default to Tier 1; escalate to Tier 2 only on a concrete signal. Tier 2 is materially more expensive in time and tokens.
 
-**Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline.
+**Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline. If the current harness has no built-in code review command or skill, escalate to Tier 2 -- Tier 1 cannot run.
 
 **Tier 2 -- `ce-code-review` (escalation).** Invoke `ce-code-review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work routes through the Residual Work Gate.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/shipping-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/shipping-workflow.md
@@ -16,7 +16,13 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
    # Use linting-agent before pushing to origin
    ```
 
-2. **Code Review** (REQUIRED)
+2. **Simplify** (Claude Code only; REQUIRED for >=30 changed lines)
+
+   Before code review, run the `/simplify` skill on the change to consolidate duplicated patterns, remove dead code, and improve reuse. Skip when the diff is purely mechanical (formatting, dependency bumps, lint fixes, generated artifacts) -- simplification has no useful yield on those.
+
+   On other harnesses, proceed directly to code review.
+
+3. **Code Review** (REQUIRED)
 
    Every change gets reviewed before shipping. Default to Tier 1 and escalate to Tier 2 only when a concrete signal calls for it. Tier 2 is materially more expensive in time and tokens -- pay that cost when a signal justifies it, not as a default.
 
@@ -33,7 +39,7 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
    When the change is small, concentrated, and outside the sensitive surface list, Tier 1 is sufficient -- do not escalate "to be safe."
 
-3. **Residual Work Gate** (REQUIRED when Tier 2 ran)
+4. **Residual Work Gate** (REQUIRED when Tier 2 ran)
 
    After Tier 2 code review completes, inspect the Residual Actionable Work summary it returned (or read the run artifact directly if the summary was not emitted). If one or more residual `downstream-resolver` findings remain, do not proceed to Final Validation until the user decides how to handle them.
 
@@ -49,7 +55,7 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
    Skip this gate entirely when the review reported `Residual actionable work: none.` or when only Tier 1 was used. Do not proceed past this gate on an `Accept and proceed` decision until the agent has recorded whether the durable sink is `PR Known Residuals` or `docs/residual-review-findings/<branch-or-head-sha>.md`.
 
-4. **Final Validation**
+5. **Final Validation**
    - All tasks marked completed
    - Testing addressed -- tests pass and new/changed behavior has corresponding test coverage (or an explicit justification for why tests are not needed)
    - Linting passes
@@ -59,7 +65,7 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
    - If the plan has a `Requirements` section (or legacy `Requirements Trace`), verify each requirement is satisfied by the completed work
    - If any `Deferred to Implementation` questions were noted, confirm they were resolved during execution
 
-5. **Prepare Operational Validation Plan** (REQUIRED)
+6. **Prepare Operational Validation Plan** (REQUIRED)
    - Add a `## Post-Deploy Monitoring & Validation` section to the PR description for every change.
    - Include concrete:
      - Log queries/search terms
@@ -93,7 +99,7 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
    - Testing notes (tests added/modified, manual testing performed)
    - Evidence context from step 1, so `ce-commit-push-pr` can decide whether to ask about capturing evidence
    - Figma design link (if applicable)
-   - The Post-Deploy Monitoring & Validation section (see Phase 3 Step 5)
+   - The Post-Deploy Monitoring & Validation section (see Phase 3 Step 6)
    - Any "Known Residuals" accepted in the Phase 3 Residual Work Gate, rendered as a dedicated section in the PR body with severity, file:line, and title per finding
 
    If the user prefers to commit without creating a PR, load the `ce-commit` skill instead.

--- a/plugins/compound-engineering/skills/ce-work-beta/references/shipping-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/shipping-workflow.md
@@ -18,15 +18,20 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
 2. **Code Review** (REQUIRED)
 
-   Every change gets reviewed before shipping. The depth scales with the change's risk profile, but review itself is never skipped.
+   Every change gets reviewed before shipping. Default to Tier 1 and escalate to Tier 2 only when a concrete signal calls for it. Tier 2 is materially more expensive in time and tokens -- pay that cost when a signal justifies it, not as a default.
 
-   **Tier 2: Full review (default)** -- REQUIRED unless Tier 1 criteria are explicitly met. Invoke the `ce-code-review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and record residual downstream work in the per-run artifact. When the plan file path is known, pass it as `plan:<path>`. This is the mandatory default -- proceed to Tier 1 only after confirming every criterion below.
+   **Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline before Final Validation. Skip the Residual Work Gate.
 
-   **Tier 1: Inline self-review** -- A lighter alternative permitted only when **all four** criteria are true. Before choosing Tier 1, explicitly state which criteria apply and why. If any criterion is uncertain, use Tier 2.
-   - Purely additive (new files only, no existing behavior modified)
-   - Single concern (one skill, one component -- not cross-cutting)
-   - Pattern-following (implementation mirrors an existing example with no novel logic)
-   - Plan-faithful (no scope growth, no deferred questions resolved with surprising answers)
+   **Tier 2 -- `ce-code-review` (escalation).** Invoke the `ce-code-review` skill with `mode:autofix`, passing `plan:<path>` when known. Then proceed to the Residual Work Gate.
+
+   Escalate to Tier 2 when **any** of the following is true:
+
+   - **Sensitive surface touched.** The diff modifies any of: authentication or authorization, payments or billing, data migrations or backfills, cryptography or secret handling, security-relevant configuration, public API or library contracts, or dependency manifests.
+   - **Large and diffuse change.** The diff exceeds >=400 changed lines **and** spans more than 3 directories or 2 distinct subsystems. Either alone is a soft signal; together they are an escalation trigger.
+   - **Very large change.** The diff exceeds >=1,000 changed lines regardless of diffusion.
+   - **Plan or task explicitly requests it.** The plan, the originating task, or another instruction in scope calls for a full / deep / thorough code review.
+
+   When the change is small, concentrated, and outside the sensitive surface list, Tier 1 is sufficient -- do not escalate "to be safe."
 
 3. **Residual Work Gate** (REQUIRED when Tier 2 ran)
 
@@ -42,7 +47,7 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
    - `Accept and proceed` — record the residual findings verbatim in a durable "Known Residuals" sink before shipping. If a PR will be created or updated in Phase 4, include them in the PR description's "Known Residuals" section (the agent owns this when calling `ce-commit-push-pr`). If the user later chooses the no-PR `ce-commit` path, create `docs/residual-review-findings/<branch-or-head-sha>.md`, include the accepted findings and source review-run context, stage it with the implementation commit, and mention the file path in the final summary. The user has acknowledged the risk, but the findings must not live only in the transient session.
    - `Stop — do not ship` — abort the shipping workflow. The user will handle findings manually before re-invoking.
 
-   Skip this gate entirely when the review reported `Residual actionable work: none.` or when only Tier 1 (inline self-review) was used. Do not proceed past this gate on an `Accept and proceed` decision until the agent has recorded whether the durable sink is `PR Known Residuals` or `docs/residual-review-findings/<branch-or-head-sha>.md`.
+   Skip this gate entirely when the review reported `Residual actionable work: none.` or when only Tier 1 was used. Do not proceed past this gate on an `Accept and proceed` decision until the agent has recorded whether the durable sink is `PR Known Residuals` or `docs/residual-review-findings/<branch-or-head-sha>.md`.
 
 4. **Final Validation**
    - All tasks marked completed
@@ -112,18 +117,20 @@ Before creating PR, verify:
 - [ ] Evidence decision handled by `ce-commit-push-pr` when the change has observable behavior
 - [ ] Commit messages follow conventional format
 - [ ] PR description includes Post-Deploy Monitoring & Validation section (or explicit no-impact rationale)
-- [ ] Code review completed (inline self-review or full `ce-code-review`)
+- [ ] Code review completed (Tier 1 harness-native or Tier 2 `ce-code-review`)
 - [ ] PR description includes summary, testing notes, and evidence when captured
 - [ ] PR description includes Compound Engineered badge with accurate model and harness
 
 ## Code Review Tiers
 
-Every change gets reviewed. The tier determines depth, not whether review happens.
+Every change gets reviewed. Default to Tier 1; escalate to Tier 2 only on a concrete signal. Tier 2 is materially more expensive in time and tokens.
 
-**Tier 2 (full review)** -- REQUIRED default. Invoke `ce-code-review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work is recorded in the run artifact for downstream routing. Always use this tier unless all four Tier 1 criteria are explicitly confirmed.
+**Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline.
 
-**Tier 1 (inline self-review)** -- permitted only when all four are true (state each explicitly before choosing):
-- Purely additive (new files only, no existing behavior modified)
-- Single concern (one skill, one component -- not cross-cutting)
-- Pattern-following (mirrors an existing example, no novel logic)
-- Plan-faithful (no scope growth, no surprising deferred-question resolutions)
+**Tier 2 -- `ce-code-review` (escalation).** Invoke `ce-code-review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work routes through the Residual Work Gate.
+
+Escalate to Tier 2 when any of these holds:
+- Sensitive surface touched (auth/authz, payments/billing, data migrations or backfills, cryptography or secrets, security-relevant config, public API or library contracts, dependency manifests)
+- Large and diffuse change (>=400 changed lines AND >3 directories or 2 subsystems)
+- Very large change (>=1,000 changed lines)
+- Plan or task explicitly requests a full / deep / thorough code review

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -319,9 +319,9 @@ Determine how to proceed based on what was provided in `<input_document>`.
    - Keep user informed of major milestones
    - When the plan defines U-IDs for Implementation Units, or the plan or origin document carries stable R-IDs (and optionally A/F/AE IDs), reference them in blockers, deferred-work notes, task summaries, and final verification — not routine status updates. U-IDs anchor units across plan edits; R/A/F/AE anchor product intent across the brainstorm-plan handoff. Use the IDs the plan supplies and do not invent ones it does not. This preserves traceability without burying signal under noise.
 
-### Phase 3-4: Quality Check and Ship It
+### Phase 3-4: Quality Check and Finishing Work
 
-When all Phase 2 tasks are complete and execution transitions to quality check, read `references/shipping-workflow.md` for the full shipping workflow: quality checks, code review, final validation, PR creation, and notification.
+When all Phase 2 tasks are complete and execution transitions to quality check, you must read `references/shipping-workflow.md` for the full shipping workflow.Do not skip this.
 
 ## Key Principles
 

--- a/plugins/compound-engineering/skills/ce-work/references/shipping-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work/references/shipping-workflow.md
@@ -1,6 +1,6 @@
 # Shipping Workflow
 
-This file contains the shipping workflow (Phase 3-4). Load it only when all Phase 2 tasks are complete and execution transitions to quality check.
+This file contains the shipping workflow (Phase 3-4). It is loaded when all Phase 2 tasks are complete and execution transitions to quality check.
 
 ## Phase 3: Quality Check
 
@@ -18,15 +18,20 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
 
 2. **Code Review** (REQUIRED)
 
-   Every change gets reviewed before shipping. The depth scales with the change's risk profile, but review itself is never skipped.
+   Every change gets reviewed before shipping. Default to Tier 1 and escalate to Tier 2 only when a concrete signal calls for it. Tier 2 is materially more expensive in time and tokens -- pay that cost when a signal justifies it, not as a default.
 
-   **Tier 2: Full review (default)** -- REQUIRED unless Tier 1 criteria are explicitly met. Invoke the `ce-code-review` skill with `mode:autofix` to run specialized reviewer agents, auto-apply safe fixes, and record residual downstream work in the per-run artifact. When the plan file path is known, pass it as `plan:<path>`. This is the mandatory default -- proceed to Tier 1 only after confirming every criterion below.
+   **Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline before Final Validation. Skip the Residual Work Gate.
 
-   **Tier 1: Inline self-review** -- A lighter alternative permitted only when **all four** criteria are true. Before choosing Tier 1, explicitly state which criteria apply and why. If any criterion is uncertain, use Tier 2.
-   - Purely additive (new files only, no existing behavior modified)
-   - Single concern (one skill, one component -- not cross-cutting)
-   - Pattern-following (implementation mirrors an existing example with no novel logic)
-   - Plan-faithful (no scope growth, no deferred questions resolved with surprising answers)
+   **Tier 2 -- `ce-code-review` (escalation).** Invoke the `ce-code-review` skill with `mode:autofix`, passing `plan:<path>` when known. Then proceed to the Residual Work Gate.
+
+   Escalate to Tier 2 when **any** of the following is true:
+
+   - **Sensitive surface touched.** The diff modifies any of: authentication or authorization, payments or billing, data migrations or backfills, cryptography or secret handling, security-relevant configuration, public API or library contracts, or dependency manifests.
+   - **Large and diffuse change.** The diff exceeds >=400 changed lines **and** spans more than 3 directories or 2 distinct subsystems. Either alone is a soft signal; together they are an escalation trigger.
+   - **Very large change.** The diff exceeds >=1,000 changed lines regardless of diffusion.
+   - **Plan or task explicitly requests it.** The plan, the originating task, or another instruction in scope calls for a full / deep / thorough code review.
+
+   When the change is small, concentrated, and outside the sensitive surface list, Tier 1 is sufficient -- do not escalate "to be safe."
 
 3. **Residual Work Gate** (REQUIRED when Tier 2 ran)
 
@@ -42,7 +47,7 @@ This file contains the shipping workflow (Phase 3-4). Load it only when all Phas
    - `Accept and proceed` — record the residual findings verbatim in a durable "Known Residuals" sink before shipping. If a PR will be created or updated in Phase 4, include them in the PR description's "Known Residuals" section (the agent owns this when calling `ce-commit-push-pr`). If the user later chooses the no-PR `ce-commit` path, create `docs/residual-review-findings/<branch-or-head-sha>.md`, include the accepted findings and source review-run context, stage it with the implementation commit, and mention the file path in the final summary. The user has acknowledged the risk, but the findings must not live only in the transient session.
    - `Stop — do not ship` — abort the shipping workflow. The user will handle findings manually before re-invoking.
 
-   Skip this gate entirely when the review reported `Residual actionable work: none.` or when only Tier 1 (inline self-review) was used. Do not proceed past this gate on an `Accept and proceed` decision until the agent has recorded whether the durable sink is `PR Known Residuals` or `docs/residual-review-findings/<branch-or-head-sha>.md`.
+   Skip this gate entirely when the review reported `Residual actionable work: none.` or when only Tier 1 was used. Do not proceed past this gate on an `Accept and proceed` decision until the agent has recorded whether the durable sink is `PR Known Residuals` or `docs/residual-review-findings/<branch-or-head-sha>.md`.
 
 4. **Final Validation**
    - All tasks marked completed
@@ -112,18 +117,20 @@ Before creating PR, verify:
 - [ ] Evidence decision handled by `ce-commit-push-pr` when the change has observable behavior
 - [ ] Commit messages follow conventional format
 - [ ] PR description includes Post-Deploy Monitoring & Validation section (or explicit no-impact rationale)
-- [ ] Code review completed (inline self-review or full `ce-code-review`)
+- [ ] Code review completed (Tier 1 harness-native or Tier 2 `ce-code-review`)
 - [ ] PR description includes summary, testing notes, and evidence when captured
 - [ ] PR description includes Compound Engineered badge with accurate model and harness
 
 ## Code Review Tiers
 
-Every change gets reviewed. The tier determines depth, not whether review happens.
+Every change gets reviewed. Default to Tier 1; escalate to Tier 2 only on a concrete signal. Tier 2 is materially more expensive in time and tokens.
 
-**Tier 2 (full review)** -- REQUIRED default. Invoke `ce-code-review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work is recorded in the run artifact for downstream routing. Always use this tier unless all four Tier 1 criteria are explicitly confirmed.
+**Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline.
 
-**Tier 1 (inline self-review)** -- permitted only when all four are true (state each explicitly before choosing):
-- Purely additive (new files only, no existing behavior modified)
-- Single concern (one skill, one component -- not cross-cutting)
-- Pattern-following (mirrors an existing example, no novel logic)
-- Plan-faithful (no scope growth, no surprising deferred-question resolutions)
+**Tier 2 -- `ce-code-review` (escalation).** Invoke `ce-code-review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work routes through the Residual Work Gate.
+
+Escalate to Tier 2 when any of these holds:
+- Sensitive surface touched (auth/authz, payments/billing, data migrations or backfills, cryptography or secrets, security-relevant config, public API or library contracts, dependency manifests)
+- Large and diffuse change (>=400 changed lines AND >3 directories or 2 subsystems)
+- Very large change (>=1,000 changed lines)
+- Plan or task explicitly requests a full / deep / thorough code review

--- a/plugins/compound-engineering/skills/ce-work/references/shipping-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work/references/shipping-workflow.md
@@ -20,7 +20,7 @@ This file contains the shipping workflow (Phase 3-4). It is loaded when all Phas
 
    Every change gets reviewed before shipping. Default to Tier 1 and escalate to Tier 2 only when a concrete signal calls for it. Tier 2 is materially more expensive in time and tokens -- pay that cost when a signal justifies it, not as a default.
 
-   **Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline before Final Validation. Skip the Residual Work Gate.
+   **Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline before Final Validation. Skip the Residual Work Gate. If the current harness has no built-in code review command or skill, escalate to Tier 2 -- Tier 1 cannot run, and "Every change gets reviewed" still applies.
 
    **Tier 2 -- `ce-code-review` (escalation).** Invoke the `ce-code-review` skill with `mode:autofix`, passing `plan:<path>` when known. Then proceed to the Residual Work Gate.
 
@@ -125,7 +125,7 @@ Before creating PR, verify:
 
 Every change gets reviewed. Default to Tier 1; escalate to Tier 2 only on a concrete signal. Tier 2 is materially more expensive in time and tokens.
 
-**Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline.
+**Tier 1 -- harness-native code review (default).** Run your built-in code review command or skill (e.g., `/review` in Claude Code). Address blocking and suggested findings inline. If the current harness has no built-in code review command or skill, escalate to Tier 2 -- Tier 1 cannot run.
 
 **Tier 2 -- `ce-code-review` (escalation).** Invoke `ce-code-review mode:autofix` with `plan:<path>` when available. Safe fixes are applied automatically; residual work routes through the Residual Work Gate.
 

--- a/plugins/compound-engineering/skills/ce-work/references/shipping-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work/references/shipping-workflow.md
@@ -16,7 +16,13 @@ This file contains the shipping workflow (Phase 3-4). It is loaded when all Phas
    # Use linting-agent before pushing to origin
    ```
 
-2. **Code Review** (REQUIRED)
+2. **Simplify** (Claude Code only; REQUIRED for >=30 changed lines)
+
+   Before code review, run the `/simplify` skill on the change to consolidate duplicated patterns, remove dead code, and improve reuse. Skip when the diff is purely mechanical (formatting, dependency bumps, lint fixes, generated artifacts) -- simplification has no useful yield on those.
+
+   On other harnesses, proceed directly to code review.
+
+3. **Code Review** (REQUIRED)
 
    Every change gets reviewed before shipping. Default to Tier 1 and escalate to Tier 2 only when a concrete signal calls for it. Tier 2 is materially more expensive in time and tokens -- pay that cost when a signal justifies it, not as a default.
 
@@ -33,7 +39,7 @@ This file contains the shipping workflow (Phase 3-4). It is loaded when all Phas
 
    When the change is small, concentrated, and outside the sensitive surface list, Tier 1 is sufficient -- do not escalate "to be safe."
 
-3. **Residual Work Gate** (REQUIRED when Tier 2 ran)
+4. **Residual Work Gate** (REQUIRED when Tier 2 ran)
 
    After Tier 2 code review completes, inspect the Residual Actionable Work summary it returned (or read the run artifact directly if the summary was not emitted). If one or more residual `downstream-resolver` findings remain, do not proceed to Final Validation until the user decides how to handle them.
 
@@ -49,7 +55,7 @@ This file contains the shipping workflow (Phase 3-4). It is loaded when all Phas
 
    Skip this gate entirely when the review reported `Residual actionable work: none.` or when only Tier 1 was used. Do not proceed past this gate on an `Accept and proceed` decision until the agent has recorded whether the durable sink is `PR Known Residuals` or `docs/residual-review-findings/<branch-or-head-sha>.md`.
 
-4. **Final Validation**
+5. **Final Validation**
    - All tasks marked completed
    - Testing addressed -- tests pass and new/changed behavior has corresponding test coverage (or an explicit justification for why tests are not needed)
    - Linting passes
@@ -59,7 +65,7 @@ This file contains the shipping workflow (Phase 3-4). It is loaded when all Phas
    - If the plan has a `Requirements` section (or legacy `Requirements Trace`), verify each requirement is satisfied by the completed work
    - If any `Deferred to Implementation` questions were noted, confirm they were resolved during execution
 
-5. **Prepare Operational Validation Plan** (REQUIRED)
+6. **Prepare Operational Validation Plan** (REQUIRED)
    - Add a `## Post-Deploy Monitoring & Validation` section to the PR description for every change.
    - Include concrete:
      - Log queries/search terms
@@ -93,7 +99,7 @@ This file contains the shipping workflow (Phase 3-4). It is loaded when all Phas
    - Testing notes (tests added/modified, manual testing performed)
    - Evidence context from step 1, so `ce-commit-push-pr` can decide whether to ask about capturing evidence
    - Figma design link (if applicable)
-   - The Post-Deploy Monitoring & Validation section (see Phase 3 Step 5)
+   - The Post-Deploy Monitoring & Validation section (see Phase 3 Step 6)
    - Any "Known Residuals" accepted in the Phase 3 Residual Work Gate, rendered as a dedicated section in the PR body with severity, file:line, and title per finding
 
    If the user prefers to commit without creating a PR, load the `ce-commit` skill instead.

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -20,14 +20,15 @@ describe("ce-work review contract", () => {
     // Phase 3 has a mandatory code review step in the reference file
     expect(shipping).toContain("2. **Code Review**")
 
-    // Two-tier rubric in reference file
-    expect(shipping).toContain("**Tier 1: Inline self-review**")
-    expect(shipping).toContain("**Tier 2: Full review (default)**")
+    // Two-tier rubric in reference file: Tier 1 is harness-native (default),
+    // Tier 2 is ce-code-review (risk-based escalation)
+    expect(shipping).toContain("**Tier 1 -- harness-native code review (default).**")
+    expect(shipping).toContain("**Tier 2 -- `ce-code-review` (escalation).**")
     expect(shipping).toContain("ce-code-review")
     expect(shipping).toContain("mode:autofix")
 
     // Quality checklist includes review
-    expect(shipping).toContain("Code review completed (inline self-review or full `ce-code-review`)")
+    expect(shipping).toContain("Code review completed (Tier 1 harness-native or Tier 2 `ce-code-review`)")
   })
 
   test("delegates commit and PR to dedicated skills", async () => {

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -13,12 +13,15 @@ describe("ce-work review contract", () => {
     const shipping = await readRepoFile("plugins/compound-engineering/skills/ce-work/references/shipping-workflow.md")
 
     // SKILL.md should not contain extracted content
-    expect(content).not.toContain("2. **Code Review**")
+    expect(content).not.toContain("3. **Code Review**")
     expect(content).not.toContain("Consider Code Review")
     expect(content).not.toContain("Code Review** (Optional)")
 
-    // Phase 3 has a mandatory code review step in the reference file
-    expect(shipping).toContain("2. **Code Review**")
+    // Phase 3 has a Claude-Code-only Simplify step at position 2 (gated on >=30 LOC)
+    // and a mandatory code review at position 3
+    expect(shipping).toContain("2. **Simplify**")
+    expect(shipping).toContain("Claude Code only")
+    expect(shipping).toContain("3. **Code Review**")
 
     // Two-tier rubric in reference file: Tier 1 is harness-native (default),
     // Tier 2 is ce-code-review (risk-based escalation)
@@ -49,8 +52,10 @@ describe("ce-work review contract", () => {
     // Review/commit content extracted to references/shipping-workflow.md
     const shipping = await readRepoFile("plugins/compound-engineering/skills/ce-work-beta/references/shipping-workflow.md")
 
-    // Extracted content in reference file
-    expect(shipping).toContain("2. **Code Review**")
+    // Extracted content in reference file: Simplify step at position 2,
+    // Code Review at position 3
+    expect(shipping).toContain("2. **Simplify**")
+    expect(shipping).toContain("3. **Code Review**")
     expect(shipping).toContain("`ce-commit-push-pr` skill")
     expect(shipping).toContain("`ce-commit` skill")
 
@@ -111,7 +116,7 @@ describe("ce-work review contract", () => {
     expect(content).toContain("`references/shipping-workflow.md`")
 
     // Extracted content is not in SKILL.md
-    expect(content).not.toContain("2. **Code Review**")
+    expect(content).not.toContain("3. **Code Review**")
     expect(content).not.toContain("## Quality Checklist")
     expect(content).not.toContain("## Code Review Tiers")
   })
@@ -123,7 +128,7 @@ describe("ce-work review contract", () => {
     expect(content).toContain("`references/shipping-workflow.md`")
 
     // Extracted content is not in SKILL.md
-    expect(content).not.toContain("2. **Code Review**")
+    expect(content).not.toContain("3. **Code Review**")
     expect(content).not.toContain("## Quality Checklist")
     expect(content).not.toContain("## Code Review Tiers")
   })


### PR DESCRIPTION
## Summary

Shipping code review previously gated the lighter "inline self-review" tier behind a four-criteria purity test (purely additive, single concern, pattern-following, plan-faithful). Almost no real change satisfied all four, so nearly every shipped change paid the cost of Tier 2's multi-agent `ce-code-review`. This PR replaces the purity gate with risk-based escalation — Tier 1 is the default, and Tier 2 fires only on concrete signals — and adds a matching short-circuit inside `ce-code-review` itself for users who explicitly ask for a quick review.

## What changed

**`ce-work` shipping workflow (mirrored to `ce-work-beta`).** Tier 1 is now harness-native code review (e.g., `/review` in Claude Code) by default. Escalation to Tier 2 (`ce-code-review`) fires when **any** of these holds:

- **Sensitive surface touched** — auth/authz, payments, data migrations or backfills, cryptography or secrets, security-relevant config, public API or library contracts, dependency manifests.
- **Large and diffuse change** — diff exceeds 400 changed lines AND spans more than 3 directories or 2 distinct subsystems.
- **Very large change** — diff exceeds 1,000 changed lines regardless of diffusion.
- **Plan or task explicitly requests it.**

**`ce-code-review` quick short-circuit.** When `$ARGUMENTS` indicates the user wants a quick / fast / light code review, the skill redirects to the harness's built-in code review tool (`/review` in Claude Code; equivalent on Gemini and other harnesses) instead of dispatching the multi-agent flow. If the harness has no built-in code review, the skill falls through to the full multi-agent review. Programmatic callers (`mode:autofix`, `mode:report-only`, `mode:headless`) bypass the short-circuit — their orchestrators own user-facing routing. The agent announces the chosen path (Quick vs Multi-agent) before doing work.

## Why these signals

The previous criteria filtered on properties orthogonal to risk (file novelty, "plan-faithful"-ness). The replacement signals track defect predictors found in code-review research: sensitive-surface ownership (industry-convergent across Google, Kubernetes OWNERS, Stripe), change diffusion (Kamei et al. TSE 2013 — spread across components predicts defects better than raw LOC), and the SmartBear/Cisco ~400 LOC inflection past which review effectiveness drops. The "large AND diffuse" composition suppresses noisy single-signal escalations.

## Also

- Renamed Phase 3-4 heading from "Quality Check and Ship It" to "Quality Check and Finishing Work" — the phase finalizes work but doesn't strictly ship anything.
- Dropped the now-redundant "(inline self-review)" parenthetical from the Residual Work Gate skip clause.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?logo=claude&logoColor=white)