### PR TITLE
fix(code-review): grant Write to JSON-pipeline reviewer agents

### DIFF
--- a/plugins/compound-engineering/agents/ce-adversarial-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-adversarial-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-adversarial-reviewer
 description: Conditional code-review persona, selected when the diff is large (>=50 changed lines) or touches high-risk domains like auth, payments, data mutations, or external APIs. Actively constructs failure scenarios to break the implementation rather than checking against known patterns.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: red
 
 ---

--- a/plugins/compound-engineering/agents/ce-api-contract-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-api-contract-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-api-contract-reviewer
 description: Conditional code-review persona, selected when the diff touches API routes, request/response types, serialization, versioning, or exported type signatures. Reviews code for breaking contract changes.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-correctness-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-correctness-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-correctness-reviewer
 description: Always-on code-review persona. Reviews code for logic errors, edge cases, state management bugs, error propagation failures, and intent-vs-implementation mismatches.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-data-migrations-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-data-migrations-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-data-migrations-reviewer
 description: Conditional code-review persona, selected when the diff touches migration files, schema changes, data transformations, or backfill scripts. Reviews code for data integrity and migration safety.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-dhh-rails-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-dhh-rails-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-dhh-rails-reviewer
 description: Conditional code-review persona, selected when Rails diffs introduce architectural choices, abstractions, or frontend patterns that may fight the framework. Reviews code from an opinionated DHH perspective.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/compound-engineering/agents/ce-julik-frontend-races-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-julik-frontend-races-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-julik-frontend-races-reviewer
 description: Conditional code-review persona, selected when the diff touches async UI code, Stimulus/Turbo lifecycles, or DOM-timing-sensitive frontend behavior. Reviews code for race conditions and janky UI failure modes.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/compound-engineering/agents/ce-kieran-python-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-kieran-python-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-kieran-python-reviewer
 description: Conditional code-review persona, selected when the diff touches Python code. Reviews changes with Kieran's strict bar for Pythonic clarity, type hints, and maintainability.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/compound-engineering/agents/ce-kieran-rails-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-kieran-rails-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-kieran-rails-reviewer
 description: Conditional code-review persona, selected when the diff touches Rails application code. Reviews Rails changes with Kieran's strict bar for clarity, conventions, and maintainability.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/compound-engineering/agents/ce-kieran-typescript-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-kieran-typescript-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-kieran-typescript-reviewer
 description: Conditional code-review persona, selected when the diff touches TypeScript code. Reviews changes with Kieran's strict bar for type safety, clarity, and maintainability.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/compound-engineering/agents/ce-maintainability-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-maintainability-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-maintainability-reviewer
 description: Always-on code-review persona. Reviews code for premature abstraction, unnecessary indirection, dead code, coupling between unrelated modules, and naming that obscures intent.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-performance-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-performance-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-performance-reviewer
 description: Conditional code-review persona, selected when the diff touches database queries, loop-heavy data transforms, caching layers, or I/O-intensive paths. Reviews code for runtime performance and scalability issues.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-previous-comments-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-previous-comments-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-previous-comments-reviewer
 description: Conditional code-review persona, selected when reviewing a PR that has existing review comments or review threads. Checks whether prior feedback has been addressed in the current diff.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: yellow
 
 ---

--- a/plugins/compound-engineering/agents/ce-project-standards-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-project-standards-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-project-standards-reviewer
 description: Always-on code-review persona. Audits changes against the project's own CLAUDE.md and AGENTS.md standards -- frontmatter rules, reference inclusion, naming conventions, cross-platform portability, and tool selection policies.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-reliability-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-reliability-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-reliability-reviewer
 description: Conditional code-review persona, selected when the diff touches error handling, retries, circuit breakers, timeouts, health checks, background jobs, or async handlers. Reviews code for production reliability and failure modes.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-security-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-security-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-security-reviewer
 description: Conditional code-review persona, selected when the diff touches auth middleware, public endpoints, user input handling, or permission checks. Reviews code for exploitable vulnerabilities.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/plugins/compound-engineering/agents/ce-swift-ios-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-swift-ios-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-swift-ios-reviewer
 description: Conditional code-review persona, selected when the diff touches Swift files (.swift), SwiftUI views, UIKit controllers, iOS entitlements, privacy manifests, Core Data model bundles, SPM manifests, storyboards/XIBs, or semantic build-setting/target/signing changes inside .pbxproj. Reviews Swift and iOS code for SwiftUI correctness, state management, memory safety, Swift concurrency, Core Data threading, and accessibility.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 ---
 

