### PR TITLE
fix(ce-worktree): resolve script path against skill dir, not user CWD

### DIFF
--- a/plugins/compound-engineering/skills/ce-worktree/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-worktree/SKILL.md
@@ -15,10 +15,10 @@ Create a worktree under `.worktrees/<branch>` with branch-specific setup that `g
 
 ## Creating a worktree
 
-Invoke the bundled script via the runtime Bash tool, using `${CLAUDE_SKILL_DIR}` so the path resolves correctly across `claude --plugin-dir` and standard marketplace-cached installs. Bare relative paths like `bash scripts/worktree-manager.sh` fail because the Bash tool runs from the user's project CWD, not the skill directory.
+Invoke the bundled script via the runtime Bash tool. On Claude Code, `${CLAUDE_SKILL_DIR}` resolves to the skill's own directory across both marketplace-cached installs and `claude --plugin-dir` local development; the runtime Bash tool's CWD is the user's project, not the skill directory, so a bare `bash scripts/worktree-manager.sh` fails. On other targets (Codex, Gemini, Pi, etc.) `${CLAUDE_SKILL_DIR}` is unset and the `:-.` fallback yields the bare relative path those harnesses expect.
 
 ```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create <branch-name> [from-branch]
+bash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create <branch-name> [from-branch]
 ```
 
 Defaults:
@@ -27,8 +27,8 @@ Defaults:
 
 Examples:
 ```bash
-bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create feat/login
-bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create fix/email-validation develop
+bash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create feat/login
+bash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create fix/email-validation develop
 ```
 
 After creation, switch to the worktree with `cd .worktrees/<branch-name>`.
@@ -69,7 +69,7 @@ Do not create a worktree for single-task work that can happen on a branch in the
 
 ## Integration
 
-`ce-work` and `ce-code-review` offer this skill as an option. When the user selects "worktree" in those flows, invoke `bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create <branch>` with a meaningful branch name derived from the work description (e.g., `feat/crowd-sniff`, `fix/email-validation`). Avoid auto-generated names like `worktree-jolly-beaming-raven` that obscure the work.
+`ce-work` and `ce-code-review` offer this skill as an option. When the user selects "worktree" in those flows, invoke `bash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create <branch>` with a meaningful branch name derived from the work description (e.g., `feat/crowd-sniff`, `fix/email-validation`). Avoid auto-generated names like `worktree-jolly-beaming-raven` that obscure the work.
 
 ## Troubleshooting
 

--- a/plugins/compound-engineering/skills/ce-worktree/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-worktree/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ce-worktree
 description: Create an isolated git worktree for parallel feature work or PR review. Use when starting work that should not disturb the current checkout, or when `ce-work` or `ce-code-review` offers a worktree option.
+allowed-tools: Bash(bash *worktree-manager.sh)
 ---
 
 # Worktree Creation
@@ -14,8 +15,10 @@ Create a worktree under `.worktrees/<branch>` with branch-specific setup that `g
 
 ## Creating a worktree
 
+Invoke the bundled script via the runtime Bash tool, using `${CLAUDE_SKILL_DIR}` so the path resolves correctly across `claude --plugin-dir` and standard marketplace-cached installs. Bare relative paths like `bash scripts/worktree-manager.sh` fail because the Bash tool runs from the user's project CWD, not the skill directory.
+
 ```bash
-bash scripts/worktree-manager.sh create <branch-name> [from-branch]
+bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create <branch-name> [from-branch]
 ```
 
 Defaults:
@@ -24,8 +27,8 @@ Defaults:
 
 Examples:
 ```bash
-bash scripts/worktree-manager.sh create feat/login
-bash scripts/worktree-manager.sh create fix/email-validation develop
+bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create feat/login
+bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create fix/email-validation develop
 ```
 
 After creation, switch to the worktree with `cd .worktrees/<branch-name>`.
@@ -66,7 +69,7 @@ Do not create a worktree for single-task work that can happen on a branch in the
 
 ## Integration
 
