### PR TITLE
feat(ce-plan,_shared): add --html flag and shared HTML output reference

### DIFF
--- a/plugins/compound-engineering/README.md
+++ b/plugins/compound-engineering/README.md
@@ -26,7 +26,7 @@ The primary entry points for engineering work, invoked as slash commands. Detail
 | [`/ce-strategy`](../../docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` — the product's target problem, approach, persona, key metrics, and tracks. Re-runnable to update. Read as grounding by `/ce-ideate`, `/ce-brainstorm`, and `/ce-plan` when present |
 | [`/ce-ideate`](../../docs/skills/ce-ideate.md) | Optional big-picture ideation: generate and critically evaluate grounded ideas, then route the strongest one into brainstorming |
 | [`/ce-brainstorm`](../../docs/skills/ce-brainstorm.md) | Interactive Q&A to think through a feature or problem and write a right-sized requirements doc before planning |
-| [`/ce-plan`](../../docs/skills/ce-plan.md) | Create structured plans for any multi-step task -- software features, research workflows, events, study plans -- with automatic confidence checking |
+| [`/ce-plan`](../../docs/skills/ce-plan.md) | Create structured plans for any multi-step task -- software features, research workflows, events, study plans -- with automatic confidence checking and optional `--html` read-mode output |
 | [`/ce-code-review`](../../docs/skills/ce-code-review.md) | Structured code review with tiered persona agents, confidence gating, and dedup pipeline |
 | [`/ce-work`](../../docs/skills/ce-work.md) | Execute work items systematically |
 | [`/ce-debug`](../../docs/skills/ce-debug.md) | Systematically find root causes and fix bugs -- traces causal chains, forms testable hypotheses, and implements test-first fixes |

--- a/plugins/compound-engineering/skills/_shared/html-output.md
+++ b/plugins/compound-engineering/skills/_shared/html-output.md
@@ -1,0 +1,619 @@
+# Shared HTML Output Reference
+
+Use this reference when a document-producing skill supports an opt-in HTML view. The output is a single self-contained HTML5 file intended for human reading and sharing. Markdown remains the workflow source of truth unless the consuming skill explicitly supports HTML.
+
+## Document Skeleton
+
+Fill placeholders before writing the artifact. Keep the skeleton static unless a skill needs a section-specific override.
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{title}}</title>
+  <style>
+    {{embedded_css}}
+  </style>
+</head>
+<body>
+  <header class="doc-header">
+    <p class="eyebrow">{{skill_name}}</p>
+    <h1>{{title}}</h1>
+    <p class="summary">{{summary}}</p>
+    <div class="pill-row" aria-label="Frontmatter">
+      {{frontmatter_pills}}
+    </div>
+    <script type="application/json" id="{{skill_slug}}-frontmatter">
+      {{frontmatter_json}}
+    </script>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Table of contents">
+      <a href="#summary">Summary</a>
+      <a href="#problem-frame">Problem Frame</a>
+      <a href="#requirements">Requirements</a>
+      <a href="#implementation-units">Implementation Units</a>
+      <a href="#test-scenarios">Test Scenarios</a>
+      <a href="#sources">Sources</a>
+    </nav>
+
+    <main>
+      {{sections}}
+    </main>
+  </div>
+
+  <footer class="doc-footer">
+    <p>{{origin_note}}</p>
+  </footer>
+</body>
+</html>
+```
+
+## Embedded CSS Theme
+
+Embed the CSS directly in the generated document. Do not link external stylesheets, fonts, scripts, or images.
+
+```css
+:root {
+  color-scheme: light dark;
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --surface-soft: #f1f5f9;
+  --surface-strong: #e2e8f0;
+  --text: #111827;
+  --text-muted: #475569;
+  --border: #cbd5e1;
+  --accent: #0f766e;
+  --accent-soft: #ccfbf1;
+  --accent-text: #115e59;
+  --danger: #b91c1c;
+  --danger-soft: #fee2e2;
+  --warning: #a16207;
+  --warning-soft: #fef3c7;
+  --success: #166534;
+  --success-soft: #dcfce7;
+  --code-bg: #0f172a;
+  --code-text: #e2e8f0;
+  --shadow: 0 1px 2px rgb(15 23 42 / 0.08);
+  --radius: 8px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+a {
+  color: var(--accent);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+.doc-header,
+.doc-footer {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 32px 24px 24px;
+}
+
+.doc-header h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  line-height: 1.05;
+  letter-spacing: 0;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent-text);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.summary {
+  max-width: 760px;
+  margin: 16px 0 0;
+  color: var(--text-muted);
+  font-size: 1.05rem;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 22px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 10px;
+  background: var(--surface);
+  color: var(--text-muted);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.pill-status-active,
+.pill-type-feat {
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+
+.pill-status-draft,
+.pill-type-refactor {
+  background: var(--surface-soft);
+}
+
+.pill-status-blocked,
+.pill-type-fix {
+  border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr);
+  gap: 24px;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 24px 40px;
+}
+
+.toc {
+  position: sticky;
+  top: 16px;
+  align-self: start;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.toc a {
+  display: block;
+  border-radius: 6px;
+  padding: 7px 9px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.toc a:hover,
+.toc a:focus {
+  background: var(--surface-soft);
+  color: var(--text);
+}
+
+main {
+  min-width: 0;
+}
+
+section,
+article,
+.notice,
+.risk,
+.table-wrap {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+section {
+  margin-bottom: 18px;
+  padding: 24px;
+}
+
+article {
+  margin-top: 14px;
+  padding: 20px;
+}
+
+h2,
+h3,
+h4 {
+  margin: 0 0 12px;
+  line-height: 1.25;
+  letter-spacing: 0;
+}
+
+h2 {
+  font-size: 1.45rem;
+}
+
+h3 {
+  font-size: 1.12rem;
+}
+
+p,
+ul,
+ol {
+  margin-top: 0;
+}
+
+ul,
+ol {
+  padding-left: 1.35rem;
+}
+
+.notice {
+  margin-bottom: 18px;
+  padding: 14px 16px;
+  background: var(--accent-soft);
+  color: var(--accent-text);
+}
+
+.risk {
+  margin-top: 12px;
+  padding: 14px 16px;
+}
+
+.risk-high {
+  border-color: color-mix(in srgb, var(--danger) 35%, var(--border));
+  background: var(--danger-soft);
+}
+
+.risk-medium {
+  border-color: color-mix(in srgb, var(--warning) 40%, var(--border));
+  background: var(--warning-soft);
+}
+
+.status-ok {
+  color: var(--success);
+  font-weight: 700;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  margin: 14px 0;
+}
+
+table {
+  width: 100%;
+  min-width: 620px;
+  border-collapse: collapse;
+  font-size: 0.94rem;
+}
+
+thead {
+  background: var(--surface-soft);
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--border);
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  color: var(--text);
+  font-weight: 700;
+}
+
+tbody tr:nth-child(even) {
+  background: color-mix(in srgb, var(--surface-soft) 55%, transparent);
+}
+
+code,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
+
+code {
+  border-radius: 5px;
+  padding: 0.12em 0.34em;
+  background: var(--surface-soft);
+}
+
+pre {
+  overflow-x: auto;
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  background: var(--code-bg);
+  color: var(--code-text);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+pre code {
+  padding: 0;
+  background: transparent;
+  color: inherit;
+}
+
+.token-keyword { color: #93c5fd; }
+.token-string { color: #86efac; }
+.token-comment { color: #94a3b8; }
+.token-symbol { color: #fbbf24; }
+
+details {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  background: var(--surface-soft);
+}
+
+summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.diagram {
+  width: 100%;
+  height: auto;
+  margin: 12px 0;
+}
+
+.diagram text {
+  fill: currentColor;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: 13px;
+}
+
+.doc-footer {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b1120;
+    --surface: #111827;
+    --surface-soft: #1f2937;
+    --surface-strong: #334155;
+    --text: #f8fafc;
+    --text-muted: #cbd5e1;
+    --border: #334155;
+    --accent: #2dd4bf;
+    --accent-soft: #143a3a;
+    --accent-text: #99f6e4;
+    --danger: #fca5a5;
+    --danger-soft: #3f1d1d;
+    --warning: #facc15;
+    --warning-soft: #3b2f13;
+    --success: #86efac;
+    --success-soft: #12351f;
+    --code-bg: #020617;
+    --code-text: #e2e8f0;
+    --shadow: 0 1px 2px rgb(0 0 0 / 0.35);
+  }
+}
+
+@media (max-width: 768px) {
+  .doc-header,
+  .doc-footer,
+  .layout {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .layout {
+    display: block;
+  }
+
+  .toc {
+    position: static;
+    margin-bottom: 16px;
+  }
+
+  section {
+    padding: 18px;
+  }
+
+  article {
+    padding: 16px;
+  }
+
+  table {
+    min-width: 0;
+  }
+
+  thead {
+    display: none;
+  }
+
+  table,
+  tbody,
+  tr,
+  td {
+    display: block;
+    width: 100%;
+  }
+
+  tr {
+    border-bottom: 1px solid var(--border);
+    padding: 8px 0;
+  }
+
+  td {
+    border-bottom: 0;
+    padding: 6px 10px;
+  }
+
+  td::before {
+    content: attr(data-label);
+    display: block;
+    color: var(--text-muted);
+    font-size: 0.76rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+}
+```
+
+## Frontmatter Contract
+
+Preserve frontmatter in two places:
+
+- Human-readable pills in the header, one chip per top-level frontmatter key that is useful to scan.
+- Machine-readable JSON inside `<script type="application/json" id="<skill>-frontmatter">`.
+
+The JSON object must round-trip to the original frontmatter keys and values:
+
+```json
+{
+  "title": "Plan Title",
+  "type": "feat",
+  "status": "active",
+  "date": "2026-05-08",
+  "origin": "docs/brainstorms/example-requirements.md"
+}
+```
+
+Pill classes use semantic names:
+
+```html
+<span class="pill pill-status-active">status: active</span>
+<span class="pill pill-type-feat">type: feat</span>
+<span class="pill pill-date">date: 2026-05-08</span>
+```
+
+Use `id="plan-frontmatter"` for ce-plan. Other skills use their skill slug, for example `id="doc-review-frontmatter"`.
+
+## Anchor-ID Conventions
+
+Use stable ASCII IDs:
+
+- `#summary`
+- `#problem-frame`
+- `#requirements`
+- `#scope-boundaries`
+- `#context-research`
+- `#key-technical-decisions`
+- `#implementation-units`
+- `#u1` through `#uN` for implementation units
+- `#system-wide-impact`
+- `#test-scenarios`
+- `#risks-open-questions`
+- `#sources`
+
+Implementation Unit IDs match the existing U-ID scheme. Do not renumber IDs when a plan is edited.
+
+## Inline-SVG Diagram Patterns
+
+Use inline SVG only. Each SVG gets `class="diagram"` and either `role="img"` with a `<title>` or `aria-hidden="true"` if decorative.
+
+### Data Flow
+
+Use for request, data, or artifact movement between systems.
+
+```svg
+<svg class="diagram" viewBox="0 0 640 180" role="img" aria-labelledby="data-flow-title" xmlns="http://www.w3.org/2000/svg">
+  <title id="data-flow-title">Data flow</title>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
+    </marker>
+  </defs>
+  <rect x="24" y="58" width="150" height="64" rx="8" fill="none" stroke="currentColor"></rect>
+  <text x="99" y="95" text-anchor="middle">Source</text>
+  <line x1="184" y1="90" x2="292" y2="90" stroke="currentColor" marker-end="url(#arrow)"></line>
+  <rect x="302" y="58" width="150" height="64" rx="8" fill="none" stroke="currentColor"></rect>
+  <text x="377" y="95" text-anchor="middle">Transform</text>
+  <line x1="462" y1="90" x2="570" y2="90" stroke="currentColor" marker-end="url(#arrow)"></line>
+  <rect x="580" y="58" width="36" height="64" rx="8" fill="none" stroke="currentColor"></rect>
+  <text x="598" y="95" text-anchor="middle">Sink</text>
+</svg>
+```
+
+### Sequence
+
+Use for ordered interactions between actors or subsystems.
+
+```svg
+<svg class="diagram" viewBox="0 0 640 260" role="img" aria-labelledby="sequence-title" xmlns="http://www.w3.org/2000/svg">
+  <title id="sequence-title">Sequence</title>
+  <defs>
+    <marker id="seq-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
+    </marker>
+  </defs>
+  <text x="100" y="28" text-anchor="middle">Actor A</text>
+  <text x="320" y="28" text-anchor="middle">Service</text>
+  <text x="540" y="28" text-anchor="middle">Actor B</text>
+  <line x1="100" y1="44" x2="100" y2="230" stroke="currentColor" stroke-dasharray="4 4"></line>
+  <line x1="320" y1="44" x2="320" y2="230" stroke="currentColor" stroke-dasharray="4 4"></line>
+  <line x1="540" y1="44" x2="540" y2="230" stroke="currentColor" stroke-dasharray="4 4"></line>
+  <line x1="108" y1="82" x2="312" y2="82" stroke="currentColor" marker-end="url(#seq-arrow)"></line>
+  <text x="210" y="74" text-anchor="middle">request</text>
+  <line x1="328" y1="142" x2="532" y2="142" stroke="currentColor" marker-end="url(#seq-arrow)"></line>
+  <text x="430" y="134" text-anchor="middle">notify</text>
+  <line x1="312" y1="202" x2="108" y2="202" stroke="currentColor" marker-end="url(#seq-arrow)"></line>
+  <text x="210" y="194" text-anchor="middle">result</text>
+</svg>
+```
+
+### Dependency
+
+Use for implementation-unit prerequisites and phase ordering.
+
+```svg
+<svg class="diagram" viewBox="0 0 640 220" role="img" aria-labelledby="dependency-title" xmlns="http://www.w3.org/2000/svg">
+  <title id="dependency-title">Dependency graph</title>
+  <defs>
+    <marker id="dep-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
+    </marker>
+  </defs>
+  <rect x="40" y="76" width="120" height="56" rx="8" fill="none" stroke="currentColor"></rect>
+  <text x="100" y="110" text-anchor="middle">U1</text>
+  <rect x="260" y="32" width="120" height="56" rx="8" fill="none" stroke="currentColor"></rect>
+  <text x="320" y="66" text-anchor="middle">U2</text>
+  <rect x="260" y="132" width="120" height="56" rx="8" fill="none" stroke="currentColor"></rect>
+  <text x="320" y="166" text-anchor="middle">U3</text>
+  <rect x="480" y="76" width="120" height="56" rx="8" fill="none" stroke="currentColor"></rect>
+  <text x="540" y="110" text-anchor="middle">U4</text>
+  <line x1="164" y1="94" x2="254" y2="66" stroke="currentColor" marker-end="url(#dep-arrow)"></line>
+  <line x1="164" y1="114" x2="254" y2="154" stroke="currentColor" marker-end="url(#dep-arrow)"></line>
+  <line x1="384" y1="60" x2="474" y2="94" stroke="currentColor" marker-end="url(#dep-arrow)"></line>
+  <line x1="384" y1="160" x2="474" y2="116" stroke="currentColor" marker-end="url(#dep-arrow)"></line>
+</svg>
+```
+
+## Anti-Bloat Rules
+
+- No external resources: no remote stylesheet links, no remote script sources, no remote images, no font CDNs.
+- Target less than 80KB for a typical Standard-tier ce-plan output.
+- No JavaScript frameworks.
+- Inline `<script>` for static metadata is required for frontmatter. Other interactivity is discouraged in v1.
+- No images. Use inline SVG when a visual is needed.
+- All identifiers are ASCII.
+- Markdown tables remain pipe-delimited. HTML tables use `<table>`, `<thead>`, `<tbody>`, and scoped `<th>`.
+
+## Reuse Contract
+
+A per-skill template extends this reference by:
+
+1. Using the skeleton and embedded CSS without external resources.
+2. Keeping the frontmatter JSON contract and pill chip contract.
+3. Replacing the default section list with that skill's canonical section list.
+4. Adding skill-specific structures such as plan Implementation Unit articles, review finding tables, or report summary callouts.
+5. Preserving the shared anchor IDs where section meanings overlap.
+
+Do not duplicate large CSS blocks in prose. Per-skill templates may include a generated sample skeleton, but the shared reference remains the canonical contract.

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -55,6 +55,32 @@ Every plan should contain:
 
 A plan is ready when an implementer can start confidently without needing the plan to write the code for them.
 
+## Output Format
+
+Default output is markdown. Unless the user explicitly requests HTML, set `OUTPUT_FORMAT=markdown`, read `references/plan-template.md`, and write the plan to:
+
+```text
+docs/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.md
+```
+
+HTML output is opt-in. Set `OUTPUT_FORMAT=html` only when `$ARGUMENTS` contains either:
+- `--html`
+- a bare `html` keyword, accepted as a fallback for harnesses that strip leading dashes
+
+When `OUTPUT_FORMAT=html`, read `references/html-plan-template.md` instead of the markdown template and write the plan to the same path convention with an `.html` extension:
+
+```text
+docs/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.html
+```
+
+Every HTML plan must emit this Implementation Note near the top:
+
+```text
+This is the HTML view of a ce-plan. Run ce-plan without --html to produce the markdown plan that ce-work consumes.
+```
+
+Markdown remains the workflow source until downstream skills explicitly support HTML inputs. Do not change flagless markdown behavior.
+
 ## Workflow
 
 ### Phase 0: Resume, Source, and Scope
@@ -483,7 +509,9 @@ Do not add these as boilerplate. Include them only when they improve execution q
 
 #### 4.2 Core Plan Template
 
-Read `references/plan-template.md` for the core plan template (frontmatter, all standard sections, fill-in placeholders) and the optional Deep extensions template (Alternative Approaches Considered, Success Metrics, Dependencies, Risk Analysis, Phased Delivery, Documentation Plan, Operational Notes). Omit clearly inapplicable optional sections — especially for Lightweight plans.
+If `OUTPUT_FORMAT=markdown`, read `references/plan-template.md` for the core plan template (frontmatter, all standard sections, fill-in placeholders) and the optional Deep extensions template (Alternative Approaches Considered, Success Metrics, Dependencies, Risk Analysis, Phased Delivery, Documentation Plan, Operational Notes). Omit clearly inapplicable optional sections — especially for Lightweight plans.
+
+If `OUTPUT_FORMAT=html`, read `references/html-plan-template.md` for the ce-plan HTML structure. The HTML template mirrors the core plan sections, renders Requirements traceability and Test Scenarios as tables, renders Implementation Units as `<article id="uN">`, preserves frontmatter as header pills plus `<script type="application/json" id="plan-frontmatter">`, and emits the Implementation Note described in Output Format.
 
 #### 4.3 Planning Rules
 
@@ -544,10 +572,18 @@ Fires **only when the plan was sourced from an upstream brainstorm doc** (Phase 
 
 **REQUIRED: Write the plan file to disk before presenting any options.**
 
-Use the Write tool to save the complete plan to:
+Use the Write tool to save the complete plan to the path that matches `OUTPUT_FORMAT`.
+
+Markdown mode:
 
 ```text
 docs/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.md
+```
+
+HTML mode:
+
+```text
+docs/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.html
 ```
 
 Confirm (use absolute path so the reference is clickable in modern terminals):
@@ -619,9 +655,16 @@ After document review and final checks, print a one-line summary of the headless
 4. **Open in Proof (web app) — review and comment to iterate with the agent** - Open the doc in Every's Proof editor, iterate with the agent via comments, or copy a link to share with others
 5. **Done for now** - Pause; the plan file is saved and can be resumed later
 
+If `OUTPUT_FORMAT=html`, replace option 1 with:
+
+1. **Open in browser** (recommended) - Open the HTML plan locally for review
+
+Keep the remaining options and renumber when the actionable-findings rule drops the deeper-review option. Do not present `Start /ce-work` as the recommended next step for HTML plans because ce-work consumes markdown plans today.
+
 **Routing.** Act on the user's selection — do not just announce it. Elaborate sub-flows (Proof HITL state machine, Issue Creation tracker detection, post-HITL resync) live in `references/plan-handoff.md`.
 
 - **Start `/ce-work`** — Invoke the `ce-work` skill via the platform's skill-invocation primitive (`Skill` in Claude Code, `Skill` in Codex, the equivalent on Gemini/Pi), passing the plan path as the skill argument. Do not merely tell the user to type `/ce-work` — fire the invocation now so the plan executes in this session.
+- **Open in browser** — Open the saved HTML file with the platform's local browser-opening primitive when available, or display the absolute HTML path for the user to open. Do not invoke `ce-work` for HTML plans until downstream HTML consumption exists.
 - **Run deeper doc review** — Re-invoke the `ce-doc-review` skill on the plan path **without** `mode:headless` so the interactive routing question and walkthrough fire. After it returns, re-render this menu with refreshed counts so the user can pick a next-stage action.
 - **Create Issue** — Detect the project tracker (`gh` for GitHub, `linear` for Linear) and create the issue from the plan file as described under "Issue Creation" in `references/plan-handoff.md`. After creation, display the issue URL and ask whether to proceed to `/ce-work` via the platform's blocking question tool.
 - **Open in Proof (web app) — review and comment to iterate with the agent** — Load the `ce-proof` skill in HITL-review mode with the plan file as `source file`, the plan title as `doc title`, identity `ai:compound-engineering` / `Compound Engineering`, and recommended next step `/ce-work`. Then follow the post-HITL resync logic in `references/plan-handoff.md`, which handles the four `ce-proof` return statuses, re-runs `ce-doc-review` after material edits, and falls back gracefully on upload failure.

--- a/plugins/compound-engineering/skills/ce-plan/references/html-plan-template.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/html-plan-template.md
@@ -1,0 +1,251 @@
+# HTML Plan Template
+
+This template extends `plugins/compound-engineering/skills/_shared/html-output.md` for ce-plan. Use it only when the user passed `--html` or the bare `html` fallback keyword in `$ARGUMENTS`.
+
+The generated file must be a complete, self-contained HTML5 document at:
+
+```text
+docs/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.html
+```
+
+Emit this Implementation Note near the top of every HTML plan:
+
+> This is the HTML view of a ce-plan. Run ce-plan without --html to produce the markdown plan that ce-work consumes.
+
+## Plan HTML Template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>[Plan Title]</title>
+  <style>
+    /* Use the embedded CSS theme from ../_shared/html-output.md. */
+  </style>
+</head>
+<body>
+  <header class="doc-header">
+    <p class="eyebrow">ce-plan HTML view</p>
+    <h1>[Plan Title]</h1>
+    <p class="summary">[1-3 line prose summary]</p>
+    <div class="pill-row" aria-label="Plan frontmatter">
+      <span class="pill pill-status-active">status: active</span>
+      <span class="pill pill-type-feat">type: feat</span>
+      <span class="pill pill-date">date: YYYY-MM-DD</span>
+      <span class="pill pill-origin">origin: [origin path when present]</span>
+    </div>
+    <script type="application/json" id="plan-frontmatter">
+      {
+        "title": "[Plan Title]",
+        "type": "[feat|fix|refactor]",
+        "status": "active",
+        "date": "YYYY-MM-DD",
+        "origin": "[optional origin path]"
+      }
+    </script>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Plan sections">
+      <a href="#summary">Summary</a>
+      <a href="#problem-frame">Problem Frame</a>
+      <a href="#requirements">Requirements</a>
+      <a href="#scope-boundaries">Scope Boundaries</a>
+      <a href="#context-research">Context &amp; Research</a>
+      <a href="#key-technical-decisions">Key Technical Decisions</a>
+      <a href="#implementation-units">Implementation Units</a>
+      <a href="#u1">U1. [Name]</a>
+      <a href="#u2">U2. [Name]</a>
+      <a href="#test-scenarios">Test Scenarios</a>
+      <a href="#risks-open-questions">Risks &amp; Open Questions</a>
+      <a href="#sources">Sources &amp; References</a>
+    </nav>
+
+    <main>
+      <aside class="notice" aria-label="Implementation note">
+        <strong>Implementation Note:</strong> This is the HTML view of a ce-plan. Run ce-plan without --html to produce the markdown plan that ce-work consumes.
+      </aside>
+
+      <section id="summary">
+        <h2>Summary</h2>
+        <p>[Forward-looking summary of the planned work.]</p>
+      </section>
+
+      <section id="problem-frame">
+        <h2>Problem Frame</h2>
+        <p>[Situational context and pain that motivate the plan.]</p>
+      </section>
+
+      <section id="requirements">
+        <h2>Requirements</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">R-ID</th>
+                <th scope="col">Requirement</th>
+                <th scope="col">Origin trace</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row" data-label="R-ID">R1</th>
+                <td data-label="Requirement">[Requirement or success criterion]</td>
+                <td data-label="Origin trace">[Prompt, origin doc, issue, or assumption]</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="scope-boundaries">
+        <h2>Scope Boundaries</h2>
+        <ul>
+          <li>[Explicit non-goal or exclusion]</li>
+        </ul>
+      </section>
+
+      <section id="context-research">
+        <h2>Context &amp; Research</h2>
+        <h3>Relevant Code and Patterns</h3>
+        <ul>
+          <li>[Existing file, class, component, or pattern to follow]</li>
+        </ul>
+        <h3>Institutional Learnings</h3>
+        <ul>
+          <li>[Relevant docs/solutions insight]</li>
+        </ul>
+        <h3>External References</h3>
+        <ul>
+          <li>[External docs or best-practice source, if used]</li>
+        </ul>
+      </section>
+
+      <section id="key-technical-decisions">
+        <h2>Key Technical Decisions</h2>
+        <ul>
+          <li><strong>[Decision]:</strong> [Rationale]</li>
+        </ul>
+      </section>
+
+      <section id="implementation-units">
+        <h2>Implementation Units</h2>
+
+        <article id="u1">
+          <h3>U1. [Name]</h3>
+          <p><strong>Goal:</strong> [What this unit accomplishes]</p>
+          <p><strong>Requirements:</strong> [R1, R2]</p>
+          <p><strong>Dependencies:</strong> [None / U1 / external prerequisite]</p>
+
+          <h4>Files</h4>
+          <ul>
+            <li>Create: <code>path/to/new_file</code></li>
+            <li>Modify: <code>path/to/existing_file</code></li>
+            <li>Test: <code>path/to/test_file</code></li>
+          </ul>
+
+          <h4>Approach</h4>
+          <ul>
+            <li>[Key design or sequencing decision]</li>
+          </ul>
+
+          <h4>Test Scenarios</h4>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Category</th>
+                  <th scope="col">Scenario</th>
+                  <th scope="col">Expected</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row" data-label="Category">Happy path</th>
+                  <td data-label="Scenario">[Specific input/action]</td>
+                  <td data-label="Expected">[Expected outcome]</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h4>Acceptance</h4>
+          <ul>
+            <li>[Outcome that should hold when this unit is complete]</li>
+          </ul>
+        </article>
+      </section>
+
+      <section id="system-wide-impact">
+        <h2>System-Wide Impact</h2>
+        <ul>
+          <li><strong>Interaction graph:</strong> [Callbacks, middleware, observers, or entry points]</li>
+          <li><strong>Error propagation:</strong> [How failures should travel across layers]</li>
+          <li><strong>State lifecycle risks:</strong> [Partial-write, cache, duplicate, or cleanup concerns]</li>
+          <li><strong>API surface parity:</strong> [Other interfaces that may require the same change]</li>
+        </ul>
+      </section>
+
+      <section id="test-scenarios">
+        <h2>Test Scenarios</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Unit</th>
+                <th scope="col">Category</th>
+                <th scope="col">Scenario</th>
+                <th scope="col">Expected</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row" data-label="Unit"><a href="#u1">U1</a></th>
+                <td data-label="Category">Happy path</td>
+                <td data-label="Scenario">[Specific input/action]</td>
+                <td data-label="Expected">[Expected outcome]</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="risks-open-questions">
+        <h2>Risks &amp; Open Questions</h2>
+        <aside class="risk risk-high">
+          <strong>[Risk]:</strong> [Mitigation or accepted tradeoff]
+        </aside>
+        <h3>Deferred to Implementation</h3>
+        <ul>
+          <li>[Question or unknown]: [Why it is intentionally deferred]</li>
+        </ul>
+      </section>
+
+      <section id="sources">
+        <h2>Sources &amp; References</h2>
+        <ul>
+          <li><strong>Origin document:</strong> <a href="[path]">[docs/brainstorms/YYYY-MM-DD-topic-requirements.md]</a></li>
+          <li>Related code: <code>[path or symbol]</code></li>
+          <li>External docs: <a href="[url]">[url]</a></li>
+        </ul>
+      </section>
+    </main>
+  </div>
+
+  <footer class="doc-footer">
+    <p>Generated by ce-plan. Markdown remains the workflow source until downstream skills support HTML inputs.</p>
+  </footer>
+</body>
+</html>
+```
+
+## Rendering Rules
+
+- Preserve every applicable section from `references/plan-template.md`; omit only sections that the markdown template marks optional and inapplicable.
+- Render Implementation Units as `<article id="uN">`, where `N` matches the stable U-ID.
+- Render Requirements traceability and Test Scenarios as real tables with `<thead>`, `<tbody>`, and scoped header cells.
+- Use `<aside class="risk risk-high">` or `<aside class="risk risk-medium">` for meaningful risk callouts.
+- Use inline SVG for diagrams in HTML mode. See `_shared/html-output.md` for data-flow, sequence, and dependency patterns.
+- Keep source links in Sources & References as normal `<a href="https://...">` links. The no-external-resource rule only forbids externally loaded CSS, JS, fonts, and images.

--- a/plugins/compound-engineering/skills/ce-plan/references/visual-communication.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/visual-communication.md
@@ -29,3 +29,17 @@ Visual aids are conditional on content patterns, not on plan depth classificatio
 - Prose is authoritative: when a visual aid and its surrounding prose disagree, the prose governs.
 
 After generating a visual aid, verify it accurately represents the plan sections it illustrates -- correct dependency edges, no missing surfaces, no merged units.
+
+## HTML Mode Diagrams
+
+When `ce-plan` runs in HTML mode, use inline SVG instead of Mermaid or ASCII diagrams. The shared HTML output reference at `plugins/compound-engineering/skills/_shared/html-output.md` defines the three reusable SVG patterns:
+
+- **Data flow** - Use when the plan needs to show artifact, request, or data movement between systems. Best fits High-Level Technical Design or System-Wide Impact when the flow is the important reader question.
+- **Sequence** - Use when the plan needs to show ordered interactions between actors, services, skills, or review loops. Best fits High-Level Technical Design or a complex Implementation Unit's optional technical design field.
+- **Dependency** - Use when the plan has non-linear Implementation Unit prerequisites. Best fits directly before or after the Implementation Units heading, with U-ID labels matching the article anchors.
+
+Format rules by output mode:
+
+- **HTML mode:** inline SVG is the default for diagrams. Keep it static, self-contained, and labeled with `role="img"` plus a `<title>` unless decorative.
+- **Markdown mode:** keep the existing Mermaid-first guidance. ASCII remains available for markdown-only annotated flows where Mermaid is too sparse.
+- **Both modes:** prose remains authoritative. If the diagram and surrounding text disagree, fix the diagram or remove it.

--- a/tests/fixtures/ce-plan/sample-plan.html
+++ b/tests/fixtures/ce-plan/sample-plan.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sample HTML Plan</title>
+  <style>
+:root {
+  color-scheme: light dark;
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --surface-soft: #f1f5f9;
+  --text: #111827;
+  --text-muted: #475569;
+  --border: #cbd5e1;
+  --accent: #0f766e;
+  --accent-soft: #ccfbf1;
+  --accent-text: #115e59;
+  --danger: #b91c1c;
+  --danger-soft: #fee2e2;
+  --warning: #a16207;
+  --warning-soft: #fef3c7;
+  --code-bg: #0f172a;
+  --code-text: #e2e8f0;
+  --shadow: 0 1px 2px rgb(15 23 42 / 0.08);
+  --radius: 8px;
+}
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+}
+a { color: var(--accent); text-underline-offset: 0.18em; }
+.doc-header, .doc-footer { max-width: 1180px; margin: 0 auto; padding: 32px 24px 24px; }
+.doc-header h1 { margin: 0; font-size: clamp(2rem, 4vw, 3.5rem); line-height: 1.05; letter-spacing: 0; }
+.eyebrow { margin: 0 0 10px; color: var(--accent-text); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+.summary { max-width: 760px; margin: 16px 0 0; color: var(--text-muted); font-size: 1.05rem; }
+.pill-row { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 22px; }
+.pill { display: inline-flex; align-items: center; min-height: 28px; border: 1px solid var(--border); border-radius: 999px; padding: 3px 10px; background: var(--surface); color: var(--text-muted); font-size: 0.82rem; font-weight: 650; }
+.pill-status-active, .pill-type-feat { background: var(--accent-soft); color: var(--accent-text); }
+.layout { display: grid; grid-template-columns: minmax(180px, 240px) minmax(0, 1fr); gap: 24px; max-width: 1180px; margin: 0 auto; padding: 0 24px 40px; }
+.toc { position: sticky; top: 16px; align-self: start; border: 1px solid var(--border); border-radius: var(--radius); padding: 10px; background: var(--surface); box-shadow: var(--shadow); }
+.toc a { display: block; border-radius: 6px; padding: 7px 9px; color: var(--text-muted); font-size: 0.9rem; text-decoration: none; }
+.toc a:hover, .toc a:focus { background: var(--surface-soft); color: var(--text); }
+main { min-width: 0; }
+section, article, .notice, .risk, .table-wrap { border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); box-shadow: var(--shadow); }
+section { margin-bottom: 18px; padding: 24px; }
+article { margin-top: 14px; padding: 20px; }
+h2, h3, h4 { margin: 0 0 12px; line-height: 1.25; letter-spacing: 0; }
+h2 { font-size: 1.45rem; }
+h3 { font-size: 1.12rem; }
+p, ul, ol { margin-top: 0; }
+ul, ol { padding-left: 1.35rem; }
+.notice { margin-bottom: 18px; padding: 14px 16px; background: var(--accent-soft); color: var(--accent-text); }
+.risk { margin-top: 12px; padding: 14px 16px; }
+.risk-high { background: var(--danger-soft); color: var(--danger); }
+.table-wrap { overflow-x: auto; margin: 14px 0; }
+table { width: 100%; min-width: 620px; border-collapse: collapse; font-size: 0.94rem; }
+thead { background: var(--surface-soft); }
+th, td { border-bottom: 1px solid var(--border); padding: 10px 12px; text-align: left; vertical-align: top; }
+th { color: var(--text); font-weight: 700; }
+tbody tr:nth-child(even) { background: var(--surface-soft); }
+code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+code { border-radius: 5px; padding: 0.12em 0.34em; background: var(--surface-soft); }
+pre { overflow-x: auto; border-radius: var(--radius); padding: 14px 16px; background: var(--code-bg); color: var(--code-text); font-size: 0.9rem; line-height: 1.5; }
+.diagram { width: 100%; height: auto; margin: 12px 0; }
+.diagram text { fill: currentColor; font-family: ui-sans-serif, system-ui, sans-serif; font-size: 13px; }
+.doc-footer { color: var(--text-muted); font-size: 0.9rem; }
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b1120;
+    --surface: #111827;
+    --surface-soft: #1f2937;
+    --text: #f8fafc;
+    --text-muted: #cbd5e1;
+    --border: #334155;
+    --accent: #2dd4bf;
+    --accent-soft: #143a3a;
+    --accent-text: #99f6e4;
+    --danger: #fca5a5;
+    --danger-soft: #3f1d1d;
+    --warning: #facc15;
+    --warning-soft: #3b2f13;
+    --code-bg: #020617;
+    --code-text: #e2e8f0;
+    --shadow: 0 1px 2px rgb(0 0 0 / 0.35);
+  }
+}
+@media (max-width: 768px) {
+  .doc-header, .doc-footer, .layout { padding-left: 16px; padding-right: 16px; }
+  .layout { display: block; }
+  .toc { position: static; margin-bottom: 16px; }
+  section { padding: 18px; }
+  article { padding: 16px; }
+  table { min-width: 0; }
+  thead { display: none; }
+  table, tbody, tr, td { display: block; width: 100%; }
+  tr { border-bottom: 1px solid var(--border); padding: 8px 0; }
+  td { border-bottom: 0; padding: 6px 10px; }
+  td::before { content: attr(data-label); display: block; color: var(--text-muted); font-size: 0.76rem; font-weight: 700; text-transform: uppercase; }
+}
+  </style>
+</head>
+<body>
+  <header class="doc-header">
+    <p class="eyebrow">ce-plan HTML view</p>
+    <h1>Sample HTML Plan</h1>
+    <p class="summary">Add an opt-in HTML output mode to ce-plan while leaving markdown output unchanged.</p>
+    <div class="pill-row" aria-label="Plan frontmatter">
+      <span class="pill pill-status-active">status: active</span>
+      <span class="pill pill-type-feat">type: feat</span>
+      <span class="pill pill-date">date: 2026-05-08</span>
+      <span class="pill pill-generated-by">generated_by: ce-plan</span>
+    </div>
+    <script type="application/json" id="plan-frontmatter">
+{"title":"Sample HTML Plan","type":"feat","status":"active","date":"2026-05-08","generated_by":"ce-plan"}
+    </script>
+  </header>
+
+  <div class="layout">
+    <nav class="toc" aria-label="Plan sections">
+      <a href="#summary">Summary</a>
+      <a href="#problem-frame">Problem Frame</a>
+      <a href="#requirements">Requirements</a>
+      <a href="#implementation-units">Implementation Units</a>
+      <a href="#u1">U1. Shared Reference</a>
+      <a href="#u2">U2. ce-plan Template</a>
+      <a href="#test-scenarios">Test Scenarios</a>
+      <a href="#risks-open-questions">Risks &amp; Open Questions</a>
+      <a href="#sources">Sources &amp; References</a>
+    </nav>
+
+    <main>
+      <aside class="notice" aria-label="Implementation note">
+        <strong>Implementation Note:</strong> This is the HTML view of a ce-plan. Run ce-plan without --html to produce the markdown plan that ce-work consumes.
+      </aside>
+
+      <section id="summary">
+        <h2>Summary</h2>
+        <p>This sample demonstrates the expected single-file HTML shape for ce-plan output.</p>
+      </section>
+
+      <section id="problem-frame">
+        <h2>Problem Frame</h2>
+        <p>Long markdown plans can be hard to scan when shared outside the immediate implementation loop.</p>
+      </section>
+
+      <section id="requirements">
+        <h2>Requirements</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">R-ID</th>
+                <th scope="col">Requirement</th>
+                <th scope="col">Origin trace</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row" data-label="R-ID">R1</th>
+                <td data-label="Requirement">Support an opt-in HTML output mode.</td>
+                <td data-label="Origin trace">Plan requirement R1</td>
+              </tr>
+              <tr>
+                <th scope="row" data-label="R-ID">R2</th>
+                <td data-label="Requirement">Keep default markdown output unchanged.</td>
+                <td data-label="Origin trace">Plan requirement R10</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="implementation-units">
+        <h2>Implementation Units</h2>
+        <svg class="diagram" viewBox="0 0 640 220" role="img" aria-labelledby="dependency-title" xmlns="http://www.w3.org/2000/svg">
+          <title id="dependency-title">Dependency graph</title>
+          <defs>
+            <marker id="dep-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor"></path>
+            </marker>
+          </defs>
+          <rect x="70" y="82" width="160" height="56" rx="8" fill="none" stroke="currentColor"></rect>
+          <text x="150" y="116" text-anchor="middle">U1 Shared reference</text>
+          <rect x="410" y="82" width="160" height="56" rx="8" fill="none" stroke="currentColor"></rect>
+          <text x="490" y="116" text-anchor="middle">U2 Template</text>
+          <line x1="236" y1="110" x2="402" y2="110" stroke="currentColor" marker-end="url(#dep-arrow)"></line>
+        </svg>
+
+        <article id="u1">
+          <h3>U1. Shared Reference</h3>
+          <p><strong>Goal:</strong> Define the reusable skeleton, CSS, frontmatter contract, anchors, and SVG patterns.</p>
+          <p><strong>Requirements:</strong> R1, R3, R5, R8</p>
+          <p><strong>Dependencies:</strong> None</p>
+          <h4>Files</h4>
+          <ul>
+            <li>Create: <code>plugins/compound-engineering/skills/_shared/html-output.md</code></li>
+            <li>Test: <code>tests/skills/ce-plan-html-output.test.ts</code></li>
+          </ul>
+          <h4>Approach</h4>
+          <ul>
+            <li>Keep shared HTML rules in one reference so later skills reuse the same contract.</li>
+          </ul>
+          <h4>Test Scenarios</h4>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Category</th>
+                  <th scope="col">Scenario</th>
+                  <th scope="col">Expected</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row" data-label="Category">Happy path</th>
+                  <td data-label="Scenario">Read the shared reference.</td>
+                  <td data-label="Expected">It includes skeleton, CSS, frontmatter, anchors, SVG, and anti-bloat rules.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <h4>Acceptance</h4>
+          <ul>
+            <li>Shared contract is explicit and self-contained.</li>
+          </ul>
+        </article>
+
+        <article id="u2">
+          <h3>U2. ce-plan Template</h3>
+          <p><strong>Goal:</strong> Provide plan-specific HTML structure for requirements, implementation units, tests, risks, and sources.</p>
+          <p><strong>Requirements:</strong> R2, R4, R6, R7, R9</p>
+          <p><strong>Dependencies:</strong> U1</p>
+          <h4>Files</h4>
+          <ul>
+            <li>Create: <code>plugins/compound-engineering/skills/ce-plan/references/html-plan-template.md</code></li>
+            <li>Modify: <code>plugins/compound-engineering/skills/ce-plan/SKILL.md</code></li>
+          </ul>
+          <h4>Approach</h4>
+          <ul>
+            <li>Branch only when HTML mode is requested and keep the markdown template path as the default.</li>
+          </ul>
+          <h4>Test Scenarios</h4>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Category</th>
+                  <th scope="col">Scenario</th>
+                  <th scope="col">Expected</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <th scope="row" data-label="Category">Integration</th>
+                  <td data-label="Scenario">Invoke ce-plan with <code>--html</code>.</td>
+                  <td data-label="Expected">The plan path ends with <code>.html</code> and uses the HTML template.</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <h4>Acceptance</h4>
+          <ul>
+            <li>HTML mode is documented and scoped as read-mode.</li>
+          </ul>
+        </article>
+      </section>
+
+      <section id="test-scenarios">
+        <h2>Test Scenarios</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Unit</th>
+                <th scope="col">Category</th>
+                <th scope="col">Scenario</th>
+                <th scope="col">Expected</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row" data-label="Unit"><a href="#u1">U1</a></th>
+                <td data-label="Category">Happy path</td>
+                <td data-label="Scenario">Parse the fixture frontmatter JSON.</td>
+                <td data-label="Expected">It round-trips to the source frontmatter object.</td>
+              </tr>
+              <tr>
+                <th scope="row" data-label="Unit"><a href="#u2">U2</a></th>
+                <td data-label="Category">Edge case</td>
+                <td data-label="Scenario">Scan for external resource loads.</td>
+                <td data-label="Expected">No stylesheet, script, font, or image is loaded from a remote URL.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="risks-open-questions">
+        <h2>Risks &amp; Open Questions</h2>
+        <aside class="risk risk-high">
+          <strong>Downstream consumers:</strong> ce-work consumes markdown today, so HTML output is explicitly read-mode until a follow-up teaches consumers to read it.
+        </aside>
+      </section>
+
+      <section id="sources">
+        <h2>Sources &amp; References</h2>
+        <ul>
+          <li>ce-plan skill: <code>plugins/compound-engineering/skills/ce-plan/SKILL.md</code></li>
+          <li>HTML inspiration: <a href="https://thariqs.github.io/html-effectiveness/">Using Claude Code: The Unreasonable Effectiveness of HTML</a></li>
+        </ul>
+      </section>
+    </main>
+  </div>
+
+  <footer class="doc-footer">
+    <p>Generated by ce-plan. Markdown remains the workflow source until downstream skills support HTML inputs.</p>
+  </footer>
+</body>
+</html>

--- a/tests/skill-agent-ce-prefix.test.ts
+++ b/tests/skill-agent-ce-prefix.test.ts
@@ -17,6 +17,10 @@ const SKILL_EXEMPTIONS = new Set<string>([
 ])
 const AGENT_EXEMPTIONS = new Set<string>([])
 
+function isSupportDirectory(entryName: string): boolean {
+  return entryName.startsWith("_")
+}
+
 function frontmatterName(filePath: string): string {
   const { data } = parseFrontmatter(readFileSync(filePath, "utf8"), filePath)
   return typeof data.name === "string" ? data.name : ""
@@ -24,7 +28,11 @@ function frontmatterName(filePath: string): string {
 
 describe("compound-engineering skill ce- prefix", () => {
   const skillDirs = readdirSync(SKILLS_DIR, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && !SKILL_EXEMPTIONS.has(entry.name))
+    .filter((entry) =>
+      entry.isDirectory() &&
+      !isSupportDirectory(entry.name) &&
+      !SKILL_EXEMPTIONS.has(entry.name),
+    )
     .map((entry) => entry.name)
 
   for (const dirName of skillDirs) {

--- a/tests/skills/ce-plan-html-output.test.ts
+++ b/tests/skills/ce-plan-html-output.test.ts
@@ -1,0 +1,121 @@
+import { readFileSync, statSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const root = process.cwd()
+const skillPath = path.join(root, "plugins/compound-engineering/skills/ce-plan/SKILL.md")
+const sharedPath = path.join(root, "plugins/compound-engineering/skills/_shared/html-output.md")
+const templatePath = path.join(root, "plugins/compound-engineering/skills/ce-plan/references/html-plan-template.md")
+const fixturePath = path.join(root, "tests/fixtures/ce-plan/sample-plan.html")
+
+const skill = readFileSync(skillPath, "utf8")
+const shared = readFileSync(sharedPath, "utf8")
+const template = readFileSync(templatePath, "utf8")
+const fixture = readFileSync(fixturePath, "utf8")
+
+function extractScriptJson(html: string, id: string): unknown {
+  const match = html.match(new RegExp(`<script type="application/json" id="${id}">([\\s\\S]*?)<\\/script>`))
+  expect(match, `Missing JSON script with id="${id}"`).not.toBeNull()
+  return JSON.parse(match![1].trim())
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+  return [...value.matchAll(pattern)].length
+}
+
+describe("ce-plan HTML output contract", () => {
+  test("SKILL.md documents HTML flag parsing without changing markdown default", () => {
+    expect(skill).toContain("`--html`")
+    expect(skill).toContain("bare `html`")
+    expect(skill).toContain("OUTPUT_FORMAT")
+    expect(skill).toContain("references/html-plan-template.md")
+    expect(skill).toContain("references/plan-template.md")
+    expect(skill).toContain("docs/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.md")
+    expect(skill).toContain("docs/plans/YYYY-MM-DD-NNN-<type>-<descriptive-name>-plan.html")
+  })
+
+  test("shared reference defines skeleton, CSS, frontmatter, anchors, SVG, and anti-bloat rules", () => {
+    expect(shared).toContain("<!DOCTYPE html>")
+    expect(shared).toContain("@media (prefers-color-scheme: dark)")
+    expect(shared).toContain("@media (max-width: 768px)")
+    expect(shared).toContain('type="application/json"')
+    expect(shared).toContain("#u1")
+    expect(shared).toContain("Data Flow")
+    expect(shared).toContain("Sequence")
+    expect(shared).toContain("Dependency")
+    expect(shared).toContain("No external resources")
+  })
+
+  test("html plan template carries plan-specific semantic structure", () => {
+    expect(template).toContain('<header class="doc-header">')
+    expect(template).toContain('<nav class="toc"')
+    expect(template).toContain('<main>')
+    expect(template).toContain('<section id="requirements">')
+    expect(template).toContain('<section id="implementation-units">')
+    expect(template).toContain('<article id="u1">')
+    expect(template).toContain('<section id="test-scenarios">')
+    expect(template).toContain('<section id="sources">')
+    expect(template).toContain('<th scope="col">R-ID</th>')
+    expect(template).toContain('<th scope="col">Category</th>')
+    expect(template).toContain("This is the HTML view of a ce-plan. Run ce-plan without --html")
+  })
+
+  test("sample fixture is a complete HTML5 document with required landmarks", () => {
+    expect(fixture.trimStart().startsWith("<!DOCTYPE html>")).toBe(true)
+    expect(fixture).toContain('<html lang="en">')
+    expect(fixture).toContain('<meta charset="utf-8">')
+    expect(fixture).toContain('<meta name="viewport" content="width=device-width, initial-scale=1">')
+    expect(fixture).toContain("<style>")
+    expect(fixture).toContain("<header")
+    expect(fixture).toContain("<nav")
+    expect(fixture).toContain("<main>")
+    expect(fixture).toContain("<footer")
+    expect(countMatches(fixture, /<section id="/g)).toBeGreaterThanOrEqual(6)
+  })
+
+  test("frontmatter JSON round-trips from the sample fixture", () => {
+    expect(extractScriptJson(fixture, "plan-frontmatter")).toEqual({
+      title: "Sample HTML Plan",
+      type: "feat",
+      status: "active",
+      date: "2026-05-08",
+      generated_by: "ce-plan",
+    })
+  })
+
+  test("sample fixture exposes frontmatter as status, type, and date pills", () => {
+    expect(fixture).toContain("pill-status-active")
+    expect(fixture).toContain("status: active")
+    expect(fixture).toContain("pill-type-feat")
+    expect(fixture).toContain("type: feat")
+    expect(fixture).toContain("pill-date")
+    expect(fixture).toContain("date: 2026-05-08")
+  })
+
+  test("implementation units have stable U-ID anchors matching nav links", () => {
+    expect(fixture).toContain('<a href="#u1">U1. Shared Reference</a>')
+    expect(fixture).toContain('<a href="#u2">U2. ce-plan Template</a>')
+    expect(fixture).toContain('<article id="u1">')
+    expect(fixture).toContain('<article id="u2">')
+  })
+
+  test("tables use real table semantics", () => {
+    expect(countMatches(fixture, /<table>/g)).toBeGreaterThanOrEqual(3)
+    expect(countMatches(fixture, /<thead>/g)).toBeGreaterThanOrEqual(3)
+    expect(countMatches(fixture, /<tbody>/g)).toBeGreaterThanOrEqual(3)
+    expect(fixture).toContain('<th scope="col">Requirement</th>')
+    expect(fixture).toContain('<th scope="row" data-label="R-ID">R1</th>')
+  })
+
+  test("sample fixture uses inline SVG and does not load external resources", () => {
+    expect(fixture).toContain("<svg")
+    expect(fixture).toContain("<title")
+    expect(fixture).not.toMatch(/<link\b[^>]+href=["']https?:/i)
+    expect(fixture).not.toMatch(/<script\b[^>]+src=["']https?:/i)
+    expect(fixture).not.toMatch(/<img\b[^>]+src=["']https?:/i)
+  })
+
+  test("sample fixture stays below the 80KB size budget", () => {
+    expect(statSync(fixturePath).size).toBeLessThan(80 * 1024)
+  })
+})


### PR DESCRIPTION
## Summary

ce-plan can now write plans as a single self-contained HTML file when invoked with `--html`. Default markdown output is unchanged.

The HTML view is a static read-mode artifact: human reviewers can open it in any browser without an editor, and frontmatter survives as both pill chips and a parseable JSON script tag. ce-work and the review skills continue to consume markdown plans, and a clear Implementation Note at the top of every HTML plan tells anyone who picks one up to run ce-plan without `--html` to produce the markdown source ce-work expects.

## Why this matters

- Plans pass 100 lines routinely, where markdown rendering starts to hurt. Two recent ce-plan PRs shipped fixes for markdown breakage in the Implementation Units template: [#766](https://github.com/EveryInc/compound-engineering-plugin/pull/766) (`fix(ce-plan): render Implementation Units as headings, not bulleted list items`) and [#765](https://github.com/EveryInc/compound-engineering-plugin/issues/765) (`ce-plan Implementation Units template breaks markdown rendering`). The pain of "plans should look right when a human reads them" is felt and recent.
- Inspired by [Thariq Shihipar's 2026-05-08 article on HTML for specs and plans](https://x.com/trq212/status/2052809885763747935) ([essay](https://thariqs.github.io/html-effectiveness/)). Markdown stays the workflow source of truth; HTML adds a shareable read-mode view.
- Pulse reports, code reviews, and compound learnings hit the same wall, so this PR establishes a shared HTML output reference (`plugins/compound-engineering/skills/_shared/html-output.md`) that other document-producing skills can adopt without re-writing CSS or HTML skeletons.

## Demo

The committed fixture at `tests/fixtures/ce-plan/sample-plan.html` is what `ce-plan --html` produces for a sample input. Download and open it in any browser to see the rendered output: status / type / date pills at the top, anchored TOC on the left, real `<table>` for Requirements traceability, real `<table>` for Test Scenarios nested inside each Implementation Unit's `<article id="uN">`, an inline SVG dependency diagram, the Implementation Note callout, and a dark-mode variant via `@media (prefers-color-scheme: dark)`. The fixture is 14KB, well under the 80KB anti-bloat budget.

Light mode, dark mode, and mobile (400px) viewports all render correctly when opened locally with headless Chrome.

## Scope

This is Phase 1 of a planned 6-phase rollout. Subsequent phases extend `--html` to the rest of the document-producing ce-* surface (ce-brainstorm, ce-strategy, ce-ideate, ce-debug, ce-doc-review, ce-code-review, ce-compound, ce-product-pulse, ce-sessions, plus the document tail), then a Phase 6 end-to-end pipeline integration test. Each phase ships as its own PR after this lands and the shared infrastructure design is validated.

Files in this PR:

- `plugins/compound-engineering/skills/_shared/html-output.md` (new) - shared HTML output reference: document skeleton, ~250-line embedded CSS theme with dark-mode and mobile breakpoints, frontmatter-as-JSON contract, anchor-ID conventions, inline-SVG patterns for data flow / sequence / dependency diagrams, anti-bloat rules, reuse contract.
- `plugins/compound-engineering/skills/ce-plan/references/html-plan-template.md` (new) - per-skill template that extends the shared skeleton with plan-specific structure: Requirements traceability `<table>`, Implementation Units as `<article id="uN">`, nested Test Scenarios tables, Implementation Note callout.
- `plugins/compound-engineering/skills/ce-plan/SKILL.md` (modified) - new "## Output Format" section, OUTPUT_FORMAT branch in Phase 4.2, post-generation menu shows "Open in browser" instead of "Start /ce-work" when in HTML mode.
- `plugins/compound-engineering/skills/ce-plan/references/visual-communication.md` (modified) - "## HTML Mode Diagrams" section pointing at the three SVG patterns in the shared reference.
- `tests/skills/ce-plan-html-output.test.ts` (new) - 10 Bun tests: HTML5 structure, frontmatter JSON round-trip, status/type/date pills, U-ID anchors matching nav, real table semantics, no external resource references, size budget under 80KB.
- `tests/fixtures/ce-plan/sample-plan.html` (new) - committed snapshot of expected output.
- `plugins/compound-engineering/README.md` (modified) - ce-plan row mentions `--html`.
- `tests/skill-agent-ce-prefix.test.ts` (modified) - exempts underscore-prefixed support directories from the `ce-` prefix invariant so `_shared/` is not treated as an installable skill. Necessary side effect of adding the shared directory; no other behavior change.

## Out of Scope (intentional follow-ups)

- Other ce-* skills get `--html` in Phases 2-5.
- Teaching ce-work / ce-doc-review / ce-code-review to consume HTML plans is a separate follow-up after Phase 5. Until then, every HTML artifact emits the Implementation Note.
- End-to-end HTML pipeline integration test is Phase 6.
- Two-way interactivity (sliders, copy-back-to-Claude buttons from the article) is a v2 concern once static HTML is stable.

## Tests

- `bun test`: 1355 pass, 0 fail (10 new tests for HTML output mode).
- `bun run release:validate`: passes; metadata still reports 49 agents, 37 skills, 0 MCP servers (the new `_shared/` directory is exempted from the installable-skill count by the prefix-invariant test).
- Default flagless ce-plan output is unchanged. The plan-template.md and the existing markdown rendering path are not touched.

## Open question

Where should the shared HTML output reference live?

  A. `plugins/compound-engineering/skills/_shared/html-output.md` (this PR)
  B. `plugins/compound-engineering/references/html-output.md` (plugin-level, not skill-scoped)
  C. A new sibling skill `ce-html-render` that other skills delegate to

I went with A because `references/` files already extend single skills today and the shared file is genuinely shared infrastructure rather than its own skill. The `_shared/` directory uses the underscore-prefix convention to signal "not an installable skill." Open to flipping if either of you prefer B or C; the next time this decision becomes load-bearing is when Phase 2 templates start importing from it.

AI was used for assistance.
