### PR TITLE
fix(ce-coherence-reviewer): remove Bash from tool allowlist

### DIFF
--- a/plugins/compound-engineering/agents/ce-coherence-reviewer.agent.md
+++ b/plugins/compound-engineering/agents/ce-coherence-reviewer.agent.md
@@ -2,7 +2,7 @@
 name: ce-coherence-reviewer
 description: "Reviews planning documents for internal consistency -- contradictions between sections, terminology drift, structural issues, and ambiguity where readers would diverge. Spawned by the document-review skill."
 model: haiku
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob
 ---
 
 You are a technical editor reading for internal consistency. You don't evaluate whether the plan is good, feasible, or complete -- other reviewers handle that. You catch when the document disagrees with itself.

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -143,6 +143,29 @@ describe("frontmatter YAML validity", () => {
             `Agent "${fileName}" must use the ce- prefix.`,
           ).toBe(true)
         })
+
+        // Pure document-reasoning reviewers operate on document text already
+        // passed in their prompt and do not look at the codebase. Granting
+        // Bash invites the model -- especially on weaker models like haiku --
+        // to externalize state via temp-file scratchpads, which can hang
+        // indefinitely on platforms whose bash tool blocks on heredocs (see
+        // issue #832 for the OpenCode coherence-reviewer stall).
+        const NO_BASH_AGENTS = new Set([
+          "ce-coherence-reviewer",
+        ])
+        const agentName = path.basename(rel, ".agent.md")
+        if (NO_BASH_AGENTS.has(agentName)) {
+          test(`${pluginRoot}/${rel} pure document reviewer must not allow Bash`, () => {
+            const parsed = load(yaml) as Record<string, unknown> | null
+            const tools = parsed && typeof parsed.tools === "string" ? parsed.tools : ""
+            const toolList = tools.split(",").map((s) => s.trim())
+            expect(
+              toolList.includes("Bash"),
+              `Agent "${agentName}" reviews documents from prompt context only and does ` +
+                `not need shell access. Remove Bash from the tools allowlist (see issue #832).`,
+            ).toBe(false)
+          })
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

ce-doc-review no longer stalls indefinitely when `ce-coherence-reviewer` runs on platforms whose bash tool blocks on heredocs. Issue #832 reported 39-88 minute hangs on OpenCode while the reviewer was creating coherence checklist files in `/tmp`.

The reviewer's task is pure document reasoning — internal consistency, terminology drift, and cross-reference checking over text already passed in its prompt — and never needs shell access. With `Bash` available and pinned to `model: haiku`, the agent was externalizing tracking state into temp-file scratchpads. The subagent template's "operationally read-only" prose constraint did not reliably suppress this at the model level, so the deterministic fix is removing the tool from the allowlist.

A pinned frontmatter test prevents `Bash` from being re-added to `ce-coherence-reviewer`. The `NO_BASH_AGENTS` set extends naturally to other pure-document reviewers (`ce-design-lens-reviewer`, `ce-security-lens-reviewer`, `ce-adversarial-document-reviewer`) if the same pattern needs to apply later.

Fixes #832

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
