### PR TITLE
refactor(agent-descriptions): trim top 7 by ~25%

### DIFF
--- a/plugins/compound-engineering/agents/ce-adversarial-document-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-adversarial-document-reviewer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ce-adversarial-document-reviewer
-description: "Conditional document-review persona, selected when the document has >5 requirements or implementation units, makes significant architectural decisions, covers high-stakes domains, or proposes new abstractions. Challenges premises, surfaces unstated assumptions, and stress-tests decisions rather than evaluating document quality."
+description: "Conditional document-review persona for high-stakes documents -- those with significant architectural decisions, new abstractions, or more than 5 requirements. Challenges premises, surfaces unstated assumptions, and stress-tests decisions rather than evaluating document quality."
 model: inherit
 tools: Read, Grep, Glob, Bash
 ---

--- a/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-learnings-researcher.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ce-learnings-researcher
-description: "Searches docs/solutions/ for applicable past learnings by frontmatter metadata. Use before implementing features, making decisions, or starting work in a documented area — surfaces prior bugs, architecture patterns, design patterns, tooling decisions, conventions, and workflow learnings so institutional knowledge carries forward."
+description: "Searches docs/solutions/ for applicable past learnings via frontmatter metadata (bugs, architecture, design patterns, conventions, workflow learnings). Use before implementing features, making decisions, or starting work in a documented area so institutional knowledge carries forward."
 model: inherit
 tools: Read, Grep, Glob, Bash
 ---

--- a/plugins/compound-engineering/agents/ce-product-lens-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-product-lens-reviewer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ce-product-lens-reviewer
-description: "Reviews planning documents as a senior product leader -- challenges premise claims, assesses strategic consequences (trajectory, identity, adoption, opportunity cost), and surfaces goal-work misalignment. Domain-agnostic: users may be end users, developers, operators, or any audience. Spawned by the document-review skill."
+description: "Reviews planning documents as a senior product leader -- challenges premise claims, assesses strategic consequences (trajectory, identity, adoption, opportunity cost), and surfaces goal-work misalignment. Spawned by the document-review skill."
 model: inherit
 tools: Read, Grep, Glob, Bash
 ---

--- a/plugins/compound-engineering/agents/ce-session-historian.agent.md
+++ b/plugins/compound-engineering/agents/ce-session-historian.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ce-session-historian
-description: "Searches Claude Code, Codex, and Cursor session history for related prior sessions about the same problem or topic. Use to surface investigation context, failed approaches, and learnings from previous sessions that the current session cannot see. Supports time-based queries for conversational use."
+description: "Searches Claude Code, Codex, and Cursor session history for prior sessions about the same problem. Use to surface investigation context, failed approaches, and learnings the current session cannot see."
 model: inherit
 ---
 

--- a/plugins/compound-engineering/agents/ce-slack-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-slack-researcher.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ce-slack-researcher
-description: "Searches Slack for organizational context relevant to the current task -- decisions, constraints, and discussions that may not be documented elsewhere. Use when the user explicitly asks to search Slack for context during ideation, planning, or brainstorming. Always surfaces the workspace identity so the user can verify the correct Slack instance was searched."
+description: "Searches Slack for organizational context -- decisions, constraints, and discussions that may not be documented elsewhere. Use when the user explicitly asks to search Slack for context during ideation, planning, or brainstorming."
 model: sonnet
 ---
 

--- a/plugins/compound-engineering/agents/ce-swift-ios-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-swift-ios-reviewer.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ce-swift-ios-reviewer
-description: Conditional code-review persona, selected when the diff touches Swift files (.swift), SwiftUI views, UIKit controllers, iOS entitlements, privacy manifests, Core Data model bundles, SPM manifests, storyboards/XIBs, or semantic build-setting/target/signing changes inside .pbxproj. Reviews Swift and iOS code for SwiftUI correctness, state management, memory safety, Swift concurrency, Core Data threading, and accessibility.
+description: Conditional code-review persona, selected when the diff touches Swift files, SwiftUI/UIKit views, iOS entitlements, privacy manifests, Core Data models, SPM manifests, storyboards/XIBs, or semantic .pbxproj changes. Reviews for SwiftUI correctness, state management, memory safety, Swift concurrency, Core Data threading, and accessibility.
 model: inherit
 tools: Read, Grep, Glob, Bash, Write
 color: blue

