### PR TITLE
fix(code-review): resolve PR base host-agnostically (GitHub Enterprise fork fix)

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -246,22 +246,23 @@ Then fetch PR metadata. Capture the base branch name and the PR base repository 
 gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url,reviews,comments --jq '{title, body, baseRefName, headRefName, url, hasPriorComments: ((.reviews | map(select(.state != "APPROVED" or .body != "")) | length) > 0 or (.comments | length) > 0)}'
 ```
 
-Derive both the host and the repository portion from the returned PR URL. Both are needed because remote URLs use the same `host` + `owner/repo` pair as the PR URL but in different shapes (HTTPS, SSH, scp-form), and any host other than `github.com` (GitHub Enterprise, self-hosted) must still match correctly. For example, from `https://github.com/EveryInc/compound-engineering-plugin/pull/348` use `github.com` as `<base-host>` and `EveryInc/compound-engineering-plugin` as `<base-repo>`. From `https://ghe.acme.com/Org/Repo/pull/12` use `ghe.acme.com` as `<base-host>` and `Org/Repo` as `<base-repo>`. Lowercase both before substituting; host and owner/repo are case-insensitive on GitHub and remote URLs may preserve user-typed casing.
+Derive both the host and the repository portion from the returned PR URL. Both are needed because remote URLs use the same `host` + `owner/repo` pair as the PR URL but in different shapes (HTTPS, SSH, scp-form), and any host other than `github.com` (GitHub Enterprise, self-hosted) must still match correctly. For example, from `https://github.com/EveryInc/compound-engineering-plugin/pull/348` use `github.com` as `<base-host>` and `EveryInc/compound-engineering-plugin` as `<base-repo>`. From `https://ghe.acme.com/Org/Repo/pull/12` use `ghe.acme.com` as `<base-host>` and `Org/Repo` as `<base-repo>`. From `https://ghe.acme.com:8443/Org/Repo/pull/12` preserve the port and use `ghe.acme.com:8443` as `<base-host>`. Lowercase both before substituting; host and owner/repo are case-insensitive on GitHub and remote URLs may preserve user-typed casing. For scp-form SSH remotes (`git@host:owner/repo.git`), match the host without the PR URL port as a fallback because scp-form syntax does not carry the web UI port.
 
 Then compute a local diff against the PR's base branch so re-reviews also include local fix commits and uncommitted edits. Substitute the PR base branch from metadata (shown here as `<base>`), the PR base host (shown here as `<base-host>`), and the PR base repository (shown here as `<base-repo>`). Resolve the base ref from the PR's actual base repository, not by assuming `origin` points at that repo:
 
 ```
 PR_BASE_REMOTE=$(git remote -v | awk -v host="<base-host>" -v repo="<base-repo>" '
+  BEGIN { host_without_port = host; sub(/:[0-9]+$/, "", host_without_port) }
   {
-    url = $2; h = ""; p = ""
+    url = $2; h = ""; p = ""; scp = 0
     if (match(url, /:\/\/[^\/]+\//))    { h = substr(url, RSTART+3, RLENGTH-4); p = substr(url, RSTART+RLENGTH) }
-    else if (match(url, /@[^:]+:/))     { h = substr(url, RSTART+1, RLENGTH-2); p = substr(url, RSTART+RLENGTH) }
+    else if (match(url, /@[^:]+:/))     { h = substr(url, RSTART+1, RLENGTH-2); p = substr(url, RSTART+RLENGTH); scp = 1 }
     else next
-    sub(/^[^@]*@/, "", h); sub(/:[0-9]+$/, "", h)
+    sub(/^[^@]*@/, "", h)
     h = tolower(h)
     if (!match(p, /^[^\/]+\/[^\/]+/)) next
     pr = substr(p, 1, RLENGTH); sub(/\.git$/, "", pr); pr = tolower(pr)
-    if (h == host && pr == repo) { print $1; exit }
+    if ((h == host || (scp && h == host_without_port)) && pr == repo) { print $1; exit }
   }')
 if [ -n "$PR_BASE_REMOTE" ]; then PR_BASE_REMOTE_REF="$PR_BASE_REMOTE/<base>"; else PR_BASE_REMOTE_REF=""; fi
 PR_BASE_REF=$(git rev-parse --verify "$PR_BASE_REMOTE_REF" 2>/dev/null || git rev-parse --verify <base> 2>/dev/null || true)

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -246,12 +246,23 @@ Then fetch PR metadata. Capture the base branch name and the PR base repository 
 gh pr view <number-or-url> --json title,body,baseRefName,headRefName,url,reviews,comments --jq '{title, body, baseRefName, headRefName, url, hasPriorComments: ((.reviews | map(select(.state != "APPROVED" or .body != "")) | length) > 0 or (.comments | length) > 0)}'
 ```
 
