### PR TITLE
feat(ce-brainstorm,ce-plan): add lean/standard local config for ce-brainstorm and ce-plan

### DIFF
--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -14,6 +14,24 @@ The durable output of this workflow is a **requirements document**. In other wor
 
 This skill does not implement code. It explores, clarifies, and documents decisions for later planning or execution.
 
+## Optional Local Config
+
+Read optional machine-local settings from `.compound-engineering/config.local.yaml` in the repo root. Resolve repo root with `git rev-parse --show-toplevel` and read from `<repo-root>/.compound-engineering/config.local.yaml`.
+
+Supported key:
+- `ce_brainstorm_mode` -- `lean` or `standard` (default `standard`)
+
+Fallback rule:
+- If the key is missing, empty, or set to an unrecognized value, use `standard`.
+
+When `ce_brainstorm_mode` resolves to `lean`:
+- Bias toward the shortest useful path to requirements clarity
+- Prefer the Phase 0.2 fast path when requirements are already mostly clear
+- Limit Phase 1.3 to only the highest-impact unresolved questions before moving to Phase 2/3
+- Keep the requirements artifact compact unless the user explicitly asks for deeper exploration
+
+User instruction in the current conversation always overrides local config.
+
 **IMPORTANT: All file references in generated documents must use repo-relative paths (e.g., `src/models/user.rb`), never absolute paths. Absolute paths break portability across machines, worktrees, and teammates.**
 
 ## Core Principles

--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -16,7 +16,15 @@ This skill does not implement code. It explores, clarifies, and documents decisi
 
 ## Optional Local Config
 
-Read optional machine-local settings from `.compound-engineering/config.local.yaml` in the repo root. Resolve repo root with `git rev-parse --show-toplevel` and read from `<repo-root>/.compound-engineering/config.local.yaml`.
+Read optional machine-local settings from `.compound-engineering/config.local.yaml` in the repo root.
+
+Use this guarded read pattern so non-git directories fall back cleanly:
+
+!`(top=$(git rev-parse --show-toplevel 2>/dev/null); [ -n "$top" ] && cat "$top/.compound-engineering/config.local.yaml" 2>/dev/null) || echo '__NO_CONFIG__'`
+
+If the block contains YAML key-value pairs, extract supported keys.
+If it shows `__NO_CONFIG__` (including non-git directories), treat as missing config and continue with defaults.
+If it shows an unresolved command string, attempt a native file-read from `.compound-engineering/config.local.yaml` only when repo root is known; otherwise treat as missing config.
 
 Supported key:
 - `ce_brainstorm_mode` -- `lean` or `standard` (default `standard`)

--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -195,6 +195,12 @@ These questions force an explicit product thesis and feed the Scope Boundaries s
 
 Follow the Interaction Rules above. Use the platform's blocking question tool when available.
 
+Mode gate:
+- If `ce_brainstorm_mode` resolves to `lean`, default to the shortest path that still produces planning-ready requirements.
+- In `lean` mode, ask only the highest-impact unresolved question at each turn, skip optional deepening loops, and move to Phase 2 once scope and success criteria are clear enough for planning.
+- In `lean` mode, preserve required rigor probes for any scope-appropriate gaps identified in Phase 1.2 before ending Phase 1.
+- If the user explicitly asks for deeper exploration, run the fuller standard-depth dialogue regardless of mode.
+
 **Guidelines:**
 - Ask what the user is already thinking before offering your own ideas. This surfaces hidden context and prevents fixation on AI-generated framings.
 - Start broad (problem, users, value) then narrow (constraints, exclusions, edge cases)

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -14,6 +14,24 @@ argument-hint: "[optional: feature description, requirements doc path, plan path
 
 This workflow produces a durable implementation plan. It does **not** implement code, run tests, or learn from execution-time results. If the answer depends on changing code and seeing what happens, that belongs in `ce-work`, not here.
 
+## Optional Local Config
+
+Read optional machine-local settings from `.compound-engineering/config.local.yaml` in the repo root. Resolve repo root with `git rev-parse --show-toplevel` and read from `<repo-root>/.compound-engineering/config.local.yaml`.
+
+Supported key:
+- `ce_plan_research_mode` -- `lean` or `standard` (default `standard`)
+
+Fallback rule:
+- If the key is missing, empty, or set to an unrecognized value, use `standard`.
+
+When `ce_plan_research_mode` resolves to `lean`:
+- Run only `ce-repo-research-analyst` in Phase 1.1 by default
+- Skip `ce-learnings-researcher` unless the user asks for institutional learnings or the change is high-risk
+- Treat external research as opt-in unless the topic is high-risk (security, payments, privacy, migrations, compliance)
+- Keep planning dialog concise and move to plan drafting sooner
+
+User instruction in the current conversation always overrides local config.
+
 ## Interaction Method
 
 When asking the user a question, use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
@@ -196,10 +214,14 @@ Prepare a concise planning context summary (a paragraph or two) to pass as input
 - Otherwise use the feature description directly
 - If `STRATEGY.md` exists, read it and include the relevant pieces (target problem, approach, active tracks) in the summary so downstream research and planning decisions are anchored to product strategy
 
-Run these agents in parallel:
+Dispatch strategy:
 
