### PR TITLE
fix(codex): respect CODEX_HOME for profile installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,27 @@ Three steps: register the marketplace, install the agent set, then install the p
    bunx @every-env/compound-plugin install compound-engineering --to codex
    ```
 
-3. **Install the plugin through Codex's TUI:** launch `codex`, run `/plugins`, find the **Compound Engineering** marketplace, select the **compound-engineering** plugin, and choose **Install**. Restart Codex after install completes. Codex's CLI does not currently have a subcommand for installing a plugin from an added marketplace -- the `/plugins` TUI is the canonical flow.
+3. **Install the plugin through Codex's TUI:** launch `codex`, run `/plugins`, find the **Compound Engineering** marketplace, select the **compound-engineering** plugin, and choose **Install**. Restart Codex after install completes. Codex's CLI can register marketplaces, but it does not currently expose a plugin-install subcommand for plugins from an added marketplace -- the `/plugins` TUI install is required for CE skills.
 
 All three steps are needed. The marketplace registration plus TUI install handles skills; the Bun step adds the review, research, and workflow agents that skills like `$ce-code-review`, `$ce-plan`, and `$ce-work` spawn in Codex. Without the agent step, delegating skills will report missing agents.
+
+For a non-default Codex profile, run every Codex-related step against the same `CODEX_HOME`. This example installs CE into a `work` profile:
+
+```bash
+CODEX_HOME="$HOME/.codex/profiles/work" codex plugin marketplace add EveryInc/compound-engineering-plugin
+CODEX_HOME="$HOME/.codex/profiles/work" bunx @every-env/compound-plugin install compound-engineering --to codex
+CODEX_HOME="$HOME/.codex/profiles/work" codex
+```
+
+Inside Codex, run `/plugins`, select **Compound Engineering**, then install **compound-engineering**. The marketplace step only makes the plugin available; the TUI install is what activates the native CE skills for that profile.
+
+For local development from this checkout, register the current worktree and use the local CLI:
+
+```bash
+CODEX_HOME="$HOME/.codex/profiles/work" codex plugin marketplace add "$PWD"
+CODEX_HOME="$HOME/.codex/profiles/work" bun run src/index.ts install ./plugins/compound-engineering --to codex
+CODEX_HOME="$HOME/.codex/profiles/work" codex
+```
 
 > **Heads up:** once Codex's native plugin spec supports custom agents, the Bun agent step goes away. The TUI install alone will be sufficient.
 

--- a/docs/solutions/integrations/native-plugin-install-strategy-2026-04-19.md
+++ b/docs/solutions/integrations/native-plugin-install-strategy-2026-04-19.md
@@ -43,7 +43,7 @@ This document records the intended install model by harness. The current priorit
 | Qwen Code | Native extension install from the CE GitHub repository and existing Claude plugin metadata | No, CE plugin install/convert target removed | Yes, before or during migration from previous `~/.qwen` custom installs | Qwen docs say Claude Code extensions install directly from GitHub and are converted automatically; native install was manually tested on 2026-04-19. |
 | OpenCode | Custom CE install to `~/.config/opencode/{skills,agents,plugins}` plus merged `opencode.json`; source commands are written only if present | Yes | Yes, every install | OpenCode plugins are JS/TS or npm hooks/tools, not a Claude-compatible marketplace install path for CE's full plugin payload. |
 | Pi | Custom CE install to `~/.pi/agent/{skills,prompts,extensions}` plus MCPorter config; source commands are written only if present | Yes, until CE ships and tests a Pi package | Yes, every install | Pi has package install support, but CE has not yet packaged the compat extension, generated skills, prompts, and MCPorter config into a tested Pi package. |
-| Codex | Custom CE install to `~/.codex/skills/compound-engineering/<skill>` and `~/.codex/agents/compound-engineering/<agent>.toml` | Yes, because native Codex plugins do not currently register bundled custom agents | Yes, every install | Avoid `~/.agents/skills` so Codex installs do not shadow Copilot's native plugin skills. Claude agents are converted to Codex TOML custom agents. |
+| Codex | Hybrid: native Codex plugin install for skills, plus CE Bun install for custom agents under the active Codex root | Yes, for agents only, because native Codex plugins do not currently register bundled custom agents | Yes, every Bun agent install | Use the same `CODEX_HOME` or `--codex-home` for every Codex step when installing into a non-default profile. |
 | Gemini CLI | Custom CE install to `~/.gemini/{skills,agents}` for now; source commands are written only if present; native extension packaging exists but does not fit CE's current repo/package layout | Yes, until CE ships a Gemini extension root, release artifact, or dedicated distribution branch/repo | Yes, every install | Avoid `~/.agents/skills`; write normalized Gemini agents to `~/.gemini/agents`. |
 | Kiro CLI | Custom CE install to project `.kiro/{skills,agents,steering,settings}` | Yes | Yes, every install; manual `cleanup --target kiro` also exists | Kiro has its own JSON agent format and project-local install root. |
 
@@ -370,6 +370,22 @@ Future Pi package work should preserve the same cleanup semantics before switchi
 
 ### Current Platform Facts
 
+Update on 2026-05-14: CE's Codex install is now a hybrid profile-aware flow:
+
+1. `codex plugin marketplace add <source>` registers the marketplace in the active Codex home.
+2. The Codex `/plugins` TUI installs the native CE plugin skills from that marketplace.
+3. `bunx @every-env/compound-plugin install compound-engineering --to codex` installs the CE custom agents that those skills delegate to.
+
+All three operations must target the same Codex root. For a named profile, set `CODEX_HOME` consistently:
+
+```bash
+CODEX_HOME="$HOME/.codex/profiles/work" codex plugin marketplace add EveryInc/compound-engineering-plugin
+CODEX_HOME="$HOME/.codex/profiles/work" bunx @every-env/compound-plugin install compound-engineering --to codex
+CODEX_HOME="$HOME/.codex/profiles/work" codex
+```
+
+Inside Codex, run `/plugins`, select the Compound Engineering marketplace, and install `compound-engineering`. The marketplace registration alone only makes the plugin available; the TUI install activates native skills. The Bun step is still required for CE's custom agents until Codex native plugins can register bundled agents.
+
 Current Codex docs describe user skills under `~/.agents/skills` and repo skills under `.agents/skills`. Codex also reads admin skills from `/etc/codex/skills` and system skills bundled by OpenAI. Codex supports symlinked skill folders and follows symlink targets.
 
 Empirical note: Codex also still discovers legacy `~/.codex/skills` entries. On 2026-04-18, we created the same skill name in both `~/.agents/skills/ce-duplicate-discovery-smoke` and `~/.codex/skills/ce-duplicate-discovery-smoke`; the Codex skill picker showed both entries.
@@ -542,11 +558,11 @@ But CE should no longer install there because Copilot plugin skills can be shado
 
 ### Future Codex Plugin Option
 
-Codex now has a documented marketplace/plugin install path, including `codex marketplace add <source>`, but CE should not use it as the primary Codex install path yet because plugin-bundled custom agents did not register in testing.
+Codex now has a documented marketplace/plugin install path. CE uses it for skills, but it still cannot be the only install path because plugin-bundled custom agents did not register in testing.
 
 Revisit Codex native plugins when Codex documents and supports plugin-bundled custom agents, or when the plugin installer can declare files that should be installed into the user's custom-agent roots.
 
-Until then, Codex native plugins are useful for local development and testing skill-only packages, but not for CE's agent-heavy workflows.
+Until then, the expected Codex install remains hybrid: native plugin install for skills, plus the CE Bun install for converted custom agents.
 
 ## Gemini CLI
 

--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -27,7 +27,7 @@ import { isManagedCodexAgentsSymlink, readCodexInstallManifest, resolveCodexMana
 import { classifyCodexLegacyPromptOwnership } from "../utils/legacy-cleanup"
 import { isSafeManagedPath, pathExists, readJson, sanitizePathName } from "../utils/files"
 import { resolveOpenCodeGlobalRoot } from "../utils/opencode-config"
-import { expandHome, resolveTargetHome } from "../utils/resolve-home"
+import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
 
 const cleanupTargets = ["codex", "opencode", "pi", "gemini", "kiro", "copilot", "droid", "qwen", "windsurf"] as const
 type CleanupTarget = typeof cleanupTargets[number]
@@ -62,7 +62,7 @@ export default defineCommand({
     codexHome: {
       type: "string",
       alias: "codex-home",
-      description: "Codex root to clean (default: ~/.codex)",
+      description: "Codex root to clean (default: $CODEX_HOME or ~/.codex)",
     },
     piHome: {
       type: "string",
@@ -121,7 +121,7 @@ export default defineCommand({
     const hasExplicitGeminiHome = hasExplicitValue(args.geminiHome)
     const hasExplicitOpenCodeHome = hasExplicitValue(args.opencodeHome)
     const roots = {
-      codexHome: resolveTargetHome(args.codexHome, path.join(os.homedir(), ".codex")),
+      codexHome: resolveCodexHome(args.codexHome),
       piHome: resolveTargetHome(args.piHome, path.join(os.homedir(), ".pi", "agent")),
       // Mirror install: respect OPENCODE_CONFIG_DIR before falling back to the
       // XDG default so cleanup scans the same directory install wrote to.

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -5,7 +5,7 @@ import { loadClaudePlugin } from "../parsers/claude"
 import { targets, validateScope } from "../targets"
 import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
 import { ensureCodexAgentsFile } from "../utils/codex-agents"
-import { expandHome, resolveTargetHome } from "../utils/resolve-home"
+import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../utils/resolve-output"
 import { detectInstalledTools } from "../utils/detect-tools"
 
@@ -35,7 +35,7 @@ export default defineCommand({
     codexHome: {
       type: "string",
       alias: "codex-home",
-      description: "Write Codex output to this .codex root (ex: ~/.codex)",
+      description: "Write Codex output to this Codex root (default: $CODEX_HOME or ~/.codex)",
     },
     piHome: {
       type: "string",
@@ -83,7 +83,7 @@ export default defineCommand({
     const plugin = await loadClaudePlugin(String(args.source))
     const outputRoot = resolveOutputRoot(args.output)
     const hasExplicitOutput = Boolean(args.output && String(args.output).trim())
-    const codexHome = resolveTargetHome(args.codexHome, path.join(os.homedir(), ".codex"))
+    const codexHome = resolveCodexHome(args.codexHome)
     const piHome = resolveTargetHome(args.piHome, path.join(os.homedir(), ".pi", "agent"))
 
     const options: ClaudeToOpenCodeOptions = {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -8,7 +8,7 @@ import { targets, validateScope } from "../targets"
 import { pathExists } from "../utils/files"
 import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
 import { ensureCodexAgentsFile } from "../utils/codex-agents"
-import { expandHome, resolveTargetHome } from "../utils/resolve-home"
+import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../utils/resolve-output"
 import { detectInstalledTools } from "../utils/detect-tools"
 
@@ -38,7 +38,7 @@ export default defineCommand({
     codexHome: {
       type: "string",
       alias: "codex-home",
-      description: "Write Codex output to this .codex root (ex: ~/.codex)",
+      description: "Write Codex output to this Codex root (default: $CODEX_HOME or ~/.codex)",
     },
     piHome: {
       type: "string",
@@ -93,7 +93,7 @@ export default defineCommand({
     try {
       const plugin = await loadClaudePlugin(resolvedPlugin.path)
       const outputRoot = resolveOutputRoot(args.output)
-      const codexHome = resolveTargetHome(args.codexHome, path.join(os.homedir(), ".codex"))
+      const codexHome = resolveCodexHome(args.codexHome)
       const piHome = resolveTargetHome(args.piHome, path.join(os.homedir(), ".pi", "agent"))
       const hasExplicitOutput = Boolean(args.output && String(args.output).trim())
 

--- a/src/targets/codex.ts
+++ b/src/targets/codex.ts
@@ -23,8 +23,16 @@ export type CodexInstallManifest = {
   agents: string[]
 }
 
-export async function writeCodexBundle(outputRoot: string, bundle: CodexBundle): Promise<void> {
-  const codexRoot = resolveCodexRoot(outputRoot)
+export type CodexWriteOptions = {
+  outputIsCodexRoot?: boolean
+}
+
+export async function writeCodexBundle(
+  outputRoot: string,
+  bundle: CodexBundle,
+  options: CodexWriteOptions = {},
+): Promise<void> {
+  const codexRoot = resolveCodexRoot(outputRoot, options)
   await ensureDir(codexRoot)
 
   const pluginName = bundle.pluginName ? sanitizeCodexPathComponent(bundle.pluginName) : undefined
@@ -163,7 +171,8 @@ export async function writeCodexBundle(outputRoot: string, bundle: CodexBundle):
   }
 }
 
-function resolveCodexRoot(outputRoot: string): string {
+function resolveCodexRoot(outputRoot: string, options: CodexWriteOptions): string {
+  if (options.outputIsCodexRoot) return outputRoot
   return path.basename(outputRoot) === ".codex" ? outputRoot : path.join(outputRoot, ".codex")
 }
 

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -58,7 +58,10 @@ export const targets: Record<string, TargetHandler> = {
     name: "codex",
     implemented: true,
     convert: convertClaudeToCodex as TargetHandler["convert"],
-    write: writeCodexBundle as TargetHandler["write"],
+    write: ((outputRoot, bundle) =>
+      writeCodexBundle(outputRoot, bundle as Parameters<typeof writeCodexBundle>[1], {
+        outputIsCodexRoot: true,
+      })) as TargetHandler["write"],
   },
   pi: {
     name: "pi",

--- a/src/utils/detect-tools.ts
+++ b/src/utils/detect-tools.ts
@@ -2,6 +2,7 @@ import os from "os"
 import path from "path"
 import { pathExists } from "./files"
 import { resolveOpenCodeGlobalRoot } from "./opencode-config"
+import { resolveCodexHome } from "./resolve-home"
 
 export type DetectedTool = {
   name: string
@@ -11,7 +12,11 @@ export type DetectedTool = {
 
 type DetectableTool = {
   name: string
-  detectPaths: (home: string, cwd: string) => string[]
+  detectPaths: (home: string, cwd: string, options: DetectPathOptions) => string[]
+}
+
+type DetectPathOptions = {
+  useCodexHomeEnv: boolean
 }
 
 const detectableTools: DetectableTool[] = [
@@ -33,7 +38,12 @@ const detectableTools: DetectableTool[] = [
   },
   {
     name: "codex",
-    detectPaths: (home) => [path.join(home, ".codex")],
+    detectPaths: (home, _cwd, options) => {
+      if (!options.useCodexHomeEnv) return [path.join(home, ".codex")]
+      const codexHome = resolveCodexHome(undefined)
+      const defaultCodexHome = path.join(home, ".codex")
+      return codexHome === defaultCodexHome ? [defaultCodexHome] : [codexHome, defaultCodexHome]
+    },
   },
   {
     name: "pi",
@@ -76,14 +86,16 @@ const detectableTools: DetectableTool[] = [
 ]
 
 export async function detectInstalledTools(
-  home: string = os.homedir(),
+  home?: string,
   cwd: string = process.cwd(),
 ): Promise<DetectedTool[]> {
+  const effectiveHome = home ?? os.homedir()
+  const options = { useCodexHomeEnv: home === undefined }
   const results: DetectedTool[] = []
   for (const target of detectableTools) {
     let detected = false
     let reason = "not found"
-    for (const p of target.detectPaths(home, cwd)) {
+    for (const p of target.detectPaths(effectiveHome, cwd, options)) {
       if (await pathExists(p)) {
         detected = true
         reason = `found ${p}`
@@ -96,7 +108,7 @@ export async function detectInstalledTools(
 }
 
 export async function getDetectedTargetNames(
-  home: string = os.homedir(),
+  home?: string,
   cwd: string = process.cwd(),
 ): Promise<string[]> {
   const tools = await detectInstalledTools(home, cwd)

--- a/src/utils/resolve-home.ts
+++ b/src/utils/resolve-home.ts
@@ -15,3 +15,8 @@ export function resolveTargetHome(value: unknown, defaultPath: string): string {
   if (!raw) return defaultPath
   return path.resolve(expandHome(raw))
 }
+
+export function resolveCodexHome(value: unknown): string {
+  const defaultPath = process.env.CODEX_HOME?.trim() || path.join(os.homedir(), ".codex")
+  return resolveTargetHome(value, path.resolve(expandHome(defaultPath)))
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1162,6 +1162,84 @@ describe("CLI", () => {
     expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(true)
   })
 
+  test("install --to codex respects CODEX_HOME when --codex-home is omitted", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-codex-env-home-"))
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-codex-env-home-ws-"))
+    const projectRoot = path.join(import.meta.dir, "..")
+    const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")
+    const codexHome = path.join(tempRoot, "profiles", "sstk")
+
+    const proc = Bun.spawn([
+      "bun",
+      "run",
+      path.join(projectRoot, "src", "index.ts"),
+      "install",
+      fixtureRoot,
+      "--to",
+      "codex",
+    ], {
+      cwd: workspaceRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: tempRoot,
+        CODEX_HOME: codexHome,
+      },
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    expect(stdout).toContain(codexHome)
+    expect(await exists(path.join(codexHome, "agents", "compound-engineering", "security-sentinel.toml"))).toBe(true)
+    expect(await exists(path.join(tempRoot, ".codex", "agents", "compound-engineering", "security-sentinel.toml"))).toBe(false)
+  })
+
+  test("install --to codex treats --codex-home as the Codex root even when it is not named .codex", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-codex-explicit-home-"))
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-codex-explicit-home-ws-"))
+    const projectRoot = path.join(import.meta.dir, "..")
+    const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")
+    const codexHome = path.join(tempRoot, "profiles", "sstk")
+
+    const proc = Bun.spawn([
+      "bun",
+      "run",
+      path.join(projectRoot, "src", "index.ts"),
+      "install",
+      fixtureRoot,
+      "--to",
+      "codex",
+      "--codex-home",
+      codexHome,
+    ], {
+      cwd: workspaceRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: tempRoot,
+      },
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    expect(await exists(path.join(codexHome, "agents", "compound-engineering", "security-sentinel.toml"))).toBe(true)
+    expect(await exists(path.join(codexHome, ".codex", "agents", "compound-engineering", "security-sentinel.toml"))).toBe(false)
+  })
+
   test("install by name ignores same-named local directory", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-shadow-"))
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-shadow-workspace-"))

--- a/tests/detect-tools.test.ts
+++ b/tests/detect-tools.test.ts
@@ -104,6 +104,43 @@ describe("detectInstalledTools", () => {
     })
   })
 
+  describe("codex CODEX_HOME", () => {
+    const originalEnv = process.env.CODEX_HOME
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.CODEX_HOME
+      } else {
+        process.env.CODEX_HOME = originalEnv
+      }
+    })
+
+    test("detects codex at CODEX_HOME for default real-user detection", async () => {
+      const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "detect-codex-env-cwd-"))
+      const customRoot = await fs.mkdtemp(path.join(os.tmpdir(), "detect-codex-env-root-"))
+
+      process.env.CODEX_HOME = customRoot
+
+      const results = await detectInstalledTools(undefined, tempCwd)
+      const codex = results.find((t) => t.name === "codex")
+      expect(codex?.detected).toBe(true)
+      expect(codex?.reason).toContain(customRoot)
+    })
+
+    test("ignores ambient CODEX_HOME when caller provides an explicit home", async () => {
+      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "detect-codex-explicit-home-"))
+      const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "detect-codex-explicit-cwd-"))
+      const customRoot = await fs.mkdtemp(path.join(os.tmpdir(), "detect-codex-explicit-root-"))
+
+      process.env.CODEX_HOME = customRoot
+
+      const results = await detectInstalledTools(tempHome, tempCwd)
+      const codex = results.find((t) => t.name === "codex")
+      expect(codex?.detected).toBe(false)
+      expect(codex?.reason).toBe("not found")
+    })
+  })
+
   test("detects copilot from project-specific skills without generic .github false positives", async () => {
     const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "detect-copilot-home-"))
     const tempCwd = await fs.mkdtemp(path.join(os.tmpdir(), "detect-copilot-cwd-"))

--- a/tests/resolve-output.test.ts
+++ b/tests/resolve-output.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import os from "os"
 import path from "path"
+import { resolveCodexHome } from "../src/utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../src/utils/resolve-output"
 
 const baseOptions = {
@@ -52,6 +53,30 @@ describe("resolveTargetOutputRoot", () => {
       const result = resolveTargetOutputRoot({ ...baseOptions, targetName: "opencode" })
       expect(result).toBe("/custom/opencode")
     })
+  })
+})
+
+describe("resolveCodexHome", () => {
+  const originalCodexHome = process.env.CODEX_HOME
+
+  afterEach(() => {
+    if (originalCodexHome === undefined) {
+      delete process.env.CODEX_HOME
+    } else {
+      process.env.CODEX_HOME = originalCodexHome
+    }
+  })
+
+  test("uses CODEX_HOME when no explicit --codex-home is provided", () => {
+    process.env.CODEX_HOME = "/tmp/custom-codex-profile"
+
+    expect(resolveCodexHome(undefined)).toBe("/tmp/custom-codex-profile")
+  })
+
+  test("lets explicit --codex-home override CODEX_HOME", () => {
+    process.env.CODEX_HOME = "/tmp/custom-codex-profile"
+
+    expect(resolveCodexHome("/tmp/explicit-codex")).toBe("/tmp/explicit-codex")
   })
 })
 


### PR DESCRIPTION
## Summary

This fixes Codex profile installs for Compound Engineering by making the Codex converter and cleanup paths honor the active Codex home consistently.

Before this change, `codex plugin marketplace add` respected `CODEX_HOME`, but the companion CE Bun install defaulted to `~/.codex`. A profile install such as `CODEX_HOME="$HOME/.codex/profiles/work" ...` could therefore register the marketplace in the profile while writing CE custom agents into the default Codex home. The result was a half-installed profile: native plugin skills could be installed through Codex, but CE skills that delegate to custom agents would still fail because the agents were in the wrong root.

## What Changed

- Added `resolveCodexHome`, which resolves Codex output roots as: explicit `--codex-home`, then `$CODEX_HOME`, then `~/.codex`.
- Updated `install`, `convert`, and `cleanup` to use that resolver.
- Updated auto-detection so `install --to all` recognizes a Codex install located at `$CODEX_HOME`.
- Made the CLI Codex target treat its resolved home as the actual Codex root, even when the path is a profile directory like `~/.codex/profiles/work` instead of a literal `.codex` directory.
- Preserved the lower-level writer behavior for callers that pass a project root directly to `writeCodexBundle`.
- Documented the profile-aware Codex setup flow with a `work` profile example and a local-worktree development variant.
- Clarified that the Codex `/plugins` TUI install is still required today: marketplace registration only makes CE available, and the TUI install activates native skills; the Bun step installs the custom agents that those skills delegate to.

## Root Cause

The Codex native command and the CE Bun installer were using different ideas of “Codex home.” Codex itself follows `CODEX_HOME`, but the CE installer hard-coded `path.join(os.homedir(), ".codex")` unless `--codex-home` was passed. That mismatch only shows up for non-default profiles, which is why the normal `~/.codex` install path appeared fine.

There was a second edge case: passing `--codex-home ~/.codex/profiles/work` should write directly into that profile root. The Codex writer historically treated any output path not named `.codex` as a project root and nested another `.codex` directory under it. The CLI now explicitly tells the Codex writer that resolved Codex homes are already Codex roots.

## User Impact

Users can now install CE into a named Codex profile with consistent commands:

```bash
CODEX_HOME="$HOME/.codex/profiles/work" codex plugin marketplace add EveryInc/compound-engineering-plugin
CODEX_HOME="$HOME/.codex/profiles/work" bunx @every-env/compound-plugin install compound-engineering --to codex
CODEX_HOME="$HOME/.codex/profiles/work" codex
```

Inside Codex, users still run `/plugins` and install `compound-engineering`. That step is expected with current Codex because there is no CLI plugin-install subcommand for plugins from added marketplaces.

## Validation

- `bun test`
- `bun run release:validate`
