### PR TITLE
feat(ce-plan): add on-demand modes for deepening and doc review to reduce default planning overhead

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -11,6 +11,11 @@
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
 # work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
 
+# --- Brainstorm / Plan pacing ---
+
+# ce_plan_deepening_mode: on_demand  # auto | on_demand (default: auto)
+# ce_plan_doc_review_mode: on_demand # auto | on_demand (default: auto)
+
 # --- Product pulse ---
 # Settings written by /ce-product-pulse first-run interview. Re-run the skill with
 # argument `setup` or `reconfigure` to edit interactively.

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -14,6 +14,29 @@ argument-hint: "[optional: feature description, requirements doc path, plan path
 
 This workflow produces a durable implementation plan. It does **not** implement code, run tests, or learn from execution-time results. If the answer depends on changing code and seeing what happens, that belongs in `ce-work`, not here.
 
+## Optional Local Config
+
+Read optional machine-local settings from `.compound-engineering/config.local.yaml` in the repo root. Resolve repo root with `git rev-parse --show-toplevel` and read from `<repo-root>/.compound-engineering/config.local.yaml`.
+
+Supported key:
+- `ce_plan_deepening_mode` -- `auto` or `on_demand` (default `auto`)
+- `ce_plan_doc_review_mode` -- `auto` or `on_demand` (default `auto`)
+
+Fallback rule:
+- If a key is missing, empty, or set to an unrecognized value, use its default.
+
+When `ce_plan_deepening_mode` resolves to `on_demand`:
+- Skip automatic deepening during normal plan generation
+- Run deepening only when the user explicitly asks to deepen (Phase 0.1 deepen intent)
+- Keep confidence checks and document review behavior unchanged unless the user instructs otherwise in the current conversation
+
+When `ce_plan_doc_review_mode` resolves to `on_demand`:
+- Skip automatic post-plan `ce-doc-review` during normal plan generation
+- Run `ce-doc-review` when the user explicitly asks for review
+- Keep deepening behavior unchanged unless the user instructs otherwise in the current conversation
+
+User instruction in the current conversation always overrides local config.
+
 ## Interaction Method
 
 When asking the user a question, use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
@@ -840,7 +863,12 @@ Plan written to <absolute path to plan>
 
 #### 5.3 Confidence Check and Deepening
 
-After writing the plan file, automatically evaluate whether the plan needs strengthening.
+After writing the plan file, evaluate whether the plan needs strengthening.
+
+Mode gate:
+- If `ce_plan_deepening_mode` resolves to `auto` (default), run the confidence check/deepening flow in this phase.
+- If `ce_plan_deepening_mode` resolves to `on_demand` and there is no explicit deepen intent from Phase 0.1, still run 5.3.1 and 5.3.2 (confidence/risk evaluation), then skip only deepening execution (5.3.3-5.3.7), report "Deepening skipped by config (`ce_plan_deepening_mode: on_demand`)" and continue to 5.3.8.
+- If the user explicitly asks to deepen, always run full deepening regardless of mode.
 
 **Two deepening modes:**
 
@@ -878,7 +906,7 @@ Build a risk profile. Treat these as high-risk signals:
 - **Deep** or high-risk plans often benefit from a targeted second pass
 - **Thin local grounding override:** If Phase 1.2 triggered external research because local patterns were thin (fewer than 3 direct examples or adjacent-domain match), always proceed to scoring regardless of how grounded the plan appears. When the plan was built on unfamiliar territory, claims about system behavior are more likely to be assumptions than verified facts. The scoring pass is cheap — if the plan is genuinely solid, scoring finds nothing and exits quickly
 
-If the plan already appears sufficiently grounded and the thin-grounding override does not apply, report "Confidence check passed — no sections need strengthening", then **load `references/plan-handoff.md` now and execute 5.3.8 → 5.3.9 → 5.4 in sequence**. Document review is mandatory — do not skip it because the confidence check passed. The two tools catch different classes of issues.
+If the plan already appears sufficiently grounded and the thin-grounding override does not apply, report "Confidence check passed — no sections need strengthening", then **load `references/plan-handoff.md` now and execute 5.3.8 → 5.3.9 → 5.4 in sequence**.
 
 ##### 5.3.3–5.3.7 Deepening Execution
 
@@ -886,7 +914,7 @@ When deepening is warranted, read `references/deepening-workflow.md` for confide
 
 ##### 5.3.8–5.4 Document Review, Final Checks, and Post-Generation Options
 
