### PR TITLE
fix(ce-compound): drop date suffix from generated doc filenames

### DIFF
--- a/plugins/compound-engineering/skills/ce-compound/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-compound/SKILL.md
@@ -129,7 +129,7 @@ Launch research subagents. Each returns text data to the orchestrator.
      - **Knowledge track**: applies_when (symptoms/root_cause/resolution_type optional)
    - Incorporates auto memory excerpts (if provided by the orchestrator) as supplementary evidence
    - Reads `references/yaml-schema.md` for category mapping into `docs/solutions/`
-   - Suggests a filename using the pattern `[sanitized-problem-slug]-[date].md`
+   - Suggests a filename using the pattern `[sanitized-problem-slug].md` — no date suffix, even if existing files in the target directory have one; the `date:` frontmatter field is the canonical creation date
    - Returns: YAML frontmatter skeleton (must include `category:` field mapped from problem_type), category directory path, suggested filename, and which track applies
    - Does not invent enum values, categories, or frontmatter fields from memory; reads the schema and mapping files above
    - Does not force bug-track fields onto knowledge-track learnings or vice versa


### PR DESCRIPTION
`ce-compound` now suggests filenames as `[slug].md` instead of `[slug]-[date].md`. The filename date was duplicate metadata — the `date:` frontmatter field is the canonical creation date, and `ce-compound-refresh` writes `last_updated:` without renaming the file, so a filename date inevitably drifted from the doc's actual freshness. The skill's instruction also tells the agent to ignore dated counterexamples in the target directory so it does not pattern-match the old convention back in. Existing dated files in this repo (and in downstream consumer repos) are untouched; `ce-compound-refresh` already matches partial slugs, so prior solution archives keep working.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