-`ce-work` and `ce-code-review` offer this skill as an option. When the user selects "worktree" in those flows, invoke `bash scripts/worktree-manager.sh create <branch>` with a meaningful branch name derived from the work description (e.g., `feat/crowd-sniff`, `fix/email-validation`). Avoid auto-generated names like `worktree-jolly-beaming-raven` that obscure the work.
+`ce-work` and `ce-code-review` offer this skill as an option. When the user selects "worktree" in those flows, invoke `bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh" create <branch>` with a meaningful branch name derived from the work description (e.g., `feat/crowd-sniff`, `fix/email-validation`). Avoid auto-generated names like `worktree-jolly-beaming-raven` that obscure the work.
 
 ## Troubleshooting
 

--- a/tests/skills/ce-worktree.test.ts
+++ b/tests/skills/ce-worktree.test.ts
@@ -27,9 +27,27 @@ describe("ce-worktree SKILL.md", () => {
   })
 
   test("instructs the agent to invoke worktree-manager.sh via a CLAUDE_SKILL_DIR-prefixed path", () => {
+    // Allow either `${CLAUDE_SKILL_DIR}` or `${CLAUDE_SKILL_DIR:-.}` (the
+    // cross-platform fallback form); both resolve correctly on Claude Code.
+    const skillDirPrefixed = /bash "\$\{CLAUDE_SKILL_DIR(?::-[^}]*)?\}\/scripts\/worktree-manager\.sh"/
     expect(
-      SKILL_BODY.includes(`bash "\${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh"`),
-      "ce-worktree/SKILL.md must instruct the agent to run 'bash \"${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh\"' — relative paths fail at runtime because the Bash tool's CWD is the user's project, not the skill directory.",
+      skillDirPrefixed.test(SKILL_BODY),
+      "ce-worktree/SKILL.md must instruct the agent to run 'bash \"${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh\"' (or with a :- fallback) — relative paths fail at runtime because the Bash tool's CWD is the user's project, not the skill directory.",
+    ).toBe(true)
+  })
+
+  // Regression guard for the cross-platform portability concern raised on
+  // PR #772. ce-worktree has no `ce_platforms` restriction, so it is exported
+  // to Codex/Gemini/Pi/etc. via filterSkillsByPlatform; none of those
+  // converters substitute `${CLAUDE_SKILL_DIR}`. Without a `:-` fallback,
+  // the variable expands to empty on those targets and `bash
+  // "/scripts/worktree-manager.sh"` fails. The `:-.` fallback yields the
+  // original bare-relative path (preserving prior behavior on those
+  // platforms) while Claude Code still gets the resolved skill directory.
+  test("uses a :- fallback so non-Claude targets get the bare relative path", () => {
+    expect(
+      SKILL_BODY.includes(`\${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh`),
+      "ce-worktree/SKILL.md must use the `${CLAUDE_SKILL_DIR:-.}` fallback form so non-Claude targets (Codex, Gemini, Pi, etc.) — where the env var is unset — fall back to the bare relative path rather than expanding to '/scripts/worktree-manager.sh'.",
     ).toBe(true)
   })
 

