### PR TITLE
fix(ce-ideate): bound scope and add topic-surface decomposition

### DIFF
--- a/docs/skills/ce-ideate.md
+++ b/docs/skills/ce-ideate.md
@@ -2,9 +2,9 @@
 
 > Discover strong, qualified directions worth exploring — across any domain — and let the rest fall away.
 
-`ce-ideate` is the upstream **discovery** skill. It's where you reach when you don't yet have a specific idea — when the question is "which directions even matter here?" rather than "let me refine the one I already have." It does the homework first (parallel grounding agents pull from your codebase, past learnings, **external prior art on the open web**, and optionally Slack and your issue tracker), generates candidates from six different conceptual frames, requires a tagged **warrant** for every idea, and presents only the survivors of an adversarial critique — with explicit reasons for what was rejected.
+`ce-ideate` is the upstream **discovery** skill. It's where you reach when you don't yet have a specific idea — when the question is "which directions even matter here?" rather than "let me refine the one I already have." It does the homework first (parallel grounding agents pull from your codebase, past learnings, **external prior art on the open web**, and optionally Slack and your issue tracker), generates candidates from six different conceptual frames, requires a tagged **basis** for every idea, and presents only the survivors of an adversarial critique — with explicit reasons for what was rejected.
 
-It runs equally well on software topics, product topics, and entirely non-software topics — naming, narrative, personal decisions, weekend trips, business strategy. The same generate-critique-survive engine; the same warrant requirement; the same anti-slop discipline.
+It runs equally well on software topics, product topics, and entirely non-software topics — naming, narrative, personal decisions, weekend trips, business strategy. The same generate-critique-survive engine; the same basis requirement; the same anti-slop discipline.
 
 This is the first step in the compound-engineering ideation chain:
 
@@ -23,7 +23,7 @@ The chain works across domains — every step supports universal mode. `ce-ideat
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Grounds in real material, generates candidates across six conceptual frames, critiques them adversarially, presents 5-7 survivors — each with a tagged warrant |
+| What does it do? | Grounds in real material, generates candidates across six conceptual frames, critiques them adversarially, presents 5-7 survivors — each with a tagged basis |
 | When to use it | Greenfield exploration, big-picture thinking, codebase audits, surprise-me runs, naming, decisions, business strategy — any domain where you want a qualified candidate set rather than a refined idea |
 | What it produces | Ranked ideation artifact in `docs/ideation/` (or to Proof for non-software topics) |
 | What's next | `/ce-brainstorm` on a chosen survivor — or save and walk away |
@@ -46,8 +46,8 @@ Asking an AI "what's worth exploring here?" usually returns:
 
 - Grounding agents do the homework first — codebase scan, past learnings, external prior art, optional Slack and issue intelligence
 - Six parallel ideation sub-agents work from different conceptual frames
-- Every idea must carry a tagged **warrant** — direct evidence, named external prior art, or a written-out first-principles argument
-- Ideas without warrant are rejected; the failure mode being prevented is "AI slop"
+- Every idea must carry a tagged **basis** — direct evidence, named external prior art, or a written-out first-principles argument
+- Ideas without a basis are rejected; the failure mode being prevented is "AI slop"
 - Survivors are scored against a consistent rubric and presented with downsides and confidence
 - A rejection summary shows what was considered and cut
 
@@ -59,9 +59,9 @@ Asking an AI "what's worth exploring here?" usually returns:
 
 Every run starts with parallel grounding agents that supply the substance ideas will be qualified against — codebase scan (in repo mode), past institutional learnings from `docs/solutions/`, external prior art via web research, and optional Slack and issue intelligence when those tools are available. **External prior art is critical**: without it, the agent is just remixing what's already in your codebase or your head. With it, ideas can cite "this is how X solved this" — concrete, verifiable, named precedent.
 
-### 2. Warrant requirement — every idea cites its basis
+### 2. Basis requirement — every idea cites its evidence
 
-Each surviving candidate carries a tagged warrant: `direct:` (quoted evidence), `external:` (named prior art), or `reasoned:` (written-out first-principles argument, not a gesture). Speculation that sounds plausible but has no basis is rejected. **Comprehensive grounding + warrant requirement is the dual anti-slop mechanism.** One without the other is weaker: grounding without warrant gives well-informed speculation; warrant without grounding gives clever-sounding rationalization.
+Each surviving candidate carries a tagged basis: `direct:` (quoted evidence), `external:` (named prior art), or `reasoned:` (written-out first-principles argument, not a gesture). Speculation that sounds plausible but has no basis is rejected. **Comprehensive grounding + basis requirement is the dual anti-slop mechanism.** One without the other is weaker: grounding without a basis gives well-informed speculation; a basis without grounding gives clever-sounding rationalization.
 
 ### 3. Six-frame divergent generation
 
@@ -69,11 +69,11 @@ Six parallel sub-agents, each biased toward a different generative frame: pain &
 
 ### 4. Adversarial filtering with stated rejection reasons
 
-The orchestrator critiques every candidate against a consistent rubric — groundedness, warrant strength, expected value, novelty, pragmatism, leverage, implementation burden, overlap. One-line reasons accompany every rejection. Survivors are presented alongside a rejection summary so you see what was considered and cut.
+The orchestrator critiques every candidate against a consistent rubric — groundedness, basis strength, expected value, novelty, pragmatism, leverage, implementation burden, overlap. One-line reasons accompany every rejection. Survivors are presented alongside a rejection summary so you see what was considered and cut.
 
 ### 5. Three modes — software, software-product, and entirely non-software
 
-The same generate-critique-survive mechanism runs across very different topic domains: things in your codebase, software products outside your repo (pages, apps, flows), or topics with no software surface at all (naming, narrative, personal decisions, business strategy). In non-software mode, a domain-agnostic facilitator takes over — same six frames, same warrant requirement, same critique, but in domain-native language.
+The same generate-critique-survive mechanism runs across very different topic domains: things in your codebase, software products outside your repo (pages, apps, flows), or topics with no software surface at all (naming, narrative, personal decisions, business strategy). In non-software mode, a domain-agnostic facilitator takes over — same six frames, same basis requirement, same critique, but in domain-native language.
 
 ### 6. Surprise-me mode — no subject required
 
@@ -91,7 +91,7 @@ You invoke `ce-ideate "DX improvements"` from inside a code repo. The agent anno
 
 Grounding agents return in parallel — a codebase summary, relevant past learnings, external prior art on developer-experience patterns. Six ideation sub-agents then generate candidates from different frames. The orchestrator merges 40+ candidates into one list, synthesizes cross-cutting combinations, and runs the adversarial critique pass — about 13 ideas are cut for being too vague, unjustified, or duplicative.
 
-You see six survivors. Each has a tagged warrant (e.g., "tests/cli.test.ts:42 spawns 14 different bash invocations"), a rationale connecting that warrant to the move's significance, downsides, confidence, and complexity. A rejection summary lists what was cut and why. Then a four-option menu: refine in conversation, open in Proof, brainstorm a chosen survivor, or save and end.
+You see six survivors. Each has a tagged basis (e.g., "tests/cli.test.ts:42 spawns 14 different bash invocations"), a rationale connecting that basis to the move's significance, downsides, confidence, and complexity. A rejection summary lists what was cut and why. Then a four-option menu: refine in conversation, open in Proof, brainstorm a chosen survivor, or save and end.
 
 ---
 
@@ -119,7 +119,7 @@ Skip `ce-ideate` when:
 ```text
 /ce-ideate            "What's worth exploring?"
    |
-   |   chosen survivor (with warrant + rationale)
+   |   chosen survivor (with basis + rationale)
    v
 /ce-brainstorm        "What does this need to be?"
    |
@@ -132,7 +132,7 @@ Skip `ce-ideate` when:
 /ce-work              "Build it."
 ```
 
-Each artifact is structured input for the next: the survivor's warrant carries forward as the brainstorm's evidence base; the brainstorm's decisions flow into the plan's requirements and scope; the plan's U-IDs and test scenarios become the guardrails `ce-work` executes against. When you select "Brainstorm a chosen idea" in the Phase 4 menu, the survivor is saved (with status `Explored`) and `ce-brainstorm` loads with that idea as the seed.
+Each artifact is structured input for the next: the survivor's basis carries forward as the brainstorm's evidence base; the brainstorm's decisions flow into the plan's requirements and scope; the plan's U-IDs and test scenarios become the guardrails `ce-work` executes against. When you select "Brainstorm a chosen idea" in the Phase 4 menu, the survivor is saved (with status `Explored`) and `ce-brainstorm` loads with that idea as the seed.
 
 The chain runs in non-software domains too — ideating on weekend-trip directions feeds a brainstorm that defines the trip, which feeds a plan that structures bookings, packing, and itinerary as guardrails.
 
@@ -181,8 +181,8 @@ Skip phrases supported anywhere in the prompt: `no external research`, `no slack
 **Why six frames? Why not just one "give me ideas" prompt?**
 Single-prompt ideation collapses into the agent's most-trained directions. Different frames force genuine breadth — cross-domain analogy and constraint-flipping in particular surface ideas no single prompt would.
 
