### PR TITLE
fix(skills): resolve bundled resources from skill roots

### DIFF
--- a/plugins/coding-tutor/skills/coding-tutor/SKILL.md
+++ b/plugins/coding-tutor/skills/coding-tutor/SKILL.md
@@ -3,6 +3,8 @@ name: coding-tutor
 description: Personalized coding tutorials that build on your existing knowledge and use your actual codebase for examples. Creates a persistent learning trail that compounds over time using the power of AI, spaced repetition and quizes.
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 This skill creates personalized coding tutorials that evolve with the learner. Each tutorial builds on previous ones, uses real examples from the current codebase, and maintains a persistent record of concepts mastered.
 
 The user asks to learn something - either a specific concept or an open "teach me something new" request.

--- a/plugins/compound-engineering/skills/ce-agent-native-architecture/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-agent-native-architecture/SKILL.md
@@ -3,6 +3,8 @@ name: ce-agent-native-architecture
 description: Build applications where agents are first-class citizens. Use this skill when designing autonomous agents, creating MCP tools, implementing self-modifying systems, or building apps where features are outcomes achieved by agents operating in a loop.
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 <overview>
 ## Agent-Native Architecture
 

--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -4,6 +4,8 @@ description: 'Explore requirements and approaches through collaborative dialogue
 argument-hint: "[feature idea or problem to explore]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Brainstorm a Feature or Improvement
 
 **Note: The current year is 2026.** Use this when dating requirements documents.

--- a/plugins/compound-engineering/skills/ce-clean-gone-branches/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-clean-gone-branches/SKILL.md
@@ -3,6 +3,8 @@ name: ce-clean-gone-branches
 description: Clean up local branches whose remote tracking branch is gone. Use when the user says "clean up branches", "delete gone branches", "prune local branches", "clean gone", or wants to remove stale local branches that no longer exist on the remote. Also handles removing associated worktrees for branches that have them.
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Clean Gone Branches
 
 Delete local branches whose remote tracking branch has been deleted, including any associated worktrees.

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -4,6 +4,8 @@ description: "Structured code review using tiered persona agents, confidence-gat
 argument-hint: "[blank to review current branch, or provide PR link]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Code Review
 
 Reviews code changes using dynamically selected reviewer personas. Spawns parallel sub-agents that return structured JSON, then merges and deduplicates findings into a single report.

--- a/plugins/compound-engineering/skills/ce-commit-push-pr/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-commit-push-pr/SKILL.md
@@ -3,6 +3,8 @@ name: ce-commit-push-pr
 description: Commit, push, and open a PR with an adaptive, value-first description that scales in depth with the change. Use when the user says "commit and PR", "ship this", "create a PR", or "open a pull request". Also handles description-only flows ("write a PR description", "rewrite the PR body", "describe this PR") without committing or pushing.
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Git Commit, Push, and PR
 
 **Asking the user:** When this skill says "ask the user", use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting the question in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.

--- a/plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound-refresh/SKILL.md
@@ -4,6 +4,8 @@ description: Refresh stale learning and pattern docs under docs/solutions/ by re
 argument-hint: "[optional: scope hint — directory, filename, module, or keyword] [mode:headless] "
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Compound Refresh
 
 Maintain the quality of `docs/solutions/` over time. This workflow reviews existing learnings against the current codebase, then refreshes any derived pattern docs that depend on them.

--- a/plugins/compound-engineering/skills/ce-compound/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound/SKILL.md
@@ -4,6 +4,8 @@ description: Document a recently solved problem to compound your team's knowledg
 argument-hint: "[optional: brief context] [mode:headless] "
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # /ce-compound
 
 Coordinate multiple subagents working in parallel to document a recently solved problem.