-**STOP. Load `references/plan-handoff.md` now before continuing.** It carries the full instructions for 5.3.8 (document review), 5.3.9 (final checks and cleanup), and 5.4 (post-generation handoff, including the Proof HITL flow, post-HITL re-review, and Issue Creation branching). **This load is non-optional** — without it, the agent renders the post-generation menu, captures the user's selection, and stops without firing the routed action. Document review at 5.3.8 is also mandatory regardless of whether the confidence check already ran.
+**STOP. Load `references/plan-handoff.md` now before continuing.** It carries the full instructions for 5.3.8 (document review), 5.3.9 (final checks and cleanup), and 5.4 (post-generation handoff, including the Proof HITL flow, post-HITL re-review, and Issue Creation branching). **This load is non-optional** — without it, the agent renders the post-generation menu, captures the user's selection, and stops without firing the routed action.
 
 After document review and final checks, present this menu using the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
 
@@ -909,4 +937,4 @@ If the user asks for another document review (either from a contextual prompt ab
 
 **Completion check:** This skill is not complete until the post-generation menu above has been presented, the user has selected an action, and the inline routing for that selection has been executed. Presenting the menu and stopping at the user's selection is not completion — fire the routed action.
 
-**Pipeline mode exception:** In LFG or any `disable-model-invocation` context, skip the interactive menu and return control to the caller after the plan file is written, confidence check has run, and `ce-doc-review` has run in headless mode (per `references/plan-handoff.md`).
+**Pipeline mode exception:** In LFG or any `disable-model-invocation` context, skip the interactive menu and return control to the caller after the plan file is written and confidence check has run; `ce-doc-review` runs or skips per `ce_plan_doc_review_mode` (per `references/plan-handoff.md`).

--- a/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
@@ -4,7 +4,11 @@ This file contains post-plan-writing instructions: document review, post-generat
 
 ## 5.3.8 Document Review
 
-After the confidence check (and any deepening), run the `ce-doc-review` skill on the plan file. Pass the plan path as the argument. When this step is reached, it is mandatory — do not skip it because the confidence check already ran. The two tools catch different classes of issues.
+After the confidence check (and any deepening), decide document-review behavior from config:
+
+- If `ce_plan_doc_review_mode` resolves to `auto` (default), run the `ce-doc-review` skill on the plan file. Pass the plan path as the argument.
+- If `ce_plan_doc_review_mode` resolves to `on_demand`, skip automatic `ce-doc-review` and continue to Final Checks. Report: `Document review skipped by config (ce_plan_doc_review_mode: on_demand)`.
+- If the user explicitly asks for document review in the current conversation, run `ce-doc-review` regardless of mode.
 
 The confidence check and ce-doc-review are complementary:
 - The confidence check strengthens rationale, sequencing, risk treatment, and grounding
@@ -14,7 +18,7 @@ If ce-doc-review returns findings that were auto-applied, note them briefly when
 
 When ce-doc-review returns "Review complete", proceed to Final Checks.
 
-**Pipeline mode:** If invoked from an automated workflow such as LFG or any `disable-model-invocation` context, run `ce-doc-review` with `mode:headless` and the plan path. Headless mode applies auto-fixes silently and returns structured findings without interactive prompts. Address any P0/P1 findings before returning control to the caller.
+**Pipeline mode:** If invoked from an automated workflow such as LFG or any `disable-model-invocation` context, apply the same mode gate above. In `auto`, run `ce-doc-review` with `mode:headless` and the plan path. In `on_demand`, skip automatic review unless explicitly requested by the caller.
 
 ## 5.3.9 Final Checks and Cleanup
 
@@ -29,7 +33,7 @@ If artifact-backed mode was used:
 
 ## 5.4 Post-Generation Options
 
-**Pipeline mode:** If invoked from an automated workflow such as LFG or any `disable-model-invocation` context, skip the interactive menu below and return control to the caller immediately. The plan file has already been written, the confidence check has already run, and ce-doc-review has already run — the caller (e.g., lfg) determines the next step.
+**Pipeline mode:** If invoked from an automated workflow such as LFG or any `disable-model-invocation` context, skip the interactive menu below and return control to the caller immediately. The plan file has already been written and the confidence check has already run; ce-doc-review may have run or been skipped based on `ce_plan_doc_review_mode`.
 
 After document-review completes, present the options using the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
 
@@ -57,9 +61,9 @@ Based on selection (the bare per-option routing is also stated inline in the SKI
   Follow `references/hitl-review.md` in the ce-proof skill. It uploads the plan, prompts the user for review in Proof's web UI, ingests each thread by reading it fresh and replying in-thread, applies agreed edits as tracked suggestions, and syncs the final markdown back to the plan file atomically on proceed.
 
   When the ce-proof skill returns:
-  - `status: proceeded` with `localSynced: true` -> the plan on disk now reflects the review. Re-run `ce-doc-review` on the updated plan before re-rendering the menu — HITL can materially rewrite the plan body, so the prior ce-doc-review pass no longer covers the current file and section 5.3.8 requires a review before any handoff option is offered. Then return to the post-generation options with the refreshed residual findings.
-  - `status: proceeded` with `localSynced: false` -> the reviewed version lives in Proof at `docUrl` but the local copy is stale. Offer to pull the Proof doc to `localPath` using the ce-proof skill's Pull workflow. If the pull happened, re-run `ce-doc-review` on the pulled file before re-rendering the options (same 5.3.8 rationale — the local plan was materially updated by the pull). If the pull was declined, include a one-line note above the menu that `<localPath>` is stale vs. Proof — otherwise `Start /ce-work` or `Create Issue` will silently use the pre-review copy.
-  - `status: done_for_now` -> the plan on disk may be stale if the user edited in Proof before leaving. Offer to pull the Proof doc to `localPath` so the local plan file stays in sync. If the pull happened, re-run `ce-doc-review` on the pulled file before re-rendering the options (same 5.3.8 rationale). If the pull was declined, include the stale-local note above the menu. `done_for_now` means the user stopped the HITL loop — it does not mean they ended the whole plan session; they may still want to start work or create an issue.
+  - `status: proceeded` with `localSynced: true` -> the plan on disk now reflects the review. If `ce_plan_doc_review_mode` is `auto`, re-run `ce-doc-review` on the updated plan before re-rendering the menu. If mode is `on_demand`, skip automatic re-review and re-render the menu with a note that review can be run on request.
+  - `status: proceeded` with `localSynced: false` -> the reviewed version lives in Proof at `docUrl` but the local copy is stale. Offer to pull the Proof doc to `localPath` using the ce-proof skill's Pull workflow. If the pull happened and `ce_plan_doc_review_mode` is `auto`, re-run `ce-doc-review` on the pulled file before re-rendering the options. If mode is `on_demand`, skip automatic re-review and re-render with a note that review can be run on request. If the pull was declined, include a one-line note above the menu that `<localPath>` is stale vs. Proof — otherwise `Start /ce-work` or `Create Issue` will silently use the pre-review copy.
+  - `status: done_for_now` -> the plan on disk may be stale if the user edited in Proof before leaving. Offer to pull the Proof doc to `localPath` so the local plan file stays in sync. If the pull happened and `ce_plan_doc_review_mode` is `auto`, re-run `ce-doc-review` on the pulled file before re-rendering the options. If mode is `on_demand`, skip automatic re-review and re-render with a note that review can be run on request. If the pull was declined, include the stale-local note above the menu. `done_for_now` means the user stopped the HITL loop — it does not mean they ended the whole plan session; they may still want to start work or create an issue.
   - `status: aborted` -> fall back to the options without changes.
 
   If the initial upload fails (network error, Proof API down), retry once after a short wait. If it still fails, tell the user the upload didn't succeed and briefly explain why, then return to the options — don't leave them wondering why the option did nothing.

--- a/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
+++ b/plugins/compound-engineering/skills/ce-setup/references/config-template.yaml
@@ -11,6 +11,11 @@
 # work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
 # work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
 
+# --- Plan deepening (optional) ---
+
+# ce_plan_deepening_mode: on_demand  # auto | on_demand (default: auto)
+# ce_plan_doc_review_mode: on_demand # auto | on_demand (default: auto)
+
 # --- Product pulse ---
 # Settings written by /ce-product-pulse first-run interview. Re-run the skill with
 # argument `setup` or `reconfigure` to edit interactively.

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -331,9 +331,9 @@ describe("ce-plan review contract", () => {
   test("SKILL.md stub points to plan-handoff reference", async () => {
     const content = await readRepoFile("plugins/compound-engineering/skills/ce-plan/SKILL.md")
 
-    // Stub references the handoff file and marks document review as mandatory
+    // Stub references the handoff file and exposes doc-review mode config
     expect(content).toContain("`references/plan-handoff.md`")
-    expect(content).toContain("Document review is mandatory")
+    expect(content).toContain("`ce_plan_doc_review_mode`")
   })
 
   test("uses headless mode in pipeline context", async () => {


### PR DESCRIPTION
- Add ce_plan_deepening_mode (auto | on_demand) to control whether plan deepening runs automatically.
- Add ce_plan_doc_review_mode (auto | on_demand) to control whether post-plan ce-doc-review runs automatically.
- Update plan handoff behavior so explicit user requests still run deepening/review regardless of mode.

## Why
- Current defaults can feel too heavy for day-to-day planning.
- Teams want to keep brainstorm/plan quality, but only pay deeper review costs when needed.
- This preserves existing default behavior (auto) while enabling a lighter local workflow via config.

## Config
ce_plan_deepening_mode: on_demand
ce_plan_doc_review_mode: on_demand