### PR TITLE
fix(ce-brainstorm,ce-plan): restore default-on requirements grouping

### DIFF
--- a/plugins/compound-engineering/skills/ce-brainstorm/references/brainstorm-sections.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/brainstorm-sections.md
@@ -66,8 +66,12 @@ When a doc is warranted, these are present.
   "Migration and compatibility" / "Contributor workflow"), group them
   under bold inline headers within the Requirements section — group by
   capability or concern, not by the order requirements were discussed.
-  R-IDs stay continuous across groups (R1, R2 in the first group; R3, R4
-  in the second; never restart at R1 per group).
+  The trigger is distinct concerns, not item count — even four
+  requirements benefit if they cover three different topics. Skip
+  grouping only when all requirements are genuinely about the same thing;
+  a long flat list is a smell that subgroups were missed. R-IDs stay
+  continuous across groups (R1, R2 in the first group; R3, R4 in the
+  second; never restart at R1 per group).
 
 ## Include when material
 
@@ -145,7 +149,8 @@ The agent also picks per artifact:
 - How much depth each present section gets
 
 (Requirements grouping is covered above in the Hard Floor item — group by
-concern when they span distinct areas, with continuous R-IDs across groups.)
+concern by default, rendering a flat list only when all requirements are
+about the same thing, with continuous R-IDs across groups.)
 
 ## Brainstorm metadata fields
 

--- a/plugins/compound-engineering/skills/ce-brainstorm/references/html-rendering.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/html-rendering.md
@@ -248,7 +248,11 @@ contracts — the agent picks shapes that fit the content.
   paragraphs. Optionally precede with an eyebrow label (small-caps tag
   above the title) for editorial polish.
 - **Requirements** — `<table>` is the default at 5+ uniform items;
-  bullets at smaller counts. Each row has the R-ID as visible text in
+  bullets at smaller counts. Concern-grouping takes precedence over the
+  flat-table default: when requirements span distinct concerns, group them
+  under bold inline headers (or per-group sections) first, then apply the
+  5+ table default *within* each group rather than flattening the whole
+  section into one table. Each row has the R-ID as visible text in
   its own column. Consider adding a "covered by" column for reverse
   traceability when ID-anchored items have downstream references in
   the same doc.

--- a/plugins/compound-engineering/skills/ce-brainstorm/references/markdown-rendering.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/markdown-rendering.md
@@ -99,10 +99,12 @@ How section types commonly render in markdown. These are patterns, not
 contracts — the agent picks the shape that fits the content.
 
 - **Summary / Problem Frame** — prose paragraphs.
-- **Requirements** — bullets with `R<N>.` prefix. Group with bold inline
-  headers when requirements span distinct concerns (group by capability,
-  not by discussion order). When requirements have status, traceability,
-  or severity that warrant additional columns, escalate to a table.
+- **Requirements** — bullets with `R<N>.` prefix. When requirements span
+  more than one concern, grouping under bold inline headers is the default
+  shape, not optional polish (group by capability, not by discussion order);
+  render a flat list only when every requirement is about the same thing.
+  When requirements have status, traceability, or severity that warrant
+  additional columns, escalate to a table.
 - **Implementation Units** — H3 heading per unit with `U<N>.` prefix.
   Fields (Goal, Files, Patterns, Test Scenarios, Verification) render as
   bullets with bold leader labels, or as sub-headings if the field has

--- a/plugins/compound-engineering/skills/ce-plan/references/html-rendering.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/html-rendering.md
@@ -248,7 +248,11 @@ contracts — the agent picks shapes that fit the content.
   paragraphs. Optionally precede with an eyebrow label (small-caps tag
   above the title) for editorial polish.
 - **Requirements** — `<table>` is the default at 5+ uniform items;
-  bullets at smaller counts. Each row has the R-ID as visible text in
+  bullets at smaller counts. Concern-grouping takes precedence over the
+  flat-table default: when requirements span distinct concerns, group them
+  under bold inline headers (or per-group sections) first, then apply the
+  5+ table default *within* each group rather than flattening the whole
+  section into one table. Each row has the R-ID as visible text in
   its own column. Consider adding a "covered by" column for reverse
   traceability when ID-anchored items have downstream references in
   the same doc.

--- a/plugins/compound-engineering/skills/ce-plan/references/markdown-rendering.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/markdown-rendering.md
@@ -99,10 +99,12 @@ How section types commonly render in markdown. These are patterns, not
 contracts — the agent picks the shape that fits the content.
 
 - **Summary / Problem Frame** — prose paragraphs.
-- **Requirements** — bullets with `R<N>.` prefix. Group with bold inline
-  headers when requirements span distinct concerns (group by capability,
-  not by discussion order). When requirements have status, traceability,
-  or severity that warrant additional columns, escalate to a table.
+- **Requirements** — bullets with `R<N>.` prefix. When requirements span
+  more than one concern, grouping under bold inline headers is the default
+  shape, not optional polish (group by capability, not by discussion order);
+  render a flat list only when every requirement is about the same thing.
+  When requirements have status, traceability, or severity that warrant
+  additional columns, escalate to a table.
 - **Implementation Units** — H3 heading per unit with `U<N>.` prefix.
   Fields (Goal, Files, Patterns, Test Scenarios, Verification) render as
   bullets with bold leader labels, or as sub-headings if the field has

--- a/plugins/compound-engineering/skills/ce-plan/references/plan-sections.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/plan-sections.md
@@ -217,11 +217,13 @@ These apply regardless of rendering format.
   metadata belongs in commit messages and tool output, not the artifact.
 - **Group Requirements by concern when they span distinct logical areas.**
   The trigger is distinct concerns, not item count — even four requirements
-  benefit from grouping if they cover three different topics. Group by
-  capability (e.g., "Packaging", "Migration and compatibility", "Contributor
-  workflow"), not by the order requirements were discussed. R-IDs stay
-  continuous across groups (R1, R2 in the first group; R3, R4 in the second;
-  never restart at R1 per group).
+  benefit from grouping if they cover three different topics. Skip grouping
+  only when all requirements are genuinely about the same thing; a long flat
+  list is a smell that subgroups were missed. Group by capability (e.g.,
+  "Packaging", "Migration and compatibility", "Contributor workflow"), not by
+  the order requirements were discussed. R-IDs stay continuous across groups
+  (R1, R2 in the first group; R3, R4 in the second; never restart at R1 per
+  group).
 
 ## Rendering
 


### PR DESCRIPTION
Requirements sections in `ce-brainstorm` and `ce-plan` docs could come out as long, undifferentiated flat lists — one recent brainstorm shipped 14 requirements with no subgroups. They now group into concern-based subgroups by default, and render flat only when every requirement is genuinely about the same thing.

The cause was a regression from #826, which moved the requirements-grouping rule into the new section contract and rendering references and dropped its strongest framing along the way. The rule flipped from default-on ("skip grouping only when all requirements are about the same thing") to a positive conditional ("group when they span distinct concerns") — which let the agent classify a long set as "one concern" and emit a flat list while feeling compliant.

This restores the default-on test in both section contracts (with the "not item count" emphasis re-added to the brainstorm copy so they match), reframes the markdown rendering guidance so grouping is the default shape rather than optional polish, and makes concern-grouping take precedence over HTML's flat-`<table>` default so a multi-concern set renders as grouped tables instead of one flat table. It also realigns a stale back-pointer in `brainstorm-sections.md` that still restated the old weak conditional.

Behavioral skill-prose change, so there is no runnable demo; the effect is only observable by composing a multi-concern requirements doc in a fresh session (the in-session skill cache means it can't be verified in the session that edited it).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
