### PR TITLE
fix(ce-compound,ce-sessions): handle non-git CWD in pre-resolved git branch

### DIFF
--- a/plugins/compound-engineering/skills/ce-compound/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound/SKILL.md
@@ -24,7 +24,7 @@ Captures problem solutions while context is fresh, creating structured documenta
 
 **Repo name (pre-resolved):** !`common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); repo="${common%/.git}"; echo "${repo##*/}"`
 
-**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null`
+**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null || true`
 
 If the lines above resolved to plain values (a folder name like `my-repo` and a branch name like `feat/my-branch`), pass them into the Session Historian dispatch in Phase 1 so the agent does not waste a turn deriving them. If they still contain backtick command strings or are empty, omit them from the dispatch and let the agent derive them at runtime.
 

--- a/plugins/compound-engineering/skills/ce-sessions/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-sessions/SKILL.md
@@ -18,7 +18,7 @@ Search your session history.
 
 **Repo name (pre-resolved):** !`common=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null); repo="${common%/.git}"; echo "${repo##*/}"`
 
-**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null`
+**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null || true`
 
 If the lines above resolved to plain values (a folder name like `my-repo` and a branch name like `feat/my-branch`), they are ready to pass to the agent. If they still contain backtick command strings or are empty, they did not resolve — omit them from the dispatch and let the agent derive them at runtime.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -56,7 +56,7 @@ If `inside_sandbox` is true, delegation would recurse or fail.
 **2. Availability Check**
 
 **Codex CLI path (pre-resolved):**
-!`command -v codex 2>/dev/null`
+!`command -v codex 2>/dev/null || true`
 
 If the line above shows an absolute path (starts with `/`, e.g., `/opt/homebrew/bin/codex`), the Codex CLI is available — proceed to the next check.
 Otherwise — empty, an unresolved command string like `command -v codex 2>/dev/null` left in place by a non-Claude harness that doesn't process `!` pre-resolution, or any other non-path value — run `command -v codex` via the shell/Bash tool to verify at runtime. If that prints an absolute path, the Codex CLI is available; proceed. If it fails or prints nothing, emit "Codex CLI not found (install via `npm install -g @openai/codex` or `brew install codex`) -- using standard mode." and set `delegation_active` to false.

--- a/tests/skill-shell-safety.test.ts
+++ b/tests/skill-shell-safety.test.ts
@@ -25,6 +25,11 @@ import { describe, expect, test } from "bun:test"
  *   - ce-compound and ce-sessions used `git rev-parse ... | sed -E '...'` which
  *     trips the permission checker as "multiple operations". Fix: replace the
  *     pipe with bash parameter expansion (e.g. strip suffix, strip prefix).