--- a/plugins/compound-engineering/skills/ce-debug/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-debug/SKILL.md
@@ -4,6 +4,8 @@ description: 'Systematically find root causes and fix bugs. Use when debugging e
 argument-hint: "[issue reference, error message, test path, or description of broken behavior]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Debug and Fix
 
 Find root causes, then fix them. This skill investigates bugs systematically — tracing the full causal chain before proposing a fix — and optionally implements the fix with test-first discipline.

--- a/plugins/compound-engineering/skills/ce-demo-reel/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-demo-reel/SKILL.md
@@ -4,6 +4,8 @@ description: "Capture a visual demo reel (GIF, terminal recording, screenshots) 
 argument-hint: "[what to capture, e.g. 'the new settings page' or 'CLI output of the migrate command']"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Demo Reel
 
 Detect project type, recommend a capture tier, record visual evidence, upload to a public URL, and return markdown for PR inclusion.

--- a/plugins/compound-engineering/skills/ce-dhh-rails-style/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-dhh-rails-style/SKILL.md
@@ -3,6 +3,8 @@ name: ce-dhh-rails-style
 description: This skill should be used when writing Ruby and Rails code in DHH's distinctive 37signals style. It applies when writing Ruby code, Rails applications, creating models, controllers, or any Ruby file. Triggers on Ruby/Rails code generation, refactoring requests, code review, or when the user mentions DHH, 37signals, Basecamp, HEY, or Campfire style. Embodies REST purity, fat models, thin controllers, Current attributes, Hotwire patterns, and the "clarity over cleverness" philosophy.
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 <objective>
 Apply 37signals/DHH Rails conventions to Ruby and Rails code. This skill provides comprehensive domain expertise extracted from analyzing production 37signals codebases (Fizzy/Campfire) and DHH's code review patterns.
 </objective>

--- a/plugins/compound-engineering/skills/ce-doc-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-doc-review/SKILL.md
@@ -4,6 +4,8 @@ description: Review requirements or plan documents using parallel persona agents
 argument-hint: "[mode:headless] [path/to/document.md]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Document Review
 
 Review requirements or plan documents through multi-persona analysis. Dispatches specialized reviewer agents in parallel, auto-applies `safe_auto` fixes, and routes remaining findings through a four-option interaction (per-finding walk-through, auto-resolve with best judgment, Append-to-Open-Questions, Report-only) for user decision.

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -5,6 +5,8 @@ argument-hint: "[feature, focus area, or constraint]"
 
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Generate Improvement Ideas
 
 **Note: The current year is 2026.** Use this when dating ideation documents and checking recent ideation artifacts.

--- a/plugins/compound-engineering/skills/ce-optimize/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-optimize/SKILL.md
@@ -4,6 +4,8 @@ description: "Run metric-driven iterative optimization loops -- define a measura
 argument-hint: "[path to optimization spec YAML, or describe the optimization goal]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Iterative Optimization Loop
 
 Run metric-driven iterative optimization. Define a goal, build measurement scaffolding, then run parallel experiments that converge toward the best solution.

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -4,6 +4,8 @@ description: "Create structured plans for multi-step tasks -- software features,
 argument-hint: "[optional: feature description, requirements doc path, plan path to deepen, or any task to plan]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Create Technical Plan
 
 **Note: The current year is 2026.** Use this when dating plans and searching for recent documentation.

--- a/plugins/compound-engineering/skills/ce-polish-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-polish-beta/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 argument-hint: "[PR number, branch name, or blank for current branch]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Polish
 
 Start the dev server, open the feature in a browser, and iterate. You use the feature, say what feels off, and fixes happen.

--- a/plugins/compound-engineering/skills/ce-product-pulse/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-product-pulse/SKILL.md
@@ -11,6 +11,8 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Product Pulse
 
 `ce-product-pulse` queries the product's data sources for a given time window and produces a compact, single-page report covering usage, performance, errors, and followups. The report is saved to `docs/pulse-reports/` and the key points are surfaced in chat.