-Use the repository portion of the returned PR URL as `<base-repo>` (for example, `EveryInc/compound-engineering-plugin` from `https://github.com/EveryInc/compound-engineering-plugin/pull/348`).
+Derive both the host and the repository portion from the returned PR URL. Both are needed because remote URLs use the same `host` + `owner/repo` pair as the PR URL but in different shapes (HTTPS, SSH, scp-form), and any host other than `github.com` (GitHub Enterprise, self-hosted) must still match correctly. For example, from `https://github.com/EveryInc/compound-engineering-plugin/pull/348` use `github.com` as `<base-host>` and `EveryInc/compound-engineering-plugin` as `<base-repo>`. From `https://ghe.acme.com/Org/Repo/pull/12` use `ghe.acme.com` as `<base-host>` and `Org/Repo` as `<base-repo>`. Lowercase both before substituting; host and owner/repo are case-insensitive on GitHub and remote URLs may preserve user-typed casing.
 
-Then compute a local diff against the PR's base branch so re-reviews also include local fix commits and uncommitted edits. Substitute the PR base branch from metadata (shown here as `<base>`) and the PR base repository identity derived from the PR URL (shown here as `<base-repo>`). Resolve the base ref from the PR's actual base repository, not by assuming `origin` points at that repo:
+Then compute a local diff against the PR's base branch so re-reviews also include local fix commits and uncommitted edits. Substitute the PR base branch from metadata (shown here as `<base>`), the PR base host (shown here as `<base-host>`), and the PR base repository (shown here as `<base-repo>`). Resolve the base ref from the PR's actual base repository, not by assuming `origin` points at that repo:
 
 ```
-PR_BASE_REMOTE=$(git remote -v | awk 'index($2, "github.com:<base-repo>") || index($2, "github.com/<base-repo>") {print $1; exit}')
+PR_BASE_REMOTE=$(git remote -v | awk -v host="<base-host>" -v repo="<base-repo>" '
+  {
+    url = $2; h = ""; p = ""
+    if (match(url, /:\/\/[^\/]+\//))    { h = substr(url, RSTART+3, RLENGTH-4); p = substr(url, RSTART+RLENGTH) }
+    else if (match(url, /@[^:]+:/))     { h = substr(url, RSTART+1, RLENGTH-2); p = substr(url, RSTART+RLENGTH) }
+    else next
+    sub(/^[^@]*@/, "", h); sub(/:[0-9]+$/, "", h)
+    h = tolower(h)
+    if (!match(p, /^[^\/]+\/[^\/]+/)) next
+    pr = substr(p, 1, RLENGTH); sub(/\.git$/, "", pr); pr = tolower(pr)
+    if (h == host && pr == repo) { print $1; exit }
+  }')
 if [ -n "$PR_BASE_REMOTE" ]; then PR_BASE_REMOTE_REF="$PR_BASE_REMOTE/<base>"; else PR_BASE_REMOTE_REF=""; fi
 PR_BASE_REF=$(git rev-parse --verify "$PR_BASE_REMOTE_REF" 2>/dev/null || git rev-parse --verify <base> 2>/dev/null || true)
 if [ -z "$PR_BASE_REF" ]; then
@@ -259,7 +270,7 @@ if [ -z "$PR_BASE_REF" ]; then
     git fetch --no-tags "$PR_BASE_REMOTE" <base>:refs/remotes/"$PR_BASE_REMOTE"/<base> 2>/dev/null || git fetch --no-tags "$PR_BASE_REMOTE" <base> 2>/dev/null || true
     PR_BASE_REF=$(git rev-parse --verify "$PR_BASE_REMOTE_REF" 2>/dev/null || git rev-parse --verify <base> 2>/dev/null || true)
   else
-    if git fetch --no-tags https://github.com/<base-repo>.git <base> 2>/dev/null; then
+    if git fetch --no-tags https://<base-host>/<base-repo>.git <base> 2>/dev/null; then
       PR_BASE_REF=$(git rev-parse --verify FETCH_HEAD 2>/dev/null || true)
     fi
     if [ -z "$PR_BASE_REF" ]; then PR_BASE_REF=$(git rev-parse --verify <base> 2>/dev/null || true); fi

--- a/tests/skills/ce-code-review-base-remote-matcher.test.ts
+++ b/tests/skills/ce-code-review-base-remote-matcher.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const SKILL_PATH = path.join(
+  process.cwd(),
+  "plugins/compound-engineering/skills/ce-code-review/SKILL.md",
+)
+const SKILL_BODY = readFileSync(SKILL_PATH, "utf8")
+
+const awkMatch = SKILL_BODY.match(
+  /awk -v host="<base-host>" -v repo="<base-repo>" '\n(?<program>[\s\S]*?\n  })'\)/,
+)
+const AWK_PROGRAM = awkMatch?.groups?.program ?? ""
+
+async function matchRemote(
+  remotes: string,
+  host: string,
+  repo: string,
+): Promise<string> {
+  const proc = Bun.spawn(
+    ["awk", "-v", `host=${host}`, "-v", `repo=${repo}`, AWK_PROGRAM],
+    {
+      stdin: new TextEncoder().encode(remotes),
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  )
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+  const exitCode = await proc.exited
+
+  expect(stderr).toBe("")
+  expect(exitCode).toBe(0)
+  return stdout.trim()
+}
+
+describe("ce-code-review PR base remote matcher", () => {
+  test("extracts the embedded AWK matcher from SKILL.md", () => {
+    expect(AWK_PROGRAM).not.toBe("")
+  })
+
+  test("matches HTTPS remotes on a ported GitHub Enterprise host", async () => {
+    await expect(
+      matchRemote(
+        "base https://ghe.acme.com:8443/Org/Repo.git (fetch)\n",
+        "ghe.acme.com:8443",
+        "org/repo",
+      ),
+    ).resolves.toBe("base")
+  })
+
+  test("matches ssh URL remotes on a ported GitHub Enterprise host", async () => {
+    await expect(
+      matchRemote(
+        "base ssh://git@ghe.acme.com:8443/Org/Repo.git (fetch)\n",
+        "ghe.acme.com:8443",
+        "org/repo",
+      ),
+    ).resolves.toBe("base")
+  })
+
+  test("allows scp-form SSH remotes to omit the PR URL port", async () => {
+    await expect(
+      matchRemote(
+        [
+          "wrongport https://ghe.acme.com:9443/Org/Repo.git (fetch)",
+          "base git@ghe.acme.com:Org/Repo.git (fetch)",
+        ].join("\n") + "\n",
+        "ghe.acme.com:8443",
+        "org/repo",
+      ),
+    ).resolves.toBe("base")
+  })
+
+  test("does not match a different port for URL-form remotes", async () => {
+    await expect(
+      matchRemote(
+        "wrongport https://ghe.acme.com:9443/Org/Repo.git (fetch)\n",
+        "ghe.acme.com:8443",
+        "org/repo",
+      ),
+    ).resolves.toBe("")
+  })
+})


### PR DESCRIPTION
## Summary

The stable `ce-code-review` skill silently picks the wrong merge base — or no base at all — on **GitHub Enterprise** or any non-`github.com` host when the reviewer is working from a fork. The base-resolution awk block in `SKILL.md` matches remotes by literal `github.com:` / `github.com/` substring, and the HTTPS fallback URL is hard-coded to `https://github.com/...`. On GHE, `PR_BASE_REMOTE` ends up empty, the script falls through to `origin`, and in fork workflows `origin` is the user's fork — so the resulting diff is either empty, incorrect, or relative to the wrong base.

