### PR TITLE
fix(html-rendering): constrain measure and surface execution notes

### DIFF
--- a/plugins/compound-engineering/skills/ce-brainstorm/references/html-rendering.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/html-rendering.md
@@ -157,6 +157,30 @@ defend against:
 These shape what "good" HTML looks like; the agent applies them per
 artifact based on content.
 
+### Readable measure, not full bleed
+
+Long-form text is unreadable at full viewport width — past ~80 characters
+per line the eye loses the return sweep and scanning slows. As a
+fallback-default (precedence tier 4, overridden by in-session direction or
+DESIGN.md), center the document in a content container and hold prose to a
+comfortable measure.
+
+- **Page container.** A centered column with a max-width in the ~820-960px
+  band (`margin-inline: auto`) keeps the doc off the far edges of wide
+  monitors while leaving room for the format's richer shapes.
+- **Prose measure.** Hold running paragraphs to roughly 65-80 characters
+  (`max-width: ~70ch` on text blocks). The named test: read a paragraph at
+  full window width on a wide display — if the return sweep to the next
+  line is effortful, the measure is too wide.
+- **Let wide content break out.** Tables, diagrams, and side-by-side
+  columns may use the full container width (or wider) when the content
+  needs it — the measure constraint is for prose, not for everything.
+
+Express the constraint in `ch`/`rem` rather than a single hardcoded pixel
+value so it survives font-size and DESIGN.md overrides. DESIGN.md or an
+in-session instruction overrides these values; this is the fallback when no
+layout preference exists.
+
 ### Markdown source is content, not design
 
 When markdown (or markdown-shaped chat context) is part of the input, use
@@ -267,7 +291,15 @@ contracts — the agent picks shapes that fit the content.
   primary always-visible surface; subsection labels (`<summary>`) are
   clickable affordances for readers to expand on demand. A single unit
   with no secondary content can skip `<details>` entirely; the rule
-  fires when content exists to hide.
+  fires when content exists to hide. The `<dl>` strip is for *descriptive*
+  fields (Goal, Files, Dependencies). A *directive* field — `Execution
+  note` is the canonical case, carrying a procedural instruction the
+  implementer must act on (e.g. "start with a failing integration test") —
+  does not belong in the strip, where it renders as a passive pair styled
+  like a date and gets skimmed past. Render it as an advisory callout (see
+  Tinted callout cards) so its visual weight matches its actionability. The
+  test: descriptive value -> metadata pair; something the reader must act
+  on -> callout.
 - **Key Technical Decisions** — repeating cards with the decision ID,
   bold decision title (often with inline code for technical
   identifiers), and prose rationale. Flat cards (not collapsibles) —
@@ -410,8 +442,8 @@ fine when the content suggests them.
 - **Side-by-side columns** for parallel content (Request / Response,
   Before / After, Two alternatives).
 - **Tinted callout cards** for content that is "different in kind"
-  (Deferred, Open Questions, advisory notes) — color-coded left
-  borders communicate kind at a glance.
+  (Deferred, Open Questions, advisory notes, unit-level execution notes)
+  — color-coded left borders communicate kind at a glance.
 
 ## Agent-consumability rules
 

--- a/plugins/compound-engineering/skills/ce-plan/references/html-rendering.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/html-rendering.md
@@ -157,6 +157,30 @@ defend against:
 These shape what "good" HTML looks like; the agent applies them per
 artifact based on content.
 
