### PR TITLE
fix(ce-commit-push-pr): URL-encode parens in badge model-slug examples

### DIFF
--- a/plugins/compound-engineering/skills/ce-commit-push-pr/references/pr-description-writing.md
+++ b/plugins/compound-engineering/skills/ce-commit-push-pr/references/pr-description-writing.md
@@ -266,7 +266,7 @@ Assemble the body in this order:
 | Codex | (omit logo param) | `000000` |
 | Gemini CLI | `googlegemini` | `4285F4` |
 
-**Model slug:** Replace spaces with underscores. Append context window and thinking level in parentheses if known. Examples: `Opus_4.6_(1M,_Extended_Thinking)`, `Sonnet_4.6_(200K)`, `Gemini_3.1_Pro`.
+**Model slug:** Replace spaces with underscores. Append context window and thinking level in parentheses if known. URL-encode literal parens as `%28` and `%29` — unencoded `(` and `)` inside a markdown image URL break some commit-message parsers (notably release-please's conventional-commits parser, which fails the whole commit on encountering them and silently skips it from the changelog). Examples: `Opus_4.6_%281M,_Extended_Thinking%29`, `Sonnet_4.6_%28200K%29`, `Gemini_3.1_Pro`.
 
 ---
 


### PR DESCRIPTION
## Summary

The Compound Engineering badge that `ce-commit-push-pr` instructs callers to append uses model slugs containing literal parens, e.g. `Opus_4.6_(1M,_Extended_Thinking)`. When that slug lands inside a markdown image URL like `![Claude Code](https://img.shields.io/badge/Opus_4.7_(1M)-D97757?...)`, the nested `(...)` defeats some conventional-commit parsers — most importantly **release-please**, which fails the whole commit body and silently skips it:

```
❯ commit could not be parsed: <sha> <subject>
❯ error message: Error: unexpected token '(' at 53:45, valid tokens [)]
❯ commits: 0
✔ Considering: 0 commits
✔ No commits for path: ., skipping
```

The commit then contributes nothing to the next release PR or changelog. Repo owners only notice when a merge to main fails to produce a release PR — after the fact, with no easy remediation since the commit is already on main.

This change updates the documented examples to URL-encode the parens (`%28` / `%29`) so shields.io still renders them as `(` / `)` while the markdown URL stays parser-clean, and adds a one-line note explaining the failure mode so future authors don't reintroduce literal parens.

## Verifying

1. Compose a PR body with the new example: `Opus_4.6_%281M,_Extended_Thinking%29`. The rendered badge looks identical to today's.
2. Merge a commit using that body into a release-please-managed repo. The commit now parses cleanly and contributes to the next release PR (previously skipped).

The change is doc-only — a single string in a reference markdown file. No code paths affected.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)