--- a/tests/skills/ce-worktree.test.ts
+++ b/tests/skills/ce-worktree.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const SKILL_PATH = path.join(
+  process.cwd(),
+  "plugins/compound-engineering/skills/ce-worktree/SKILL.md",
+)
+const SKILL_BODY = readFileSync(SKILL_PATH, "utf8")
+
+describe("ce-worktree SKILL.md", () => {
+  // Regression guard for https://github.com/EveryInc/compound-engineering-plugin/issues/764.
+  //
+  // The runtime Bash tool runs from the user's project CWD, not the skill
+  // directory — so `bash scripts/worktree-manager.sh` resolves against the
+  // user's project root, where the script does not exist, and fails with
+  // "No such file or directory". The fix is to invoke via
+  // `${CLAUDE_SKILL_DIR}` so the path resolves to the skill's own scripts
+  // directory across both marketplace-cached installs and `claude --plugin-dir`
+  // local development.
+  test("does not invoke worktree-manager.sh via a bare relative path", () => {
+    const codeFenceMatches = SKILL_BODY.match(/^bash scripts\/worktree-manager\.sh/gm)
+    expect(
+      codeFenceMatches,
+      "ce-worktree/SKILL.md re-introduced the bare 'bash scripts/worktree-manager.sh' antipattern — use 'bash \"${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh\"' instead. Bare relative paths fail at runtime because the Bash tool's CWD is the user's project, not the skill directory.",
+    ).toBeNull()
+  })
+
+  test("instructs the agent to invoke worktree-manager.sh via a CLAUDE_SKILL_DIR-prefixed path", () => {
+    expect(
+      SKILL_BODY.includes(`bash "\${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh"`),
+      "ce-worktree/SKILL.md must instruct the agent to run 'bash \"${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh\"' — relative paths fail at runtime because the Bash tool's CWD is the user's project, not the skill directory.",
+    ).toBe(true)
+  })
+
+  // Regression guard: each script invocation is `bash <abs-path>` at runtime,
+  // which does not match the user's typical allow rules (most have
+  // `Bash(bash -c:*)` at most, not `Bash(bash:*)`). Without `allowed-tools`
+  // granting permission for the specific script, users without
+  // `defaultMode: bypassPermissions` get an approval prompt every time they
+  // run the skill. The pattern is pinned to the script filename —
+  // `Bash(bash *)` would be too broad.
+  test("declares a narrow allowed-tools pattern for worktree-manager.sh", () => {
+    const frontmatter = SKILL_BODY.match(/^---\n([\s\S]*?)\n---/)
+    expect(frontmatter, "ce-worktree/SKILL.md must have YAML frontmatter").not.toBeNull()
+    const allowedTools = frontmatter![1].match(/^allowed-tools:\s*(.+)$/m)
+    expect(
+      allowedTools,
+      "ce-worktree/SKILL.md must declare `allowed-tools:` so users without bypassPermissions don't get a prompt every run.",
+    ).not.toBeNull()
+    const tools = allowedTools![1]
+    expect(
+      tools.includes(`Bash(bash *worktree-manager.sh)`),
+      `ce-worktree/SKILL.md allowed-tools must include 'Bash(bash *worktree-manager.sh)' so the runtime Bash call passes the permission check without granting blanket Bash access (got: ${tools})`,
+    ).toBe(true)
+    expect(
+      /Bash\(bash \*\)/.test(tools),
+      `ce-worktree/SKILL.md allowed-tools must NOT use the broad 'Bash(bash *)' pattern — pin to the script filename instead (got: ${tools})`,
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- `/ce-worktree` invoked `bash scripts/worktree-manager.sh`, a relative path the runtime Bash tool resolves against the user's project CWD (not the skill directory). The bundled script lives under `<plugin-cache>/skills/ce-worktree/scripts/`, so every invocation failed with "No such file or directory".
- Switched the four invocation sites to `bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh"` and added a narrow `allowed-tools: Bash(bash *worktree-manager.sh)` so users without `bypassPermissions` are not prompted every run. This mirrors the proven pattern already in `ce-update`.
- Added `tests/skills/ce-worktree.test.ts` with three regression guards: forbid the bare relative-path antipattern, require the `${CLAUDE_SKILL_DIR}`-prefixed form, and require the narrow `allowed-tools` entry. Mirrors `tests/skills/ce-update.test.ts`.

Note: the same `bash scripts/<name>.sh` antipattern exists in seven other skills (`ce-optimize`, `ce-resolve-pr-feedback`, `ce-code-review`, `ce-session-inventory`, `ce-polish-beta`, `ce-setup`, `ce-clean-gone-branches`). Out of scope here — issue #764 only covers `ce-worktree` — but worth a follow-up.

Fixes #764

## Test plan

- [x] `bun test tests/skills/ce-worktree.test.ts` — 3 new regression tests pass
- [x] `bun test` — full suite (1336 tests) passes
- [x] `bun run release:validate` — clean
- [x] Manually verified the fixed path resolves and runs in the cached install layout: `bash "${CLAUDE_SKILL_DIR}/scripts/worktree-manager.sh"` finds and executes the script
- [x] Manually reproduced the original bug: `bash scripts/worktree-manager.sh` from the project root fails with "No such file or directory"

🤖 Generated with [Claude Code](https://claude.com/claude-code)