### PR TITLE
feat(ce-code-review): emit a schema'd envelope.json in headless mode

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -85,6 +85,7 @@ Sequence:
 - **Apply only `safe_auto -> review-fixer` findings in a single pass.** No bounded re-review rounds. Leave `gated_auto`, `manual`, `human`, and `release` work unresolved and return them in the structured output.
 - **Return all non-auto findings as structured text output.** Use the headless output envelope format (see Stage 6 below) preserving severity, autofix_class, owner, requires_verification, confidence, pre_existing, and suggested_fix per finding. Enrich with detail-tier fields (why_it_matters, evidence[]) from the per-agent artifact files on disk (see Detail enrichment in Stage 6).
 - **Write a run artifact** under `/tmp/compound-engineering/ce-code-review/<run-id>/` summarizing findings, applied fixes, and advisory outputs. Include the artifact path in the structured output.
+- **Write a machine-readable envelope.** Alongside the run artifact, write `<run-id>/envelope.json` containing the merged finding set (post-Stage-5b), verdict, and counts, conforming to `references/envelope-schema.json`. Validate it against that schema before emitting `Review complete`; if it does not validate, emit the degraded envelope (`Code review degraded (headless mode). Reason: <reason>.`) rather than a malformed file. This is the stable contract for programmatic callers -- the prose output below remains the human-facing handoff. See Step 4 for the field mapping.
 - **Do not file tickets or externalize work.** The caller receives structured findings and routes downstream work itself.
 - **Do not switch the shared checkout.** If the caller passes an explicit PR or branch target, `mode:headless` must run in an isolated checkout/worktree or stop instead of running `gh pr checkout` / `git checkout`. When stopping, emit `Review failed (headless mode). Reason: cannot switch shared checkout. Re-invoke with base:<ref> to review the current checkout, or run from an isolated worktree.`
 - **Not safe for concurrent use on a shared checkout.** Unlike `mode:report-only`, headless mutates files (applies `safe_auto` fixes). Callers must not run headless concurrently with other mutating operations on the same checkout.
@@ -621,6 +622,7 @@ Intent: <intent-summary>
 Reviewers: <reviewer-list with conditional justifications>
 Verdict: <Ready to merge | Ready with fixes | Not ready>
 Artifact: /tmp/compound-engineering/ce-code-review/<run-id>/
+Envelope: /tmp/compound-engineering/ce-code-review/<run-id>/envelope.json
 
 Applied N safe_auto fixes.
 
@@ -683,6 +685,7 @@ Review complete
 **Formatting rules:**
 - The `[needs-verification]` marker appears only on findings where `requires_verification: true`.
 - The `Artifact:` line gives callers the path to the full run artifact for machine-readable access to the complete findings schema. The text envelope is the primary handoff; the artifact is for debugging and full-fidelity access.
+- The `Envelope:` line points at `envelope.json` -- the schema'd, merged finding set (`references/envelope-schema.json`). Programmatic callers should prefer it over parsing this prose; the prose remains the human-facing handoff.
 - Findings with `owner: release` appear in the Advisory section (they are operational/rollout items, not code fixes).
 - Findings with `pre_existing: true` appear in the Pre-existing section regardless of autofix_class.
 - The Verdict appears in the metadata header (deliberately reordered from the interactive format where it appears at the bottom) so programmatic callers get the verdict first.
@@ -824,6 +827,7 @@ The fixer accepts two queue shapes depending on which caller invoked it:
   - residual actionable work
   - advisory-only outputs
   Per-agent full-detail JSON files (`{reviewer_name}.json`) are already present in this directory from Stage 4 dispatch.
