### PR TITLE
docs(skills): reframe README around the 4-step core loop

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -6,36 +6,65 @@ For runtime behavior and contributor reference, the `SKILL.md` in each skill's s
 
 ---
 
-## The compound-engineering ideation chain
+## The compound-engineering core loop
 
 ```text
-/ce-ideate         /ce-brainstorm      /ce-plan             /ce-work
-"What's worth      "What does this     "What's needed       "Build it."
- exploring?"        need to be?"        to accomplish
-                                        this?"
+   [/ce-ideate]       (optional) "What's worth exploring?"
+        │
+        ▼
+┌─→ /ce-brainstorm    "What does this need to be?"
+│       │
+│       ▼
+│   /ce-plan          "What's needed to accomplish this?"
+│       │
+│       ▼
+│   /ce-work          "Build it."
+│       │
+│       ▼
+└── /ce-compound      "Capture what we learned."
 ```
 
-`/ce-strategy` anchors the chain upstream. `/ce-product-pulse` closes the outer feedback loop with a read on what users experienced. `/ce-compound` and `/ce-compound-refresh` capture and maintain the institutional memory the chain reads as grounding.
+`/ce-compound` is the closer that makes the loop *compound*: it writes learnings into `docs/solutions/`, which the next iteration's `/ce-brainstorm` and `/ce-plan` read as grounding — that return arrow is the whole point. `/ce-ideate` is an optional prelude for when you don't yet know what to work on. Everything else in this catalog is either an anchor around the loop or an on-demand tool used when a specific need arises — not a step you walk through every time.
 
 ---
 
-## Core Workflow
+## The Core Loop
 
-The primary entry points for engineering work.
+The steps of every engineering iteration. `/ce-ideate` runs only when you need to find a direction first; the other four run in order per piece of work.
+
+| Skill | Description |
+|-------|-------------|
+| [`/ce-ideate`](./ce-ideate.md) | *Optional first step* — discover strong, qualified directions worth exploring with six conceptual frames, warrant requirement, adversarial filtering |
+| [`/ce-brainstorm`](./ce-brainstorm.md) | Define what something should become — collaborative dialogue, named gap lenses, right-sized requirements doc |
+| [`/ce-plan`](./ce-plan.md) | Bound execution with guardrails — U-IDs, test scenarios, automatic confidence check; WHAT decisions, not HOW code |
+| [`/ce-work`](./ce-work.md) | Execute against the plan's guardrails — figure out the HOW with code in front of you, ship through quality gates |
+| [`/ce-compound`](./ce-compound.md) | Close the loop by capturing what you learned into `docs/solutions/` so the next iteration starts smarter — bug track + knowledge track |
+
+---
+
+## Around the Loop
+
+Skills that anchor, feed, or maintain the loop without being steps inside it.
 
 | Skill | Description |
 |-------|-------------|
 | [`/ce-strategy`](./ce-strategy.md) | Create or maintain `STRATEGY.md` — the upstream anchor read by `ce-ideate`, `ce-brainstorm`, and `ce-plan` as grounding |
-| [`/ce-ideate`](./ce-ideate.md) | Discover strong, qualified directions worth exploring — six conceptual frames, warrant requirement, adversarial filtering |
-| [`/ce-brainstorm`](./ce-brainstorm.md) | Define what something should become — collaborative dialogue, named gap lenses, right-sized requirements doc |
-| [`/ce-plan`](./ce-plan.md) | Bound execution with guardrails — U-IDs, test scenarios, automatic confidence check; WHAT decisions, not HOW code |
-| [`/ce-work`](./ce-work.md) | Execute against the plan's guardrails — figure out the HOW with code in front of you, ship through quality gates |
+| [`/ce-product-pulse`](./ce-product-pulse.md) | Outer feedback loop — single-page time-windowed report on usage, performance, errors, followups; saved to `docs/pulse-reports/` as a timeline |
+| [`/ce-compound-refresh`](./ce-compound-refresh.md) | Maintain `docs/solutions/` over time — five outcomes (Keep / Update / Consolidate / Replace / Delete), Interactive + Autofix modes |
+
+---
+
+## On-Demand
+
+Invoked when a specific need arises — not part of any chain.
+
+| Skill | Description |
+|-------|-------------|
 | [`/ce-debug`](./ce-debug.md) | Find root causes systematically — causal chain gate, predictions for uncertain links, smart escalation |
 | [`/ce-code-review`](./ce-code-review.md) | Structured code review with tiered persona agents, confidence-gated findings, four modes |
-| [`/ce-compound`](./ce-compound.md) | Document a recently solved problem to compound team knowledge — bug track + knowledge track |
-| [`/ce-compound-refresh`](./ce-compound-refresh.md) | Maintain `docs/solutions/` over time — five outcomes (Keep / Update / Consolidate / Replace / Delete), Interactive + Autofix modes |
+| [`/ce-doc-review`](./ce-doc-review.md) | Review requirements or plan documents using parallel persona agents — coherence, feasibility, product-lens, design-lens, security-lens, scope-guardian, adversarial |
+| [`/ce-simplify-code`](./ce-simplify-code.md) | Refine recently changed code — three parallel reviewer agents (reuse, quality, efficiency); behavior preservation verified |
 | [`/ce-optimize`](./ce-optimize.md) | Metric-driven iterative optimization loops — three-tier evaluation, parallel experiments, persistence discipline |
-| [`/ce-product-pulse`](./ce-product-pulse.md) | Single-page time-windowed report on usage, performance, errors, followups; saved to `docs/pulse-reports/` as a timeline |
 
 ---
 
@@ -46,15 +75,6 @@ The primary entry points for engineering work.
 | [`/ce-sessions`](./ce-sessions.md) | Search session history across Claude Code, Codex, and Cursor for context relevant to a question |
 | [`/ce-slack-research`](./ce-slack-research.md) | Search Slack for interpreted organizational context — workspace identity, research-value assessment, cross-cutting analysis |
 | [`/ce-riffrec-feedback-analysis`](./ce-riffrec-feedback-analysis.md) | Turn raw [Riffrec](https://github.com/kieranklaassen/riffrec) recordings into structured feedback — quick bug or extensive analysis with `ce-brainstorm` handoff |
-
----
-
-## Review & Quality
-
-| Skill | Description |
-|-------|-------------|
-| [`/ce-doc-review`](./ce-doc-review.md) | Review requirements or plan documents using parallel persona agents — coherence, feasibility, product-lens, design-lens, security-lens, scope-guardian, adversarial |
-| [`/ce-simplify-code`](./ce-simplify-code.md) | Refine recently changed code — three parallel reviewer agents (reuse, quality, efficiency); behavior preservation verified |
 
 ---
 


### PR DESCRIPTION
The skills index framed the workflow as an 11-skill "Core Workflow" table. That read as a 7+ step loop and buried the namesake compounding behavior. The README now leads with a 4-step core loop (ce-brainstorm, ce-plan, ce-work, ce-compound), with ce-ideate as an optional first step. The top-down ASCII diagram routes a return arrow from ce-compound back to ce-brainstorm, so the compounding is visible: each iteration's learnings feed the next iteration's grounding. Skills outside the loop split into Around the Loop (ce-strategy, ce-product-pulse, ce-compound-refresh) and On-Demand (debug, code-review, doc-review, simplify-code, optimize). The former "Review & Quality" section folded into On-Demand.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
