### PR TITLE
fix(ce-setup): detect codex global skills

### DIFF
--- a/plugins/compound-engineering/skills/ce-setup/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-setup/SKILL.md
@@ -142,7 +142,7 @@ For each selected dependency, in order:
 
 2. **If approved:** Run the install command using a shell execution tool. After the command completes, verify installation:
    - For a CLI tool, run the dependency's check command (e.g., `command -v agent-browser`).
-   - For an agent skill, prefer `npx --yes skills list --global --json | jq -r '.[].name' | grep -qx <skill-name>` when `npx` is available; otherwise fall back to checking that `~/.claude/skills/<skill-name>` exists (file, directory, or symlink).
+   - For an agent skill, prefer `npx --yes skills list --global --json | jq -r '.[].name' | grep -qx <skill-name>` when `npx` is available; otherwise fall back to checking that `~/.claude/skills/<skill-name>`, `~/.agents/skills/<skill-name>`, or `~/.codex/skills/<skill-name>` exists (file, directory, or symlink).
 
 3. **If verification succeeds:** Report success.
 

--- a/plugins/compound-engineering/skills/ce-setup/scripts/check-health
+++ b/plugins/compound-engineering/skills/ce-setup/scripts/check-health
@@ -23,9 +23,8 @@ deps=(
 
 # Agent skills installed via the `skills` CLI (vercel-labs/skills).
 # Format: name|tier|install_cmd|url
-# Presence is resolved authoritatively via `npx --yes skills list --global --json`
-# when npx and jq are available; otherwise falls back to a Claude Code path
-# probe at ~/.claude/skills/<name>.
+# Presence is resolved via `npx --yes skills list --global --json`
+# when npx and jq are available, then by probing known global skill roots.
 
 skills=(
   "ast-grep|recommended|npx skills add ast-grep/agent-skill -g -y|https://github.com/ast-grep/agent-skill"
@@ -92,7 +91,25 @@ fi
 
 skill_ok=0; skill_total=0
 skill_results=()
-skills_root="$HOME/.claude/skills"
+skill_roots=(
+  "$HOME/.claude/skills"
+  "$HOME/.agents/skills"
+  "$HOME/.codex/skills"
+)
+
+skill_exists_on_disk() {
+  local name="$1"
+  local root
+
+  for root in "${skill_roots[@]}"; do
+    if [ -e "$root/$name" ]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 for entry in "${skills[@]}"; do
   IFS='|' read -r name tier install_cmd url <<< "$entry"
   skill_total=$((skill_total + 1))
@@ -102,7 +119,9 @@ for entry in "${skills[@]}"; do
     if printf '%s\n' "$installed_skill_names" | grep -qx "$name"; then
       is_installed="yes"
     fi
-  elif [ -e "$skills_root/$name" ]; then
+  fi
+
+  if [ "$is_installed" = "no" ] && skill_exists_on_disk "$name"; then
     is_installed="yes"
   fi
 

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -1,0 +1,73 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "fs/promises"
+import os from "os"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const checkHealthScript = path.join(
+  import.meta.dir,
+  "..",
+  "..",
+  "plugins",
+  "compound-engineering",
+  "skills",
+  "ce-setup",
+  "scripts",
+  "check-health",
+)
+
+type RunResult = {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+async function runCheckHealth(home: string, pathValue: string): Promise<RunResult> {
+  const proc = Bun.spawn(["bash", checkHealthScript], {
+    cwd: home,
+    env: {
+      ...process.env,
+      HOME: home,
+      PATH: pathValue,
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  })
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+
+  return { exitCode, stdout, stderr }
+}
+
+async function writeExecutable(filePath: string, content: string): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, content)
+  await chmod(filePath, 0o755)
+}
+
+describe("ce-setup check-health", () => {
+  test("detects global Codex skills under ~/.agents/skills when skills CLI misses them", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+
+    try {
+      await mkdir(path.join(root, ".agents", "skills", "ast-grep"), { recursive: true })
+
+      const binDir = path.join(root, "bin")
+      await writeExecutable(
+        path.join(binDir, "npx"),
+        "#!/usr/bin/env bash\nprintf '%s\\n' '[{\"name\":\"other-skill\"}]'\n",
+      )
+
+      const result = await runCheckHealth(root, `${binDir}:/usr/bin:/bin`)
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain("Skills  1/1")
+      expect(result.stdout).toContain("1/1 skills")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

`ce-setup` now recognizes Codex/global agent skills installed under `~/.agents/skills` or legacy `~/.codex/skills` when the `skills` CLI does not list them.

The health check still treats `npx skills list --global --json` as the first signal, but it now follows with a filesystem probe across the known global skill roots instead of only checking `~/.claude/skills`. The setup instructions use the same fallback paths so post-install verification matches the script behavior.

## Testing

- `bun test`
- `bun run release:validate`
- Manual check with a temporary HOME containing only `~/.agents/skills/ast-grep`, which now reports `Skills 1/1`

Fixes #736

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