+- **In headless mode, also write `envelope.json`** -- the merged finding set as machine-readable JSON, conforming to `references/envelope-schema.json`. This is the programmatic-caller contract (the prose envelope is the human handoff). Populate it from the same merged Stage 5 finding set the prose output renders: per-finding `severity`, `file`, `line`, `title`, `autofix_class`, `owner`, `requires_verification`, `confidence`, `pre_existing`, and `reviewers` come from the merge tier; `why_it_matters`, `evidence`, and `suggested_fix` from the same artifact lookup the prose `Why:`/`Evidence:`/`Suggested fix:` lines use (omit the detail-tier fields when no artifact matched). Set `verdict` and `counts` to match the prose header, `applied_safe_auto_fixes` to the applied count, and `schema_version` to `1.0.0`. Validate against the schema before emitting `Review complete`; on failure, emit the degraded envelope instead of writing a malformed file.
 - Also write `metadata.json` alongside the findings so downstream skills (e.g., `ce-polish-beta`) can verify the artifact matches the current branch and HEAD. Minimum fields:
   ```json
   {
@@ -892,6 +896,10 @@ If the platform doesn't support parallel sub-agents, run reviewers sequentially.
 ### Findings Schema
 
 @./references/findings-schema.json
+
+### Envelope Schema
+
+@./references/envelope-schema.json
 
 ### Review Output Template
 

--- a/plugins/compound-engineering/skills/ce-code-review/references/envelope-schema.json
+++ b/plugins/compound-engineering/skills/ce-code-review/references/envelope-schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Code Review Merged Envelope",
+  "description": "Machine-readable handoff written by mode:headless after Stage 5 merge: the post-dedup, post-gating, synthesized finding set plus verdict and counts. Companion to the prose headless envelope -- the prose stays the primary human-facing handoff; this file is the stable contract for programmatic callers, who should prefer it over parsing the prose. Per-finding fields mirror findings-schema.json (the per-reviewer sub-agent schema) so the merge step can populate them directly, plus a `reviewers` list carried from the merge tier.",
+  "type": "object",
+  "required": ["schema_version", "run_id", "verdict", "counts", "findings"],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "SemVer of this envelope schema. Bump the major on a breaking change so consumers can gate on it. Current: 1.0.0."
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Run identifier; matches the run-artifact directory name and metadata.json."
+    },
+    "verdict": {
+      "type": "string",
+      "enum": ["Ready to merge", "Ready with fixes", "Not ready"],
+      "description": "Native verdict vocabulary, unchanged from the prose envelope's Verdict line. Consumers map to their own states."
+    },
+    "applied_safe_auto_fixes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Count of safe_auto fixes applied in the single headless pass. Mirrors the prose 'Applied N safe_auto fixes.' line."
+    },
+    "counts": {
+      "type": "object",
+      "description": "Per-severity counts over `findings`. sum equals findings.length.",
+      "required": ["P0", "P1", "P2", "P3"],
+      "properties": {
+        "P0": { "type": "integer", "minimum": 0 },
+        "P1": { "type": "integer", "minimum": 0 },
+        "P2": { "type": "integer", "minimum": 0 },
+        "P3": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "description": "Merged, deduped, confidence-gated findings -- the same set rendered in the prose envelope's finding sections (gated-auto, manual, advisory, pre-existing).",
+      "items": {
+        "type": "object",
+        "required": [
+          "severity",
+          "file",
+          "line",
+          "title",
+          "autofix_class",
+          "owner",
+          "requires_verification",
+          "confidence",
+          "pre_existing",
+          "reviewers"
+        ],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["P0", "P1", "P2", "P3"]
+          },
+          "file": {
+            "type": "string",
+            "description": "Relative file path from repository root."
+          },
+          "line": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Primary line number of the issue."
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 100,
+            "description": "Short, specific issue title."
+          },
+          "why_it_matters": {
+            "type": "string",
+            "description": "Impact and failure mode. Detail-tier: omitted when no contributing-reviewer artifact matched (same condition under which the prose envelope omits the Why: line)."
+          },
+          "suggested_fix": {
+            "type": ["string", "null"],
+            "description": "Concrete minimal fix, or null when there is no code-level change to propose."
+          },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Code-grounded evidence. Detail-tier: may be empty when no artifact matched."
+          },
+          "autofix_class": {
+            "type": "string",
+            "enum": ["safe_auto", "gated_auto", "manual", "advisory"]
+          },
+          "owner": {
+            "type": "string",
+            "enum": ["review-fixer", "downstream-resolver", "human", "release"]
+          },
+          "requires_verification": {
+            "type": "boolean",
+            "description": "Whether any fix must be re-verified. Mirrors the prose [needs-verification] marker."
+          },
+          "confidence": {
+            "type": "integer",
+            "enum": [0, 25, 50, 75, 100],
+            "description": "Anchored confidence score (see findings-schema.json for anchor definitions)."
+          },
+          "pre_existing": {
+            "type": "boolean",
+            "description": "True if the issue exists in unchanged code unrelated to the diff. Pre-existing findings render in the prose envelope's Pre-existing section regardless of autofix_class."
+          },
+          "reviewers": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "description": "Persona name(s) that contributed this merged finding (e.g. ['correctness', 'security'])."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`mode:headless` is documented as the mode "for programmatic skill-to-skill invocation" (SKILL.md §"Headless mode rules"), but its only specified machine handoff is the **prose** text envelope (§"Headless output format"). Programmatic callers must parse that prose with a grammar — header sentinel, `Verdict:` line, `[P1][gated_auto -> …]` finding lines, terminator — which breaks on cosmetic drift (a preamble line, trailing text on the header, a reworded section heading).

The run-artifact directory already exists, but the structured data in it isn't a usable contract for the merged result:
- per-reviewer `{reviewer}.json` files are **pre-merge / pre-dedup / pre-gating**;
- `metadata.json` carries only run_id/branch/head_sha/verdict;
- the "synthesized findings" artifact (Step 4) has **no documented shape**.

So the post-merge, synthesized finding set — the thing a caller actually wants — is only emitted in a *specified* form as prose.

(Context: we consume `mode:headless` from a downstream CI reviewer and have repeatedly lost expensive reviews to prose-format mismatches; this is the upstream half of the fix.)

## Proposal

In headless mode, additionally write a machine-readable `<run-id>/envelope.json` containing the **merged** finding set (post-Stage-5b), verdict, and counts, against a new published `references/envelope-schema.json`. Surface its path on a new `Envelope:` line in the prose output.

- **Additive / non-breaking.** The prose envelope is byte-identical; only new lines and files are added. It remains the primary human-facing handoff; JSON is the machine handoff.
- **Low maintainer burden.** The merged findings already exist in-context at Stage 5, and you already write per-reviewer JSON against `findings-schema.json` — this serializes data you have, it isn't a new computation. Per-finding fields are lifted 1:1 from `findings-schema.json` (plus a `reviewers` list from the merge tier), so the field mapping is mechanical.
- **Self-validating.** The skill validates the file against the schema before emitting `Review complete`; on failure it emits the existing degraded envelope rather than writing a malformed file.

## Changes
- `skills/ce-code-review/references/envelope-schema.json` — new draft-07 schema for the merged envelope.
- `skills/ce-code-review/SKILL.md` — headless-mode rule, an `Envelope:` line + formatting note in the output format, the field mapping in Step 4, and registration in Included References.

## Validation
- `bun test` — 1395 pass / 0 fail (unchanged from base).
- `bun run scripts/release/validate.ts` — metadata in sync.
- Schema is valid draft-07 and accepts a representative merged envelope.

Happy to adjust naming, schema shape, or whether this should extend to `autofix`/`interactive` modes too — wanted to keep the first cut minimal and headless-only.
