### PR TITLE
feat(ce-work-beta): adaptive effort selection for Codex delegation batches

### DIFF
--- a/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
+++ b/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
@@ -9,7 +9,7 @@
 # work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
 # work_delegate_decision: auto   # auto | ask (default: auto)
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
-# work_delegate_effort: high     # minimal | low | medium | high | xhigh — floor, not a cap (omit to use ~/.codex/config.toml default)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
 
 # --- Product pulse ---
 # Settings written by /ce-product-pulse first-run interview. Re-run the skill with

--- a/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
+++ b/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
@@ -9,7 +9,7 @@
 # work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
 # work_delegate_decision: auto   # auto | ask (default: auto)
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
-# work_delegate_effort: high     # minimal | low | medium | high | xhigh — floor (minimum), not a cap; ce-work-beta picks per-batch and applies max(pick, floor). Omit to defer to ~/.codex/config.toml default (medium on stock Codex).
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh — floor, not a cap (omit to use ~/.codex/config.toml default)
 
 # --- Product pulse ---
 # Settings written by /ce-product-pulse first-run interview. Re-run the skill with

--- a/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
+++ b/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
@@ -9,7 +9,7 @@
 # work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
 # work_delegate_decision: auto   # auto | ask (default: auto)
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
-# work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh — floor (minimum), not a cap; ce-work-beta picks per-batch and applies max(pick, floor). Omit to defer to ~/.codex/config.toml default (medium on stock Codex).
 
 # --- Product pulse ---
 # Settings written by /ce-product-pulse first-run interview. Re-run the skill with

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -65,8 +65,8 @@ Store the resolved state for downstream consumption:
 - `sandbox_mode` -- `yolo` or `full-auto` (from config or default `yolo`)
 - `consent_granted` -- boolean (from config `work_delegate_consent`)
 - `delegate_model` -- string from config, or unset (defer to Codex config)
-- `delegate_effort` -- string from config, or unset (defer to Codex config). Floor for per-batch effort selection (not the value passed to `codex exec`).
-- `effective_effort` -- per-batch derived value, one of `default | medium | high | xhigh` (or `minimal`/`low` if floor applies). Computed before each delegated batch from `delegate_effort` and the batch's picked level per `references/codex-delegation-workflow.md` ("Per-Batch Effort"). This — not `delegate_effort` — is what feeds the `codex exec` invocation. When delegation is active, derive `effective_effort` immediately before each batch; never pass `delegate_effort` directly.
+- `delegate_effort` -- string from config, or unset (defer to Codex config). Floor for per-batch effort selection; not passed directly to `codex exec`.
+- `effective_effort` -- per-batch derived value (`default | medium | high | xhigh`), computed before each batch from `delegate_effort` and the picked level per `references/codex-delegation-workflow.md` ("Per-Batch Effort"). Feeds the `codex exec` invocation in place of `delegate_effort`.
 
 ---
 

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -65,7 +65,8 @@ Store the resolved state for downstream consumption:
 - `sandbox_mode` -- `yolo` or `full-auto` (from config or default `yolo`)
 - `consent_granted` -- boolean (from config `work_delegate_consent`)
 - `delegate_model` -- string from config, or unset (defer to Codex config)
-- `delegate_effort` -- string from config, or unset (defer to Codex config)
+- `delegate_effort` -- string from config, or unset (defer to Codex config). Floor for per-batch effort selection (not the value passed to `codex exec`).
+- `effective_effort` -- per-batch derived value, one of `default | medium | high | xhigh` (or `minimal`/`low` if floor applies). Computed before each delegated batch from `delegate_effort` and the batch's picked level per `references/codex-delegation-workflow.md` ("Per-Batch Effort"). This — not `delegate_effort` — is what feeds the `codex exec` invocation. When delegation is active, derive `effective_effort` immediately before each batch; never pass `delegate_effort` directly.
 
 ---
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -88,6 +88,30 @@ On decline:
 
 Delegate all units in one batch. If the plan exceeds 5 units, split into batches at the plan's own phase boundaries, or in groups of roughly 5 -- never splitting units that share files. Skip delegation entirely if every unit is trivial.
 