This PR makes base resolution host-agnostic: the agent derives both `<base-host>` and `<base-repo>` from the same PR URL it already parses, and the awk block extracts `(host, owner/repo)` from each remote URL generically. No behavior change for `github.com` users.

## How this was uncovered

While building **`ce-code-review-beta`** in #784 (Codex CLI delegation), the Codex code-review bot flagged the identical hard-coding pattern in the beta variant's `resolve-base.sh`:

> The PR-base detection is hard-coded to `https://github.com/...` and later remote matching is hard-coded to `github.com:` / `github.com/`, so reviews on GitHub Enterprise (or any non-`github.com` host) will fail to identify the true base remote. In fork setups this can silently fall back to `origin`, producing the wrong merge base (or no base) even when the correct upstream remote exists.

That feedback was resolved in #784. Auditing the stable skill on `main` confirmed the same root cause — now living inline in `SKILL.md` after #815 replaced the standalone script with prose-driven base detection. This PR ports the fix.

## What changed

`plugins/compound-engineering/skills/ce-code-review/SKILL.md` — base-resolution prose and awk:

- **Prose:** instructs the agent to derive both `<base-host>` and `<base-repo>` from the PR URL (previously only the repo portion). Calls out case-insensitivity and shows a GHE example alongside the existing `github.com` example.
- **awk:** replaces the two `index($2, "github.com:<base-repo>") || index($2, "github.com/<base-repo>")` substring checks with a per-remote parser that handles:
  - `https://[user@]host[:port]/owner/repo[.git]`
  - `ssh://[user@]host[:port]/owner/repo[.git]`
  - scp-form `user@host:owner/repo[.git]`
  - Strips userinfo, port, and trailing `.git`; lowercases host and owner/repo before exact-equality comparison.
