### PR TITLE
fix(code-review): resolve base helper from skill directory

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -292,28 +292,25 @@ If the output is non-empty, inform the user: "You have uncommitted changes on th
 git checkout <branch>
 ```
 
-Then detect the review base branch and compute the merge-base. Run the bundled `resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names). Resolve the script via the harness's plugin/skill directory variables (never via the reviewed repo's working directory), so a repo-controlled `scripts/resolve-base.sh` cannot be used for arbitrary code execution at review time:
+Then detect the review base branch and compute the merge-base. Run the bundled `resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names). Resolve the script via `${CLAUDE_SKILL_DIR}` (never via the reviewed repo's working directory), so a repo-controlled `scripts/resolve-base.sh` cannot be used for arbitrary code execution at review time:
 
 ```
 RESOLVE_SCRIPT=""
-for base in "${CLAUDE_SKILL_DIR:-}" "${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"; do
-  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then
-    real_base=$(cd "$base" 2>/dev/null && pwd -P) || real_base=""
-    real_cwd=$(pwd -P)
-    case "$real_base" in
-      ""|"$real_cwd"|"$real_cwd"/*) continue ;;
-    esac
-    RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh"
-    break
-  fi
-done
-if [ -z "$RESOLVE_SCRIPT" ]; then printf '%s\n' 'ERROR: resolve-base.sh is unavailable because the harness did not expose a trusted plugin or skill directory, or the exposed path resolves inside the reviewed repo. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory.'; exit 1; fi
+if [ -n "${CLAUDE_SKILL_DIR:-}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh" ]; then
+  real_base=$(cd "${CLAUDE_SKILL_DIR}" 2>/dev/null && pwd -P) || real_base=""
+  real_cwd=$(pwd -P)
+  case "$real_base" in
+    ""|"$real_cwd"|"$real_cwd"/*) ;;
+    *) RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh" ;;
+  esac
+fi
+if [ -z "$RESOLVE_SCRIPT" ]; then printf '%s\n' 'ERROR: resolve-base.sh is unavailable because ${CLAUDE_SKILL_DIR} is not exposed or resolves inside the reviewed repo. Re-run with `base:<ref>` or use a harness that exposes the skill directory.'; exit 1; fi
 RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
 
-If the plugin/skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a branch review without the base branch would only show uncommitted changes and silently miss all committed work.
+If `${CLAUDE_SKILL_DIR}` is unavailable or resolves inside the reviewed repo, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a branch review without the base branch would only show uncommitted changes and silently miss all committed work.
 
 On success, produce the diff:
 
@@ -325,28 +322,25 @@ You may still fetch additional PR metadata with `gh pr view` for title, body, li
 
 **If no argument (standalone on current branch):**
 
-Detect the review base branch and compute the merge-base using the same bundled `resolve-base.sh` script as branch mode. Resolve the script via the harness's plugin/skill directory variables (never via the reviewed repo's working directory):
+Detect the review base branch and compute the merge-base using the same bundled `resolve-base.sh` script as branch mode. Resolve the script via `${CLAUDE_SKILL_DIR}` (never via the reviewed repo's working directory):
 
 ```
 RESOLVE_SCRIPT=""
-for base in "${CLAUDE_SKILL_DIR:-}" "${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"; do
-  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then
-    real_base=$(cd "$base" 2>/dev/null && pwd -P) || real_base=""
-    real_cwd=$(pwd -P)
-    case "$real_base" in
-      ""|"$real_cwd"|"$real_cwd"/*) continue ;;
-    esac
-    RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh"
-    break
-  fi
-done
-if [ -z "$RESOLVE_SCRIPT" ]; then printf '%s\n' 'ERROR: resolve-base.sh is unavailable because the harness did not expose a trusted plugin or skill directory, or the exposed path resolves inside the reviewed repo. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory.'; exit 1; fi
+if [ -n "${CLAUDE_SKILL_DIR:-}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh" ]; then
+  real_base=$(cd "${CLAUDE_SKILL_DIR}" 2>/dev/null && pwd -P) || real_base=""
+  real_cwd=$(pwd -P)
+  case "$real_base" in
+    ""|"$real_cwd"|"$real_cwd"/*) ;;
+    *) RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh" ;;
+  esac
+fi
+if [ -z "$RESOLVE_SCRIPT" ]; then printf '%s\n' 'ERROR: resolve-base.sh is unavailable because ${CLAUDE_SKILL_DIR} is not exposed or resolves inside the reviewed repo. Re-run with `base:<ref>` or use a harness that exposes the skill directory.'; exit 1; fi
 RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
 
-If the plugin/skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a standalone review without the base branch would only show uncommitted changes and silently miss all committed work on the branch.
+If `${CLAUDE_SKILL_DIR}` is unavailable or resolves inside the reviewed repo, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a standalone review without the base branch would only show uncommitted changes and silently miss all committed work on the branch.
 
 On success, produce the diff:
 

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -298,9 +298,10 @@ Then detect the review base branch and compute the merge-base. Run the bundled `
 RESOLVE_SCRIPT=""
 if [ -n "${CLAUDE_SKILL_DIR:-}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh" ]; then
   real_base=$(cd "${CLAUDE_SKILL_DIR}" 2>/dev/null && pwd -P) || real_base=""
-  real_cwd=$(pwd -P)
+  repo_top=$(git rev-parse --show-toplevel 2>/dev/null) || repo_top=""
+  if [ -n "$repo_top" ]; then real_repo=$(cd "$repo_top" 2>/dev/null && pwd -P) || real_repo=""; else real_repo=$(pwd -P); fi
   case "$real_base" in
-    ""|"$real_cwd"|"$real_cwd"/*) ;;
+    ""|"$real_repo"|"$real_repo"/*) ;;
     *) RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh" ;;
   esac
 fi
@@ -328,9 +329,10 @@ Detect the review base branch and compute the merge-base using the same bundled 
 RESOLVE_SCRIPT=""
 if [ -n "${CLAUDE_SKILL_DIR:-}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh" ]; then
   real_base=$(cd "${CLAUDE_SKILL_DIR}" 2>/dev/null && pwd -P) || real_base=""
-  real_cwd=$(pwd -P)
+  repo_top=$(git rev-parse --show-toplevel 2>/dev/null) || repo_top=""
+  if [ -n "$repo_top" ]; then real_repo=$(cd "$repo_top" 2>/dev/null && pwd -P) || real_repo=""; else real_repo=$(pwd -P); fi
   case "$real_base" in
-    ""|"$real_cwd"|"$real_cwd"/*) ;;
+    ""|"$real_repo"|"$real_repo"/*) ;;
     *) RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh" ;;
   esac
 fi

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -292,17 +292,20 @@ If the output is non-empty, inform the user: "You have uncommitted changes on th
 git checkout <branch>
 ```
 
-Then detect the review base branch and compute the merge-base. Run the skill-directory `resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names):
+Then detect the review base branch and compute the merge-base. Run the bundled `resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names). Resolve the script via the harness's plugin/skill directory variables (never via the reviewed repo's working directory), so a `scripts/resolve-base.sh` that happens to exist in the repo under review cannot be executed by mistake:
 
 ```
-RESOLVE_SCRIPT="${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh"
-if [ -z "${CLAUDE_SKILL_DIR:-}" ] || [ ! -f "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the skill directory is not exposed. Re-run with `base:<ref>` or use a harness that exposes the skill directory."; exit 1; fi
+RESOLVE_SCRIPT=""
+for base in "${CLAUDE_SKILL_DIR:-}" "${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"; do
+  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then RESOLVE_SCRIPT="$base/scripts/resolve-base.sh"; break; fi
+done
+if [ -z "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the harness did not expose the plugin or skill directory. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory."; exit 1; fi
 RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
 
-If the skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a branch review without the base branch would only show uncommitted changes and silently miss all committed work.
+If the plugin/skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a branch review without the base branch would only show uncommitted changes and silently miss all committed work.
 
 On success, produce the diff:
 
@@ -314,17 +317,20 @@ You may still fetch additional PR metadata with `gh pr view` for title, body, li
 
 **If no argument (standalone on current branch):**
 
-Detect the review base branch and compute the merge-base using the same skill-directory `resolve-base.sh` script as branch mode:
+Detect the review base branch and compute the merge-base using the same bundled `resolve-base.sh` script as branch mode. Resolve the script via the harness's plugin/skill directory variables (never via the reviewed repo's working directory):
 
 ```
-RESOLVE_SCRIPT="${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh"
-if [ -z "${CLAUDE_SKILL_DIR:-}" ] || [ ! -f "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the skill directory is not exposed. Re-run with `base:<ref>` or use a harness that exposes the skill directory."; exit 1; fi
+RESOLVE_SCRIPT=""
+for base in "${CLAUDE_SKILL_DIR:-}" "${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"; do
+  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then RESOLVE_SCRIPT="$base/scripts/resolve-base.sh"; break; fi
+done
+if [ -z "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the harness did not expose the plugin or skill directory. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory."; exit 1; fi
 RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
 
-If the skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a standalone review without the base branch would only show uncommitted changes and silently miss all committed work on the branch.
+If the plugin/skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a standalone review without the base branch would only show uncommitted changes and silently miss all committed work on the branch.
 
 On success, produce the diff:
 

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -292,15 +292,17 @@ If the output is non-empty, inform the user: "You have uncommitted changes on th
 git checkout <branch>
 ```
 
-Then detect the review base branch and compute the merge-base. Run the `scripts/resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names):
+Then detect the review base branch and compute the merge-base. Run the skill-directory `resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names):
 
 ```
-RESOLVE_OUT=$(bash scripts/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+RESOLVE_SCRIPT="${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh"
+if [ -z "${CLAUDE_SKILL_DIR:-}" ] || [ ! -f "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the skill directory is not exposed. Re-run with `base:<ref>` or use a harness that exposes the skill directory."; exit 1; fi
+RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
 
-If the script outputs an error, stop instead of falling back to `git diff HEAD`; a branch review without the base branch would only show uncommitted changes and silently miss all committed work.
+If the skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a branch review without the base branch would only show uncommitted changes and silently miss all committed work.
 
 On success, produce the diff:
 
@@ -312,15 +314,17 @@ You may still fetch additional PR metadata with `gh pr view` for title, body, li
 
 **If no argument (standalone on current branch):**
 
-Detect the review base branch and compute the merge-base using the same `scripts/resolve-base.sh` script as branch mode:
+Detect the review base branch and compute the merge-base using the same skill-directory `resolve-base.sh` script as branch mode:
 
 ```
-RESOLVE_OUT=$(bash scripts/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+RESOLVE_SCRIPT="${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh"
+if [ -z "${CLAUDE_SKILL_DIR:-}" ] || [ ! -f "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the skill directory is not exposed. Re-run with `base:<ref>` or use a harness that exposes the skill directory."; exit 1; fi
+RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
 
-If the script outputs an error, stop instead of falling back to `git diff HEAD`; a standalone review without the base branch would only show uncommitted changes and silently miss all committed work on the branch.
+If the skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`; a standalone review without the base branch would only show uncommitted changes and silently miss all committed work on the branch.
 
 On success, produce the diff:
 

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -292,14 +292,22 @@ If the output is non-empty, inform the user: "You have uncommitted changes on th
 git checkout <branch>
 ```
 
-Then detect the review base branch and compute the merge-base. Run the bundled `resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names). Resolve the script via the harness's plugin/skill directory variables (never via the reviewed repo's working directory), so a `scripts/resolve-base.sh` that happens to exist in the repo under review cannot be executed by mistake:
+Then detect the review base branch and compute the merge-base. Run the bundled `resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names). Resolve the script via the harness's plugin/skill directory variables (never via the reviewed repo's working directory), so a repo-controlled `scripts/resolve-base.sh` cannot be used for arbitrary code execution at review time:
 
 ```
 RESOLVE_SCRIPT=""
 for base in "${CLAUDE_SKILL_DIR:-}" "${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"; do
-  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then RESOLVE_SCRIPT="$base/scripts/resolve-base.sh"; break; fi
+  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then
+    real_base=$(cd "$base" 2>/dev/null && pwd -P) || real_base=""
+    real_cwd=$(pwd -P)
+    case "$real_base" in
+      ""|"$real_cwd"|"$real_cwd"/*) continue ;;
+    esac
+    RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh"
+    break
+  fi
 done
-if [ -z "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the harness did not expose the plugin or skill directory. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory."; exit 1; fi
+if [ -z "$RESOLVE_SCRIPT" ]; then printf '%s\n' 'ERROR: resolve-base.sh is unavailable because the harness did not expose a trusted plugin or skill directory, or the exposed path resolves inside the reviewed repo. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory.'; exit 1; fi
 RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
@@ -322,9 +330,17 @@ Detect the review base branch and compute the merge-base using the same bundled 
 ```
 RESOLVE_SCRIPT=""
 for base in "${CLAUDE_SKILL_DIR:-}" "${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"; do
-  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then RESOLVE_SCRIPT="$base/scripts/resolve-base.sh"; break; fi
+  if [ -n "$base" ] && [ -f "$base/scripts/resolve-base.sh" ]; then
+    real_base=$(cd "$base" 2>/dev/null && pwd -P) || real_base=""
+    real_cwd=$(pwd -P)
+    case "$real_base" in
+      ""|"$real_cwd"|"$real_cwd"/*) continue ;;
+    esac
+    RESOLVE_SCRIPT="$real_base/scripts/resolve-base.sh"
+    break
+  fi
 done
-if [ -z "$RESOLVE_SCRIPT" ]; then echo "ERROR: resolve-base.sh is unavailable because the harness did not expose the plugin or skill directory. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory."; exit 1; fi
+if [ -z "$RESOLVE_SCRIPT" ]; then printf '%s\n' 'ERROR: resolve-base.sh is unavailable because the harness did not expose a trusted plugin or skill directory, or the exposed path resolves inside the reviewed repo. Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory.'; exit 1; fi
 RESOLVE_OUT=$(bash "$RESOLVE_SCRIPT") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -676,17 +676,19 @@ describe("ce-code-review contract", () => {
     expect(content).toContain('echo "ERROR: Unable to resolve PR base branch')
 
     // Branch and standalone modes delegate to resolve-base.sh from the harness-exposed
-    // plugin or skill directory and check its ERROR: output. The script itself emits
-    // ERROR: when the base is unresolved.
+    // skill directory and check its ERROR: output. The script itself emits ERROR: when
+    // the base is unresolved.
     expect(content).toContain('"${CLAUDE_SKILL_DIR:-}"')
-    expect(content).toContain('"${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"')
-    expect(content).toContain('[ -f "$base/scripts/resolve-base.sh" ]')
+    expect(content).toContain('[ -f "${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh" ]')
     // No bare relative-path fallback to `scripts/resolve-base.sh` -- that would resolve
     // against the reviewed repo's CWD and could execute a repo-controlled script.
     expect(content).not.toContain('RESOLVE_SCRIPT="scripts/resolve-base.sh"')
     expect(content).not.toMatch(/bash\s+scripts\/resolve-base\.sh/)
+    // No CLAUDE_PLUGIN_ROOT fallback -- AGENTS.md documents CLAUDE_SKILL_DIR as the
+    // canonical primitive for skill-bundled scripts; adding a second variable is bloat.
+    expect(content).not.toContain("CLAUDE_PLUGIN_ROOT")
     expect(content).toContain(
-      "Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory.",
+      "Re-run with `base:<ref>` or use a harness that exposes the skill directory.",
     )
     const resolveScript = await readRepoFile(
       "plugins/compound-engineering/skills/ce-code-review/scripts/resolve-base.sh",
@@ -695,26 +697,22 @@ describe("ce-code-review contract", () => {
 
     // Branch and standalone modes must stop on script error, not fall back
     expect(content).toContain(
-      "If the plugin/skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`",
+      "is unavailable or resolves inside the reviewed repo, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`",
     )
   })
 
-  test("resolve-base probe rejects repo-controlled paths and preserves fallback order", async () => {
+  test("resolve-base probe resolves CLAUDE_SKILL_DIR and rejects repo-controlled paths", async () => {
     const content = await readRepoFile("plugins/compound-engineering/skills/ce-code-review/SKILL.md")
     const snippet = extractResolveProbe(content)
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ce-code-review-contract-"))
 
     try {
       const skillDir = path.join(tempDir, "skill-dir")
-      const pluginRoot = path.join(tempDir, "plugin-root")
-      const missingSkillDir = path.join(tempDir, "missing-skill-dir")
       const evilCwd = path.join(tempDir, "evil-cwd")
       const evilSkillDir = path.join(evilCwd, ".evil")
 
       for (const dir of [
         path.join(skillDir, "scripts"),
-        path.join(pluginRoot, "skills", "ce-code-review", "scripts"),
-        missingSkillDir,
         path.join(evilCwd, "scripts"),
         path.join(evilSkillDir, "scripts"),
       ]) {
@@ -722,66 +720,36 @@ describe("ce-code-review contract", () => {
       }
 
       fs.writeFileSync(path.join(skillDir, "scripts", "resolve-base.sh"), "echo BASE:from-skill-dir\n")
-      fs.writeFileSync(
-        path.join(pluginRoot, "skills", "ce-code-review", "scripts", "resolve-base.sh"),
-        "echo BASE:from-plugin-root\n",
-      )
       fs.writeFileSync(path.join(evilCwd, "scripts", "resolve-base.sh"), "echo BASE:from-cwd-evil\n")
       fs.writeFileSync(path.join(evilSkillDir, "scripts", "resolve-base.sh"), "echo BASE:from-cwd-evil\n")
 
       const realSkillDir = fs.realpathSync(skillDir)
-      const realPluginRoot = fs.realpathSync(pluginRoot)
-      const realMissingSkillDir = fs.realpathSync(missingSkillDir)
       const realEvilSkillDir = fs.realpathSync(evilSkillDir)
       const realEvilCwd = fs.realpathSync(evilCwd)
       const skillResolveScript = path.join(realSkillDir, "scripts", "resolve-base.sh")
-      const pluginResolveScript = path.join(
-        realPluginRoot,
-        "skills",
-        "ce-code-review",
-        "scripts",
-        "resolve-base.sh",
-      )
 
+      // Unset: must fail closed, never fall through to the reviewed-repo decoy
       const unset = runResolveProbe(snippet, realEvilCwd, {})
       expect(unset.status).not.toBe(0)
       expect(unset.output).toContain("Re-run with `base:<ref>`")
+      expect(unset.output).not.toContain("from-cwd-evil")
 
-      expect(runResolveProbe(snippet, realEvilCwd, { CLAUDE_SKILL_DIR: realSkillDir }).output).toContain(
-        `RESOLVED:${skillResolveScript}`,
-      )
+      // Empty: same fail-closed behavior
+      const empty = runResolveProbe(snippet, realEvilCwd, { CLAUDE_SKILL_DIR: "" })
+      expect(empty.status).not.toBe(0)
+      expect(empty.output).toContain("Re-run with `base:<ref>`")
 
-      expect(runResolveProbe(snippet, realEvilCwd, { CLAUDE_PLUGIN_ROOT: realPluginRoot }).output).toContain(
-        `RESOLVED:${pluginResolveScript}`,
-      )
-
+      // Happy path: resolves to the bundled helper, even with a decoy in the CWD
       expect(
-        runResolveProbe(snippet, realEvilCwd, {
-          CLAUDE_SKILL_DIR: realSkillDir,
-          CLAUDE_PLUGIN_ROOT: realPluginRoot,
-        }).output,
+        runResolveProbe(snippet, realEvilCwd, { CLAUDE_SKILL_DIR: realSkillDir }).output,
       ).toContain(`RESOLVED:${skillResolveScript}`)
 
-      expect(
-        runResolveProbe(snippet, realEvilCwd, {
-          CLAUDE_SKILL_DIR: realEvilSkillDir,
-          CLAUDE_PLUGIN_ROOT: realPluginRoot,
-        }).output,
-      ).toContain(`RESOLVED:${pluginResolveScript}`)
-
-      expect(
-        runResolveProbe(snippet, realEvilCwd, {
-          CLAUDE_SKILL_DIR: "",
-          CLAUDE_PLUGIN_ROOT: realPluginRoot,
-        }).output,
-      ).toContain(`RESOLVED:${pluginResolveScript}`)
-
-      expect(
-        runResolveProbe(snippet, realEvilCwd, {
-          CLAUDE_SKILL_DIR: realMissingSkillDir,
-          CLAUDE_PLUGIN_ROOT: realPluginRoot,
-        }).output,
-      ).toContain(`RESOLVED:${pluginResolveScript}`)
+      // Hostile harness: CLAUDE_SKILL_DIR points inside the reviewed-repo CWD --
+      // must be rejected and fail closed, NOT execute the decoy.
+      const evil = runResolveProbe(snippet, realEvilCwd, { CLAUDE_SKILL_DIR: realEvilSkillDir })
+      expect(evil.status).not.toBe(0)
+      expect(evil.output).toContain("Re-run with `base:<ref>`")
+      expect(evil.output).not.toContain("from-cwd-evil")
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true })
     }

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -680,6 +680,10 @@ describe("ce-code-review contract", () => {
     // the base is unresolved.
     expect(content).toContain('"${CLAUDE_SKILL_DIR:-}"')
     expect(content).toContain('[ -f "${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh" ]')
+    // Reject helper paths against the reviewed-repo top-level, not just CWD --
+    // otherwise a launch from a monorepo subdirectory leaves repo-controlled
+    // sibling paths (e.g., `<repo-root>/.evil`) accepted.
+    expect(content).toContain("git rev-parse --show-toplevel")
     // No bare relative-path fallback to `scripts/resolve-base.sh` -- that would resolve
     // against the reviewed repo's CWD and could execute a repo-controlled script.
     expect(content).not.toContain('RESOLVE_SCRIPT="scripts/resolve-base.sh"')
@@ -750,6 +754,32 @@ describe("ce-code-review contract", () => {
       expect(evil.status).not.toBe(0)
       expect(evil.output).toContain("Re-run with `base:<ref>`")
       expect(evil.output).not.toContain("from-cwd-evil")
+
+      // Monorepo subdir attack: reviewer launched from a subdirectory of the reviewed
+      // repo. CLAUDE_SKILL_DIR points at a sibling of the subdir (e.g., `<repo-root>/.evil`)
+      // -- it lives outside the CWD subdir but is still repo-controlled. The guard must
+      // reject it by comparing against the repo top-level, not just the CWD.
+      const monorepoRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ce-code-review-monorepo-"))
+      try {
+        const subDir = path.join(monorepoRoot, "services", "foo")
+        const sneakSkill = path.join(monorepoRoot, ".evil")
+        fs.mkdirSync(subDir, { recursive: true })
+        fs.mkdirSync(path.join(sneakSkill, "scripts"), { recursive: true })
+        fs.writeFileSync(
+          path.join(sneakSkill, "scripts", "resolve-base.sh"),
+          "echo BASE:from-monorepo-evil\n",
+        )
+        execSync("git init -q", { cwd: monorepoRoot })
+
+        const realSubDir = fs.realpathSync(subDir)
+        const realSneakSkill = fs.realpathSync(sneakSkill)
+        const monorepo = runResolveProbe(snippet, realSubDir, { CLAUDE_SKILL_DIR: realSneakSkill })
+        expect(monorepo.status).not.toBe(0)
+        expect(monorepo.output).toContain("Re-run with `base:<ref>`")
+        expect(monorepo.output).not.toContain("from-monorepo-evil")
+      } finally {
+        fs.rmSync(monorepoRoot, { recursive: true, force: true })
+      }
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true })
     }

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -1,10 +1,54 @@
-import { readFile } from "fs/promises"
-import path from "path"
+import { execSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { readFile } from "node:fs/promises"
 import { describe, expect, test } from "bun:test"
 import { parseFrontmatter } from "../src/utils/frontmatter"
 
 async function readRepoFile(relativePath: string): Promise<string> {
   return readFile(path.join(process.cwd(), relativePath), "utf8")
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`
+}
+
+function runResolveProbe(snippet: string, cwd: string, env: NodeJS.ProcessEnv) {
+  try {
+    return {
+      status: 0,
+      output: execSync(`bash -c ${shellQuote(snippet)}`, {
+        cwd,
+        env: {
+          PATH: process.env.PATH,
+          ...env,
+        },
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    }
+  } catch (error) {
+    const failed = error as { status?: number; stdout?: Buffer | string; stderr?: Buffer | string }
+    return {
+      status: failed.status ?? 1,
+      output: `${failed.stdout?.toString() ?? ""}${failed.stderr?.toString() ?? ""}`,
+    }
+  }
+}
+
+function extractResolveProbe(content: string): string {
+  const blocks = content.match(
+    /RESOLVE_SCRIPT=""\n[\s\S]*?BASE=\$\(echo "\$RESOLVE_OUT" \| sed 's\/\^BASE:\/\/'\)/g,
+  )
+
+  expect(blocks).toHaveLength(2)
+  expect(blocks?.[0]).toBe(blocks?.[1])
+
+  return blocks![0].replace(
+    `BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')`,
+    `echo "RESOLVED:$RESOLVE_SCRIPT"`,
+  )
 }
 
 describe("ce-code-review contract", () => {
@@ -653,6 +697,94 @@ describe("ce-code-review contract", () => {
     expect(content).toContain(
       "If the plugin/skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`",
     )
+  })
+
+  test("resolve-base probe rejects repo-controlled paths and preserves fallback order", async () => {
+    const content = await readRepoFile("plugins/compound-engineering/skills/ce-code-review/SKILL.md")
+    const snippet = extractResolveProbe(content)
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ce-code-review-contract-"))
+
+    try {
+      const skillDir = path.join(tempDir, "skill-dir")
+      const pluginRoot = path.join(tempDir, "plugin-root")
+      const missingSkillDir = path.join(tempDir, "missing-skill-dir")
+      const evilCwd = path.join(tempDir, "evil-cwd")
+      const evilSkillDir = path.join(evilCwd, ".evil")
+
+      for (const dir of [
+        path.join(skillDir, "scripts"),
+        path.join(pluginRoot, "skills", "ce-code-review", "scripts"),
+        missingSkillDir,
+        path.join(evilCwd, "scripts"),
+        path.join(evilSkillDir, "scripts"),
+      ]) {
+        fs.mkdirSync(dir, { recursive: true })
+      }
+
+      fs.writeFileSync(path.join(skillDir, "scripts", "resolve-base.sh"), "echo BASE:from-skill-dir\n")
+      fs.writeFileSync(
+        path.join(pluginRoot, "skills", "ce-code-review", "scripts", "resolve-base.sh"),
+        "echo BASE:from-plugin-root\n",
+      )
+      fs.writeFileSync(path.join(evilCwd, "scripts", "resolve-base.sh"), "echo BASE:from-cwd-evil\n")
+      fs.writeFileSync(path.join(evilSkillDir, "scripts", "resolve-base.sh"), "echo BASE:from-cwd-evil\n")
+
+      const realSkillDir = fs.realpathSync(skillDir)
+      const realPluginRoot = fs.realpathSync(pluginRoot)
+      const realMissingSkillDir = fs.realpathSync(missingSkillDir)
+      const realEvilSkillDir = fs.realpathSync(evilSkillDir)
+      const realEvilCwd = fs.realpathSync(evilCwd)
+      const skillResolveScript = path.join(realSkillDir, "scripts", "resolve-base.sh")
+      const pluginResolveScript = path.join(
+        realPluginRoot,
+        "skills",
+        "ce-code-review",
+        "scripts",
+        "resolve-base.sh",
+      )
+
+      const unset = runResolveProbe(snippet, realEvilCwd, {})
+      expect(unset.status).not.toBe(0)
+      expect(unset.output).toContain("Re-run with `base:<ref>`")
+
+      expect(runResolveProbe(snippet, realEvilCwd, { CLAUDE_SKILL_DIR: realSkillDir }).output).toContain(
+        `RESOLVED:${skillResolveScript}`,
+      )
+
+      expect(runResolveProbe(snippet, realEvilCwd, { CLAUDE_PLUGIN_ROOT: realPluginRoot }).output).toContain(
+        `RESOLVED:${pluginResolveScript}`,
+      )
+
+      expect(
+        runResolveProbe(snippet, realEvilCwd, {
+          CLAUDE_SKILL_DIR: realSkillDir,
+          CLAUDE_PLUGIN_ROOT: realPluginRoot,
+        }).output,
+      ).toContain(`RESOLVED:${skillResolveScript}`)
+
+      expect(
+        runResolveProbe(snippet, realEvilCwd, {
+          CLAUDE_SKILL_DIR: realEvilSkillDir,
+          CLAUDE_PLUGIN_ROOT: realPluginRoot,
+        }).output,
+      ).toContain(`RESOLVED:${pluginResolveScript}`)
+
+      expect(
+        runResolveProbe(snippet, realEvilCwd, {
+          CLAUDE_SKILL_DIR: "",
+          CLAUDE_PLUGIN_ROOT: realPluginRoot,
+        }).output,
+      ).toContain(`RESOLVED:${pluginResolveScript}`)
+
+      expect(
+        runResolveProbe(snippet, realEvilCwd, {
+          CLAUDE_SKILL_DIR: realMissingSkillDir,
+          CLAUDE_PLUGIN_ROOT: realPluginRoot,
+        }).output,
+      ).toContain(`RESOLVED:${pluginResolveScript}`)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 
   test("orchestration callers pass explicit mode flags", async () => {

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -631,12 +631,19 @@ describe("ce-code-review contract", () => {
     // PR mode still has an inline error for unresolved base
     expect(content).toContain('echo "ERROR: Unable to resolve PR base branch')
 
-    // Branch and standalone modes delegate to resolve-base.sh from the skill directory and
-    // check its ERROR: output.
-    // The script itself emits ERROR: when the base is unresolved.
-    expect(content).toContain('${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh')
-    expect(content).not.toContain('[ -f "$RESOLVE_SCRIPT" ] || RESOLVE_SCRIPT="scripts/resolve-base.sh"')
-    expect(content).toContain("Re-run with `base:<ref>` or use a harness that exposes the skill directory.")
+    // Branch and standalone modes delegate to resolve-base.sh from the harness-exposed
+    // plugin or skill directory and check its ERROR: output. The script itself emits
+    // ERROR: when the base is unresolved.
+    expect(content).toContain('"${CLAUDE_SKILL_DIR:-}"')
+    expect(content).toContain('"${CLAUDE_PLUGIN_ROOT:+${CLAUDE_PLUGIN_ROOT}/skills/ce-code-review}"')
+    expect(content).toContain('[ -f "$base/scripts/resolve-base.sh" ]')
+    // No bare relative-path fallback to `scripts/resolve-base.sh` -- that would resolve
+    // against the reviewed repo's CWD and could execute a repo-controlled script.
+    expect(content).not.toContain('RESOLVE_SCRIPT="scripts/resolve-base.sh"')
+    expect(content).not.toMatch(/bash\s+scripts\/resolve-base\.sh/)
+    expect(content).toContain(
+      "Re-run with `base:<ref>` or use a harness that exposes the plugin/skill directory.",
+    )
     const resolveScript = await readRepoFile(
       "plugins/compound-engineering/skills/ce-code-review/scripts/resolve-base.sh",
     )
@@ -644,7 +651,7 @@ describe("ce-code-review contract", () => {
 
     // Branch and standalone modes must stop on script error, not fall back
     expect(content).toContain(
-      "If the skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`",
+      "If the plugin/skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`",
     )
   })
 

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -631,9 +631,12 @@ describe("ce-code-review contract", () => {
     // PR mode still has an inline error for unresolved base
     expect(content).toContain('echo "ERROR: Unable to resolve PR base branch')
 
-    // Branch and standalone modes delegate to resolve-base.sh and check its ERROR: output.
+    // Branch and standalone modes delegate to resolve-base.sh from the skill directory and
+    // check its ERROR: output.
     // The script itself emits ERROR: when the base is unresolved.
-    expect(content).toContain("scripts/resolve-base.sh")
+    expect(content).toContain('${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh')
+    expect(content).not.toContain('[ -f "$RESOLVE_SCRIPT" ] || RESOLVE_SCRIPT="scripts/resolve-base.sh"')
+    expect(content).toContain("Re-run with `base:<ref>` or use a harness that exposes the skill directory.")
     const resolveScript = await readRepoFile(
       "plugins/compound-engineering/skills/ce-code-review/scripts/resolve-base.sh",
     )
@@ -641,7 +644,7 @@ describe("ce-code-review contract", () => {
 
     // Branch and standalone modes must stop on script error, not fall back
     expect(content).toContain(
-      "If the script outputs an error, stop instead of falling back to `git diff HEAD`",
+      "If the skill directory is unavailable, the helper script is missing, or the script outputs an error, stop instead of falling back to `git diff HEAD`",
     )
   })
 


### PR DESCRIPTION
## Summary

`ce-code-review` is a skill, but its branch-mode and standalone-mode bash blocks invoked the merge-base helper as `bash scripts/resolve-base.sh`. The Bash tool runs from the user's project CWD — not the skill directory — so that path resolves against the **reviewed repo**, not the bundled skill. Two concrete failure modes:

1. **Correctness (loud-fail):** in any reviewed repo without a `scripts/resolve-base.sh`, bash exits non-zero, the existing `||` branch prints `ERROR: resolve-base.sh failed`, and the skill aborts. Branch and standalone modes are effectively unusable on the common case — users have to fall back to `base:<ref>` or PR mode.
2. **Security (silent-corruption):** if the reviewed repo *does* ship its own `scripts/resolve-base.sh`, the reviewer executes that repo-controlled script with no error and computes a plausible-looking but completely attacker-controlled merge-base. Low-likelihood, high-impact for a tool whose job is summarizing untrusted code.

This PR resolves the helper from `${CLAUDE_SKILL_DIR}` instead, with an in-CWD-rejection check and an explicit fail-closed branch when the variable is unavailable or hostile.

## Why this went unnoticed

- **PR mode dominates real usage.** `/ce-code-review <NNN>` resolves the base from `gh pr view` and never touches `resolve-base.sh`, so most invocations don't hit the broken path.
- **The error read like a config problem.** `ERROR: resolve-base.sh failed` looks like "set up your repo" rather than "the skill is misrouting." Users likely worked around it with `base:<ref>` and moved on.
- **The contract test only matched output strings**, not that the path resolves through the harness rather than the CWD — so CI was happy. The updated test in this PR pins the probe shape and forbids the bare relative-path form.

## What changed

- Branch and standalone modes now resolve `resolve-base.sh` from `${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh`. AGENTS.md documents `${CLAUDE_SKILL_DIR}` as the canonical primitive for skill-bundled scripts and asserts it resolves correctly across `claude --plugin-dir` and standard marketplace-cached installs.
- The candidate is `realpath`'d and rejected if it resolves to the reviewed repo's CWD or any path inside it — so even a misconfigured or hostile harness that points `${CLAUDE_SKILL_DIR}` at a directory inside the reviewed repo cannot be used to execute a repo-controlled script.
- If the variable is unexposed or resolves inside the reviewed repo, the skill prints a precise error and stops, telling the user to re-run with `base:<ref>` or use a harness that exposes the skill directory.
- The pre-existing fail-closed posture is preserved: under any failure (missing variable, missing script, script-emitted `ERROR:`), the reviewer refuses to fall back to `git diff HEAD`, which would only show uncommitted changes and silently miss every committed change on the branch.
- **No bare relative-path fallback.** Adding `scripts/resolve-base.sh` as a last-resort would re-introduce the original CWD-resolution bug *and* the script-shadowing security path, so the contract test now asserts that fallback is absent (`expect(content).not.toMatch(/bash\s+scripts\/resolve-base\.sh/)`).

## Cross-platform behavior

This skill is converted for non-Claude targets (Codex, Cursor, Gemini, etc.) and the `${CLAUDE_SKILL_DIR}` variable remains literal in the converted output. On those platforms the probe finds no script and the skill fails closed with a clear instruction to pass `base:<ref>` — strictly safer than executing a CWD-relative script. PR mode (`<NNN>`) is unaffected and continues to resolve the base from PR metadata via `gh`.

## Empirical evidence

Reproduced in a throwaway repo with a decoy `scripts/resolve-base.sh` that prints `BASE:DECOYWASEXECUTED` and exits 0 — i.e., a worst-case reviewed repo carrying its own helper at the path the old code probed. Same CWD, same decoy, both invocations:

```
== OLD (bash scripts/resolve-base.sh) ==
$ bash scripts/resolve-base.sh
BASE:DECOYWASEXECUTED
exit=0

== NEW (probe block, with CLAUDE_SKILL_DIR set) ==
$ # probe resolves RESOLVE_SCRIPT to the bundled helper, ignores the decoy
exit=0
BASE=a9bafc43416f078e9841994b6112509d5049266b   # real merge-base from the bundled helper
```

The OLD path silently executed the reviewed repo's script and returned its forged base. The NEW path resolved through `${CLAUDE_SKILL_DIR}`, ignored the decoy, and returned the real `git merge-base` sha. The loud-fail case (no decoy present in the reviewed repo) produces `bash: scripts/resolve-base.sh: No such file or directory` (exit 127) under OLD and the documented fail-closed error under NEW with no harness variable set.

## Verification

- `bun test tests/review-skill-contract.test.ts` — 26 pass, including the updated `fails closed when merge-base is unresolved` contract (pins the new probe shape, asserts absence of the relative-path fallback) and a new `resolve-base probe resolves CLAUDE_SKILL_DIR and rejects repo-controlled paths` test that exercises the probe end-to-end against synthetic harnesses (unset, empty, happy-path with CWD decoy present, and hostile harness pointing into the reviewed-repo CWD).
- `bun test` — full suite (1240 tests) passes.
- `bun run release:validate` — clean.

## Test plan

- [x] Branch mode on a feature branch with `${CLAUDE_SKILL_DIR}` set: helper resolves, diff is correct against merge-base.
- [x] Standalone mode on the current branch: same as above.
- [x] Reviewed repo containing a decoy `scripts/resolve-base.sh`: decoy is **not** executed; bundled helper runs.
- [x] Hostile harness with `${CLAUDE_SKILL_DIR}` pointing inside the reviewed repo: rejected, fail-closed; decoy not executed.
- [x] Harness with no `${CLAUDE_SKILL_DIR}` exposed: skill prints the documented error and stops; no `git diff HEAD` fallback.
- [x] PR mode (`<NNN>`): unchanged — still resolves base from PR metadata.