+## Per-Batch Effort Resolution
+
+Before each batch, assess complexity to determine `effective_effort`. The config `work_delegate_effort` acts as a floor — `effective_effort` will never be lower than the config value.
+
+**Complexity tiers:**
+
+| Tier | Signals | Effort |
+|------|---------|--------|
+| Trivial | ≤2 files, no behavioral change (config, rename, typo) | default (no flag) |
+| Moderate | 3–9 files, clear scope, no high-risk areas | `medium` |
+| Complex | 5+ files OR touches auth, payments, migrations, external APIs, or error handling | `high` |
+| Architectural | 10+ files OR cross-cutting changes OR multiple high-risk areas | `xhigh` |
+
+**Resolution steps:**
+1. Count implementation files in the batch's combined `Files:` list (Create + Modify paths; exclude Test paths)
+2. Check for high-risk signals: auth/session logic, payments, database migrations, external API calls, error handling with retries/fallbacks, changes spanning 3+ layers
+3. Select the matching tier
+4. If `delegate_effort` is set in config, apply as floor using ordering `medium < high < xhigh`; if the tier is "default (no flag)", the config floor wins
+5. If `delegate_effort` is unset in config, use the tier directly — "default (no flag)" means omit the effort flag and let Codex use its built-in default
+
+When `effective_effort` resolves to "default (no flag)", omit the effort flag entirely from the invocation.
+
+Use `effective_effort` in place of `delegate_effort` throughout the Execution Loop.
+
 ## Prompt Template
 
 At the start of delegated execution, create a per-run OS-temp scratch directory via `mktemp -d` and capture its **absolute path** for all downstream use. All scratch files for this invocation live under that directory. Do not use `.context/` — these scratch files are per-run throwaway that get cleaned up when delegated execution ends (see Cleanup below), matching the repo Scratch Space convention for one-shot artifacts. Do not pass unresolved shell-variable strings to non-shell tools (Write, Read); use the absolute path returned by `mktemp -d`.