--- a/plugins/compound-engineering/agents/ce-testing-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-testing-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-testing-reviewer
 description: Always-on code-review persona. Reviews code for test coverage gaps, weak assertions, brittle implementation-coupled tests, and missing edge case coverage.
 model: inherit
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, Write
 color: blue
 
 ---

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -575,6 +575,40 @@ describe("ce-code-review contract", () => {
     }
   })
 
+  test("JSON-pipeline persona agents grant Write so they can save run artifacts", async () => {
+    // The ce-code-review subagent template instructs each persona to write its full
+    // analysis to /tmp/compound-engineering/ce-code-review/{run_id}/{reviewer}.json.
+    // Without Write in tools, that "one permitted write" cannot happen and headless
+    // detail enrichment loses its Why:/Evidence: source. See issue #733.
+    const personas = [
+      "ce-correctness-reviewer",
+      "ce-testing-reviewer",
+      "ce-maintainability-reviewer",
+      "ce-project-standards-reviewer",
+      "ce-security-reviewer",
+      "ce-performance-reviewer",
+      "ce-api-contract-reviewer",
+      "ce-data-migrations-reviewer",
+      "ce-reliability-reviewer",
+      "ce-adversarial-reviewer",
+      "ce-previous-comments-reviewer",
+      "ce-dhh-rails-reviewer",
+      "ce-kieran-rails-reviewer",
+      "ce-kieran-python-reviewer",
+      "ce-kieran-typescript-reviewer",
+      "ce-julik-frontend-races-reviewer",
+      "ce-swift-ios-reviewer",
+    ]
+
+    for (const persona of personas) {
+      const content = await readRepoFile(`plugins/compound-engineering/agents/${persona}.agent.md`)
+      const parsed = parseFrontmatter(content)
+      const tools = String(parsed.data.tools ?? "")
+
+      expect(tools).toContain("Write")
+    }
+  })
+
   test("leaves data-migration-expert as the unstructured review format", async () => {
     const content = await readRepoFile(
       "plugins/compound-engineering/agents/ce-data-migration-expert.agent.md",


### PR DESCRIPTION
## Summary

Persona reviewers spawned by `/ce-code-review` were not writing run-artifact files to `/tmp/compound-engineering/ce-code-review/<run-id>/`, even though the subagent template explicitly instructs each persona to do so as "the one permitted write." Headless detail enrichment depends on those files for `Why:` and `Evidence:` lines, so the missing artifacts silently degraded review output.

The cause was a declaration mismatch: all 17 JSON-pipeline persona agents declared `tools: Read, Grep, Glob, Bash` in frontmatter — `Write` was never granted. The skill's instruction to use the file-write tool was unsatisfiable. Adding `Write` to each persona's allowlist makes the documented contract actually executable.

## Change

| Layer | Persona agents updated |
|-------|------------------------|
| Always-on (4) | `ce-correctness-reviewer`, `ce-testing-reviewer`, `ce-maintainability-reviewer`, `ce-project-standards-reviewer` |
| Cross-cutting conditional (7) | `ce-security-reviewer`, `ce-performance-reviewer`, `ce-api-contract-reviewer`, `ce-data-migrations-reviewer`, `ce-reliability-reviewer`, `ce-adversarial-reviewer`, `ce-previous-comments-reviewer` |
| Stack-specific (6) | `ce-dhh-rails-reviewer`, `ce-kieran-rails-reviewer`, `ce-kieran-python-reviewer`, `ce-kieran-typescript-reviewer`, `ce-julik-frontend-races-reviewer`, `ce-swift-ios-reviewer` |

Unstructured-output agents (`ce-agent-native-reviewer`, `ce-learnings-researcher`, `ce-schema-drift-detector`, `ce-deployment-verification-agent`, `ce-data-migration-expert`) were left untouched — they don't follow the artifact-write contract.

## Regression guard

Added `tests/review-skill-contract.test.ts` "JSON-pipeline persona agents grant Write so they can save run artifacts", which iterates all 17 personas and asserts `Write` is in their `tools` frontmatter. The pre-existing assertion only covered Read/Grep/Glob/Bash and missed this gap.

`bun test` (1047 tests) passes; `bun run release:validate` is clean.

Fixes #733

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)