### PR TITLE
fix(ce-commit-push-pr): use body-file for PR descriptions

### DIFF
--- a/plugins/compound-engineering/skills/ce-commit-push-pr/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-commit-push-pr/SKILL.md
@@ -71,16 +71,21 @@ Use the current branch and existing PR check from context. If the current branch
 
 **Compare and confirm.** Briefly explain what the new description covers differently from the old one. Ask the user to confirm before applying. If the user provided focus, confirm it was addressed.
 
-If confirmed, apply with `gh pr edit`. Substitute `<TITLE>` verbatim; if it contains `"`, `` ` ``, `$`, or `\`, escape them or switch to single quotes. The body is best written to a temp file first to avoid shell-escaping the whole markdown body:
+If confirmed, apply with `gh pr edit`. Substitute `<TITLE>` verbatim; if it contains `"`, `` ` ``, `$`, or `\`, escape them or switch to single quotes.
+
+The body **must** be written to a temp file and passed via `--body-file <path>`. Never use `--body-file -`, stdin pipes, heredoc-to-stdin, or `--body "$(cat ...)"` — wrappers and stdin handling can silently produce an empty PR body while `gh` still exits 0 and returns a URL.
 
 ```bash
 BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/ce-pr-body.XXXXXX") && cat > "$BODY_FILE" <<'__CE_PR_BODY_END__'
 <the composed body markdown goes here, verbatim>
 __CE_PR_BODY_END__
-gh pr edit --title "<TITLE>" --body "$(cat "$BODY_FILE")"
 ```
 
 The quoted sentinel keeps `$VAR`, backticks, and any literal `EOF` inside the body from being expanded.
+
+```bash
+gh pr edit --title "<TITLE>" --body-file "$BODY_FILE"
+```
 
 Report the PR URL.
 
@@ -178,7 +183,9 @@ When evidence is not possible (docs-only, markdown-only, changelog-only, release
 
 ### Step 7: Create or update the PR
 
-Apply via `gh pr create` (new PR) or `gh pr edit` (existing PR). The body is best written to a temp file first to avoid shell-escaping the whole markdown body. Substitute `<TITLE>` verbatim; if it contains `"`, `` ` ``, `$`, or `\`, escape them or switch to single quotes:
+Apply via `gh pr create` (new PR) or `gh pr edit` (existing PR). Substitute `<TITLE>` verbatim; if it contains `"`, `` ` ``, `$`, or `\`, escape them or switch to single quotes.
+
+The body **must** be written to a temp file and passed via `--body-file <path>`. Never use `--body-file -`, stdin pipes, heredoc-to-stdin, or `--body "$(cat ...)"` — wrappers and stdin handling can silently produce an empty PR body while `gh` still exits 0 and returns a URL.
 
 ```bash
 BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/ce-pr-body.XXXXXX") && cat > "$BODY_FILE" <<'__CE_PR_BODY_END__'
@@ -191,7 +198,7 @@ The quoted sentinel keeps `$VAR`, backticks, and any literal `EOF` inside the bo
 #### New PR (no existing PR from Step 3)
 
 ```bash
-gh pr create --title "<TITLE>" --body "$(cat "$BODY_FILE")"
+gh pr create --title "<TITLE>" --body-file "$BODY_FILE"
 ```
 
 Keep the title under 72 characters; the writing reference already emits a conventional-commit title in that range.
@@ -207,7 +214,7 @@ The new commits are already on the PR from Step 5. Report the PR URL, then ask w
   3. If confirmed, apply with `gh pr edit`:
 
      ```bash
-     gh pr edit --title "<TITLE>" --body "$(cat "$BODY_FILE")"
+     gh pr edit --title "<TITLE>" --body-file "$BODY_FILE"
      ```
 
   Then report the PR URL (Step 8).


### PR DESCRIPTION
The ce-commit-push-pr skill now writes composed PR descriptions to a temp file and passes them to GitHub CLI with `--body-file`, avoiding shell command substitution for markdown bodies.

This applies the same safer path to description updates, new PR creation, and existing PR rewrites while keeping the generated body content verbatim.

Validation: `bun run release:validate`; `git diff --check`.