@@ -239,7 +263,7 @@ codex exec \
 **Conditional flags** — only include each line when the corresponding skill-state value is set:
 
 - If `delegate_model` is set, insert `  -m "<delegate_model>" \` as a line before `$SANDBOX_FLAG`.
-- If `delegate_effort` is set, insert `  -c 'model_reasoning_effort="<delegate_effort>"' \` as a line before `$SANDBOX_FLAG`.
+- If `effective_effort` is set (resolved via Per-Batch Effort Resolution above), insert `  -c 'model_reasoning_effort="<effective_effort>"' \` as a line before `$SANDBOX_FLAG`.
 
 When either value is unset, omit its line entirely — Codex resolves the default from the user's `~/.codex/config.toml` (and ultimately the CLI's own built-in default). Do not substitute a placeholder string for unset values.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -111,18 +111,19 @@ A few edge cases worth handling explicitly:
 
 **Floor and resolution — hard rules**
 
-These are deterministic; do not improvise.
+Effort levels are ordered: `minimal < low < medium < high < xhigh`.
 
-The floor algebra treats `default` as equivalent to `medium`, because Codex's built-in default reasoning effort is `medium` — omitting the flag and emitting `medium` produce the same runtime behavior. Treating `default` as below `medium` would invert the floor (a `minimal` floor on a `default` pick would emit `minimal`, *lower* than what the unset-config path produces). The ordering used for `max()` is therefore:
+Compute `effective_effort`:
 
-`minimal < low < {default ≡ medium} < high < xhigh`
+- If `delegate_effort` is unset: `effective_effort = picked_level`.
+- If `delegate_effort` is set: substitute `default` → `medium` in `picked_level`, then `effective_effort = max(picked_level, delegate_effort)`.
 
-1. If `delegate_effort` is unset, `effective_effort = picked_level`.
-2. If `delegate_effort` is set, `effective_effort = max(picked_level, delegate_effort)` under the ordering above. Concretely:
-   - Pick `default` + floor `minimal` | `low` | `medium` → `default` (omit flag; Codex's built-in `medium` already meets or exceeds the floor).
-   - Pick `default` + floor `high` | `xhigh` → floor wins; emit floor.
-   - Pick `medium` | `high` | `xhigh` + any floor → emit `max(picked_level, floor)`, where `minimal` and `low` are below `medium` in the ordering.
-3. When `effective_effort` is `default`, omit the `model_reasoning_effort` flag entirely. Never pass the literal string `"default"`.
+Emit based on `effective_effort`:
+
+- `medium`, `high`, or `xhigh` → emit `-c 'model_reasoning_effort="<value>"'`.
+- `default` → omit the flag (defer to `~/.codex/config.toml`). Reachable only when `delegate_effort` is unset and the pick is `default`.
+
+Never pass the literal string `"default"` to `codex exec`.
 
 Store `effective_effort` as a per-batch derived state value (alongside the session-level `delegate_effort`) and use it in place of `delegate_effort` throughout the Execution Loop.
 
@@ -277,7 +278,7 @@ codex exec \
 **Conditional flags** — only include each line when the corresponding skill-state value is set:
 
 - If `delegate_model` is set, insert `  -m "<delegate_model>" \` as a line before `$SANDBOX_FLAG`.
-- If `effective_effort` is set AND not `default` (resolved via Per-Batch Effort above), insert `  -c 'model_reasoning_effort="<effective_effort>"' \` as a line before `$SANDBOX_FLAG`. When `effective_effort` is `default`, omit the line — never pass the literal string `"default"`.
+- If `effective_effort` is `medium`, `high`, or `xhigh` (resolved via Per-Batch Effort above), insert `  -c 'model_reasoning_effort="<effective_effort>"' \` as a line before `$SANDBOX_FLAG`. When `effective_effort` is `default` (only possible when `delegate_effort` is unset and the pick is `default`), omit the line — never pass the literal string `"default"`.
 
 When either value is unset, omit its line entirely — Codex resolves the default from the user's `~/.codex/config.toml` (and ultimately the CLI's own built-in default). Do not substitute a placeholder string for unset values.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -88,31 +88,43 @@ On decline:
 
 Delegate all units in one batch. If the plan exceeds 5 units, split into batches at the plan's own phase boundaries, or in groups of roughly 5 -- never splitting units that share files. Skip delegation entirely if every unit is trivial.
 
-## Per-Batch Effort Resolution
+## Per-Batch Effort
 
-Before each batch, assess complexity to determine `effective_effort`. The config `work_delegate_effort` acts as a floor — `effective_effort` will never be lower than the config value.
+Each batch picks an effort level proportional to its complexity, then resolves against the config floor before invocation.
 
-**Complexity tiers:**
+**Effort levels — guidelines, not predicates**
 
-| Tier | Signals | Effort |
-|------|---------|--------|
-| Trivial | ≤2 files, no behavioral change (config, rename, typo) | default (no flag) |
-| Moderate | 3–4 files, no high-risk areas | `medium` |
-| Complex | 5–9 files, OR any high-risk area (auth, payments, migrations, external APIs, error handling) regardless of file count | `high` |
-| Architectural | ≥10 files, OR cross-cutting changes, OR two or more high-risk areas | `xhigh` |
+Pick the level that best fits the batch. These are signals to weigh, not boxes to tick — use judgment.
 
-Tiers are mutually exclusive. Evaluate top-down and stop at the first match; high-risk signals always promote at least to Complex even if the file count would otherwise fall in Moderate.
+- **default (no flag)** — trivial work with no behavioral change: a one-line config tweak, a rename, a typo or comment-only fix, a pure documentation update. Defers to the user's `~/.codex/config.toml` default (which is `medium` on a stock Codex install).
+- **`medium`** — small, well-scoped behavioral changes that stay clear of high-risk areas. A handful of files, a single concern, no novel architecture.
+- **`high`** — work that touches a high-risk area (auth/session logic, payments, database migrations, external API contracts, error handling with retries/fallbacks), or work spanning enough surface area that one mistake could cascade.
+- **`xhigh`** — architectural work: cross-cutting refactors, multiple high-risk areas in the same batch, changes that propagate broadly, or anywhere a wrong call meaningfully degrades the project.
 
-**Resolution steps:**
-1. Count implementation files in the batch's combined `Files:` list (Create + Modify paths; exclude Test paths)
-2. Check for high-risk signals: auth/session logic, payments, database migrations, external API calls, error handling with retries/fallbacks, changes spanning 3+ layers
-3. Select the matching tier using the top-down rule above
-4. If `delegate_effort` is set in config, apply as floor using ordering `minimal < low < medium < high < xhigh`. The resolved `effective_effort` is `max(tier_effort, floor)`. If the tier is "default (no flag)", the config floor wins regardless of value.
-5. If `delegate_effort` is unset in config, use the tier directly — "default (no flag)" means omit the effort flag and let Codex use its built-in default
+When in doubt, lean up one level — under-resourcing risky work costs more than over-resourcing routine work. Briefly note the picked level and the signal that drove it (e.g., "`high` — touches db/migrations") so the choice is auditable.
 
-When `effective_effort` resolves to "default (no flag)", omit the effort flag entirely from the invocation.
+A few edge cases worth handling explicitly:
+- **Test-only batches:** classify by what the tests *exercise*, not by file paths. Tests for auth flows, payment logic, or migrations get the same level the equivalent implementation work would get.
+- **Mixed-complexity batches:** the batch picks one level. If a single batch combines a typo unit and a payments rewrite, pick the higher level. If the spread feels wasteful, prefer splitting at the batching step (see Batching above) over averaging it out.
+- **Deletion-only batches:** classify by the risk of what is being removed, not by counts of remaining content. Removing an auth module is `high` even if the batch produces zero `Modify` content.
+- **Documentation- or comment-only batches:** `default`.
 
-Use `effective_effort` in place of `delegate_effort` throughout the Execution Loop.
+**Floor and resolution — hard rules**
+
+These are deterministic; do not improvise.
+
+The floor algebra treats `default` as equivalent to `medium`, because Codex's built-in default reasoning effort is `medium` — omitting the flag and emitting `medium` produce the same runtime behavior. Treating `default` as below `medium` would invert the floor (a `minimal` floor on a `default` pick would emit `minimal`, *lower* than what the unset-config path produces). The ordering used for `max()` is therefore:
+
+`minimal < low < {default ≡ medium} < high < xhigh`
+
+1. If `delegate_effort` is unset, `effective_effort = picked_level`.
+2. If `delegate_effort` is set, `effective_effort = max(picked_level, delegate_effort)` under the ordering above. Concretely:
+   - Pick `default` + floor `minimal` | `low` | `medium` → `default` (omit flag; Codex's built-in `medium` already meets or exceeds the floor).
+   - Pick `default` + floor `high` | `xhigh` → floor wins; emit floor.
+   - Pick `medium` | `high` | `xhigh` + any floor → emit `max(picked_level, floor)`, where `minimal` and `low` are below `medium` in the ordering.
+3. When `effective_effort` is `default`, omit the `model_reasoning_effort` flag entirely. Never pass the literal string `"default"`.
+
+Store `effective_effort` as a per-batch derived state value (alongside the session-level `delegate_effort`) and use it in place of `delegate_effort` throughout the Execution Loop.
 
 ## Prompt Template
 
@@ -265,7 +277,7 @@ codex exec \
 **Conditional flags** — only include each line when the corresponding skill-state value is set:
 
 - If `delegate_model` is set, insert `  -m "<delegate_model>" \` as a line before `$SANDBOX_FLAG`.
-- If `effective_effort` is set (resolved via Per-Batch Effort Resolution above), insert `  -c 'model_reasoning_effort="<effective_effort>"' \` as a line before `$SANDBOX_FLAG`.
+- If `effective_effort` is set AND not `default` (resolved via Per-Batch Effort above), insert `  -c 'model_reasoning_effort="<effective_effort>"' \` as a line before `$SANDBOX_FLAG`. When `effective_effort` is `default`, omit the line — never pass the literal string `"default"`.
 
 When either value is unset, omit its line entirely — Codex resolves the default from the user's `~/.codex/config.toml` (and ultimately the CLI's own built-in default). Do not substitute a placeholder string for unset values.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -97,15 +97,17 @@ Before each batch, assess complexity to determine `effective_effort`. The config
 | Tier | Signals | Effort |
 |------|---------|--------|
 | Trivial | ≤2 files, no behavioral change (config, rename, typo) | default (no flag) |
-| Moderate | 3–9 files, clear scope, no high-risk areas | `medium` |
-| Complex | 5+ files OR touches auth, payments, migrations, external APIs, or error handling | `high` |
-| Architectural | 10+ files OR cross-cutting changes OR multiple high-risk areas | `xhigh` |
+| Moderate | 3–4 files, no high-risk areas | `medium` |
+| Complex | 5–9 files, OR any high-risk area (auth, payments, migrations, external APIs, error handling) regardless of file count | `high` |
+| Architectural | ≥10 files, OR cross-cutting changes, OR two or more high-risk areas | `xhigh` |
+
+Tiers are mutually exclusive. Evaluate top-down and stop at the first match; high-risk signals always promote at least to Complex even if the file count would otherwise fall in Moderate.
 
 **Resolution steps:**
 1. Count implementation files in the batch's combined `Files:` list (Create + Modify paths; exclude Test paths)
 2. Check for high-risk signals: auth/session logic, payments, database migrations, external API calls, error handling with retries/fallbacks, changes spanning 3+ layers
-3. Select the matching tier
-4. If `delegate_effort` is set in config, apply as floor using ordering `medium < high < xhigh`; if the tier is "default (no flag)", the config floor wins
+3. Select the matching tier using the top-down rule above
+4. If `delegate_effort` is set in config, apply as floor using ordering `minimal < low < medium < high < xhigh`. The resolved `effective_effort` is `max(tier_effort, floor)`. If the tier is "default (no flag)", the config floor wins regardless of value.
 5. If `delegate_effort` is unset in config, use the tier directly — "default (no flag)" means omit the effort flag and let Codex use its built-in default
 
 When `effective_effort` resolves to "default (no flag)", omit the effort flag entirely from the invocation.


### PR DESCRIPTION
## Summary

Codex delegation previously used a single fixed effort level for every batch — whatever `work_delegate_effort` was set to in config (or Codex's built-in default if unset). This means trivial one-file changes burn the same reasoning budget as architectural rewrites, or complex auth changes get under-resourced if the config floor is set conservatively.

This adds per-batch effort selection based on complexity signals, with `work_delegate_effort` in config acting as a floor.

## Motivation

A fixed effort level is a poor fit for delegation workflows where batch complexity varies significantly:
- Setting it high wastes tokens on trivial changes (config tweaks, renames)
- Setting it low under-resources high-risk work (auth, migrations, external APIs)
- There's no middle ground with a single config value

Per-batch selection means each batch gets the effort it warrants, while the config floor preserves user intent ("never go below `medium`").

## Design

**Tiers:**
| Tier | Signals | Effort |
|------|---------|--------|
| Trivial | ≤2 files, no behavioral change | default (no flag) |
| Moderate | 3–9 files, clear scope, no high-risk areas | `medium` |
| Complex | 5+ files OR auth/payments/migrations/external APIs/error handling | `high` |
| Architectural | 10+ files OR cross-cutting changes OR multiple high-risk areas | `xhigh` |

**Why "default (no flag)" for trivial, not `low`?** Omitting the flag defers to the user's `~/.codex/config.toml` default rather than forcing `low`. A user who has configured a higher default in their Codex config shouldn't have it overridden for trivial work just because the skill has an opinion.

**Floor behavior example:** with `work_delegate_effort: medium` in config:
- Trivial batch → `medium` (floor wins over "default")
- Moderate batch → `medium` (tier matches floor)
- Complex batch → `high` (tier exceeds floor, scales up)
- Architectural batch → `xhigh` (tier exceeds floor, scales up)

With no config floor set:
- Trivial batch → no flag (Codex default applies)
- Complex batch → `high`

## Scope

Only touches `codex-delegation-workflow.md`, a reference file loaded on demand during delegation. No changes to `SKILL.md` or stable `ce-work`.

## Test plan

- [ ] Trivial batch with no config floor — confirm effort flag omitted
- [ ] Trivial batch with `work_delegate_effort: medium` floor — confirm `medium` (floor wins)
- [ ] Moderate batch with no config floor — confirm `medium`
- [ ] Complex batch touching auth/migrations — confirm effort bumps to `high`
- [ ] Architectural batch (10+ files) — confirm `xhigh`
- [ ] Config floor higher than tier (e.g., floor=`high`, tier=`medium`) — confirm floor wins