### PR TITLE
fix(ce-work-beta): update Codex sandbox flags to current CLI syntax

### DIFF
--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -68,7 +68,7 @@ If `consent_granted` is not true (from config `work_delegate_consent`):
 Present a one-time consent warning using the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension)). The consent warning explains:
 - Delegation sends implementation units to `codex exec` as a structured prompt
 - **yolo mode** (`--dangerously-bypass-approvals-and-sandbox`): Full system access including network. Required for verification steps that run tests or install dependencies. **Recommended.**
-- **full-auto mode** (`-s workspace-write`): Workspace-write sandbox, no network access.
+- **full-auto mode** (`-s workspace-write`): Workspace-write sandbox, no network access by default. Network can be re-enabled by setting `network_access = true` under `[sandbox_workspace_write]` in `~/.codex/config.toml`.
 
 Present the sandbox mode choice: (1) yolo (recommended), (2) full-auto.
 

--- a/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -67,8 +67,8 @@ If `consent_granted` is not true (from config `work_delegate_consent`):
 
 Present a one-time consent warning using the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension)). The consent warning explains:
 - Delegation sends implementation units to `codex exec` as a structured prompt
-- **yolo mode** (`--yolo`): Full system access including network. Required for verification steps that run tests or install dependencies. **Recommended.**
-- **full-auto mode** (`--full-auto`): Workspace-write sandbox, no network access.
+- **yolo mode** (`--dangerously-bypass-approvals-and-sandbox`): Full system access including network. Required for verification steps that run tests or install dependencies. **Recommended.**
+- **full-auto mode** (`-s workspace-write`): Workspace-write sandbox, no network access.
 
 Present the sandbox mode choice: (1) yolo (recommended), (2) full-auto.
 
@@ -224,7 +224,7 @@ SANDBOX_MODE="<sandbox_mode>"
 
 # Resolve sandbox flag
 if [ "$SANDBOX_MODE" = "full-auto" ]; then
-  SANDBOX_FLAG="--full-auto"
+  SANDBOX_FLAG="-s workspace-write"
 else
   SANDBOX_FLAG="--dangerously-bypass-approvals-and-sandbox"
 fi


### PR DESCRIPTION
## Summary

- `--full-auto` is not a valid flag in the current Codex CLI — verified against `codex exec --help` (Codex 0.128.0+). The actual sandbox flag is `-s workspace-write`. The bash script was passing `--full-auto` directly to `codex exec`, which would cause delegation to fail at runtime.
- `--yolo` is also not a valid flag — the actual flag for full bypass is `--dangerously-bypass-approvals-and-sandbox`. The script already used the correct flag; only the description shown during the consent flow was wrong.
- Added a note that `workspace-write` blocks network access by default but network can be re-enabled via `~/.codex/config.toml`.

## Changes

`plugins/compound-engineering/skills/ce-work-beta/references/codex-delegation-workflow.md`:
- Line 70: consent description: `--yolo` → `--dangerously-bypass-approvals-and-sandbox`
- Line 71: consent description: `--full-auto` → `-s workspace-write`; added note on re-enabling network access
- Line 227: bash script: `SANDBOX_FLAG="--full-auto"` → `SANDBOX_FLAG="-s workspace-write"`

## Open question

The internal mode names `yolo` and `full-auto` (used as config values and consent UI labels) derive from the old CLI flags that no longer exist. Options:
1. Keep as-is — they're internal labels that don't reach the CLI, and changing them breaks existing user configs
2. Align with Codex CLI terminology — e.g. `bypass` / `workspace` or `danger` / `sandbox`
3. Use more descriptive names that map clearly to the underlying behavior regardless of CLI spelling

Deferring for now since it's a separate concern from the flag correctness fix and would require a migration path for existing configs.

## Test plan

- [ ] Inspect diff — three lines changed, no logic change for yolo path
- [ ] Verify `codex exec --help` still shows `-s workspace-write` as a valid sandbox mode value
- [ ] `bun run release:validate` passes