### PR TITLE
fix(review): escape literal pipes in finding table cells

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/references/review-output-template.md
+++ b/plugins/compound-engineering/skills/ce-code-review/references/review-output-template.md
@@ -4,6 +4,8 @@ Use this **exact format** when presenting synthesized review findings. Findings 
 
 **IMPORTANT:** Use pipe-delimited markdown tables (`| col | col |`). Do NOT use ASCII box-drawing characters.
 
+**IMPORTANT:** Escape literal pipe characters in table cells. Any `|` that appears inside a finding title, issue description, code snippet, regex pattern, or delimited-string example (e.g. cache key examples like `userName + "|" + groups`) must be written as `\|` so column boundaries are determined only by unescaped pipes. Unescaped pipes split the cell across columns and corrupt the row's `Reviewer`, `Confidence`, and `Route` values.
+
 ## Example
 
 ```markdown
@@ -116,6 +118,7 @@ This fails because: no pipe-delimited tables, no severity-grouped `###` headers,
 ## Formatting Rules
 
 - **Pipe-delimited markdown tables** for findings -- never ASCII box-drawing characters or per-finding horizontal-rule separators between entries (the report-level `---` before the verdict is still required)
+- **Escape literal `|` in table cells** -- any `|` inside a finding title, issue description, code snippet, regex pattern, or delimited-string example must be written as `\|`. Unescaped pipes are parsed as column separators and corrupt the row's `Reviewer`, `Confidence`, and `Route` columns. Applies especially to cache-key delimiter examples, regex alternations, and logical-OR operators quoted inside findings.
 - **Severity-grouped sections** -- `### P0 -- Critical`, `### P1 -- High`, `### P2 -- Moderate`, `### P3 -- Low`. Omit empty severity levels.
 - **Stable sequential finding numbers** -- assign finding numbers once after sorting, continue them across severity sections, and reuse those same numbers when findings are repeated in Residual Actionable Work. Do not restart at `1` for each severity or route bucket.
 - **Always include file:line location** for code review issues

--- a/plugins/compound-engineering/skills/ce-doc-review/references/review-output-template.md
+++ b/plugins/compound-engineering/skills/ce-doc-review/references/review-output-template.md
@@ -4,6 +4,8 @@ Use this **exact format** when presenting synthesized review findings in Interac
 
 **IMPORTANT:** Use pipe-delimited markdown tables (`| col | col |`). Do NOT use ASCII box-drawing characters.
 
+**IMPORTANT:** Escape literal pipe characters in table cells. Any `|` that appears inside a finding's section reference, issue description, code snippet, regex pattern, or delimited-string example must be written as `\|` so column boundaries are determined only by unescaped pipes. Unescaped pipes split the cell across columns and corrupt the row's `Reviewer`, `Confidence`, and `Tier` values.
+
 This template describes the Phase 4 interactive presentation — what the user sees before the routing question (`references/walkthrough.md`) fires. The headless-mode envelope is documented in `references/synthesis-and-presentation.md` (Phase 4 "Route Remaining Findings" section) and is separate from this template.
 
 **Vocabulary note.** Internal enum values (`safe_auto`, `gated_auto`, `manual`, `FYI`) live in the schema and synthesis pipeline. User-facing rendered text uses plain-language labels instead: fixes (for `safe_auto`), proposed fixes (for `gated_auto`), decisions (for `manual`), and FYI observations (for `FYI`). The `Tier` column in the tables below is the one place that still names the internal enum so the user can see the synthesis decision; everything else reads as plain language.


### PR DESCRIPTION
## Summary

Code-review findings whose titles or descriptions contained a literal `|` (cache-key delimiter examples, regex alternations, logical-OR operators) corrupted the synthesized findings table — unescaped pipes were parsed as column separators, splitting content across the `Reviewer`, `Confidence`, and `Route` columns. The findings JSON was correct upstream; the bug lived purely in the prose-driven serialization step.

Adds an escape rule to both `ce-code-review` and `ce-doc-review` `review-output-template.md` files: literal `|` inside a table cell must be written as `\|`. The rule sits next to the existing pipe-table directive at the top of each template, plus as a parallel bullet in `ce-code-review`'s `Formatting Rules` section where the issue reporter expected to find it. The same gap was latent in `ce-doc-review`'s template, so both ship together.

Synthesis is purely LLM-prose-driven from these `@`-included templates, so there is no unit-test surface; manual verification is to run `/ce-code-review` on a diff containing a `|`-bearing finding and confirm the table renders intact.

Fixes #761

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)