+### Readable measure, not full bleed
+
+Long-form text is unreadable at full viewport width — past ~80 characters
+per line the eye loses the return sweep and scanning slows. As a
+fallback-default (precedence tier 4, overridden by in-session direction or
+DESIGN.md), center the document in a content container and hold prose to a
+comfortable measure.
+
+- **Page container.** A centered column with a max-width in the ~820-960px
+  band (`margin-inline: auto`) keeps the doc off the far edges of wide
+  monitors while leaving room for the format's richer shapes.
+- **Prose measure.** Hold running paragraphs to roughly 65-80 characters
+  (`max-width: ~70ch` on text blocks). The named test: read a paragraph at
+  full window width on a wide display — if the return sweep to the next
+  line is effortful, the measure is too wide.
+- **Let wide content break out.** Tables, diagrams, and side-by-side
+  columns may use the full container width (or wider) when the content
+  needs it — the measure constraint is for prose, not for everything.
+
+Express the constraint in `ch`/`rem` rather than a single hardcoded pixel
+value so it survives font-size and DESIGN.md overrides. DESIGN.md or an
+in-session instruction overrides these values; this is the fallback when no
+layout preference exists.
+
 ### Markdown source is content, not design
 
 When markdown (or markdown-shaped chat context) is part of the input, use
@@ -267,7 +291,15 @@ contracts — the agent picks shapes that fit the content.
   primary always-visible surface; subsection labels (`<summary>`) are
   clickable affordances for readers to expand on demand. A single unit
   with no secondary content can skip `<details>` entirely; the rule
-  fires when content exists to hide.
+  fires when content exists to hide. The `<dl>` strip is for *descriptive*
+  fields (Goal, Files, Dependencies). A *directive* field — `Execution
+  note` is the canonical case, carrying a procedural instruction the
+  implementer must act on (e.g. "start with a failing integration test") —
+  does not belong in the strip, where it renders as a passive pair styled
+  like a date and gets skimmed past. Render it as an advisory callout (see
+  Tinted callout cards) so its visual weight matches its actionability. The
+  test: descriptive value -> metadata pair; something the reader must act
+  on -> callout.
 - **Key Technical Decisions** — repeating cards with the decision ID,
   bold decision title (often with inline code for technical
   identifiers), and prose rationale. Flat cards (not collapsibles) —
@@ -410,8 +442,8 @@ fine when the content suggests them.
 - **Side-by-side columns** for parallel content (Request / Response,
   Before / After, Two alternatives).
 - **Tinted callout cards** for content that is "different in kind"
-  (Deferred, Open Questions, advisory notes) — color-coded left
-  borders communicate kind at a glance.
+  (Deferred, Open Questions, advisory notes, unit-level execution notes)
+  — color-coded left borders communicate kind at a glance.
 
 ## Agent-consumability rules
 


### PR DESCRIPTION
Two readability defects in the HTML output of `ce-brainstorm` and `ce-plan` (both share `html-rendering.md`).

**Full-bleed text.** Generated HTML docs rendered edge-to-edge on wide monitors, with prose lines running far past a comfortable reading measure — hard to scan, the eye loses the return sweep. The rendering reference had detailed typography, color, and diagram guidance but said nothing about page layout, so there was nothing steering the agent toward a constrained column. Now docs center in a content container (~820–960px band) with prose held to a ~70ch measure, while tables, diagrams, and side-by-side columns may still break out wider. It's a fallback-default (precedence tier 4) expressed in `ch`/`rem`, so DESIGN.md or in-session direction overrides it and it survives font-size changes.

**Buried execution notes.** A unit's `Execution note` is a procedural directive the implementer must act on ("start with a failing integration test"), but the reference described the unit metadata strip as a plain `<dl>` of Goal/Files/Dependencies without distinguishing descriptive fields from directives. Following it, the agent rendered the note as a passive `<dt>/<dd>` pair styled like a date — the one field that changes *how* you build the unit looked like the least important line on the card. The reference now says descriptive values stay in the `<dl>` while a directive renders as an advisory callout (a pattern the format already had for "advisory notes"). Named test: descriptive value → metadata pair; something the reader must act on → callout.

No runnable demo — skill-prose change; the effect is only observable by composing an HTML artifact in a fresh session (the in-session skill cache means it can't be verified in the session that edited it). Both copies of `html-rendering.md` stay byte-identical; `release:validate` is clean.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