--- a/plugins/compound-engineering/skills/ce-proof/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-proof/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools:
   - WebFetch
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Proof - Collaborative Markdown Editor
 
 Proof is a collaborative document editor for humans and agents. It supports two modes:

--- a/plugins/compound-engineering/skills/ce-release-notes/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-release-notes/SKILL.md
@@ -5,6 +5,8 @@ argument-hint: "[optional: question about a past release]"
 disable-model-invocation: true
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Compound-Engineering Release Notes
 
 Look up what shipped in recent releases of the compound-engineering plugin. Bare invocation summarizes the last 5 plugin releases. Argument invocation searches the last 40 releases and answers a specific question, citing the release version that introduced the change.
@@ -22,7 +24,7 @@ Version-like inputs (`2.65.0`, `v2.65.0`, `compound-engineering-v2.65.0`) are qu
 
 ## Phase 2 — Fetch Releases (Summary Mode)
 
-Run the helper from the skill directory:
+Run the bundled helper:
 
 ```bash
 python3 scripts/list-plugin-releases.py --limit 40

--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/SKILL.md
@@ -5,6 +5,8 @@ argument-hint: "[PR number, comment URL, or blank for current branch's PR]"
 allowed-tools: Bash(gh *), Bash(git *), Read
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Resolve PR Review Feedback
 
 Evaluate and fix PR review feedback, then reply and resolve threads. Spawns parallel agents for each thread.

--- a/plugins/compound-engineering/skills/ce-riffrec-feedback-analysis/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-riffrec-feedback-analysis/SKILL.md
@@ -3,6 +3,8 @@ name: ce-riffrec-feedback-analysis
 description: Riffrec product-feedback workflow. ALWAYS load when the user posts a `riffrec-*.zip`, a bundle with `session.json` + `events.json` + `recording.webm` + `voice.webm`, a video/audio recording for product feedback, or asks how to capture and share Riffrec sessions. Routes between setup, quick bug report, and extensive analysis.
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Riffrec Feedback Analysis
 
 Turn raw product feedback into structured evidence for downstream agents. This skill is the consumption side of [Riffrec](https://github.com/kieranklaassen/riffrec), a capture tool that records synchronized screen + voice + event sessions and emits a `riffrec-*.zip` bundle.

--- a/plugins/compound-engineering/skills/ce-sessions/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-sessions/SKILL.md
@@ -3,6 +3,8 @@ name: ce-sessions
 description: "Search and ask questions about coding agent session history across Claude Code, Codex, and Cursor. Use when asking what was worked on, what was tried before, how a problem was investigated across sessions, what happened recently, or any question about past agent sessions. Also use when the user references prior sessions, previous attempts, or past investigations — even without saying 'sessions' explicitly."
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # /ce-sessions
 
 Search session history across Claude Code, Codex, and Cursor and synthesize findings about what was worked on, tried, decided, or learned in prior sessions.

--- a/plugins/compound-engineering/skills/ce-setup/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-setup/SKILL.md
@@ -4,6 +4,8 @@ description: "Diagnose and configure compound-engineering environment. Checks CL
 disable-model-invocation: true
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Compound Engineering Setup
 
 ## Interaction Method

--- a/plugins/compound-engineering/skills/ce-strategy/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-strategy/SKILL.md
@@ -4,6 +4,8 @@ description: "Create or maintain STRATEGY.md - the product's target problem, app
 argument-hint: "[optional: section to revisit, e.g. 'metrics' or 'approach']"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Product Strategy
 
 **Note: The current year is 2026.** Use this when dating the strategy document.

--- a/plugins/compound-engineering/skills/ce-update/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-update/SKILL.md
@@ -12,6 +12,8 @@ ce_platforms: [claude]
 allowed-tools: Bash(bash *upstream-version.sh), Bash(bash *currently-loaded-version.sh), Bash(bash *marketplace-name.sh)
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Check Plugin Version
 
 Verify the installed compound-engineering plugin version matches the upstream

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -5,6 +5,8 @@ disable-model-invocation: true
 argument-hint: "[Plan doc path or description of work. Blank to auto use latest plan doc] [delegate:codex]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Work Execution Command
 
 Execute work efficiently while maintaining quality and finishing features.

--- a/plugins/compound-engineering/skills/ce-work/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work/SKILL.md
@@ -4,6 +4,8 @@ description: Execute work efficiently while maintaining quality and finishing fe
 argument-hint: "[Plan doc path or description of work. Blank to auto use latest plan doc]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Work Execution Command
 
 Execute work efficiently while maintaining quality and finishing features.

--- a/plugins/compound-engineering/skills/ce-worktree/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-worktree/SKILL.md
@@ -4,6 +4,8 @@ description: Create an isolated git worktree for parallel feature work or PR rev
 allowed-tools: Bash(bash *worktree-manager.sh)
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 # Worktree Creation
 
 Create a worktree under `.worktrees/<branch>` with branch-specific setup that `git worktree add` alone does not handle:
@@ -15,7 +17,7 @@ Create a worktree under `.worktrees/<branch>` with branch-specific setup that `g
 
 ## Creating a worktree
 
