### PR TITLE
fix(ce-commit-push-pr): require user-visible bug summaries

### DIFF
--- a/plugins/compound-engineering/skills/ce-commit-push-pr/references/pr-description-writing.md
+++ b/plugins/compound-engineering/skills/ce-commit-push-pr/references/pr-description-writing.md
@@ -9,6 +9,8 @@ The diff is already visible on GitHub. The description exists to explain what th
 
 If the lead sentence describes what was moved, renamed, or added rather than what's now possible or fixed, rewrite it. This applies to every section, not just the opening — restating the diff is the failure mode this skill exists to prevent.
 
+For user-facing bugs, run an extra before/after pass before writing the mechanism: name what the user would have seen before and what they now see instead. Only then mention the technical cause or fix, and only if it helps the reviewer understand risk. A lead like "Playback hooks now ignore late async responses" is still too mechanical if the visible bug was "old videos, thumbnails, or errors could appear after switching selections."
+
 ---
 
 ## Step Pre-A: Resolve the range and base
@@ -63,6 +65,7 @@ Match weight to weight. When in doubt, shorter wins. Subtract fix-up commits (re
 | Performance improvement | Include before/after measurements as a markdown table. |
 
 For small + simple PRs, the value-led sentence is the entire description.
+For small + non-trivial bugfixes, the 3-5 sentence target still needs a user-visible before/after lead when the bug affected UI, CLI output, workflow output, or any other user-observable behavior. Concision is not a reason to skip the visible symptom.
 
 ---
 


### PR DESCRIPTION
## Summary

PR descriptions for user-facing bugs now have to name the visible before/after experience before explaining the implementation fix. This closes the gap where a technically correct summary could still lead with async or hook mechanics while hiding what the user actually saw, like stale videos, thumbnails, or errors after switching selections.

## Test plan

- `bun run release:validate`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