- **HTTPS fallback URL:** `https://github.com/<base-repo>.git` → `https://<base-host>/<base-repo>.git`.

## Why this is safe to merge

- **No new dependencies, no new scripts**: the change stays inline per #815's design intent (prose-driven base detection).
- **No behavior change on `github.com`**: the new awk produces the same remote pick for canonical `github.com` URLs, verified across HTTPS, scp-form, mixed-case, userinfo, port, and `.git`/no-`.git` variants.
- **Boundary case preserved**: `org/repo` PR does not spuriously match a remote at `org/repo-extra` (exact equality, not substring).
- **No test regressions**: full `bun test` suite passes (1340/1340); `bun run release:validate` clean.
- **Diff is small**: 1 file, +15/-4 lines.

## Test plan

- [x] `bun test` — all 1340 tests pass on this branch
- [x] `bun run release:validate` — metadata in sync
- [x] Awk smoke test with realistic remote URL forms:
  - `git@ghe.acme.com:EveryInc/compound-engineering-plugin.git` matches `(ghe.acme.com, everyinc/compound-engineering-plugin)` ✓
  - `https://x-token@ghe.acme.com/Org/Repo.git` matches `(ghe.acme.com, org/repo)` ✓
  - `git@github.com:org/repo-extra.git` does **not** match `(github.com, org/repo)` ✓
  - `git@github.com:org/repo.git` still matches `(github.com, org/repo)` ✓ (regression guard)

## Related

- Upstream feedback that surfaced this: [Codex review on #784](https://github.com/EveryInc/compound-engineering-plugin/pull/784#issuecomment-4390521308)
- Fix in beta variant: davidalee/compound-engineering-plugin@c09b90d7 (part of PR #784)
- Prior design context: #815 (replaced the standalone `resolve-base.sh` with inline prose)