### PR TITLE
fix(ce-code-review): resolve base helper from skill dir

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -2,6 +2,7 @@
 name: ce-code-review
 description: "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR."
 argument-hint: "[blank to review current branch, or provide PR link]"
+allowed-tools: Bash(bash *resolve-base.sh)
 ---
 
 # Code Review
@@ -292,10 +293,10 @@ If the output is non-empty, inform the user: "You have uncommitted changes on th
 git checkout <branch>
 ```
 
-Then detect the review base branch and compute the merge-base. Run the `scripts/resolve-base.sh` script, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names):
+Then detect the review base branch and compute the merge-base. Run the bundled `resolve-base.sh` script via the runtime Bash tool, which handles fork-safe remote resolution with multi-fallback detection (PR metadata -> `origin/HEAD` -> `gh repo view` -> common branch names). On Claude Code, `${CLAUDE_SKILL_DIR}` resolves to the skill's own directory; the runtime Bash tool's CWD is the user's project, not the skill directory, so a bare `bash scripts/resolve-base.sh` fails. On other targets (Codex, Gemini, Pi, etc.) `${CLAUDE_SKILL_DIR}` is unset and the `:-.` fallback yields the bare relative path those harnesses expect:
 
 ```
-RESOLVE_OUT=$(bash scripts/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+RESOLVE_OUT=$(bash "${CLAUDE_SKILL_DIR:-.}/scripts/resolve-base.sh") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```
@@ -312,10 +313,10 @@ You may still fetch additional PR metadata with `gh pr view` for title, body, li
 
 **If no argument (standalone on current branch):**
 
-Detect the review base branch and compute the merge-base using the same `scripts/resolve-base.sh` script as branch mode:
+Detect the review base branch and compute the merge-base using the same bundled `resolve-base.sh` script as branch mode:
 
 ```
-RESOLVE_OUT=$(bash scripts/resolve-base.sh) || { echo "ERROR: resolve-base.sh failed"; exit 1; }
+RESOLVE_OUT=$(bash "${CLAUDE_SKILL_DIR:-.}/scripts/resolve-base.sh") || { echo "ERROR: resolve-base.sh failed"; exit 1; }
 if [ -z "$RESOLVE_OUT" ] || echo "$RESOLVE_OUT" | grep -q '^ERROR:'; then echo "${RESOLVE_OUT:-ERROR: resolve-base.sh produced no output}"; exit 1; fi
 BASE=$(echo "$RESOLVE_OUT" | sed 's/^BASE://')
 ```

--- a/tests/skills/ce-code-review.test.ts
+++ b/tests/skills/ce-code-review.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const SKILL_PATH = path.join(
+  process.cwd(),
+  "plugins/compound-engineering/skills/ce-code-review/SKILL.md",
+)
+const SKILL_BODY = readFileSync(SKILL_PATH, "utf8")
+
+describe("ce-code-review SKILL.md", () => {
+  test("does not invoke resolve-base.sh via a bare relative path", () => {
+    const codeFenceMatches = SKILL_BODY.match(/^RESOLVE_OUT=\$\(bash scripts\/resolve-base\.sh\)/gm)
+    expect(
+      codeFenceMatches,
+      "ce-code-review/SKILL.md re-introduced the bare 'bash scripts/resolve-base.sh' antipattern -- use 'bash \"${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh\"' instead. Bare relative paths fail at runtime because the Bash tool's CWD is the user's project, not the skill directory.",
+    ).toBeNull()
+  })
+
+  test("instructs the agent to invoke resolve-base.sh via a CLAUDE_SKILL_DIR-prefixed path", () => {
+    const skillDirPrefixed = /bash "\$\{CLAUDE_SKILL_DIR(?::-[^}]*)?\}\/scripts\/resolve-base\.sh"/
+    expect(
+      skillDirPrefixed.test(SKILL_BODY),
+      "ce-code-review/SKILL.md must instruct the agent to run 'bash \"${CLAUDE_SKILL_DIR}/scripts/resolve-base.sh\"' (or with a :- fallback) -- relative paths fail at runtime because the Bash tool's CWD is the user's project, not the skill directory.",
+    ).toBe(true)
+  })
+
+  test("uses a :- fallback so non-Claude targets get the bare relative path", () => {
+    expect(
+      SKILL_BODY.includes(`\${CLAUDE_SKILL_DIR:-.}/scripts/resolve-base.sh`),
+      "ce-code-review/SKILL.md must use the `${CLAUDE_SKILL_DIR:-.}` fallback form so non-Claude targets (Codex, Gemini, Pi, etc.) -- where the env var is unset -- fall back to the bare relative path rather than expanding to '/scripts/resolve-base.sh'.",
+    ).toBe(true)
+  })
+
+  test("declares a narrow allowed-tools pattern for resolve-base.sh", () => {
+    const frontmatter = SKILL_BODY.match(/^---\n([\s\S]*?)\n---/)
+    expect(frontmatter, "ce-code-review/SKILL.md must have YAML frontmatter").not.toBeNull()
+    const allowedTools = frontmatter![1].match(/^allowed-tools:\s*(.+)$/m)
+    expect(
+      allowedTools,
+      "ce-code-review/SKILL.md must declare `allowed-tools:` so users without bypassPermissions don't get a prompt every run.",
+    ).not.toBeNull()
+    const tools = allowedTools![1]
+    expect(
+      tools.includes(`Bash(bash *resolve-base.sh)`),
+      `ce-code-review/SKILL.md allowed-tools must include 'Bash(bash *resolve-base.sh)' so the runtime Bash call passes the permission check without granting blanket Bash access (got: ${tools})`,
+    ).toBe(true)
+    expect(
+      /Bash\(bash \*\)/.test(tools),
+      `ce-code-review/SKILL.md allowed-tools must NOT use the broad 'Bash(bash *)' pattern -- pin to the script filename instead (got: ${tools})`,
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
Howdy! Human here. 🤣 I had my clanker send some tokens on a PR to fix #811. This LGTM, let me know if this was helpful. 🙏🏻 Thanks again for all your great work. 

## Summary

Fixes the ce-code-review scope detection path that could make the skill look for `scripts/resolve-base.sh` in the user's project root instead of the bundled skill directory.

## What changed

- Add a narrow `allowed-tools` grant for `resolve-base.sh` so the runtime helper call does not require a recurring permission prompt.
- Update both branch-mode and standalone-mode helper invocations to use `${CLAUDE_SKILL_DIR:-.}/scripts/resolve-base.sh`, matching the existing ce-worktree helper-path pattern.
- Add regression coverage that rejects the bare `bash scripts/resolve-base.sh` antipattern and pins the permission pattern.

## Validation

- `bun test tests/skills/ce-code-review.test.ts tests/review-skill-contract.test.ts tests/skills/ce-worktree.test.ts tests/skills/ce-update.test.ts`
- `bun test` (1349 pass, 0 fail)

Fixes #811