-**Why warrant? Isn't this just AI hand-waving?**
-Without warrant, plausible-sounding ideas with no basis pass through unfiltered. The warrant requirement means every survivor cites real evidence, real prior art, or a written-out argument. You can audit the basis.
+**Why a basis requirement? Isn't this just AI hand-waving?**
+Without a basis, plausible-sounding ideas pass through unfiltered. The basis requirement means every survivor cites real evidence, real prior art, or a written-out argument. You can audit it.
 
 **Does it really work for non-software topics?**
 Yes. The same generate-critique-survive engine runs in domain-native language for naming, narrative, personal decisions, and business strategy. Codebase grounding is replaced by user-context synthesis and external research.

--- a/docs/skills/ce-ideate.md
+++ b/docs/skills/ce-ideate.md
@@ -67,19 +67,23 @@ Each surviving candidate carries a tagged basis: `direct:` (quoted evidence), `e
 
 Six parallel sub-agents, each biased toward a different generative frame: pain & friction, inversion/removal/automation, assumption-breaking, leverage & compounding, cross-domain analogy, and constraint-flipping. Single-prompt ideation collapses into the agent's most-trained directions — different frames force genuine breadth, especially cross-domain analogy and constraint-flipping which surface ideas no single prompt would.
 
-### 4. Adversarial filtering with stated rejection reasons
+### 4. Topic-surface decomposition — axis coverage as a dispatch invariant
+
+Frames decide *how to think* about a topic; **axes** decide *what part of the topic to think on*. Before frame dispatch, the orchestrator decomposes the topic into 3-5 orthogonal axes derived from grounding (e.g., for "social sharing" — send, discovery, arrival, compounding, actor types). Each frame is then instructed to spread its ideas across axes, and an axis-coverage check after generation catches blind spots — if any axis has zero ideas, a bounded recovery dispatch fills it. The failure mode this prevents: six lenses converging on the most salient interpretation of a topic and missing the rest of its surface entirely. Atomic topics (a name, a tagline) and surprise-me runs skip decomposition cleanly.
+
+### 5. Adversarial filtering with stated rejection reasons
 
 The orchestrator critiques every candidate against a consistent rubric — groundedness, basis strength, expected value, novelty, pragmatism, leverage, implementation burden, overlap. One-line reasons accompany every rejection. Survivors are presented alongside a rejection summary so you see what was considered and cut.
 
-### 5. Three modes — software, software-product, and entirely non-software
+### 6. Three modes — software, software-product, and entirely non-software
 
 The same generate-critique-survive mechanism runs across very different topic domains: things in your codebase, software products outside your repo (pages, apps, flows), or topics with no software surface at all (naming, narrative, personal decisions, business strategy). In non-software mode, a domain-agnostic facilitator takes over — same six frames, same basis requirement, same critique, but in domain-native language.
 
-### 6. Surprise-me mode — no subject required
+### 7. Surprise-me mode — no subject required
 
 `/ce-ideate "surprise me"` skips the subject step entirely. Sub-agents discover their own subjects from grounding material. Different frames finding different subjects is the feature, not a bug — cross-cutting combinations across discovered subjects often produce the strongest ideas.
 
-### 7. Issue-tracker intent
+### 8. Issue-tracker intent
 
 Phrases like "what users are reporting" or "biggest issue patterns" trigger an issue-intelligence agent that pulls real GitHub issues and feeds clustered themes into the ideation frames.
 

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -240,16 +240,24 @@ Run grounding agents in parallel in the **foreground** (do not background — re
 
 1. **Quick context scan** — dispatch a general-purpose sub-agent using the platform's cheapest capable model (e.g., `model: "haiku"` in Claude Code) with this prompt:
 
-   > Read the project's AGENTS.md (or CLAUDE.md only as compatibility fallback, then README.md if neither exists), then discover the top-level directory layout using the native file-search/glob tool (e.g., `Glob` with pattern `*` or `*/*` in Claude Code). Also read `STRATEGY.md` if it exists — it captures the product's target problem, approach, persona, metrics, and tracks. Read any other root-level `*.md` files briefly (e.g., `NOTES.md`, `TODO.md`, `FEEDBACK.md`) — these are *additional context*, not authoritative direction, and Phase 2's constraint-vs-background framing keeps them from steering ideation. Return a concise summary (under 30 lines) covering:
+   > Read the project's AGENTS.md (or CLAUDE.md only as compatibility fallback, then README.md if neither exists), then discover the top-level directory layout using the native file-search/glob tool (e.g., `Glob` with pattern `*` or `*/*` in Claude Code). Also read `STRATEGY.md` if it exists — it captures the product's target problem, approach, persona, metrics, and tracks.
+   >
+   > **Two paths for other root-level `*.md` files**, depending on whether the focus hint names them:
+   >
+   > - **User-named references** — if the focus hint names a specific root-level `*.md` file (e.g., focus is "ideate based on FEEDBACK.md", "use NOTES.md as input", "review the gaps in TODO.md"), fully read that file and include its content under a heading `User-named references`. Phase 2 treats these as *constraint*, so sub-agents need actual content, not a gist. Quote or summarize substantive sections; keep one-line gists for files that are mentioned but not the actual subject.
+   > - **Additional context** — for any other root-level `*.md` files (not named in the focus), read briefly and include a one-line gist under a heading `Additional context`. Phase 2 treats these as *background*, so a gist is sufficient.
+   >
+   > Return a concise summary (under 40 lines, longer if user-named references include substantive content) covering:
    >
    > - project shape (language, framework, top-level directory layout)
    > - notable patterns or conventions
    > - obvious pain points or gaps
    > - likely leverage points for improvement
    > - product strategy summary, if `STRATEGY.md` was present — include the approach and active tracks verbatim so ideation can weight toward strategy-aligned directions
-   > - **additional context from other root markdown** — for each non-project-defining `*.md` file at root, give a one-line gist under a heading `Additional context`. Do not promote its content into the project-defining sections above; it's background, not direction.
+   > - `User-named references` section (when the focus hint named root-level `*.md` files)
+   > - `Additional context` section (when other root-level `*.md` files exist that the focus did not name)
    >
-   > Keep the scan shallow — read only top-level documentation and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
+   > Keep the scan shallow otherwise — read only top-level documentation and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
    >
    > Focus hint: {focus_hint}
 
@@ -286,7 +294,8 @@ When dispatching `ce-web-researcher`, pass: the focus hint, a brief planning con
 Consolidate all dispatched results into a short grounding summary using these sections (omit any section that produced nothing):
 
 - **Codebase context** *(repo mode)* — project shape, notable patterns, pain points, leverage points (project-defining files: AGENTS.md/CLAUDE.md/README.md/STRATEGY.md) OR **Topic context** *(elsewhere mode)* — topic shape, stated constraints, user-named pain points, opportunity hooks
-- **Additional context** *(repo mode, when codebase scan found other root-level markdown)* — one-line gists per file. Surfaced separately from project-defining context so Phase 2 can treat it as background, not direction
+- **User-named references** *(repo mode, when the focus hint named root-level `*.md` files)* — full content from files the user explicitly named in their prompt or focus. Phase 2 treats these as constraint
+- **Additional context** *(repo mode, when other root-level markdown was discovered but not named)* — one-line gists per file. Phase 2 treats these as background, not direction
 - **Past learnings** — relevant institutional knowledge from `docs/solutions/`
 - **Issue intelligence** *(when present, repo mode only)* — theme summaries with titles, descriptions, issue counts, and trend directions
 - **External context** *(when web research ran)* — prior art, adjacent solutions, market signals, cross-domain analogies. Note "(reused from earlier dispatch)" when V15 reuse fired
@@ -304,7 +313,7 @@ Dispatch parallel ideation sub-agents on the inherited model (do not tier down -
 
 Give each sub-agent: the grounding summary, the focus hint, the per-agent volume target, and an instruction to generate raw candidates only (not critique). Each agent's first few ideas tend to be obvious -- push past them. Ground every idea in the Phase 1 grounding summary.
 
-**Constraint vs background.** In the dispatch prompt, mark the user's prompt, focus hint, and any named references as *constraints* — ideas that violate them are out regardless of basis. Mark the rest of the grounding summary (codebase context, additional context, learnings, external context) as *background* — informative, not directive. Background can support an idea's basis and inform direction; it must not pull ideation toward whatever was loudest in the corpus when the user named a different focus. This is the primary defense against grounding noise (an unrelated `FEEDBACK.md`, a tangentially-cited prior-art result) shaping survivors against user intent.
+**Constraint vs background.** In the dispatch prompt, mark the user's prompt, focus hint, and any *User-named references* (root-level files the user named in their focus and the codebase-scan fully read) as *constraints* — ideas that violate them are out regardless of basis. Mark the rest of the grounding summary (codebase context, additional context, learnings, external context) as *background* — informative, not directive. Background can support an idea's basis and inform direction; it must not pull ideation toward whatever was loudest in the corpus when the user named a different focus. This is the primary defense against grounding noise (an unrelated `FEEDBACK.md` the user did not name, a tangentially-cited prior-art result) shaping survivors against user intent.
 
 Assign each sub-agent a different ideation frame as a **starting bias, not a constraint**. Prompt each to begin from its assigned perspective but follow any promising thread -- cross-cutting ideas that span multiple frames are valuable.
 

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -2,6 +2,7 @@
 name: ce-ideate
 description: "Generate and critically evaluate grounded ideas about a topic. Use when asking what to improve, requesting idea generation, exploring surprising directions, or wanting the AI to proactively suggest strong options before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on X', 'surprise me', 'what would you change', or any request for AI-generated suggestions rather than refining the user's own idea."
 argument-hint: "[feature, focus area, or constraint]"
+
 ---
 
 # Generate Improvement Ideas
@@ -50,16 +51,19 @@ If no argument is provided, proceed with open-ended ideation.
 Look in `docs/ideation/` for ideation documents created within the last 30 days.
 
 Treat a prior ideation doc as relevant when:
+
 - the topic matches the requested focus
 - the path or subsystem overlaps the requested focus
 - the request is open-ended and there is an obvious recent open ideation doc
 - the issue-grounded status matches: do not offer to resume a non-issue ideation when the current argument indicates issue-tracker intent, or vice versa — treat these as distinct topics
 
 If a relevant doc exists, ask whether to:
+
 1. continue from it
 2. start fresh
 
 If continuing:
+
 - read the document
 - summarize what has already been explored
 - preserve previous idea statuses
@@ -179,10 +183,12 @@ Infer two things from the argument and any intake so far:
 - **Volume override** — any hint that changes candidate or survivor counts
 
 Default volume:
+
 - each ideation sub-agent generates about 6-8 ideas (yielding ~36-48 raw ideas across 6 frames in the default path, or ~24-32 across 4 frames in issue-tracker mode; roughly 25-30 survivors after dedupe in the 6-frame path and fewer in the 4-frame path)
 - keep the top 5-7 survivors
 
 Honor clear overrides such as:
+
 - `top 3`
 - `100 ideas`
 - `go deep`
@@ -235,13 +241,15 @@ Run grounding agents in parallel in the **foreground** (do not background — re
 1. **Quick context scan** — dispatch a general-purpose sub-agent using the platform's cheapest capable model (e.g., `model: "haiku"` in Claude Code) with this prompt:
 
    > Read the project's AGENTS.md (or CLAUDE.md only as compatibility fallback, then README.md if neither exists), then discover the top-level directory layout using the native file-search/glob tool (e.g., `Glob` with pattern `*` or `*/*` in Claude Code). Also read `STRATEGY.md` if it exists — it captures the product's target problem, approach, persona, metrics, and tracks. Return a concise summary (under 30 lines) covering:
+   >
    > - project shape (language, framework, top-level directory layout)
    > - notable patterns or conventions
    > - obvious pain points or gaps
    > - likely leverage points for improvement
    > - product strategy summary, if `STRATEGY.md` was present — include the approach and active tracks verbatim so ideation can weight toward strategy-aligned directions
+   > - **other markdown at root** — list any other root-level `*.md` files by name (e.g., `NOTES.md`, `TODO.md`) under a heading `Additional documents present`. Do **not** read their contents into the summary. They will be surfaced to the user before Phase 2 dispatch so they can name any that should inform ideation; unnamed root-level documents are treated as incidental, not project context.
    >
-   > Keep the scan shallow — read only top-level documentation, `STRATEGY.md` if present, and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
+   > Keep the scan shallow — read only the project-defining files (AGENTS.md/CLAUDE.md/README.md/STRATEGY.md) and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
    >
    > Focus hint: {focus_hint}
 
@@ -278,6 +286,7 @@ When dispatching `ce-web-researcher`, pass: the focus hint, a brief planning con
 Consolidate all dispatched results into a short grounding summary using these sections (omit any section that produced nothing):
 
 - **Codebase context** *(repo mode)* OR **Topic context** *(elsewhere mode)* — project/topic shape, notable patterns or stated constraints, pain points, leverage points
+- **Additional documents present** *(repo mode, when codebase scan listed any)* — names of other root-level markdown files the scan found but did not read. Surface this list verbatim with a one-line invitation: "Pass any of these in if I should include them as context before generation; otherwise I'll proceed without." Proceed without blocking — the user can interrupt to name a file, or stay silent and let unnamed docs remain out of grounding.
 - **Past learnings** — relevant institutional knowledge from `docs/solutions/`
 - **Issue intelligence** *(when present, repo mode only)* — theme summaries with titles, descriptions, issue counts, and trend directions
 - **External context** *(when web research ran)* — prior art, adjacent solutions, market signals, cross-domain analogies. Note "(reused from earlier dispatch)" when V15 reuse fired
@@ -294,6 +303,8 @@ Generate the full candidate list before critiquing any idea.
 Dispatch parallel ideation sub-agents on the inherited model (do not tier down -- creative ideation needs the orchestrator's reasoning level). Omit the `mode` parameter so the user's configured permission settings apply. Dispatch count is mode-conditional: **4 sub-agents only when issue-tracker intent was detected in Phase 0.2 AND the issue intelligence agent returned usable themes** (see override below — cluster-derived frames capped at 4); **6 sub-agents otherwise**, including the insufficient-issue-signal fallback from Phase 1 where intent triggered but themes were not returned. Each targets ~6-8 ideas (yielding ~36-48 raw ideas across 6 frames or ~24-32 across 4 frames, roughly 25-30 survivors after dedupe in the 6-frame path and fewer in the 4-frame path). Adjust per-agent targets when volume overrides apply (e.g., "100 ideas" raises it, "top 3" may lower the survivor count instead).
 
 Give each sub-agent: the grounding summary, the focus hint, the per-agent volume target, and an instruction to generate raw candidates only (not critique). Each agent's first few ideas tend to be obvious -- push past them. Ground every idea in the Phase 1 grounding summary.
+
+**Constraint vs background.** In the dispatch prompt, mark the user's prompt, focus hint, and any named references as *constraints* — ideas that violate them are out regardless of warrant. Mark the rest of the grounding summary (codebase context, learnings, external context, additional documents the user opted in) as *background* — informative, not directive. Background is for grounding warrants and informing direction; it must not pull ideation toward whatever was loudest in the corpus when the user named a different focus. This is the primary defense against grounding noise (an unrelated `FEEDBACK.md`, a tangentially-cited prior-art result) shaping survivors against user intent.
 
 Assign each sub-agent a different ideation frame as a **starting bias, not a constraint**. Prompt each to begin from its assigned perspective but follow any promising thread -- cross-cutting ideas that span multiple frames are valuable.
 
@@ -329,6 +340,7 @@ Warrant is required, not optional. If a sub-agent cannot articulate warrant of a
 - Bias toward the warrant type your frame naturally produces — pain/inversion/leverage tend toward `direct:`; analogy and constraint-flipping tend toward `reasoned:`; assumption-breaking is mixed — but don't exclude other warrant types.
 - Apply the meeting-test as a default floor: would this idea warrant team discussion? If not, it's below the floor and does not surface. The floor is relaxed only when Phase 0.5 detected tactical focus signals.
 - Stay within the subject's identity. Product expansions, new surfaces, new markets, retirements, and architectural pivots are fair game when warrant supports them. Subject-replacement moves (abandoning the project, pivoting to unrelated domains, becoming a different organization) are out regardless of warrant.
+- **Honor the asked scope.** When the focus hint names a part of the subject (a flow, a stage, a section, a feature within a larger product — e.g., "account settings", "onboarding flow", "pricing page copy", "gameplay rules"), ideate at full ambition *within that scope*. Expanding the surface to the whole subject — proposing fundamental changes to the broader product when the user named one slice — is a scope mismatch even when no subject-replacement occurred. Big-picture thinking still applies; it just operates inside the bounded surface the user named, not by widening the surface.
 
 **Surprise-me mode addendum.** When Phase 0.2 routed to surprise-me, include this additional instruction in each sub-agent's dispatch prompt:
 

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -240,16 +240,16 @@ Run grounding agents in parallel in the **foreground** (do not background — re
 
 1. **Quick context scan** — dispatch a general-purpose sub-agent using the platform's cheapest capable model (e.g., `model: "haiku"` in Claude Code) with this prompt:
 
-   > Read the project's AGENTS.md (or CLAUDE.md only as compatibility fallback, then README.md if neither exists), then discover the top-level directory layout using the native file-search/glob tool (e.g., `Glob` with pattern `*` or `*/*` in Claude Code). Also read `STRATEGY.md` if it exists — it captures the product's target problem, approach, persona, metrics, and tracks. Return a concise summary (under 30 lines) covering:
+   > Read the project's AGENTS.md (or CLAUDE.md only as compatibility fallback, then README.md if neither exists), then discover the top-level directory layout using the native file-search/glob tool (e.g., `Glob` with pattern `*` or `*/*` in Claude Code). Also read `STRATEGY.md` if it exists — it captures the product's target problem, approach, persona, metrics, and tracks. Read any other root-level `*.md` files briefly (e.g., `NOTES.md`, `TODO.md`, `FEEDBACK.md`) — these are *additional context*, not authoritative direction, and Phase 2's constraint-vs-background framing keeps them from steering ideation. Return a concise summary (under 30 lines) covering:
    >
    > - project shape (language, framework, top-level directory layout)
    > - notable patterns or conventions
    > - obvious pain points or gaps
    > - likely leverage points for improvement
    > - product strategy summary, if `STRATEGY.md` was present — include the approach and active tracks verbatim so ideation can weight toward strategy-aligned directions
-   > - **other markdown at root** — list any other root-level `*.md` files by name (e.g., `NOTES.md`, `TODO.md`) under a heading `Additional documents present`. Do **not** read their contents into the summary. They will be surfaced to the user before Phase 2 dispatch so they can name any that should inform ideation; unnamed root-level documents are treated as incidental, not project context.
+   > - **additional context from other root markdown** — for each non-project-defining `*.md` file at root, give a one-line gist under a heading `Additional context`. Do not promote its content into the project-defining sections above; it's background, not direction.
    >
-   > Keep the scan shallow — read only the project-defining files (AGENTS.md/CLAUDE.md/README.md/STRATEGY.md) and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
+   > Keep the scan shallow — read only top-level documentation and directory structure. Do not analyze GitHub issues, templates, or contribution guidelines. Do not do deep code search.
    >
    > Focus hint: {focus_hint}
 
@@ -285,8 +285,8 @@ When dispatching `ce-web-researcher`, pass: the focus hint, a brief planning con
 
 Consolidate all dispatched results into a short grounding summary using these sections (omit any section that produced nothing):
 
-- **Codebase context** *(repo mode)* OR **Topic context** *(elsewhere mode)* — project/topic shape, notable patterns or stated constraints, pain points, leverage points
-- **Additional documents present** *(repo mode, when codebase scan listed any)* — names of other root-level markdown files the scan found but did not read. Surface this list verbatim with a one-line invitation: "Pass any of these in if I should include them as context before generation; otherwise I'll proceed without." Proceed without blocking — the user can interrupt to name a file, or stay silent and let unnamed docs remain out of grounding.
+- **Codebase context** *(repo mode)* — project shape, notable patterns, pain points, leverage points (project-defining files: AGENTS.md/CLAUDE.md/README.md/STRATEGY.md) OR **Topic context** *(elsewhere mode)* — topic shape, stated constraints, user-named pain points, opportunity hooks
+- **Additional context** *(repo mode, when codebase scan found other root-level markdown)* — one-line gists per file. Surfaced separately from project-defining context so Phase 2 can treat it as background, not direction
 - **Past learnings** — relevant institutional knowledge from `docs/solutions/`
 - **Issue intelligence** *(when present, repo mode only)* — theme summaries with titles, descriptions, issue counts, and trend directions
 - **External context** *(when web research ran)* — prior art, adjacent solutions, market signals, cross-domain analogies. Note "(reused from earlier dispatch)" when V15 reuse fired
@@ -304,7 +304,7 @@ Dispatch parallel ideation sub-agents on the inherited model (do not tier down -
 
 Give each sub-agent: the grounding summary, the focus hint, the per-agent volume target, and an instruction to generate raw candidates only (not critique). Each agent's first few ideas tend to be obvious -- push past them. Ground every idea in the Phase 1 grounding summary.
 
-**Constraint vs background.** In the dispatch prompt, mark the user's prompt, focus hint, and any named references as *constraints* — ideas that violate them are out regardless of warrant. Mark the rest of the grounding summary (codebase context, learnings, external context, additional documents the user opted in) as *background* — informative, not directive. Background is for grounding warrants and informing direction; it must not pull ideation toward whatever was loudest in the corpus when the user named a different focus. This is the primary defense against grounding noise (an unrelated `FEEDBACK.md`, a tangentially-cited prior-art result) shaping survivors against user intent.
+**Constraint vs background.** In the dispatch prompt, mark the user's prompt, focus hint, and any named references as *constraints* — ideas that violate them are out regardless of basis. Mark the rest of the grounding summary (codebase context, additional context, learnings, external context) as *background* — informative, not directive. Background can support an idea's basis and inform direction; it must not pull ideation toward whatever was loudest in the corpus when the user named a different focus. This is the primary defense against grounding noise (an unrelated `FEEDBACK.md`, a tangentially-cited prior-art result) shaping survivors against user intent.
 
 Assign each sub-agent a different ideation frame as a **starting bias, not a constraint**. Prompt each to begin from its assigned perspective but follow any promising thread -- cross-cutting ideas that span multiple frames are valuable.
 
@@ -325,26 +325,26 @@ Each sub-agent returns this structure per idea:
 
 - **title**
 - **summary** (2-4 sentences)
-- **warrant** (required, tagged) — one of:
+- **basis** (required, tagged) — one of:
   - `direct:` quoted line / specific file / named issue / explicit user-supplied context
   - `external:` named prior art, domain research, adjacent pattern, with source
   - `reasoned:` explicit first-principles argument for why this move likely applies — not a gesture; the argument is written out
-- **why_it_matters** — connects the warrant to the move's significance
+- **why_it_matters** — connects the basis to the move's significance
 - **meeting_test** — one line confirming this would warrant team discussion (waived when Phase 0.5 detected tactical focus signals)
 
-Warrant is required, not optional. If a sub-agent cannot articulate warrant of at least one type, the idea does not surface. The failure mode to prevent is generic "AI-slop" ideas that sound plausible but lack a basis the user can verify.
+Basis is required, not optional. If a sub-agent cannot articulate a basis of at least one type, the idea does not surface. The failure mode to prevent is generic "AI-slop" ideas that sound plausible but lack a basis the user can verify.
 
 **Generation rules (uniform across frames, all modes):**
 
-- Every idea carries articulated warrant. Unjustified speculation does not surface, regardless of how plausible it sounds.
-- Bias toward the warrant type your frame naturally produces — pain/inversion/leverage tend toward `direct:`; analogy and constraint-flipping tend toward `reasoned:`; assumption-breaking is mixed — but don't exclude other warrant types.
+- Every idea carries an articulated basis. Unjustified speculation does not surface, regardless of how plausible it sounds.
+- Bias toward the basis type your frame naturally produces — pain/inversion/leverage tend toward `direct:`; analogy and constraint-flipping tend toward `reasoned:`; assumption-breaking is mixed — but don't exclude other basis types.
 - Apply the meeting-test as a default floor: would this idea warrant team discussion? If not, it's below the floor and does not surface. The floor is relaxed only when Phase 0.5 detected tactical focus signals.
-- Stay within the subject's identity. Product expansions, new surfaces, new markets, retirements, and architectural pivots are fair game when warrant supports them. Subject-replacement moves (abandoning the project, pivoting to unrelated domains, becoming a different organization) are out regardless of warrant.
+- Stay within the subject's identity. Product expansions, new surfaces, new markets, retirements, and architectural pivots are fair game when the basis supports them. Subject-replacement moves (abandoning the project, pivoting to unrelated domains, becoming a different organization) are out regardless of basis.
 - **Honor the asked scope.** When the focus hint names a part of the subject (a flow, a stage, a section, a feature within a larger product — e.g., "account settings", "onboarding flow", "pricing page copy", "gameplay rules"), ideate at full ambition *within that scope*. Expanding the surface to the whole subject — proposing fundamental changes to the broader product when the user named one slice — is a scope mismatch even when no subject-replacement occurred. Big-picture thinking still applies; it just operates inside the bounded surface the user named, not by widening the surface.
 
 **Surprise-me mode addendum.** When Phase 0.2 routed to surprise-me, include this additional instruction in each sub-agent's dispatch prompt:
 
-> No user-specified subject. Through your frame's lens, explore the Phase 1 material and identify the subject(s) you find most interesting for this frame. Different frames finding different subjects is the feature — cross-subject divergence is what makes surprise-me valuable. Each idea still carries warrant; warrant may include identification of the subject itself (why *this* subject is worth ideating on through your lens, citing what in the Phase 1 material signals it).
+> No user-specified subject. Through your frame's lens, explore the Phase 1 material and identify the subject(s) you find most interesting for this frame. Different frames finding different subjects is the feature — cross-subject divergence is what makes surprise-me valuable. Each idea still carries a basis; the basis may include identification of the subject itself (why *this* subject is worth ideating on through your lens, citing what in the Phase 1 material signals it).
 
 After all sub-agents return:
 

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -200,7 +200,7 @@ Use reasonable interpretation rather than formal parsing.
 
 #### 0.6 Cost Transparency Notice
 
-Before dispatching Phase 1, surface the agent count for the inferred mode in one short line so multi-agent cost is not invisible. Compute the count from the actual dispatch decision: 1 grounding-context agent (codebase scan in repo mode; user-context synthesis in elsewhere) + 1 learnings (skip in elsewhere-non-software) + 1 web researcher + 6 ideation = baseline 9 in repo mode and elsewhere-software, 8 in elsewhere-non-software. When issue-tracker intent triggers (repo mode only): add 1 for the issue-intelligence agent and drop ideation from 6 to 4, for a net -1 (baseline 8). Add 1 if the user opted into Slack research. Subtract 1 if the user issued a web-research skip phrase or V15 reuse will fire. In **surprise-me mode**, agent count is the same but per-agent exploration is deeper — note "(surprise-me mode: deeper exploration per agent)" when active.
+Before dispatching Phase 1, surface the agent count for the inferred mode in one short line so multi-agent cost is not invisible. Compute the count from the actual dispatch decision: 1 grounding-context agent (codebase scan in repo mode; user-context synthesis in elsewhere) + 1 learnings (skip in elsewhere-non-software) + 1 web researcher + 6 ideation = baseline 9 in repo mode and elsewhere-software, 8 in elsewhere-non-software. When issue-tracker intent triggers (repo mode only): add 1 for the issue-intelligence agent and drop ideation from 6 to 4, for a net -1 (baseline 8). Add 1 if the user opted into Slack research. Subtract 1 if the user issued a web-research skip phrase or V15 reuse will fire. In **surprise-me mode**, agent count is the same but per-agent exploration is deeper — note "(surprise-me mode: deeper exploration per agent)" when active. Phase 2's axis-coverage check may dispatch up to 2 additional recovery sub-agents when generation leaves any topic axis empty (skipped in surprise-me mode); when not in surprise-me, append "(+up to 2 if axis-coverage requires recovery)" to the count line.
 
 Examples (defaults, no skips, no opt-ins):
 
@@ -291,7 +291,7 @@ When dispatching `ce-web-researcher`, pass: the focus hint, a brief planning con
 
 #### Consolidated Grounding Summary
 
-Consolidate all dispatched results into a short grounding summary using these sections (omit any section that produced nothing):
+Consolidate all dispatched results into a short grounding summary using these sections (omit any section that produced nothing). Phase 1.5 will append a `Topic axes` section to this same summary after consolidation completes:
 
 - **Codebase context** *(repo mode)* — project shape, notable patterns, pain points, leverage points (project-defining files: AGENTS.md/CLAUDE.md/README.md/STRATEGY.md) OR **Topic context** *(elsewhere mode)* — topic shape, stated constraints, user-named pain points, opportunity hooks
 - **User-named references** *(repo mode, when the focus hint named root-level `*.md` files)* — full content from files the user explicitly named in their prompt or focus. Phase 2 treats these as constraint
@@ -305,13 +305,44 @@ Consolidate all dispatched results into a short grounding summary using these se
 
 **Slack context** (opt-in, both modes) — never auto-dispatch. When the user asks for Slack context and Slack tools are available (look for any `slack-researcher` agent or `slack` MCP tools in the current environment), dispatch `ce-slack-researcher` with the focus hint in parallel with other Phase 1 agents. When tools are present but the user did not ask, mention availability in the grounding summary so they can opt in. When the user asked but no Slack tools are reachable, surface the install hint instead.
 
+### Phase 1.5: Topic-Surface Decomposition
+
+Before dispatching frame agents in Phase 2, decompose the topic into 3-5 orthogonal **axes** that name *what aspects of the subject to think about*. Phase 2 frames determine *how to think* (the lens); axes determine *what to think on* (the surface). Without an explicit axis list, parallel frames tend to converge on whichever interpretation of the subject is most salient at first read — other parts of the surface go unexamined regardless of how many frames run. Lens diversity alone does not produce surface coverage.
+
+This step is a single orchestrator-side analysis against the grounding summary already in context. No sub-agent dispatch, no additional grounding read, no user-facing question.
+
+**Axis criteria:**
+
+- **3-5 axes.** Fewer than 3 means the topic is atomic — skip per the rule below. More than 5 fragments dispatch and produces thin coverage on each.
+- **Orthogonal.** A single idea should naturally fall on one axis, not span multiple. Merge axes that overlap heavily.
+- **Derived from grounding.** The grounding summary contains the substance the axes name; do not pick axes from a generic template (e.g., "discovery / engagement / retention" applied to every topic).
+- **At the same level.** Don't mix "the entire pricing page" with "the $9.99 tier copy" in the same list.
+- **Named in the topic's language.** "Send mechanics" beats "outbound flow optimization." Use words a reader of the topic would recognize, not meta-language about ideation.
+
+**Worked examples (illustrative, not a template — derive from actual grounding):**
+
+| Topic | Axes |
+|---|---|
+| Social sharing of crossfire and convergence pages | Send mechanics; discovery (receive side); arrival/dwell experience; compounding over time; actor types (first-party, expert, reader) |
+| Improve our authentication system | Sign-in flow; session management; account recovery; permissions; identity providers |
+| Dark mode for our app | Visual surfaces; toggle UX; system-preference detection; asset variants; edge cases (third-party content) |
+| Cache invalidation in the data layer | Trigger surfaces; coordination across replicas; staleness tolerance per data class; observability of invalidation events |
+
+**Skip condition.** Some subjects are atomic and resist meaningful decomposition — a single string output (a name, a tagline), a narrowly-scoped tactical fix ("the typo on line 47 of README"), or a topic where the candidate axes *are* the deliverable (e.g., "what surface should the API expose?"). When 3+ orthogonal axes that pass the criteria above cannot be generated, skip decomposition. Note `Decomposition skipped — atomic subject` in the grounding summary so the artifact records the choice.
+
+**Surprise-me skip.** In surprise-me mode there is no settled subject to decompose — different frames will surface different subjects in Phase 2, and the cross-cutting synthesis step there serves the analogous coverage role. Skip Phase 1.5 in surprise-me mode and note `Decomposition skipped — surprise-me mode` in the grounding summary.
+
+Append the axis list (or skip-reason) to the consolidated grounding summary under a section labeled `Topic axes`. Phase 2 reads this section to thread axes into sub-agent prompts; Phase 3 uses it for axis-spread scoring; Phase 5's artifact template includes it under Grounding Context.
+
 ### Phase 2: Divergent Ideation
 
 Generate the full candidate list before critiquing any idea.
 
 Dispatch parallel ideation sub-agents on the inherited model (do not tier down -- creative ideation needs the orchestrator's reasoning level). Omit the `mode` parameter so the user's configured permission settings apply. Dispatch count is mode-conditional: **4 sub-agents only when issue-tracker intent was detected in Phase 0.2 AND the issue intelligence agent returned usable themes** (see override below — cluster-derived frames capped at 4); **6 sub-agents otherwise**, including the insufficient-issue-signal fallback from Phase 1 where intent triggered but themes were not returned. Each targets ~6-8 ideas (yielding ~36-48 raw ideas across 6 frames or ~24-32 across 4 frames, roughly 25-30 survivors after dedupe in the 6-frame path and fewer in the 4-frame path). Adjust per-agent targets when volume overrides apply (e.g., "100 ideas" raises it, "top 3" may lower the survivor count instead).
 
-Give each sub-agent: the grounding summary, the focus hint, the per-agent volume target, and an instruction to generate raw candidates only (not critique). Each agent's first few ideas tend to be obvious -- push past them. Ground every idea in the Phase 1 grounding summary.
+Give each sub-agent: the grounding summary, the focus hint, the per-agent volume target, the **topic axis list from Phase 1.5** (when decomposition produced one), and an instruction to generate raw candidates only (not critique). Each agent's first few ideas tend to be obvious -- push past them. Ground every idea in the Phase 1 grounding summary.
+
+**Axis spread instruction.** When an axis list is present, instruct each sub-agent to distribute its ideas across multiple axes — the frame's lens applies to every axis, but ideas should not all cluster on one. Each idea must be tagged with the axis it targets. The frame is a lens; the axis list is the surface map. A frame that plausibly reaches an axis should produce at least one idea there before doubling up on a different axis. When decomposition was skipped (atomic subject or surprise-me), omit the axis instruction entirely — do not invent axes at dispatch time.
 
 **Constraint vs background.** In the dispatch prompt, mark the user's prompt, focus hint, and any *User-named references* (root-level files the user named in their focus and the codebase-scan fully read) as *constraints* — ideas that violate them are out regardless of basis. Mark the rest of the grounding summary (codebase context, additional context, learnings, external context) as *background* — informative, not directive. Background can support an idea's basis and inform direction; it must not pull ideation toward whatever was loudest in the corpus when the user named a different focus. This is the primary defense against grounding noise (an unrelated `FEEDBACK.md` the user did not name, a tangentially-cited prior-art result) shaping survivors against user intent.
 
@@ -334,6 +365,7 @@ Each sub-agent returns this structure per idea:
 
 - **title**
 - **summary** (2-4 sentences)
+- **axis** — required when Phase 1.5 produced an axis list. Pick the one axis this idea most centrally targets; do not span. Omit entirely when decomposition was skipped.
 - **basis** (required, tagged) — one of:
   - `direct:` quoted line / specific file / named issue / explicit user-supplied context
   - `external:` named prior art, domain research, adjacent pattern, with source
@@ -359,8 +391,9 @@ After all sub-agents return:
 
 1. Merge and dedupe into one master candidate list.
 2. Synthesize cross-cutting combinations -- scan for ideas from different frames that combine into something stronger. In specified mode, expect 3-5 additions at most. **In surprise-me mode, cross-cutting is the magic layer** — frames often converge on overlapping subjects or find complementary angles; expect 5-8 additions and give this step more attention. Surface combinations that span multiple frame-chosen subjects as a distinctive surprise-me output pattern.
-3. If a focus was provided, weight the merged list toward it without excluding stronger adjacent ideas.
-4. Spread ideas across multiple dimensions when justified: workflow/DX, reliability, extensibility, missing capabilities, docs/knowledge compounding, quality/maintenance, leverage on future work.
+3. **Axis-coverage check (when Phase 1.5 produced an axis list; skipped otherwise).** Count ideas per axis after dedupe. For any axis with zero ideas, dispatch one recovery sub-agent (any unused frame, or the frame whose lens fits the missing axis best — e.g., Pain & friction for usability axes, Cross-domain analogy for distribution or compounding axes) targeting that axis specifically. The recovery dispatch carries the same per-idea output contract and ~3-5 ideas as its target. **Cap recovery at 2 axes total** — if more than 2 axes are empty after the first round, accept thin coverage rather than fanning out further. After recovery returns, merge into the master list and dedupe again. Note empty axes that were not recovered in the rejection summary as "axis: <name> — recovery skipped (cap reached)" so the gap is visible to the user.
+4. If a focus was provided, weight the merged list toward it without excluding stronger adjacent ideas.
+5. Spread ideas across multiple dimensions when justified: workflow/DX, reliability, extensibility, missing capabilities, docs/knowledge compounding, quality/maintenance, leverage on future work.
 
 **Checkpoint A (V17).** Immediately after the cross-cutting synthesis step completes and the raw candidate list is consolidated, write `<scratch-dir>/raw-candidates.md` (using the absolute path captured in Phase 1) containing the full candidate list with sub-agent attribution. This protects the most expensive output (6 parallel sub-agent dispatches + dedupe) before Phase 3 critique potentially compacts context. Best-effort: if the write fails (disk full, permissions), log a warning and proceed; the checkpoint is not load-bearing. Not cleaned up at the end of the run (the run directory is preserved so the V15 cache remains reusable across run-ids in the same session — see Phase 6).
 

--- a/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
@@ -21,6 +21,7 @@ Rejection criteria:
 - **unjustified — no articulated warrant** (sub-agent failed to provide `direct:`, `external:`, or `reasoned:` justification, or the stated warrant does not actually support the claimed move)
 - **below ambition floor** (fails the meeting-test: would not warrant team discussion — except when Phase 0.5 detected tactical focus signals, in which case this criterion is waived)
 - **subject-replacement** (abandons or replaces the subject of ideation rather than operating on it — e.g., "pivot to an unrelated domain," "become a different organization")
+- **scope overrun** (expands beyond the asked scope rather than ideating within it — e.g., proposes changes to the whole product when the user asked about one flow, stage, or section). Allowed only when the warrant explicitly justifies the expansion; default is reject or downgrade.
 
 Score survivors using a consistent rubric weighing: groundedness in stated context, **warrant strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage on future work, implementation burden, and overlap with stronger ideas.
 

--- a/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
@@ -18,12 +18,12 @@ Rejection criteria:
 - too expensive relative to likely value
 - already covered by existing workflows or docs
 - interesting but better handled as a brainstorm variant, not a product improvement
-- **unjustified — no articulated warrant** (sub-agent failed to provide `direct:`, `external:`, or `reasoned:` justification, or the stated warrant does not actually support the claimed move)
+- **unjustified — no articulated basis** (sub-agent failed to provide `direct:`, `external:`, or `reasoned:` justification, or the stated basis does not actually support the claimed move)
 - **below ambition floor** (fails the meeting-test: would not warrant team discussion — except when Phase 0.5 detected tactical focus signals, in which case this criterion is waived)
 - **subject-replacement** (abandons or replaces the subject of ideation rather than operating on it — e.g., "pivot to an unrelated domain," "become a different organization")
-- **scope overrun** (expands beyond the asked scope rather than ideating within it — e.g., proposes changes to the whole product when the user asked about one flow, stage, or section). Allowed only when the warrant explicitly justifies the expansion; default is reject or downgrade.
+- **scope overrun** (expands beyond the asked scope rather than ideating within it — e.g., proposes changes to the whole product when the user asked about one flow, stage, or section). Allowed only when the basis explicitly justifies the expansion; default is reject or downgrade.
 
-Score survivors using a consistent rubric weighing: groundedness in stated context, **warrant strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage on future work, implementation burden, and overlap with stronger ideas.
+Score survivors using a consistent rubric weighing: groundedness in stated context, **basis strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage on future work, implementation burden, and overlap with stronger ideas.
 
 Target output:
 - keep 5-7 survivors by default
@@ -40,8 +40,8 @@ Present only the surviving ideas in structured form:
 
 - title
 - description
-- **warrant** (tagged `direct:` / `external:` / `reasoned:`, with the quoted evidence, cited source, or written-out argument)
-- rationale (how the warrant connects to the move's significance)
+- **basis** (tagged `direct:` / `external:` / `reasoned:`, with the quoted evidence, cited source, or written-out argument)
+- rationale (how the basis connects to the move's significance)
 - downsides
 - confidence score
 - estimated complexity
@@ -94,8 +94,8 @@ mode: <repo-grounded | elsewhere-software | elsewhere-non-software>
 
 ### 1. <Idea Title>
 **Description:** [Concrete explanation]
-**Warrant:** [`direct:` / `external:` / `reasoned:` — the actual basis, quoted or cited]
-**Rationale:** [How the warrant connects to the move's significance]
+**Basis:** [`direct:` / `external:` / `reasoned:` — quoted, cited, or written-out argument]
+**Rationale:** [How the basis connects to the move's significance]
 **Downsides:** [Tradeoffs or costs]
 **Confidence:** [0-100%]
 **Complexity:** [Low / Medium / High]
@@ -228,7 +228,7 @@ After the fallback completes (any path), continue back to the Phase 6 menu so th
 Before finishing, check:
 
 - the idea set is grounded in the stated context (codebase in repo mode; user-supplied context in elsewhere mode)
-- **every surviving idea has articulated warrant** (`direct:`, `external:`, or `reasoned:`) that actually supports the claimed move — speculation dressed as ambition was rejected, with reasons
+- **every surviving idea has an articulated basis** (`direct:`, `external:`, or `reasoned:`) that actually supports the claimed move — speculation dressed as ambition was rejected, with reasons
 - **every surviving idea passes the meeting-test** unless Phase 0.5 detected tactical focus signals that waived the floor
 - **no surviving idea replaces the subject** rather than operating on it
 - the candidate list was generated before filtering

--- a/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
@@ -23,7 +23,9 @@ Rejection criteria:
 - **subject-replacement** (abandons or replaces the subject of ideation rather than operating on it — e.g., "pivot to an unrelated domain," "become a different organization")
 - **scope overrun** (expands beyond the asked scope rather than ideating within it — e.g., proposes changes to the whole product when the user asked about one flow, stage, or section). Allowed only when the basis explicitly justifies the expansion; default is reject or downgrade.
 
-Score survivors using a consistent rubric weighing: groundedness in stated context, **basis strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage on future work, implementation burden, and overlap with stronger ideas.
+Score survivors using a consistent rubric weighing: groundedness in stated context, **basis strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage on future work, implementation burden, overlap with stronger ideas, and **axis spread** (when Phase 1.5 produced an axis list) — survivor sets that cover the topic's surface outscore sets that cluster on one axis, all else equal.
+
+**Axis coverage as a list-level concern.** When axes were defined, axis spread is evaluated across the survivor set, not per-idea. After per-idea filtering, check the survivor set: if axis coverage is uneven and stronger candidates exist on under-represented axes, prefer the spread when promoting borderline candidates. Phase 2's recovery dispatch should already have surfaced candidates for empty axes; this is a polish step on the survivor selection. If an axis ends up with zero survivors despite recovery (or because recovery hit the 2-axis cap), note it in the rejection summary as a deliberate gap rather than an oversight.
 
 Target output:
 - keep 5-7 survivors by default
@@ -40,6 +42,7 @@ Present only the surviving ideas in structured form:
 
 - title
 - description
+- **axis** (when Phase 1.5 produced an axis list)
 - **basis** (tagged `direct:` / `external:` / `reasoned:`, with the quoted evidence, cited source, or written-out argument)
 - rationale (how the basis connects to the move's significance)
 - downsides
@@ -90,10 +93,14 @@ mode: <repo-grounded | elsewhere-software | elsewhere-non-software>
 ## Grounding Context
 [Grounding summary from Phase 1 — labeled "Codebase Context" in repo mode, "Topic Context" in elsewhere mode]
 
+## Topic Axes
+[3-5 axes from Phase 1.5, one per line, OR a single line `Decomposition skipped — atomic subject` / `Decomposition skipped — surprise-me mode` when Phase 1.5 was skipped. Omit this section entirely if not applicable.]
+
 ## Ranked Ideas
 
 ### 1. <Idea Title>
 **Description:** [Concrete explanation]
+**Axis:** [Topic axis this idea targets — omit when decomposition was skipped]
 **Basis:** [`direct:` / `external:` / `reasoned:` — quoted, cited, or written-out argument]
 **Rationale:** [How the basis connects to the move's significance]
 **Downsides:** [Tradeoffs or costs]
@@ -106,6 +113,9 @@ mode: <repo-grounded | elsewhere-software | elsewhere-non-software>
 | # | Idea | Reason Rejected |
 |---|------|-----------------|
 | 1 | <Idea> | <Reason rejected> |
+
+[When applicable, append axis-coverage gaps as their own rows so the gap is visible:]
+| - | axis: <name> | recovery skipped (cap reached) — no survivors on this axis |
 ```
 
 If resuming:
@@ -231,6 +241,7 @@ Before finishing, check:
 - **every surviving idea has an articulated basis** (`direct:`, `external:`, or `reasoned:`) that actually supports the claimed move — speculation dressed as ambition was rejected, with reasons
 - **every surviving idea passes the meeting-test** unless Phase 0.5 detected tactical focus signals that waived the floor
 - **no surviving idea replaces the subject** rather than operating on it
+- when Phase 1.5 produced an axis list, the survivor set spreads across axes rather than clustering on one — and any axis with zero survivors is noted as a deliberate gap in the rejection summary, not silently absent
 - the candidate list was generated before filtering
 - the original many-ideas -> critique -> survivors mechanism was preserved
 - if sub-agents were used, they improved diversity without replacing the core workflow

--- a/plugins/compound-engineering/skills/ce-ideate/references/universal-ideation.md
+++ b/plugins/compound-engineering/skills/ce-ideate/references/universal-ideation.md
@@ -41,26 +41,26 @@ Generate the full candidate list before critiquing any idea. Use the same six fr
 
 Aim for 5-8 ideas per frame. After generating, merge and dedupe; scan for cross-cutting combinations (3-5 additions at most; more in surprise-me mode, where different frames often discover different subjects and combinations are the magic layer).
 
-**Per-idea output contract (mirrors SKILL.md Phase 2):** each idea carries title, summary, **warrant** (required, tagged `direct:` quoted evidence / `external:` named prior art or domain research / `reasoned:` written-out first-principles argument), why-it-matters connecting the warrant to the move's significance, and a one-line meeting-test self-check (waived when tactical focus signals were detected in Phase 0.5). Warrant is required, not optional — unjustified speculation does not surface.
+**Per-idea output contract (mirrors SKILL.md Phase 2):** each idea carries title, summary, **basis** (required, tagged `direct:` quoted evidence / `external:` named prior art or domain research / `reasoned:` written-out first-principles argument), why-it-matters connecting the basis to the move's significance, and a one-line meeting-test self-check (waived when tactical focus signals were detected in Phase 0.5). Basis is required, not optional — unjustified speculation does not surface.
 
 **Generation rules:**
 
-- Every idea carries articulated warrant. The failure mode to prevent is plausible-sounding speculation that lacks any basis the user can verify.
-- Bias toward the warrant type your frame naturally produces — pain/inversion/leverage tend toward `direct:`; analogy and constraint-flipping tend toward `reasoned:` — but don't exclude other types. When a frame produces reasoned warrant, write the argument out, don't gesture at it.
+- Every idea carries an articulated basis. The failure mode to prevent is plausible-sounding speculation that lacks any basis the user can verify.
+- Bias toward the basis type your frame naturally produces — pain/inversion/leverage tend toward `direct:`; analogy and constraint-flipping tend toward `reasoned:` — but don't exclude other types. When a frame produces a reasoned basis, write the argument out, don't gesture at it.
 - Apply the meeting-test as a default floor: would this idea warrant the equivalent of team discussion (or whatever maps to "worth talking through" in this topic's native domain)? If not, it's below the floor and does not surface. The floor is relaxed only when Phase 0.5 detected tactical focus signals.
-- Stay within the subject's identity. Expansions, new surfaces, new directions, retirements are fair game when warrant supports them. Subject-replacement moves (abandoning the subject, pivoting to an unrelated domain) are out regardless of warrant.
+- Stay within the subject's identity. Expansions, new surfaces, new directions, retirements are fair game when the basis supports them. Subject-replacement moves (abandoning the subject, pivoting to an unrelated domain) are out regardless of basis.
 
-**Surprise-me mode in this reference.** When Phase 0.2 routed to surprise-me, there is no user-specified subject. Through each frame's lens, explore the Phase 1 grounding (user-context synthesis + web research) and identify the subject(s) you find most interesting for that lens. Different frames finding different subjects is the feature. Warrant may include identification of the subject itself — why this subject is worth ideating on through this lens, citing what in the Phase 1 material signals it.
+**Surprise-me mode in this reference.** When Phase 0.2 routed to surprise-me, there is no user-specified subject. Through each frame's lens, explore the Phase 1 grounding (user-context synthesis + web research) and identify the subject(s) you find most interesting for that lens. Different frames finding different subjects is the feature. The basis may include identification of the subject itself — why this subject is worth ideating on through this lens, citing what in the Phase 1 material signals it.
 
 ## How to converge
 
-Apply adversarial critique. For each candidate, write a one-line reason if rejected. **Warrant-integrity check:** reject any idea lacking articulated warrant, any idea whose stated warrant does not actually support the claimed move (speculation dressed as ambition), and any idea that replaces the subject rather than operating on it. Score survivors using a consistent rubric weighing: groundedness in stated context, **warrant strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage, implementation burden, and overlap with stronger candidates.
+Apply adversarial critique. For each candidate, write a one-line reason if rejected. **Basis-integrity check:** reject any idea lacking an articulated basis, any idea whose stated basis does not actually support the claimed move (speculation dressed as ambition), and any idea that replaces the subject rather than operating on it. Score survivors using a consistent rubric weighing: groundedness in stated context, **basis strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage, implementation burden, and overlap with stronger candidates.
 
 Target 5-7 survivors by default. If too many survive, run a second stricter pass. If fewer than five survive, report that honestly rather than lowering the bar.
 
 ## When to wrap up
 
-Present survivors before any persistence. For each: title, description, **warrant** (tagged `direct:` / `external:` / `reasoned:`, with the quoted evidence, cited source, or written-out argument), rationale (how the warrant connects to the move's significance), downsides, confidence, complexity. Then a brief rejection summary so the user can see what was considered and cut.
+Present survivors before any persistence. For each: title, description, **basis** (tagged `direct:` / `external:` / `reasoned:`, with the quoted evidence, cited source, or written-out argument), rationale (how the basis connects to the move's significance), downsides, confidence, complexity. Then a brief rejection summary so the user can see what was considered and cut.
 
 Persistence is opt-in. The terminal review loop is a complete ideation cycle. Refinement happens in conversation with no file or network cost. Persistence triggers only when the user explicitly chooses to save, share, or hand off.
 

--- a/plugins/compound-engineering/skills/ce-ideate/references/universal-ideation.md
+++ b/plugins/compound-engineering/skills/ce-ideate/references/universal-ideation.md
@@ -28,6 +28,33 @@ Apply the discrimination test before asking anything. Would swapping one piece o
 
 When the user provides rich context up front (a paste, a brief, an existing draft), confirm understanding in one line and skip intake.
 
+## How to decompose
+
+Before generating, decompose the topic into 3-5 orthogonal **axes** that name *what aspects of the subject to think about*. Frames in "How to generate" determine *how to think* (the lens); axes determine *what to think on* (the surface). Without explicit axes, the same topic interpreted six ways through six lenses still leaves most of the surface unexamined — lens diversity does not produce surface coverage on its own.
+
+This step is the facilitator's own analysis — no sub-agent, no additional research. The Phase 1 grounding supplies the substance.
+
+Axes should be:
+
+- **3-5 in number.** Fewer means atomic — skip decomposition. More fragments coverage.
+- **Orthogonal.** A single idea should fall on one axis, not span multiple.
+- **Derived from grounding**, not from a generic template.
+- **At the same level** of granularity.
+- **Named in the topic's language**, not meta-language about ideation.
+
+**Worked examples (illustrative, not a template):**
+
+- "Name my new coffee shop" → atomic; skip decomposition (the candidate *is* a name)
+- "Plot ideas for a short story" → atomic; skip decomposition (the candidate *is* a plot)
+- "Brand strategy for a launch" → axes might be: positioning; visual identity; voice; launch channels; pricing/packaging
+- "Career options for the next 5 years" → axes might be: domain (industry/role); structure (employee/founder/freelance); geography; growth ambition; financial floor
+
+**Skip condition.** Many elsewhere-non-software topics are atomic by nature — a single name, tagline, or one-shot creative output. When 3+ orthogonal axes do not emerge, skip decomposition and note `Decomposition skipped — atomic subject` in the grounding summary.
+
+**Surprise-me skip.** No settled subject in surprise-me mode; skip decomposition and note `Decomposition skipped — surprise-me mode`.
+
+Record the axes (or skip-reason) at the head of generation. Generation will distribute ideas across axes; convergence will weight axis spread alongside other rubric criteria.
+
 ## How to generate
 
 Generate the full candidate list before critiquing any idea. Use the same six frames as software ideation, described in domain-agnostic language. Each frame is a **starting bias, not a constraint** — follow promising threads across frames.
@@ -39,9 +66,11 @@ Generate the full candidate list before critiquing any idea. Use the same six fr
 - **Cross-domain analogy** — how do completely different fields solve a structurally similar problem? The grounding domain is the user's topic; the analogy domain is anywhere else (other industries, biology, games, infrastructure, history). Push past the obvious analogy to non-obvious ones.
 - **Constraint-flipping** — invert the obvious constraint to its opposite or extreme. What if the budget were 10x or 0? What if there were one constraint instead of ten, or ten instead of one? Use the resulting design as a candidate even if the flip itself is not realistic.
 
-Aim for 5-8 ideas per frame. After generating, merge and dedupe; scan for cross-cutting combinations (3-5 additions at most; more in surprise-me mode, where different frames often discover different subjects and combinations are the magic layer).
+Aim for 5-8 ideas per frame. **When axes are present, distribute ideas across axes** — each frame's lens applies to every axis, but ideas should not all cluster on one. Tag each idea with the axis it targets. After generating, merge and dedupe; scan for cross-cutting combinations (3-5 additions at most; more in surprise-me mode, where different frames often discover different subjects and combinations are the magic layer).
 
-**Per-idea output contract (mirrors SKILL.md Phase 2):** each idea carries title, summary, **basis** (required, tagged `direct:` quoted evidence / `external:` named prior art or domain research / `reasoned:` written-out first-principles argument), why-it-matters connecting the basis to the move's significance, and a one-line meeting-test self-check (waived when tactical focus signals were detected in Phase 0.5). Basis is required, not optional — unjustified speculation does not surface.
+**Axis-coverage check (when axes are present).** After merging, count ideas per axis. If any axis has zero ideas, generate one additional small batch (3-5 ideas) targeting the empty axis with the frame whose lens best fits — Pain & friction for usability gaps, Cross-domain analogy for distribution or compounding gaps, etc. Cap recovery at 2 axes; beyond that, accept thin coverage rather than fan out. Note any axis that was not recovered in the rejection summary so the gap is visible.
+
+**Per-idea output contract (mirrors SKILL.md Phase 2):** each idea carries title, summary, **axis** (when decomposition produced an axis list — pick the one this idea most centrally targets; omit when skipped), **basis** (required, tagged `direct:` quoted evidence / `external:` named prior art or domain research / `reasoned:` written-out first-principles argument), why-it-matters connecting the basis to the move's significance, and a one-line meeting-test self-check (waived when tactical focus signals were detected in Phase 0.5). Basis is required, not optional — unjustified speculation does not surface.
 
 **Generation rules:**
 
@@ -54,13 +83,13 @@ Aim for 5-8 ideas per frame. After generating, merge and dedupe; scan for cross-
 
 ## How to converge
 
-Apply adversarial critique. For each candidate, write a one-line reason if rejected. **Basis-integrity check:** reject any idea lacking an articulated basis, any idea whose stated basis does not actually support the claimed move (speculation dressed as ambition), and any idea that replaces the subject rather than operating on it. Score survivors using a consistent rubric weighing: groundedness in stated context, **basis strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage, implementation burden, and overlap with stronger candidates.
+Apply adversarial critique. For each candidate, write a one-line reason if rejected. **Basis-integrity check:** reject any idea lacking an articulated basis, any idea whose stated basis does not actually support the claimed move (speculation dressed as ambition), and any idea that replaces the subject rather than operating on it. Score survivors using a consistent rubric weighing: groundedness in stated context, **basis strength** (`direct:` > `external:` > `reasoned:`; none excluded, but direct-evidence ideas score higher all else equal), expected value, novelty, pragmatism, leverage, implementation burden, overlap with stronger candidates, and **axis spread** (when axes were defined) — survivor sets that cover the topic's surface outscore sets that cluster on one axis, all else equal. Axis spread is a list-level concern, not a per-idea reject reason; apply it after per-idea filtering when choosing among comparable candidates.
 
 Target 5-7 survivors by default. If too many survive, run a second stricter pass. If fewer than five survive, report that honestly rather than lowering the bar.
 
 ## When to wrap up
 
-Present survivors before any persistence. For each: title, description, **basis** (tagged `direct:` / `external:` / `reasoned:`, with the quoted evidence, cited source, or written-out argument), rationale (how the basis connects to the move's significance), downsides, confidence, complexity. Then a brief rejection summary so the user can see what was considered and cut.
+Present survivors before any persistence. For each: title, description, **axis** (when decomposition produced an axis list), **basis** (tagged `direct:` / `external:` / `reasoned:`, with the quoted evidence, cited source, or written-out argument), rationale (how the basis connects to the move's significance), downsides, confidence, complexity. Then a brief rejection summary so the user can see what was considered and cut — including any axis that ended up with zero survivors despite recovery, so the coverage gap is visible.
 
 Persistence is opt-in. The terminal review loop is a complete ideation cycle. Refinement happens in conversation with no file or network cost. Persistence triggers only when the user explicitly chooses to save, share, or hand off.
 


### PR DESCRIPTION
This PR addresses two distinct quality issues in `ce-ideate`, both surfaced from real-run review.

## 1. Scope discipline — over-indexing on loudest corpus material

Improving on `ce-ideate` to lift ideation quality and prevent over-indexing on artifacts it finds, which can happen based on certain repos. When this happens, the agent treats whatever was loudest in the corpus as direction, even when the user prompted a different focus. Ideation also widened past the user's named slice, proposing fundamental product changes when the user asked about one stage, flow, or section. The existing "subject identity" rule did not catch this.

The codebase scan now reads other root-level `*.md` files briefly and surfaces them under a separate "Additional context" heading rather than promoting them into project-defining sections. Phase 2 dispatch then distinguishes constraint (user prompt, focus hint, named refs) from background (everything else in the grounding summary), so additional context informs ideas without steering them.

A new "Honor the asked scope" generation rule and matching "scope overrun" rejection criterion catch ideas that drift past the user-named slice, at generation and again at critique.

Renamed "warrant" to "basis" throughout the skill, references, and user-facing doc. "Warrant" read as legal jargon when it surfaced in user-facing output; "basis" reads naturally. The `direct:` / `external:` / `reasoned:` sub-tags are unchanged. Verb usages ("would this warrant team discussion") are preserved.

## 2. Idea breadth — lens diversity without surface diversity

Even when scope is honored, parallel ideation frames tend to converge on whichever interpretation of the topic is most salient at first read. Lens diversity (six frames) does not produce surface diversity on its own — six lenses applied to one interpretation still leaves most of the topic unexamined. Concretely, an ideation run on "social sharing of crossfire and convergence pages" produced seven send-side artifact ideas (OG cards, embeds, audiograms) and zero receive-side, AI-discovery, or compounding-cadence ideas, despite all being in scope.

A new Phase 1.5 (Topic-Surface Decomposition) runs between grounding and frame dispatch. The orchestrator decomposes the topic into 3-5 orthogonal **axes** named in the topic's language and derived from grounding (not a generic template). Frames decide *how to think* (the lens); axes decide *what to think on* (the surface). Dispatch is now `(frame × axis)` rather than `(frame × single-interpretation)`.

Phase 2 sub-agent prompts include the axis list and instruct each frame to distribute ideas across multiple axes, with a per-idea `axis` tag. After merge and dedupe, an axis-coverage check counts ideas per axis; any empty axis triggers one bounded recovery dispatch (one frame, one axis), capped at 2 axes. Phase 3 scoring weighs axis spread alongside other rubric criteria. Phase 5 records the axis list in the artifact under `Topic Axes` and surfaces uncovered axes as deliberate gaps in the rejection summary.

Skip conditions: atomic subjects (a name, a tagline, a typo fix) and surprise-me mode skip decomposition entirely with the skip-reason recorded in the grounding summary. The universal-ideation reference, post-ideation-workflow reference, and user-facing skill doc are all updated for parity.

## Verification

Verified empirically by re-running ideation on the same topic in an external repo. Pass 1 (pre-decomposition) produced 7 survivors all on the send side of social sharing — every idea was about how content leaves the site. Pass 2 (post-decomposition) produced 7 survivors spanning all 5 derived axes, including AI-mediated discovery (axis the agent surfaced from grounding without prompting), warm-channel asymmetry, expert activation, citation infrastructure, corpus pivots, live-archive cadence, and automated cadenced posting. The receive-side blind spot is closed; the agent identified an even sharper missing axis (AI legibility) than was predicted by hand.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-Opus_4.7_%281M_context%29-D97757?logo=claude&logoColor=white)
