### PR TITLE
fix(ce-proof): update HITL flow for Proof v2

### DIFF
--- a/docs/skills/ce-proof.md
+++ b/docs/skills/ce-proof.md
@@ -2,9 +2,9 @@
 
 > Create, share, view, comment on, and run human-in-the-loop review loops over markdown documents via [Proof](https://www.proofeditor.ai), Every's collaborative markdown editor.
 
-`ce-proof` is the **collaborative-doc** skill. Proof is a real-time markdown editor where humans and agents both work on the same document — the user annotates with comments and suggestions in their browser; the agent ingests those threads and applies tracked edits. The skill exposes both Proof's web API (no install; create, read, edit shared docs via HTTP) and the local bridge (drives the macOS Proof app at `localhost:9847`). Most chain skills use it for HITL review handoffs.
+`ce-proof` is the **collaborative-doc** skill. Proof is a real-time markdown editor where humans and agents both work on the same document — the user annotates with comments and suggestions in their browser; the agent ingests those threads, applies agreed edits, and replies in place. The skill exposes both Proof's web API (no install; create, read, edit shared docs via HTTP) and the local bridge (drives the macOS Proof app at `localhost:9847`). Most chain skills use it for HITL review handoffs.
 
-The most common use is **HITL review mode**: upload a local markdown file (a brainstorm, a plan, a learning), let the user annotate in Proof's UI, ingest each comment thread as a tracked edit, then sync the reviewed doc back to disk atomically.
+The most common use is **HITL review mode**: upload a local markdown file (a brainstorm, a plan, a learning), let the user annotate in Proof's UI, ingest each comment thread, apply agreed edits, then sync the reviewed doc back to disk atomically.
 
 ---
 
@@ -12,7 +12,7 @@ The most common use is **HITL review mode**: upload a local markdown file (a bra
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Uploads markdown to Proof, lets the user comment / suggest in the web UI, ingests feedback as in-thread replies and tracked edits, syncs the reviewed doc back to local |
+| What does it do? | Uploads markdown to Proof, lets the user comment / suggest in the web UI, ingests feedback as in-thread replies and agreed edits, syncs the reviewed doc back to local |
 | When to use it | "Share to Proof", "view this in Proof", "HITL this doc with me", "iterate with Proof on this draft"; auto-invoked on `ce-brainstorm` / `ce-plan` / `ce-ideate` HITL handoffs |
 | What it produces | A shareable Proof URL, an iterative review loop, and (when the source is a local file) a synced markdown file with the user's edits |
 | Two layers | Web API (HTTP, no install) and Local Bridge (drives macOS Proof app) |
@@ -35,11 +35,14 @@ Reviewing markdown drafts collaboratively is harder than it looks:
 `ce-proof` runs collaboration through Proof's structured API:
 
 - **Web API** for shared docs — no install needed; create, read, edit via HTTP; user gets a shareable URL with an access token
+- **Direct shared-link reads** — agents can fetch Proof URLs with `Accept: application/json` or `Accept: text/markdown`, no browser automation needed
 - **Local Bridge** when the macOS Proof app is running — drives the open document directly via `localhost:9847`
 - **HITL review mode** as the primary chain integration — atomic upload + iterative ingest + atomic end-sync to disk
 - **Consistent identity** — `by: "ai:compound-engineering"` on every op; `name: "Compound Engineering"` bound once via `/presence`
-- **`baseToken` discipline** — read once, mutate many; on `STALE_BASE` re-read and retry once; verify before retry on potentially-applied mutations
-- **Idempotency keys** for safe retries on the same logical write
+- **Efficient ingest passes** — filtered comment reads, one block-edit batch for content changes, one comment batch for replies/resolutions
+- **Rewrite-last edit strategy** — exact replacements and block edits first; whole-doc replacement only when truly unavoidable
+- **`baseToken` discipline** — seed from a read, chain the next token from mutation responses; on `STALE_BASE` re-read and retry once; verify before retry on potentially-applied mutations
+- **Idempotency keys** for safe exact-request retries without duplicate writes
 
 ---
 
@@ -60,22 +63,22 @@ The Human-in-the-Loop Review path (loaded from `references/hitl-review.md`) is t
 
 - Upload a local markdown file to Proof; user gets a URL
 - User annotates in Proof's web UI (comments, suggested edits)
-- Skill ingests the threads — reads each comment, replies in-thread, applies agreed edits as tracked suggestions (`status: "accepted"` for in-place commits with audit trail)
+- Skill ingests the threads — reads filtered comment state, applies agreed edits with `/edit/v2`, replies in-thread, and resolves handled threads in a batched comment mutation
 - On end-sync, syncs the final markdown back to the local file **atomically** (write to temp sibling, then `mv`)
 
 Two entry points, identical mechanics:
 - **Direct user request** — bare phrase like "share this to proof so we can iterate" or "HITL this doc"
 - **Upstream skill handoff** — `ce-brainstorm` / `ce-ideate` / `ce-plan` finishes a draft and passes it for review
 
-### 3. Mutation discipline — `baseToken` reuse + verify-before-retry
+### 3. Mutation discipline — token chaining + verify-before-retry
 
 Every Proof mutation requires a `baseToken`. The skill teaches the right pattern:
 
-- **Read once, mutate many** — `mutationBase.token` from `/state` is good for many mutations; `STALE_BASE` is recoverable
-- **On `STALE_BASE` / `BASE_TOKEN_REQUIRED` / `MISSING_BASE` / `INVALID_BASE_TOKEN`** — re-read `/state`, retry once with same payload + fresh token
+- **Read once, chain tokens** — seed from `/state` or `/snapshot`, then reuse the next `mutationBase.token` returned by successful mutations
+- **On `STALE_BASE` / `BASE_TOKEN_REQUIRED` / `MISSING_BASE` / `INVALID_BASE_TOKEN`** — re-read `/state`, rebuild the body with a fresh token, retry once with a new idempotency key
 - **On `INVALID_OPERATIONS` / `INVALID_REQUEST` / 422 errors** — fix the payload first, don't retry blindly
 - **On `COLLAB_SYNC_FAILED` / 5xx / network timeout / `202 with collab.status: "pending"`** — the canonical doc *may* have been written; re-read `/state` and check whether the intended mark/edit is already present **before retrying**
-- **`Idempotency-Key`** is recommended on every mutation; required when contract demands it. Same key on retry collapses the duplicate; new key means a new logical write
+- **`Idempotency-Key`** is recommended on every mutation; required when contract demands it. Reuse the same key only for an exact same-body resend; if the body changes (including a fresh `baseToken`), mint a new key
 
 > Duplicate-mark incidents usually come from retrying a `comment.add` or `suggestion.add` after a timeout without verifying. When in doubt: re-read, diff, then decide.
 
@@ -83,16 +86,40 @@ Every Proof mutation requires a `baseToken`. The skill teaches the right pattern
 
 Proof has two write surfaces with **load-bearing differences** the skill teaches:
 
-- **`/api/agent/{slug}/ops`** — top-level `type` field; one operation per call. Best for marks (`comment.add`, `suggestion.add`, `comment.reply`, etc.)
-- **`/api/agent/{slug}/edit/v2`** — `operations` array where each entry has `op`. Atomic batch — every op lands or none. Best for block-level edits (`replace_block`, `insert_after`, `find_replace_in_block`, etc.)
+- **`/api/agent/{slug}/ops`** — top-level `type` for one mark op, or top-level `operations` for batched comment thread mutations. Best for comments, suggestions, replies, and resolves.
+- **`/api/agent/{slug}/edit/v2`** — `operations` array where each entry has `op`. Atomic batch — every op lands or none. Best for block-level edits and bulk sweeps (`replace_block`, `insert_after`, `find_replace_in_doc`, etc.)
 
 Sending an `op`-shaped operation to `/ops` returns 422; the wire format isn't interchangeable. The skill documents both.
 
-### 5. Tracked suggestion with `status: "accepted"`
+### 5. Fast HITL passes — edit batch, then comment batch
+
+For normal HITL feedback, the comment thread is the audit trail. The efficient pass shape is:
+
+- Read `GET /state?kinds=comment` so provenance/authorship marks never pollute the needs-reply list
+- Apply agreed content edits with one `/edit/v2` batch where possible
+- Use `find_replace_in_doc` for literal doc-wide replacements such as terminology or punctuation sweeps
+- Reply to and resolve handled threads in one `/ops` batch using `comment.reply` with `resolve: true`
+
+This turns an 8-comment review from dozens of sequential reply/resolve/state-read requests into a small number of authoritative mutations.
+
+### 6. Rewrite Is The Last Resort
+
+Agents should not start by replacing the full document. The preferred edit ladder is:
+
+- `find_replace_in_doc` for exact repeated substitutions
+- `/edit/v2` block operations for known paragraphs, list items, sections, insertions, and deletions
+- `suggestion.add` when visible track changes are the desired review surface
+- `rewrite.apply` only when the user explicitly wants a whole-doc replacement or the change cannot be expressed safely with narrower operations
+
+That keeps human comments stable, avoids clobbering live collaborators, and makes retries easier to reason about.
+
+### 7. Tracked suggestion with `status: "accepted"`
 
 `suggestion.add` defaults to creating a pending suggestion the user must accept/reject. The skill also exposes `status: "accepted"` — creates the suggestion mark **and** commits the change in one call. The mark persists as audit trail with per-edit attribution; the user can still reject to revert. Useful when the agent is confident and the user wants to see what landed without an explicit accept step.
 
-### 6. `LIVE_CLIENTS_PRESENT` awareness
+The HITL default is now `/edit/v2` plus an in-thread reply; use accepted suggestions when a visible track-change mark is itself part of the desired review experience.
+
+### 8. `LIVE_CLIENTS_PRESENT` awareness
 
 While a client is connected to a Proof doc, the skill knows what's safe:
 
@@ -103,7 +130,7 @@ While a client is connected to a Proof doc, the skill knows what's safe:
 
 The skill tells callers to reserve `rewrite.apply` for no-client scenarios and use the granular ops or `/edit/v2` during active sessions.
 
-### 7. Atomic end-sync to local file
+### 9. Atomic end-sync to local file
 
 When the source was a local markdown file, end-sync writes the reviewed Proof state back to disk **atomically**:
 
@@ -117,7 +144,7 @@ jq -jr '.markdown' "$STATE_TMP" > "$TMP" && mv "$TMP" "$LOCAL"
 
 The skill also asks the user to confirm before writing when the pull isn't directly asked for (e.g., as a side-effect of HITL completion) — silent overwrites are surprising.
 
-### 8. Consistent agent identity
+### 10. Consistent agent identity
 
 The skill enforces `by: "ai:compound-engineering"` on every op and `X-Agent-Id: ai:compound-engineering` in headers. Display name `Compound Engineering` is bound once per session via `/presence`. **Don't use `ai:compound` or other ad-hoc variants** — identity stays uniform unless a caller explicitly overrides for a sub-agent context.
 
@@ -133,8 +160,8 @@ User opens the URL in their browser. Adds 4 inline comments and 2 suggested edit
 
 The skill reads `/state`, finds 6 new marks. For each comment thread:
 - Reads the thread fresh
-- Composes a reply addressing the concern (with `comment.reply`)
-- For agreed edits, posts a tracked suggestion (`suggestion.add` with `status: "accepted"`) — change lands with an audit-trail mark
+- Applies agreed content edits through `/edit/v2` in a small batch
+- Posts thread replies and resolves handled comments with one `/ops` comment batch
 
 After all threads are processed, the skill asks the user to confirm the end-sync. User confirms. The skill atomically writes the reviewed markdown back to `docs/plans/2026-05-04-001-feat-notification-mute-plan.md`. Returns control to `ce-plan` Phase 5.4 with `status: proceeded` and `localSynced: true`.
 
@@ -145,7 +172,7 @@ After all threads are processed, the skill asks the user to confirm the end-sync
 Reach for `ce-proof` when:
 
 - You want a shareable URL for a markdown doc (brainstorm, plan, learning, draft)
-- You want HITL review with comment threads, tracked edits, and atomic disk sync at the end
+- You want HITL review with comment threads, agent-applied edits, and atomic disk sync at the end
 - A chain skill (`ce-brainstorm`, `ce-plan`, `ce-ideate`) handed off for human review
 - You're working from a Proof URL and want the agent to participate
 
@@ -195,34 +222,37 @@ Direct invocation for ad-hoc Proof work:
 | Op (Web API `/ops`) | Purpose |
 |---------------------|---------|
 | `comment.add` | Comment on a quote |
-| `comment.reply` | Reply within a thread |
+| `comment.reply` | Reply within a thread; `resolve: true` replies and closes in one mutation |
 | `comment.resolve` / `comment.unresolve` | Toggle thread resolution |
 | `suggestion.add` | Tracked edit (pending or `status: "accepted"`) |
 | `suggestion.accept` / `suggestion.reject` | Resolve a suggestion |
-| `rewrite.apply` | Whole-doc replacement (blocked by `LIVE_CLIENTS_PRESENT`) |
+| `rewrite.apply` | Last-resort whole-doc replacement (blocked by `LIVE_CLIENTS_PRESENT`) |
 
 | Endpoint | Wire format | Best for |
 |----------|-------------|----------|
-| `/api/agent/{slug}/ops` | Top-level `type` | Marks (comment, suggestion) |
-| `/api/agent/{slug}/edit/v2` | `operations: [{op, ...}, ...]` | Atomic block batches |
+| `/api/agent/{slug}/ops` | Top-level `type` or comment `operations` batch | Marks, batched replies/resolves |
+| `/api/agent/{slug}/edit/v2` | `operations: [{op, ...}, ...]` | Atomic block batches and `find_replace_in_doc` sweeps |
 
-Identity defaults: `by: "ai:compound-engineering"`, `name: "Compound Engineering"`. `Idempotency-Key` recommended on every mutation.
+Identity defaults: `by: "ai:compound-engineering"`, `X-Agent-Id: ai:compound-engineering`, `name: "Compound Engineering"`. `Idempotency-Key` recommended on every mutation and required when the contract says so.
 
 ---
 
 ## FAQ
 
 **Why two endpoint shapes?**
-Different concerns. `/ops` handles per-call mark mutations (one comment, one suggestion). `/edit/v2` handles atomic batches of block-level edits (one call commits 12 block changes or none). The wire formats differ — sending `op` shape to `/ops` returns 422.
+Different concerns. `/ops` handles mark mutations, including batched existing-thread comment replies/resolves. `/edit/v2` handles atomic batches of block-level edits and document-wide literal replacement. The wire formats differ — sending `op` shape to `/ops` returns 422.
+
+**Should I rewrite the whole doc?**
+Almost never as a first move. Use `find_replace_in_doc` for literal sweeps and block-level `/edit/v2` for scoped edits. Use `rewrite.apply` only when the user asked for full replacement or the change cannot be represented with narrower operations.
 
 **What's the right mutation pattern?**
-Read `/state` once, capture `mutationBase.token`, reuse for many mutations. On `STALE_BASE`, re-read and retry once with fresh token. On potentially-applied errors (5xx, timeout, `202 pending`), re-read and check whether the change is already present before retrying — duplicate marks come from retrying without verifying.
+Read `/state?kinds=comment` for comment ingest or `/snapshot` for block refs, capture `mutationBase.token`, then update your cached token from successful mutation responses. On `STALE_BASE`, re-read and retry once with fresh token. On potentially-applied errors (5xx, timeout, `202 pending`), re-read and check whether the change is already present before retrying — duplicate marks come from retrying without verifying.
 
 **Why the `ai:compound-engineering` identity?**
 For consistent attribution. Mark authorship in the rendered doc shows who edited; if the agent uses `ai:compound` one day and `ai:compound-engineering` the next, the audit trail looks fragmented. The skill enforces one identity unless a caller explicitly overrides.
 
 **What does HITL review mode do?**
-Upload a local markdown file to Proof, let the user annotate via comments and suggestions in the web UI, ingest each thread (read fresh, reply, apply agreed edits as tracked suggestions), then sync the reviewed markdown back to the local file atomically. The full loop spec is in `references/hitl-review.md`.
+Upload a local markdown file to Proof, let the user annotate via comments and suggestions in the web UI, ingest each thread with filtered comment reads, apply agreed edits through Proof's edit APIs, reply/resolve in-thread, then sync the reviewed markdown back to the local file atomically. The full loop spec is in `references/hitl-review.md`.
 
 **Can I edit a doc while a user is connected?**
 Yes for `/edit/v2`, `suggestion.add` (including `status: "accepted"`), and all comment ops. No for `rewrite.apply` — it's blocked by `LIVE_CLIENTS_PRESENT` because it would clobber in-flight Yjs edits.

--- a/plugins/compound-engineering/skills/ce-brainstorm/references/handoff.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/handoff.md
@@ -81,7 +81,7 @@ Load the `ce-proof` skill in HITL-review mode with:
 - **identity:** `ai:compound-engineering` / `Compound Engineering`
 - **recommended next step:** `ce-plan` (shown in the ce-proof skill's final terminal output)
 
-Follow `references/hitl-review.md` in the ce-proof skill. It uploads the doc, prompts the user for review in Proof's web UI, ingests each thread by reading it fresh and replying in-thread, applies agreed edits as tracked suggestions, and syncs the final markdown back to the source file atomically on proceed.
+Follow `references/hitl-review.md` in the ce-proof skill. It uploads the doc, prompts the user for review in Proof's web UI, ingests filtered comment threads, applies agreed edits through the current Proof edit APIs, replies/resolves in-thread, and syncs the final markdown back to the source file atomically on proceed.
 
 When the ce-proof skill returns control:
 

--- a/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
+++ b/plugins/compound-engineering/skills/ce-ideate/references/post-ideation-workflow.md
@@ -124,7 +124,7 @@ If resuming:
 
 ### 5.2 Proof Save (default for elsewhere mode; on request for repo mode)
 
-Hand off the ideation content to the `ce-proof` skill in HITL review mode. This uploads the doc, runs an iterative review loop (user annotates in Proof, agent ingests feedback and applies tracked edits), and (in repo mode) syncs the reviewed markdown back to `docs/ideation/`.
+Hand off the ideation content to the `ce-proof` skill in HITL review mode. This uploads the doc, runs an iterative review loop (user annotates in Proof, agent ingests feedback, applies agreed edits, and replies/resolves in-thread), and (in repo mode) syncs the reviewed markdown back to `docs/ideation/`.
 
 Load the `ce-proof` skill in HITL-review mode with:
 

--- a/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
@@ -63,7 +63,7 @@ Based on selection (the bare per-option routing is also stated inline in the SKI
   - identity: `ai:compound-engineering` / `Compound Engineering`
   - recommended next step: `/ce-work` (shown in the ce-proof skill's final terminal output)
 
-  Follow `references/hitl-review.md` in the ce-proof skill. It uploads the plan, prompts the user for review in Proof's web UI, ingests each thread by reading it fresh and replying in-thread, applies agreed edits as tracked suggestions, and syncs the final markdown back to the plan file atomically on proceed.
+  Follow `references/hitl-review.md` in the ce-proof skill. It uploads the plan, prompts the user for review in Proof's web UI, ingests filtered comment threads, applies agreed edits through the current Proof edit APIs, replies/resolves in-thread, and syncs the final markdown back to the plan file atomically on proceed.
 
   When the ce-proof skill returns:
   - `status: proceeded` with `localSynced: true` -> the plan on disk now reflects the review. Re-run `ce-doc-review` on the updated plan before re-rendering the menu — HITL can materially rewrite the plan body, so the prior ce-doc-review pass no longer covers the current file and section 5.3.8 requires a review before any handoff option is offered. Then return to the post-generation options with the refreshed residual findings.

--- a/plugins/compound-engineering/skills/ce-proof/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-proof/SKILL.md
@@ -26,7 +26,7 @@ Set the display name once per doc session by posting to presence with the `X-Age
 
 ## Human-in-the-Loop Review Mode
 
-Human-in-the-loop iteration over an existing local markdown file: upload to Proof, let the user annotate in Proof's web UI, ingest feedback as in-thread replies and tracked edits, and sync the final doc back to disk. Two entry points, identical mechanics — load `references/hitl-review.md` for the full loop spec (invocation contract, mark classification, idempotent ingest passes, exception-based terminal reporting, end-sync atomic write) in either case:
+Human-in-the-loop iteration over an existing local markdown file: upload to Proof, let the user annotate in Proof's web UI, ingest feedback as in-thread replies and agreed edits, and sync the final doc back to disk. Two entry points, identical mechanics — load `references/hitl-review.md` for the full loop spec (invocation contract, mark classification, idempotent ingest passes, exception-based terminal reporting, end-sync atomic write) in either case:
 
 - **Direct user request** — a bare user phrase naming a local markdown file and asking to iterate collaboratively via Proof: "share this to proof so we can iterate", "iterate with proof on this doc", "HITL this file with me", "let's get feedback on this in proof", "open this in proof editor so I can review". The file is whichever markdown the user just created, edited, or referenced; if ambiguous, ask which file. This is a first-class entry point — do not require an upstream caller.
 - **Upstream skill handoff** — `ce-brainstorm`, `ce-ideate`, or `ce-plan` finishes a draft and hands it off for human review before the next phase, passing the file path and title explicitly.
@@ -61,14 +61,32 @@ Use the `tokenUrl` as the shareable link. The `_links` give you the exact API pa
 
 ### Read a Shared Document
 
+If you already have a shared Proof URL, no browser automation is needed. Fetch the URL directly with content negotiation:
+
+```bash
+curl -s -H "Accept: application/json" "https://www.proofeditor.ai/d/{slug}?token=<token>"
+curl -s -H "Accept: text/markdown" "https://www.proofeditor.ai/d/{slug}?token=<token>"
+```
+
+The JSON response includes the markdown, API links, and agent auth hints. Use `/state` when you need mutation metadata, marks, or presence:
+
 ```bash
 curl -s "https://www.proofeditor.ai/api/agent/{slug}/state" \
   -H "x-share-token: <token>"
 ```
 
+For comment-ingest workflows, prefer the server-side filter:
+
+```bash
+curl -s "https://www.proofeditor.ai/api/agent/{slug}/state?kinds=comment" \
+  -H "x-share-token: <token>"
+```
+
+`state.marks` is a union of comments, suggestions, and provenance/authorship marks. The `?kinds=comment` filter avoids treating human-authored provenance marks as review comments.
+
 ### Edit a Shared Document
 
-All operations go to `POST https://www.proofeditor.ai/api/agent/{slug}/ops`
+Comment, suggestion, and rewrite operations go to `POST https://www.proofeditor.ai/api/agent/{slug}/ops`. Block edits use `/api/agent/{slug}/edit/v2`.
 
 **Note:** Use the `/api/agent/{slug}/ops` path (from `_links` in create response), NOT `/api/documents/{slug}/ops`.
 
@@ -79,13 +97,24 @@ All operations go to `POST https://www.proofeditor.ai/api/agent/{slug}/ops`
 
 **Wire-format reminder.** `/api/agent/{slug}/ops` uses a top-level `type` field; `/api/agent/{slug}/edit/v2` uses an `operations` array where each entry has `op`. Do not mix — sending `op` to `/ops` returns 422.
 
-**Every mutation requires a `baseToken`.** Reuse the `mutationBase.token` from the most recent `/state` or `/snapshot` read — tokens don't go stale in seconds, and `STALE_BASE` is a recoverable error. On `BASE_TOKEN_REQUIRED` or `STALE_BASE`, re-read and retry once. Only do a pre-mutation read if no prior read has happened in this session. See the baseToken recipe in `references/hitl-review.md`.
+**Every mutation requires a `baseToken`.** Reuse the `mutationBase.token` from the most recent `/state` or `/snapshot` read, then update it from successful mutation responses (`.mutationBase.token`). On `BASE_TOKEN_REQUIRED` or `STALE_BASE`, re-read and retry once. Only do a pre-mutation read if no prior read has happened in this session or you need fresh document/comment/snapshot content. See the baseToken recipe in `references/hitl-review.md`.
 
 `/edit/v2` block refs are a separate concern: they can drift across revisions, so re-fetch `/snapshot` for fresh refs before a block edit if any writes have landed since your last snapshot.
 
+### Edit Strategy: Avoid Whole-Doc Rewrite
+
+Do not default to full-document replacement. Pick the narrowest edit primitive that matches the requested change:
+
+1. **Literal repeated change:** use `/edit/v2` with `find_replace_in_doc` (optionally constrained by `fromRef`, `toRef`, or `block_filter`). This is the fastest and least error-prone path for terminology renames, punctuation/style sweeps, and other exact text substitutions.
+2. **Known block or section change:** use `/edit/v2` block operations from a fresh `/snapshot`: `replace_block`, `insert_before`, `insert_after`, `delete_block`, `replace_range`, or `find_replace_in_block`.
+3. **Visible track-changes desired:** use `/ops` `suggestion.add` (pending or `status: "accepted"`) when the user should see a suggestion mark and reject/revert affordance for that specific edit.
+4. **Whole-doc replacement:** use `rewrite.apply` only as a last resort when the user explicitly asks to replace the entire document, when the intended change is genuinely global and cannot be expressed as block/range/find-replace operations, and when no live clients are present. Before rewriting, read current state, preserve comments/marks expectations, and mention that the rewrite is broad.
+
+When in doubt, start with `/snapshot` and build a small `/edit/v2` batch. A narrow failed edit is easier to inspect and retry than a broad rewrite, and it avoids clobbering concurrent human work.
+
 **Retry discipline after mutation errors — verify before retrying.** An error response is not proof that nothing was written.
 
-- `STALE_BASE`, `BASE_TOKEN_REQUIRED`, `MISSING_BASE`, `INVALID_BASE_TOKEN` — pre-commit, token-related. Re-read `/state` and retry once with the same payload and a fresh `baseToken`. A generic mutate helper can auto-retry these.
+- `STALE_BASE`, `BASE_TOKEN_REQUIRED`, `MISSING_BASE`, `INVALID_BASE_TOKEN` — pre-commit, token-related. Re-read `/state`, rebuild the request body with a fresh `baseToken`, and retry once with a new `Idempotency-Key`.
 - `ANCHOR_NOT_FOUND`, `ANCHOR_AMBIGUOUS` — pre-commit, but the `quote` no longer uniquely matches content. Re-reading does not help by itself; the caller must tighten or regenerate the anchor before retrying. Do not auto-retry blindly.
 - `INVALID_OPERATIONS`, `INVALID_REQUEST`, `INVALID_REF`, `INVALID_BLOCK_MARKDOWN`, `INVALID_RANGE`, `INVALID_MARKDOWN`, 422 — pre-commit, but the payload is wrong. Do not retry blindly; fix the payload first.
 - `COLLAB_SYNC_FAILED`, `REWRITE_BARRIER_FAILED`, `PROJECTION_STALE`, `INTERNAL_ERROR`, 5xx, network timeout, and any **202 with `collab.status: "pending"`** — the canonical doc may have been written even though the call looks like a failure. Before any retry, re-read `/state` and check whether the intended mark/edit is already present; only retry if it isn't.
@@ -93,7 +122,7 @@ All operations go to `POST https://www.proofeditor.ai/api/agent/{slug}/ops`
 
 Duplicate-mark incidents usually come from retrying a `comment.add` or `suggestion.add` after a timeout without verifying. When in doubt: re-read, diff, then decide.
 
-**`Idempotency-Key` header** is recommended on every mutation for safe automation retries; required when `/state.contract.idempotencyRequired` is true. Use the same key when retrying the exact same logical write (same payload) so the server can collapse the retry. A new key means a new write — even if the payload is identical.
+**`Idempotency-Key` header** is recommended on every mutation for safe automation retries; required when `/state.contract.idempotencyRequired` is true. Use the same key only when resending the exact same serialized request body. If the body changes — including because you replaced `baseToken` after `STALE_BASE` — mint a new key or Proof will reject it as key reuse with a different payload.
 
 **Comment on text:**
 ```json
@@ -104,6 +133,21 @@ Duplicate-mark incidents usually come from retrying a `comment.add` or `suggesti
 ```json
 {"type": "comment.reply", "markId": "<id>", "by": "ai:compound-engineering", "text": "Reply text", "baseToken": "<token>"}
 ```
+
+**Reply and resolve in one mutation:**
+```json
+{"type": "comment.reply", "markId": "<id>", "by": "ai:compound-engineering", "text": "Fixed.", "resolve": true, "baseToken": "<token>"}
+```
+
+**Batch existing-thread comment mutations:**
+```json
+{"by": "ai:compound-engineering", "baseToken": "<token>", "operations": [
+  {"type": "comment.reply", "markId": "<id-1>", "text": "Fixed.", "resolve": true},
+  {"type": "comment.reply", "markId": "<id-2>", "text": "Leaving this open because X."}
+]}
+```
+
+Batch `/ops` supports `comment.reply`, `comment.resolve`, and `comment.unresolve` for existing threads. Use it for HITL ingest passes instead of issuing separate reply and resolve requests per thread.
 
 **Resolve / unresolve a comment:**
 ```json
@@ -131,10 +175,12 @@ Duplicate-mark incidents usually come from retrying a `comment.add` or `suggesti
 
 `suggestion.resolve` is not supported — use accept or reject instead.
 
-**Bulk rewrite (whole-doc replacement):**
+**Whole-doc rewrite (last resort):**
 ```json
 {"type": "rewrite.apply", "content": "full new markdown", "by": "ai:compound-engineering", "baseToken": "<token>"}
 ```
+
+Prefer `find_replace_in_doc` or block-level `/edit/v2` operations first. `rewrite.apply` is broad, disruptive, and blocked while live clients are connected.
 
 **Block-level edits via `/edit/v2`** (separate endpoint, separate shape):
 ```bash
@@ -163,8 +209,11 @@ Per-op body shape (singular `block` vs plural `blocks` is load-bearing — sendi
 | `delete_block` | `ref` |
 | `replace_range` | `fromRef`, `toRef`, `blocks: [{markdown}, ...]` |
 | `find_replace_in_block` | `ref`, `find`, `replace`, `occurrence: "first" \| "all"` |
+| `find_replace_in_doc` | `find`, `replace`, `occurrence: "first" \| "all"`, optional `fromRef`, `toRef`, `block_filter` |
 
-Read `/snapshot` to get stable block `ref` IDs. `operations` commits atomically — either every op lands or none do — so one `/edit/v2` call can batch dozens of block edits safely and efficiently (see the bulk-sweep guidance in `references/hitl-review.md` Phase 2.4).
+Read `/snapshot` to get block `ref` IDs and `mutationBase.token`. `ref` values are opaque request tokens tied to the snapshot/baseToken; re-read `/snapshot` before follow-up block edits if writes have landed. `operations` commits atomically — either every op lands or none do — so one `/edit/v2` call can batch dozens of block edits safely and efficiently (see the bulk-sweep guidance in `references/hitl-review.md` Phase 2.4). Successful full responses include the next `mutationBase.token` and fresh `snapshot.blocks[].ref` values for chaining.
+
+For literal doc-wide sweeps, prefer `find_replace_in_doc` over many block replacements or a whole-doc rewrite. Validate large batches with `?dryRun=1` or `?validate=1`; use `?return=minimal` when you only need `ok`, `revision`, `appliedCount`, and the next `mutationBase`.
 
 **Editing while a client is connected is fine.** `/edit/v2`, `suggestion.add` (including `status: "accepted"`), and all comment ops work during active collab. Only `rewrite.apply` is blocked by `LIVE_CLIENTS_PRESENT` — it would clobber in-flight Yjs edits.
 
@@ -179,7 +228,7 @@ Read `/snapshot` to get stable block `ref` IDs. `operations` commits atomically 
 Requires Proof.app running. Bridge at `http://localhost:9847`.
 
 **Required headers:**
-- `X-Agent-Id: claude` (identity for presence)
+- `X-Agent-Id: ai:compound-engineering` (identity for presence; keep aligned with `by`)
 - `Content-Type: application/json`
 - `X-Window-Id: <uuid>` (when multiple docs open)
 
@@ -198,7 +247,7 @@ Requires Proof.app running. Bridge at `http://localhost:9847`.
 | POST | `/marks/resolve` | `{"markId":"<id>","by":"ai:compound-engineering"}` |
 | POST | `/marks/accept` | `{"markId":"<id>"}` |
 | POST | `/marks/reject` | `{"markId":"<id>"}` |
-| POST | `/rewrite` | `{"content":"full markdown","by":"ai:compound-engineering"}` |
+| POST | `/rewrite` | Last-resort whole-doc replacement: `{"content":"full markdown","by":"ai:compound-engineering"}` |
 | POST | `/presence` | `{"status":"reading","summary":"..."}` |
 | GET | `/events/pending` | Poll for user actions |
 
@@ -211,37 +260,62 @@ Requires Proof.app running. Bridge at `http://localhost:9847`.
 When given a Proof URL like `https://www.proofeditor.ai/d/abc123?token=xxx`:
 
 1. Extract the slug (`abc123`) and token from the URL
-2. Read the document state via the API
-3. Add comments or suggest edits using the ops endpoint
+2. Read the document via content negotiation on the shared URL or via `/api/agent/{slug}/state` when you need marks/mutation metadata
+3. For content edits, prefer `/edit/v2` `find_replace_in_doc` or block operations; use `/ops` for comments, suggestions, and comment replies/resolution
 4. The author sees changes in real-time
 
 ```bash
-# Read once — the same response yields both the doc content and the baseToken for every mutation below.
+SHARE_URL="https://www.proofeditor.ai/d/abc123?token=xxx"
+curl -s -H "Accept: application/json" "$SHARE_URL"
+curl -s -H "Accept: text/markdown" "$SHARE_URL"
+
+# Read once for content + the initial baseToken.
+# After each successful mutation, update BASE from the response's mutationBase.token.
 STATE=$(curl -s "https://www.proofeditor.ai/api/agent/abc123/state" \
   -H "x-share-token: xxx")
 BASE=$(printf '%s' "$STATE" | jq -r '.mutationBase.token')
 # Inspect doc fields as needed: printf '%s' "$STATE" | jq '.markdown, .revision'
 
 # Comment
-curl -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
+OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
   -H "Content-Type: application/json" \
   -H "x-share-token: xxx" \
   -H "X-Agent-Id: ai:compound-engineering" \
-  -d "$(jq -n --arg base "$BASE" '{type:"comment.add",quote:"text",by:"ai:compound-engineering",text:"comment",baseToken:$base}')"
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d "$(jq -n --arg base "$BASE" '{type:"comment.add",quote:"text",by:"ai:compound-engineering",text:"comment",baseToken:$base}')")
+NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
+[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
 
 # Suggest edit (tracked, pending)
-curl -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
+OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
   -H "Content-Type: application/json" \
   -H "x-share-token: xxx" \
   -H "X-Agent-Id: ai:compound-engineering" \
-  -d "$(jq -n --arg base "$BASE" '{type:"suggestion.add",kind:"replace",quote:"old",by:"ai:compound-engineering",content:"new",baseToken:$base}')"
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d "$(jq -n --arg base "$BASE" '{type:"suggestion.add",kind:"replace",quote:"old",by:"ai:compound-engineering",content:"new",baseToken:$base}')")
+NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
+[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
 
 # Suggest and immediately apply (tracked, committed)
-curl -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
+OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
   -H "Content-Type: application/json" \
   -H "x-share-token: xxx" \
   -H "X-Agent-Id: ai:compound-engineering" \
-  -d "$(jq -n --arg base "$BASE" '{type:"suggestion.add",kind:"replace",quote:"old",by:"ai:compound-engineering",content:"new",status:"accepted",baseToken:$base}')"
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d "$(jq -n --arg base "$BASE" '{type:"suggestion.add",kind:"replace",quote:"old",by:"ai:compound-engineering",content:"new",status:"accepted",baseToken:$base}')")
+NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
+[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
+
+# Direct content edit (preferred when visible suggestion marks are not needed)
+SNAPSHOT=$(curl -s "https://www.proofeditor.ai/api/agent/abc123/snapshot" \
+  -H "x-share-token: xxx")
+EDIT_BASE=$(printf '%s' "$SNAPSHOT" | jq -r '.mutationBase.token')
+curl -X POST "https://www.proofeditor.ai/api/agent/abc123/edit/v2?return=minimal" \
+  -H "Content-Type: application/json" \
+  -H "x-share-token: xxx" \
+  -H "X-Agent-Id: ai:compound-engineering" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d "$(jq -n --arg base "$EDIT_BASE" '{by:"ai:compound-engineering",baseToken:$base,operations:[{op:"find_replace_in_doc",find:"old",replace:"new",occurrence:"all"}]}')"
 ```
 
 ## Workflow: Create and Share a New Document
@@ -267,14 +341,28 @@ curl -s -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
 # 4. Share the URL
 echo "$URL"
 
-# 5. Make edits using the ops endpoint (baseToken required)
+# 5. Make comment/suggestion edits using the ops endpoint (baseToken required)
 BASE=$(curl -s "https://www.proofeditor.ai/api/agent/$SLUG/state" \
   -H "x-share-token: $TOKEN" | jq -r '.mutationBase.token')
-curl -X POST "https://www.proofeditor.ai/api/agent/$SLUG/ops" \
+OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/$SLUG/ops" \
   -H "Content-Type: application/json" \
   -H "x-share-token: $TOKEN" \
   -H "X-Agent-Id: ai:compound-engineering" \
-  -d "$(jq -n --arg base "$BASE" '{type:"comment.add",quote:"Content here",by:"ai:compound-engineering",text:"Added a note",baseToken:$base}')"
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d "$(jq -n --arg base "$BASE" '{type:"comment.add",quote:"Content here",by:"ai:compound-engineering",text:"Added a note",baseToken:$base}')")
+NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
+[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
+
+# For content edits, prefer /edit/v2 over rewrite.apply.
+SNAPSHOT=$(curl -s "https://www.proofeditor.ai/api/agent/$SLUG/snapshot" \
+  -H "x-share-token: $TOKEN")
+EDIT_BASE=$(printf '%s' "$SNAPSHOT" | jq -r '.mutationBase.token')
+curl -X POST "https://www.proofeditor.ai/api/agent/$SLUG/edit/v2?return=minimal" \
+  -H "Content-Type: application/json" \
+  -H "x-share-token: $TOKEN" \
+  -H "X-Agent-Id: ai:compound-engineering" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d "$(jq -n --arg base "$EDIT_BASE" '{by:"ai:compound-engineering",baseToken:$base,operations:[{op:"find_replace_in_doc",find:"Content",replace:"Updated content",occurrence:"all"}]}')"
 ```
 
 ## Workflow: Pull a Proof Doc to Local
@@ -310,6 +398,7 @@ rm "$STATE_TMP"
 
 - Use `/state` content as source of truth before editing
 - During active collab use `edit/v2` (direct block changes) or `suggestion.add` (tracked changes); reserve `rewrite.apply` for no-client scenarios since it's blocked by `LIVE_CLIENTS_PRESENT` when anyone is connected
+- Prefer `find_replace_in_doc` and block-level `/edit/v2` edits before considering `rewrite.apply`
 - Don't span table cells in a single replace
 - Always include `by: "ai:compound-engineering"` on every op and `X-Agent-Id: ai:compound-engineering` in headers for consistent attribution
 - Reuse `baseToken` from your most recent `/state` or `/snapshot` read; on `STALE_BASE`, re-read and retry once

--- a/plugins/compound-engineering/skills/ce-proof/references/hitl-review.md
+++ b/plugins/compound-engineering/skills/ce-proof/references/hitl-review.md
@@ -1,6 +1,6 @@
 # HITL Review Mode
 
-Human-in-the-loop iteration loop for a markdown document shared via Proof. Invoked either by an upstream skill (`ce-brainstorm`, `ce-ideate`, `ce-plan`) handing off a draft it produced, or directly by the user asking to iterate on an existing markdown file they already have on disk ("share this to proof and iterate", "HITL this doc with me"). Mechanics are identical in both cases: upload the local doc, let the user annotate in Proof's web UI, ingest feedback as in-thread replies and tracked edits, and sync the final doc back to disk.
+Human-in-the-loop iteration loop for a markdown document shared via Proof. Invoked either by an upstream skill (`ce-brainstorm`, `ce-ideate`, `ce-plan`) handing off a draft it produced, or directly by the user asking to iterate on an existing markdown file they already have on disk ("share this to proof and iterate", "HITL this doc with me"). Mechanics are identical in both cases: upload the local doc, let the user annotate in Proof's web UI, ingest feedback as in-thread replies and agreed edits, and sync the final doc back to disk.
 
 This mode assumes a local markdown file exists. There is no "from scratch" entry — if the user wants a fresh doc, create one with the normal proof create workflow first, then invoke HITL.
 
@@ -65,25 +65,26 @@ At the start of the pass, update presence to `status: "acting"` with a short sum
 ### 2.1 Read fresh state
 
 ```
-GET /api/agent/{slug}/state
+GET /api/agent/{slug}/state?kinds=comment
 Headers: x-share-token: <token>
 ```
 
 Capture:
 - `markdown` (current body — includes any user direct edits and accepted suggestions)
 - `revision`
-- `marks` (object keyed by markId)
+- `marks` (object keyed by markId, filtered to comment marks)
 - `mutationBase.token` — the baseToken required for this round's mutations
 
 ### 2.2 Identify marks that need attention
 
 Filter `marks` to items where **all** of the following hold:
 
+- `kind` is `comment` (the `?kinds=comment` read should already guarantee this, but keep the local guard)
 - `by` starts with `human:` (authored by a human, not the agent)
 - `resolved` is `false`
 - Either `thread` has no entry authored by any `ai:*` identity, **OR** the latest entry in `thread` is authored by `human:*` with an `at` timestamp newer than the latest `ai:*` entry (user responded to a prior agent reply)
 
-Skip everything else. Agent-authored marks, resolved threads, and threads already replied to with no new human response are done.
+Skip everything else. Agent-authored marks, resolved threads, non-comment marks, and threads already replied to with no new human response are done. Do not build needs-reply filters from `by` alone — Proof's full `marks` bag can include provenance/authored marks that share a `human:` prefix but are not review comments.
 
 ### 2.3 Read each mark and decide how to respond
 
@@ -101,13 +102,24 @@ Real feedback blends types — "this is wrong, rename to Y" is both objection an
 
 **Invariant:** every attention-needing mark ends the pass with an agent reply in its thread. Unreplied = "still to do" — the next pass re-classifies it. This is what makes the loop idempotent without a sidecar: mark state *is* the state. Even when the agent disagrees or can't decide, reply (with reasoning or a question) rather than silently skip.
 
-**Parallelize independent thread ops.** `comment.reply` and `comment.resolve` across different marks don't conflict — they touch different thread state and a stale `baseToken` on one doesn't poison another (retry-on-`STALE_BASE` is cheap, per-mark, and local). When there are more than ~3 attention-needing marks that classify as plain replies or resolves, dispatch them in parallel — either via multiple tool calls in one turn or via sub-agents (`Agent`/`Task` in Claude Code, `spawn_agent` in Codex, `subagent` in Pi). Keep block-mutating edits (`suggestion.add`, `/edit/v2`) sequential or batch them through one `/edit/v2` call — concurrent block edits can stale one another's `baseToken` and force retries, and they interact in ways that are easier to reason about as an ordered sequence.
+**Batch thread replies and resolves.** Build all thread responses during the pass, then write them with a single `/ops` batch whenever possible. `comment.reply` accepts `resolve: true`, so a handled thread should usually be one operation, not `reply` plus `resolve`. The batched `/ops` shape uses one `baseToken` and one mutation:
+
+```json
+{"by":"ai:compound-engineering","baseToken":"<token>","operations":[
+  {"type":"comment.reply","markId":"<id-1>","text":"Updated the terminology.","resolve":true},
+  {"type":"comment.reply","markId":"<id-2>","text":"I disagree because X; leaving this open."}
+]}
+```
+
+Only include existing-thread comment mutations in a batch: `comment.reply`, `comment.resolve`, and `comment.unresolve`. Leave `resolve` off (or set it false) when the thread remains open for a user decision. This replaces the older pattern of N separate reply/resolve calls or sub-agent parallelism; batching is faster, easier to reason about, and creates one authoritative marks mutation.
 
 ### 2.4 Apply edits
 
 The user is collaborating in the doc, not waiting on approval. Every mutation works with live clients — only whole-doc `rewrite.apply` is gated. Pick the tool that matches intent:
 
-**Default: `suggestion.add` with `status: "accepted"`** for content changes anchored on a quote (reword, rename, clarify, correct, add a sentence inline). One call creates a tracked suggestion mark *and* commits the change. The user sees committed text (no pending approval needed), and the mark persists as audit trail with per-edit attribution and a one-click reject-to-revert. This is the right primitive for HITL auto-applied edits — it gives the user a reversible trail without asking them to re-review anything.
+**Default: `/edit/v2` for agent-applied content changes.** The comment thread is the review/audit trail: the user asked for the change, the agent applies it, then replies in-thread with what changed. Use block edits for direct fixes, insertions, deletions, and coordinated rewrites so the doc does not accumulate extra suggestion marks for work the user already requested.
+
+**Use `suggestion.add` with `status: "accepted"`** when a visible track-change mark is itself valuable — for example, the user asked to preserve a reject-to-revert affordance for a specific edit, or the change is judgment-sensitive enough that the visible suggestion trail is clearer than only replying in the comment thread. One call creates the suggestion mark *and* commits the change.
 
 ```json
 {"type":"suggestion.add","kind":"replace","quote":"<anchor>","content":"<new>","by":"ai:compound-engineering","status":"accepted","baseToken":"<token>"}
@@ -115,7 +127,7 @@ The user is collaborating in the doc, not waiting on approval. Every mutation wo
 
 Use `kind: "insert" | "delete" | "replace"` as appropriate; all three support `status: "accepted"`.
 
-**Use `/edit/v2` silently** only when the trail is actively wrong or technically blocked:
+**Use `/edit/v2` especially when:**
 
 - **Atomicity is required** — multiple coordinated edits must commit together or not at all (e.g., insert new section + update a reference in another block + delete the obsolete paragraph). `/edit/v2` takes an `operations` array that commits atomically; separate `suggestion.add` calls can partially succeed.
 - **Pre-user self-correction** — the agent is fixing its own output *before* the user has looked at the doc (e.g., spotted a mistake mid-ingest-pass). A tracked mark would imply "there was an old version," which is misleading from the user's perspective.
@@ -140,12 +152,21 @@ Per-op body shape (singular `block` for `replace_block`; plural `blocks:[{markdo
 {"op":"insert_before","ref":"b3","blocks":[{"markdown":"new block"}]}
 {"op":"delete_block","ref":"b6"}
 {"op":"find_replace_in_block","ref":"b4","find":"old","replace":"new","occurrence":"first"}
+{"op":"find_replace_in_doc","find":"old","replace":"new","occurrence":"all"}
 {"op":"replace_range","fromRef":"b2","toRef":"b5","blocks":[{"markdown":"..."}]}
 ```
 
-Block `ref` values drift across revisions — re-fetch `/snapshot` for fresh refs before each `/edit/v2` call if any writes have landed since the last snapshot.
+Block `ref` values are opaque request tokens tied to the snapshot/baseToken. Re-fetch `/snapshot` for fresh refs before another `/edit/v2` call if any writes have landed since the last snapshot. Full successful `/edit/v2` responses include a fresh `mutationBase.token` and, unless `?return=minimal` was used, a fresh snapshot for chaining.
 
-**Bulk mechanical sweep — prefer one `/edit/v2` call over N `suggestion.add` calls.** When a uniform change hits more than ~5 blocks (emdash sweep, terminology rename across a doc, heading-style normalization), batch it as a single `/edit/v2` with many `operations`. One round-trip, one atomic commit, one audit entry — versus N separate ops-endpoint calls, N baseToken reads (without the caching below), and N tracked marks for what is one logical change. Use `suggestion.add` + `accepted` when edits are distinct and anchored (each deserves its own reject-to-revert trail); use `/edit/v2` batch when they're variations of the same mechanical rule.
+**Bulk mechanical sweep — prefer `find_replace_in_doc` when the rule is literal.** For terminology renames, punctuation swaps, or other literal doc-wide replacements, use one `/edit/v2` operation:
+
+```json
+{"op":"find_replace_in_doc","find":"old term","replace":"new term","occurrence":"all"}
+```
+
+Run the same payload through `/edit/v2?dryRun=1` first for large sweeps; dry-run returns `valid`, `appliedCount`, and per-op `results[]` without writing. For the real write, use `/edit/v2?return=minimal` when you only need `ok`, `revision`, `appliedCount`, and the next `mutationBase.token`. Responses with `operationResults` include per-block match counts; treat those refs as reporting/display data and re-read `/snapshot` before follow-up block-ref mutations.
+
+When the edit is semantic rather than literal, batch `replace_block`, `insert_*`, `delete_block`, or `replace_range` operations in one `/edit/v2` call. Use `suggestion.add` + `accepted` when edits are distinct and each deserves its own visible reject-to-revert trail.
 
 **Use pending `suggestion.add` (no status)** when the change is judgment-sensitive enough that the agent wants explicit user approval before commit — rare in HITL, since the point of auto-applied edits is to reduce round-trips. Most judgment-sensitive cases are better handled by leaving the thread open with a clarifying question.
 
@@ -153,15 +174,16 @@ Block `ref` values drift across revisions — re-fetch `/snapshot` for fresh ref
 
 **Mutation requirements (every write, including replies and resolves):**
 
-- Top-level field is `type` on `/ops`; `operations[].op` on `/edit/v2`. Do not mix.
+- Top-level field is `type` on single `/ops` writes; top-level `operations` on `/ops` comment batches; `operations[].op` on `/edit/v2`. Do not mix `/ops` `type` entries with `/edit/v2` `op` entries.
 - Include `baseToken` from `/state.mutationBase.token` (or `/snapshot.mutationBase.token` for `/edit/v2`).
 - Set `by: "ai:compound-engineering"` and header `X-Agent-Id: ai:compound-engineering`.
-- Include an `Idempotency-Key` header (fresh UUID per logical write). Reuse the same key on a proven retry of the same payload; use a new key for a new logical write.
-- Reply: `{"type":"comment.reply","markId":"<id>","by":"ai:compound-engineering","text":"..."}`. Resolve: `{"type":"comment.resolve","markId":"<id>","by":"ai:compound-engineering"}`. Reopen if needed: `{"type":"comment.unresolve", ...}`.
+- Include an `Idempotency-Key` header. Reuse the same key only for an exact same-body resend; if you rebuild the body with a fresh `baseToken`, mint a new key.
+- Successful mutation responses include the next `mutationBase.token`; reuse it for the next write instead of re-reading only to get a token.
+- Reply and resolve together when done: `{"type":"comment.reply","markId":"<id>","text":"...","resolve":true}` inside a `/ops` batch. Reopen if needed: `{"type":"comment.unresolve", ...}`.
 
 **Retry after any error is verify-first, not retry-first.** The Proof API can commit canonically and still return a non-2xx or a 202 with `collab.status: "pending"`; network timeouts can hit after the server has already written. Retrying without verifying is the most common cause of duplicate marks (same comment twice, same suggestion twice) that then need a manual cleanup pass.
 
-- On `STALE_BASE` / `BASE_TOKEN_REQUIRED` / `MISSING_BASE` / `INVALID_BASE_TOKEN`: pre-commit, token-related. Re-read `/state`, send the same payload with a fresh `baseToken`, retry once. The `mutate()` helper below auto-retries these.
+- On `STALE_BASE` / `BASE_TOKEN_REQUIRED` / `MISSING_BASE` / `INVALID_BASE_TOKEN`: pre-commit, token-related. Re-read `/state`, rebuild the request body with a fresh `baseToken`, and retry once with a new `Idempotency-Key`. The `mutate()` helper below auto-retries these.
 - On `ANCHOR_NOT_FOUND` / `ANCHOR_AMBIGUOUS`: pre-commit, but the `quote` no longer matches uniquely. Re-read is not enough; the caller must tighten or regenerate the anchor before retrying. The helper surfaces the error instead of auto-retrying.
 - On `INVALID_OPERATIONS` / `INVALID_REQUEST` / `INVALID_REF` / `INVALID_BLOCK_MARKDOWN` / `INVALID_RANGE` / `INVALID_MARKDOWN` / 422: the payload is wrong. Do not retry — fix the payload and send a new write.
 - On `COLLAB_SYNC_FAILED` / `REWRITE_BARRIER_FAILED` / `PROJECTION_STALE` / `INTERNAL_ERROR` / 5xx / network error / timeout / **202 with `collab.status: "pending"`**: the write may have landed. Re-read `/state`, diff against the intended change (mark exists? suggestion applied? quote replaced?), and only retry if the server did not actually commit it. If the diff shows the write did land, treat the call as successful even though the response said otherwise.
@@ -287,7 +309,7 @@ Do **not** delete the Proof doc. It remains the durable review record; the calle
 
 ### BaseToken-aware mutation
 
-Reuse `baseToken` from the most recent `/state` read. Only re-read on `STALE_BASE` / `BASE_TOKEN_REQUIRED`. For an ingest pass this means one `/state` read at Phase 2.1 feeds every subsequent mutation, not N reads for N mutations.
+Seed `baseToken` from the most recent `/state` or `/snapshot` read, then update it from each successful mutation response's `mutationBase.token`. Only re-read on `STALE_BASE` / `BASE_TOKEN_REQUIRED` or when you need fresh document/comment/snapshot content. For an ingest pass this means one comment-filtered `/state` read, one `/edit/v2` batch if content changes are needed, and one `/ops` comment batch for replies/resolutions.
 
 Two retry classes, and they behave differently. The helper below only covers the safe class; the ambiguous class needs a caller-supplied verifier because "did this write land?" depends on what the payload was (look for a markId, a quote replacement, a thread reply, etc.).
 
@@ -299,11 +321,9 @@ BASE=<cached from most recent /state or /snapshot read>
 
 mutate() {
   local PAYLOAD="$1"  # jq template without baseToken
-  local IDEM_KEY BODY RESP CODE
-  # Fresh key per logical write (per mutate() call). The same key is then
-  # reused below only within the retry of this single logical write — NOT
-  # across different payloads, which would make the server collapse
-  # distinct writes as duplicates and silently drop later edits.
+  local IDEM_KEY BODY RESP CODE NEXT_BASE
+  # Fresh key for this request body. If the body changes, including because
+  # baseToken changes after STALE_BASE, the retry below mints a new key.
   IDEM_KEY=$(uuidgen)
   BODY=$(jq -n --arg base "$BASE" --argjson payload "$PAYLOAD" '$payload + {baseToken: $base}')
   RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/$SLUG/ops" \
@@ -324,6 +344,7 @@ mutate() {
     BASE=$(curl -s "https://www.proofeditor.ai/api/agent/$SLUG/state" \
       -H "x-share-token: $TOKEN" | jq -r '.mutationBase.token')
     BODY=$(jq -n --arg base "$BASE" --argjson payload "$PAYLOAD" '$payload + {baseToken: $base}')
+    IDEM_KEY=$(uuidgen)
     RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/$SLUG/ops" \
       -H "Content-Type: application/json" \
       -H "x-share-token: $TOKEN" \
@@ -331,11 +352,15 @@ mutate() {
       -H "Idempotency-Key: $IDEM_KEY" \
       -d "$BODY")
   fi
+  NEXT_BASE=$(printf '%s' "$RESP" | jq -r '.mutationBase.token // empty')
+  if [ -n "$NEXT_BASE" ]; then
+    BASE="$NEXT_BASE"
+  fi
   printf '%s' "$RESP"
 }
 ```
 
-The `Idempotency-Key` is minted fresh at the top of each call (one key per logical write). The retry inside the same call reuses that key so the server can collapse a duplicate TCP-level send, but a later `mutate()` for a different payload gets its own key. Minting outside the function would make every call share one key, and the server would treat the second and subsequent writes as duplicates of the first and silently drop them.
+The `Idempotency-Key` is minted for the exact request body being sent. If a retry rebuilds the body with a fresh `baseToken`, that is a different payload hash, so it needs a new key; reusing the previous key would trigger `IDEMPOTENCY_KEY_REUSED`. Reuse the same key only for a transport-level resend of the exact same body. Minting outside the function would make unrelated writes share one key, and the server would treat later payloads as invalid key reuse.
 
 **Ambiguous failures (anything outside the pre-commit set above — `COLLAB_SYNC_FAILED`, `INTERNAL_ERROR`, 5xx, network timeout, 202 with `collab.status: "pending"`):** do not retry from this helper. Re-read `/state` in the caller, diff the marks/content against the intended change, and only re-issue the write if the diff proves nothing landed. Pattern:
 


### PR DESCRIPTION
## Summary

`ce-proof` now teaches agents the Proof v2-native HITL workflow: read only review comments, make narrow content edits through `/edit/v2`, batch thread replies/resolutions, and reserve whole-document rewrites for true last-resort cases. This should make Proof review loops faster and safer while avoiding the stale-token, duplicate-mark, and full-rewrite habits that came from the v1-era contract.

The mutation examples now match Proof v2's stricter contract: `/ops` examples include `Idempotency-Key`, successful writes chain the next `mutationBase.token`, and retries that rebuild the body with a fresh `baseToken` mint a fresh key instead of tripping `IDEMPOTENCY_KEY_REUSED`.

## What changed

- Reframes HITL content edits around `find_replace_in_doc` and block-level `/edit/v2`, with `suggestion.add` reserved for visible track-change cases and `rewrite.apply` documented as last resort.
- Adds efficient comment handling through `state?kinds=comment`, batched `/ops` replies/resolves, and `comment.reply` with `resolve: true`.
- Corrects copy-paste examples for Proof v2 mutation safety, including token chaining, idempotency keys on `/ops`, exact-body retry semantics, and consistent `ai:compound-engineering` bridge identity.
- Updates `ce-brainstorm`, `ce-ideate`, and `ce-plan` handoff wording so upstream skills no longer promise tracked suggestions as the default HITL edit path.

## Verification

- `bun run release:validate`
- `bun test tests/frontmatter.test.ts`
- `bun test tests/release-metadata.test.ts`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