--- a/plugins/compound-engineering/agents/ce-web-researcher.agent.md
+++ b/plugins/compound-engineering/agents/ce-web-researcher.agent.md
@@ -1,6 +1,6 @@
 ---
 name: ce-web-researcher
-description: "Performs iterative web research and returns structured external grounding (prior art, adjacent solutions, market signals, cross-domain analogies). Use when ideating outside the codebase, validating prior art, scanning competitor patterns, finding cross-domain analogies, or any task that benefits from current external context. Prefer over manual web searches when the orchestrator needs structured external grounding."
+description: "Performs iterative web research and returns structured external grounding. Use when ideating outside the codebase, validating prior art, scanning competitor patterns, finding cross-domain analogies, or fetching market signals. Prefer over manual web searches for structured external context."
 model: sonnet
 tools: WebSearch, WebFetch
 ---


### PR DESCRIPTION
## Summary

Agent descriptions are loaded into the Claude Code system prompt at session start, embedded in the `Agent` tool's `subagent_type` parameter docs. With 49 agents in this plugin, those descriptions add ~10.6K chars of always-loaded weight on every session.

This PR trims the top 7 longest agent descriptions by ~25% on average. Routing precision is preserved — every trigger condition that determines when an agent is dispatched is kept; only redundant restatement and operational notes were removed.

Companion to PR #802 (which trims the top 7 skills). Together: ~3K chars (~750 tokens) of always-loaded weight cut.

## Before / after

| Agent | Before | After | Δ |
|---|---:|---:|---:|
| ce-swift-ios-reviewer | 424 | 340 | -20% |
| ce-web-researcher | 420 | 293 | -30% |
| ce-slack-researcher | 363 | 231 | -36% |
| ce-learnings-researcher | 335 | 287 | -14% |
| ce-adversarial-document-reviewer | 331 | 281 | -15% |
| ce-product-lens-reviewer | 325 | 244 | -25% |
| ce-session-historian | 300 | 203 | -32% |
| **Total** | **2,498** | **1,879** | **-25%** |

Plugin-wide agent description weight: 10,610 → 9,991 chars.

## What was trimmed (and what was preserved)

The bloat was a different shape than the skill descriptions:

- **Redundant restatement** — `ce-web-researcher` defined "structured external grounding" with a parenthetical list (prior art, adjacent solutions, market signals, cross-domain analogies), then immediately enumerated the same examples again as use cases. Collapsed.
- **Operational details that belong in the agent body** — `ce-slack-researcher`'s "always surfaces the workspace identity so the user can verify the correct Slack instance was searched" is a behavioral guarantee, not a routing rule. `ce-session-historian`'s "supports time-based queries for conversational use" is API surface, not dispatch criteria. Moved out.
- **Over-precise file-type enumeration** — `ce-swift-ios-reviewer` specified ".swift", "(.swift)", "Core Data model bundles", "build-setting/target/signing changes inside .pbxproj". Compressed to clear categories without losing routability for storyboards, .pbxproj changes, or SPM manifests.
- **Audience clarification that doesn't help routing** — `ce-product-lens-reviewer`'s "Domain-agnostic: users may be end users, developers, operators, or any audience" is reader-context for the agent itself; routing doesn't need it.

What was deliberately kept:
- Every concrete file-type or document-property condition that triggers dispatch (e.g., "more than 5 requirements", "storyboards/XIBs", "semantic .pbxproj changes").
- Clauses that distinguish one agent from a similar one (e.g., "rather than evaluating document quality" on `ce-adversarial-document-reviewer`).
- Cross-references that document orchestration (e.g., "Spawned by the document-review skill").

## Test plan

- `bun test tests/frontmatter.test.ts` — 348 pass.
- `bun run release:validate` — no drift; agent count unchanged at 49.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