+ *   - ce-compound and ce-sessions used `git rev-parse --abbrev-ref HEAD 2>/dev/null`
+ *     with no fallback. Outside a git repo, `git rev-parse` exits 128;
+ *     `2>/dev/null` suppresses stderr but the non-zero exit propagates and
+ *     Claude Code reports "Shell command failed for pattern" (issue #730). Fix:
+ *     pair `2>/dev/null` with `|| true` or `|| echo '__SENTINEL__'`.
  */
 
 const PLUGIN_SKILLS_GLOB = ["plugins/compound-engineering/skills", "plugins/coding-tutor/skills"]
@@ -142,6 +147,45 @@ function hasNestedQuotedStringInCommandSubst(cmd: string): boolean {
 }
 
 /**
+ * Returns true when the command's *trailing* top-level statement suppresses
+ * stderr with `2>/dev/null` but has no `||` fallback. The trailing statement
+ * determines the command's overall exit code (after `;` or `&&` chains). When
+ * that exit code is non-zero, Claude Code reports "Shell command failed for
+ * pattern" and aborts skill load before its body runs (issue #730). Established
+ * defensive pattern: pair `2>/dev/null` with `|| true` or `|| echo '__SENTINEL__'`.
+ *
+ * `2>/dev/null` inside an earlier `;`-chained statement is fine if the trailing
+ * statement (e.g., a final `echo`) succeeds — that case is not flagged.
+ */
+function hasUnguardedErrorSuppression(cmd: string): boolean {
+  let depth = 0
+  let inSingleQuote = false
+  let inDoubleQuote = false
+  let lastSeparatorEnd = 0
+
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i]
+    const next = cmd[i + 1]
+
+    if (!inDoubleQuote && c === "'") { inSingleQuote = !inSingleQuote; continue }
+    if (!inSingleQuote && c === '"') { inDoubleQuote = !inDoubleQuote; continue }
+    if (inSingleQuote || inDoubleQuote) continue
+
+    if (c === '$' && next === '(') { depth++; i++; continue }
+    if (c === '(') { depth++; continue }
+    if (c === ')') { depth--; continue }
+
+    if (depth === 0) {
+      if (c === ';') { lastSeparatorEnd = i + 1; continue }
+      if (c === '&' && next === '&') { lastSeparatorEnd = i + 2; i++; continue }
+    }
+  }
+
+  const trailing = cmd.slice(lastSeparatorEnd)
+  return trailing.includes("2>/dev/null") && !trailing.includes("||")
+}
+
+/**
  * Returns true when the command contains a top-level pipe (`|` that is not
  * `||`). Claude Code's permission checker treats piped commands as separate
  * operations and may require approval for each, causing skill-load failure
@@ -232,6 +276,44 @@ describe("hasNestedQuotedStringInCommandSubst", () => {
   })
 })
 
+describe("hasUnguardedErrorSuppression", () => {
+  test("flags single-statement `2>/dev/null` with no fallback", () => {
+    expect(hasUnguardedErrorSuppression("git rev-parse --abbrev-ref HEAD 2>/dev/null")).toBe(true)
+  })
+
+  test("flags `command -v <name> 2>/dev/null` with no fallback", () => {
+    expect(hasUnguardedErrorSuppression("command -v codex 2>/dev/null")).toBe(true)
+  })
+
+  test("does not flag `2>/dev/null || true`", () => {
+    expect(hasUnguardedErrorSuppression("git rev-parse --abbrev-ref HEAD 2>/dev/null || true")).toBe(false)
+  })
+
+  test("does not flag `2>/dev/null || echo '__SENTINEL__'`", () => {
+    expect(hasUnguardedErrorSuppression("git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo '__DEFAULT_BRANCH_UNRESOLVED__'")).toBe(false)
+  })
+
+  test("does not flag commands without `2>/dev/null`", () => {
+    expect(hasUnguardedErrorSuppression("git status")).toBe(false)
+  })
+
+  test("does not flag `2>/dev/null` inside a guarded subshell", () => {
+    expect(hasUnguardedErrorSuppression("(top=$(git rev-parse --show-toplevel 2>/dev/null); cat \"$top/file\") || echo '__NO_CONFIG__'")).toBe(false)
+  })
+
+  test("does not flag `2>/dev/null` in non-trailing statement followed by always-succeeding tail", () => {
+    expect(hasUnguardedErrorSuppression('common=$(git rev-parse --git-common-dir 2>/dev/null); repo="${common%/.git}"; echo "${repo##*/}"')).toBe(false)
+  })
+
+  test("flags `2>/dev/null` on the trailing statement of a `;` chain", () => {
+    expect(hasUnguardedErrorSuppression("setup; cmd 2>/dev/null")).toBe(true)
+  })
+
+  test("flags `2>/dev/null` on the trailing statement of an `&&` chain", () => {
+    expect(hasUnguardedErrorSuppression("setup && cmd 2>/dev/null")).toBe(true)
+  })
+})
+
 describe("hasTopLevelPipe", () => {
   test("flags a simple pipe", () => {
     expect(hasTopLevelPipe("git rev-parse --git-common-dir 2>/dev/null | sed -E 's|x||'")).toBe(true)
@@ -299,6 +381,19 @@ describe("skill `!` pre-resolution commands avoid Claude Code denylist", () => {
       expect(
         offenders,
         `Claude Code rejects \`$(...)\` containing a double-quoted string as "Unhandled node type: string" (e.g., \`basename "$(dirname "$common")"\`). Replace nested \`$()\` with parameter expansion (\`\${var%/suffix}\`), pipe to sed, or extract to a script invoked as \`bash "\${CLAUDE_SKILL_DIR}/scripts/<name>.sh"\`.\nOffending commands:\n${formatted}`,
+      ).toEqual([])
+    })
+
+    test(`${rel} pre-resolution commands that suppress stderr with \`2>/dev/null\` also include a \`||\` fallback (issue #730)`, () => {
+      const offenders = preResolutionCommands.filter(({ command }) =>
+        hasUnguardedErrorSuppression(command),
+      )
+      const formatted = offenders
+        .map(({ lineNumber, command }) => `  line ${lineNumber}: ${command}`)
+        .join("\n")
+      expect(
+        offenders,
+        `\`2>/dev/null\` only suppresses stderr — the non-zero exit code still propagates. Outside the success path (e.g., \`git rev-parse\` outside a git repo), Claude Code reports "Shell command failed for pattern" and aborts skill load. Pair \`2>/dev/null\` with \`|| true\` (when an empty result is fine) or \`|| echo '__SENTINEL__'\` (when the agent should distinguish "did not resolve" from "resolved to empty").\nOffending commands:\n${formatted}`,
       ).toEqual([])
     })
 

--- a/tests/skill-shell-safety.test.ts
+++ b/tests/skill-shell-safety.test.ts
@@ -178,11 +178,11 @@ function hasUnguardedErrorSuppression(cmd: string): boolean {
     if (depth === 0) {
       if (c === ';') { lastSeparatorEnd = i + 1; continue }
       if (c === '&' && next === '&') { lastSeparatorEnd = i + 2; i++; continue }
+      if (c === '|' && next === '|') { lastSeparatorEnd = i + 2; i++; continue }
     }
   }
 
-  const trailing = cmd.slice(lastSeparatorEnd)
-  return trailing.includes("2>/dev/null") && !trailing.includes("||")
+  return cmd.slice(lastSeparatorEnd).includes("2>/dev/null")
 }
 
 /**
@@ -311,6 +311,10 @@ describe("hasUnguardedErrorSuppression", () => {
 
   test("flags `2>/dev/null` on the trailing statement of an `&&` chain", () => {
     expect(hasUnguardedErrorSuppression("setup && cmd 2>/dev/null")).toBe(true)
+  })
+
+  test("flags `2>/dev/null` on the trailing statement of an `||` chain (a `||` belonging to an earlier statement does not protect a later unguarded one)", () => {
+    expect(hasUnguardedErrorSuppression("probe || git rev-parse --abbrev-ref HEAD 2>/dev/null")).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

- `/ce-compound` and `/ce-sessions` failed to load outside a git repo because `!`git rev-parse --abbrev-ref HEAD 2>/dev/null`` exits 128 with no fallback. `2>/dev/null` only swallows stderr — the non-zero exit propagates and Claude Code reports "Shell command failed for pattern". Pair with `|| true` so the line resolves to an empty value (the existing prose already handles "are empty, omit them from the dispatch").
- Distinct from issue #722 / PR #723, which fixed the *Repo name* line on the same skills (a pipe triggering "multiple operations requiring approval"). #730 is the *Git branch* line — left unchanged by #723 — with a different failure mode (non-zero exit, not permission check).
- Also fixes the same bug class in `ce-work-beta` (`command -v codex 2>/dev/null` exits 1 on machines without codex).
- Adds a `hasUnguardedErrorSuppression` check to `tests/skill-shell-safety.test.ts` that flags any pre-resolution command whose **trailing** top-level statement uses `2>/dev/null` without an `||` fallback. The check ignores non-trailing suppressions where a later always-succeeding statement (e.g., a final `echo`) ensures exit 0, so it catches real `#730`-class bugs without false-positiving on the `Repo name` line.

## Test plan

- [x] `bun test tests/skill-shell-safety.test.ts` — 81 pass, the new per-skill check fails on the unfixed lines and passes after the fix
- [x] `bun test` — full suite (1045 tests) passes
- [x] `bun run release:validate` — clean
- [x] Manual: `cd /tmp && bash -c 'git rev-parse --abbrev-ref HEAD 2>/dev/null || true'; echo \$?` → exit 0
- [ ] Smoke test in a fresh non-git directory: `/ce-compound` and `/ce-sessions` load without "Shell command failed for pattern"

Fixes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)