-Invoke the bundled script via the runtime Bash tool. On Claude Code, `${CLAUDE_SKILL_DIR}` resolves to the skill's own directory across both marketplace-cached installs and `claude --plugin-dir` local development; the runtime Bash tool's CWD is the user's project, not the skill directory, so a bare `bash scripts/worktree-manager.sh` fails. On other targets (Codex, Gemini, Pi, etc.) `${CLAUDE_SKILL_DIR}` is unset and the `:-.` fallback yields the bare relative path those harnesses expect.
+Invoke the bundled script via the runtime Bash tool using the concrete path expression below. On Claude Code, `${CLAUDE_SKILL_DIR}` resolves to the skill's own directory across both marketplace-cached installs and `claude --plugin-dir` local development; the runtime Bash tool's cwd is the user's project, not the skill directory, so a bare `bash scripts/worktree-manager.sh` fails. On other targets (Codex, Gemini, Pi, etc.) `${CLAUDE_SKILL_DIR}` is unset and the `:-.` fallback yields the bare relative path those harnesses expect.
 
 ```bash
 bash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create <branch-name> [from-branch]

--- a/plugins/compound-engineering/skills/lfg/SKILL.md
+++ b/plugins/compound-engineering/skills/lfg/SKILL.md
@@ -4,6 +4,8 @@ description: Run the full autonomous engineering pipeline end-to-end (plan, work
 argument-hint: "[feature description]"
 ---
 
+**Bundled resource paths:** Resolve every path in this skill that starts with `assets/`, `references/`, or `scripts/` relative to this `SKILL.md` file's directory (the skill directory), not the user's project cwd.
+
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 1) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
 When invoking any skill referenced below, resolve its name against the available-skills list the host platform provides and use that exact entry. Some platforms list skills under a plugin namespace (e.g., `compound-engineering:ce-plan`); others list the bare name. Invoking a short-form guess that isn't in the list will fail — always match a listed entry verbatim before calling the Skill/Task tool.


### PR DESCRIPTION
## Summary

Clarifies how skill-local bundled resource paths are resolved across Compound Engineering skills.

Skills that reference `assets/`, `references/`, or `scripts/` now explicitly state that those paths must be resolved relative to the current `SKILL.md` directory, not the user's project cwd.

This matters for portability across agent runtimes. Claude Code, Codex, Cursor, and other environments can differ in their working directory and skill loading behavior, so relying on implicit cwd resolution can make bundled references fail outside one specific harness.

## Changes

- Added a consistent bundled resource path rule to skills that reference `assets/`, `references/`, or `scripts/`.
- Normalized ad-hoc helper/script wording to point back to the shared rule.
- Kept skill references self-contained and independent of the user's project cwd.

## Validation

- `git diff --check`
- `bun run release:validate`
