### PR TITLE
fix(commit): auto-create feature branch on default branch

### DIFF
--- a/plugins/compound-engineering/skills/ce-commit-push-pr/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-commit-push-pr/SKILL.md
@@ -50,7 +50,7 @@ The remote default branch returns something like `origin/main`; strip the `origi
 Branch routing:
 
 - **Detached HEAD** — explain a branch is required and ask whether to create a feature branch. If yes, derive a name from the change content. If no, stop.
-- **On default branch with work to do** (uncommitted, unpushed, or no upstream) — ask whether to create a feature branch (pushing default directly is not supported). If yes, continue at Step 3 (which handles branch creation safely). If no, stop.
+- **On default branch with work to do** (uncommitted, unpushed, or no upstream) — automatically create a feature branch (pushing the default directly is not supported). Derive a name from the change content and continue at Step 3, which handles branch creation safely. Do not ask whether to branch — committing on the default is not an option here.
 - **On default branch with no work** — report no feature branch work and stop.
 - **Feature branch** — continue.
 

--- a/plugins/compound-engineering/skills/ce-commit/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-commit/SKILL.md
@@ -82,7 +82,7 @@ Keep this lightweight:
 
 ### Step 4: Stage and commit
 
-If the current branch from the context above is `main`, `master`, or the resolved default branch from Step 1, warn the user and ask whether to continue committing here or create a feature branch first. Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_user` in Gemini, `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question. If the user chooses to create a branch, derive the name from the change content, create it with `git checkout -b <branch-name>`, then continue.
+If the current branch from the context above is `main`, `master`, or the resolved default branch from Step 1, automatically create a feature branch before committing. Derive the branch name from the change content, create it with `git checkout -b <branch-name>`, run `git branch --show-current` to confirm, and use the new branch as the current branch for the rest of the workflow. Do not ask whether to branch — committing on the default branch is not an option here.
 
 Write the commit message:
 - **Subject line**: Concise, imperative mood, focused on *why* not *what*. Follow the convention determined in Step 2.


### PR DESCRIPTION
Running `ce-commit` or `ce-commit-push-pr` on `main`/`master` no longer interrupts with a "create a feature branch or commit directly?" prompt — the skills now derive a branch name from the change content and create it without asking. Committing on the default branch was never a real option in this repo (branch protection blocks the eventual push/merge), so the prompt was friction without choice. The detached-HEAD question and the unpushed-commits carry-forward question in `branch-creation.md` are preserved — those are real branching decisions, not no-ops.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