-- Task ce-repo-research-analyst(Scope: technology, architecture, patterns. {planning context summary})
-- Task ce-learnings-researcher(planning context summary)
+- If `ce_plan_research_mode` resolves to `standard` (default), run these agents in parallel:
+  - Task ce-repo-research-analyst(Scope: technology, architecture, patterns. {planning context summary})
+  - Task ce-learnings-researcher(planning context summary)
+- If `ce_plan_research_mode` resolves to `lean`, run only:
+  - Task ce-repo-research-analyst(Scope: technology, architecture, patterns. {planning context summary})
+  - Skip `ce-learnings-researcher` unless the user explicitly asks for institutional learnings or the topic is high-risk
 Collect:
 - Technology stack and versions (used in section 1.2 to make sharper external research decisions)
 - Architectural patterns and conventions to follow

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -16,7 +16,15 @@ This workflow produces a durable implementation plan. It does **not** implement 
 
 ## Optional Local Config
 
-Read optional machine-local settings from `.compound-engineering/config.local.yaml` in the repo root. Resolve repo root with `git rev-parse --show-toplevel` and read from `<repo-root>/.compound-engineering/config.local.yaml`.
+Read optional machine-local settings from `.compound-engineering/config.local.yaml` in the repo root.
+
+Use this guarded read pattern so non-git directories fall back cleanly:
+
+!`(top=$(git rev-parse --show-toplevel 2>/dev/null); [ -n "$top" ] && cat "$top/.compound-engineering/config.local.yaml" 2>/dev/null) || echo '__NO_CONFIG__'`
+
+If the block contains YAML key-value pairs, extract supported keys.
+If it shows `__NO_CONFIG__` (including non-git directories), treat as missing config and continue with defaults.
+If it shows an unresolved command string, attempt a native file-read from `.compound-engineering/config.local.yaml` only when repo root is known; otherwise treat as missing config.
 
 Supported key:
 - `ce_plan_research_mode` -- `lean` or `standard` (default `standard`)

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -261,6 +261,13 @@ Ask the user only if the posture would materially change sequencing or risk and 
 
 Based on the origin document, user signals, and local findings, decide whether external research adds value.
 
+Mode gate:
+- If `ce_plan_research_mode` resolves to `lean`, default to **skip external research**.
+- In `lean` mode, run external research only when either condition is true:
+  - The topic is high-risk (security, payments, privacy, external APIs, migrations, compliance), or
+  - The user explicitly asks for external research.
+- If neither condition is true, announce the skip briefly and continue to Phase 1.4.
+
 **Read between the lines.** Pay attention to signals from the conversation so far:
 - **User familiarity** — Are they pointing to specific files or patterns? They likely know the codebase well.
 - **User intent** — Do they want speed or thoroughness? Exploration or execution?
@@ -277,7 +284,7 @@ The ce-repo-research-analyst output includes a structured Technology & Infrastru
 - If the scan detected deployment infrastructure (Docker, K8s, serverless), note it in the planning context passed to downstream agents so they can account for deployment constraints
 - If the scan detected a monorepo and scoped to a specific service, pass that service's tech context to downstream research agents -- not the aggregate of all services. If the scan surfaced the workspace map without scoping, use the feature description to identify the relevant service before proceeding with research
 
-**Always lean toward external research when:**
+**When `ce_plan_research_mode` resolves to `standard`, always lean toward external research when:**
 - The topic is high-risk: security, payments, privacy, external APIs, migrations, compliance
 - The codebase lacks relevant local patterns -- fewer than 3 direct examples of the pattern this plan needs
 - Local patterns exist for an adjacent domain but not the exact one -- e.g., the codebase has HTTP clients but not webhook receivers, or has background jobs but not event-driven pub/sub. Adjacent patterns suggest the team is comfortable with the technology layer but may not know domain-specific pitfalls. When this signal is present, frame the external research query around the domain gap specifically, not the general technology
@@ -296,7 +303,7 @@ Announce the decision briefly before continuing. Examples:
 
 #### 1.3 External Research (Conditional)
 
-If Step 1.2 indicates external research is useful, run these agents in parallel:
+If Step 1.2 indicates external research is useful (and in `lean` mode, only when the mode gate is satisfied), run these agents in parallel:
 
 - Task ce-best-practices-researcher(planning context summary)
 - Task ce-framework-docs-researcher(planning context summary)

--- a/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
+++ b/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
@@ -11,6 +11,10 @@
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
 # work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
 
+# --- Planning/brainstorm pacing (optional) ---
+# ce_brainstorm_mode: lean       # lean | standard (default: standard)
+# ce_plan_research_mode: lean    # lean | standard (default: standard)
+
 # --- Product pulse ---
 # Settings written by /ce-product-pulse first-run interview. Re-run the skill with
 # argument `setup` or `reconfigure` to edit interactively.


### PR DESCRIPTION
Sometimes I want to have lighter brainstorming and planning sessions.

So this PR adds optional keys to override the mode.

- Optional `.compound-engineering/config.local.yaml` keys `ce_brainstorm_mode` and `ce_plan_research_mode` to reduce workflow heaviness per repo. 
- Default invalid/missing values to `standard` (so no change)