### PR TITLE
fix(ce-brainstorm,ce-plan): add conceptual-diagram affordance to brainstorm docs

### DIFF
--- a/plugins/compound-engineering/skills/ce-brainstorm/references/brainstorm-sections.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/brainstorm-sections.md
@@ -101,6 +101,30 @@ worse than omitting it.
   together prevent downstream invention of paths. When omitting from a
   behavioral brainstorm, note the reason in the doc.
 
+- **Visualizations** — include a diagram when the brainstorm contains a
+  diagram-shaped concept that a picture carries faster than prose. Common
+  shapes: a data-shape transformation (before/after schema or field
+  mapping), a source-of-truth fan-out (one authority feeding many derived
+  surfaces), state-or-lifecycle logic, a multi-step flow, or a quantitative
+  comparison. A diagram is cross-cutting, not a section of its own — it sits
+  next to the Key Decision, Requirements group, or Flow it illustrates. The
+  named test: *does the picture let a reader grasp the concept faster than
+  the paragraph alone?* If yes, add it; if the prose already conveys it at a
+  glance, skip it. One diagram per load-bearing concept — don't add visuals
+  for ceremony. This affordance is the conceptual-diagram path; it is
+  distinct from the wireframe affordance (a wireframe is for visual-product
+  UI and does not apply to non-visual systems like data models or agent
+  workflows, but a conceptual diagram does).
+
+  **Diagrams complement prose; they never replace it.** A diagram is an
+  on-ramp to the prose it illustrates, not a substitute. The IDed prose
+  (Requirements, Key Decisions, Acceptance Examples) stays complete and
+  standalone — a reader who ignores every diagram still gets the full
+  content in text, and a downstream agent that reads the artifact as linear
+  text is never left with a relationship that exists only in an SVG. Adding
+  a before/after diagram is not license to thin the requirement or decision
+  prose it depicts.
+
 - **Acceptance Examples** — include when any requirement has a
   state-dependent or conditional shape ("When X, Y") where prose alone leaves
   ambiguity about edge cases. **Always include AEs covering

--- a/plugins/compound-engineering/skills/ce-brainstorm/references/html-rendering.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/html-rendering.md
@@ -324,6 +324,23 @@ across categories, a bar chart is the right shape; if it's component
 relationships, a topology diagram; if it's process flow across
 participants, a swim lane; etc.
 
+**Conceptual diagrams are not wireframes.** The wireframe affordance below
+is scoped to brainstorm requirements docs about *visual products* and is
+excluded for non-visual systems. That exclusion is about wireframes only —
+a brainstorm about a data model, schema, agent workflow, or migration is
+still free to use a conceptual diagram (a before/after field map, a
+source-of-truth fan-out, a state diagram). Don't let the wireframe
+exclusion suppress a conceptual diagram the content warrants.
+
+**Diagrams complement prose; they never replace it.** A diagram is an
+accelerant placed next to the prose it illustrates, not a substitute. The
+IDed prose stays complete and standalone — a reader who ignores every
+diagram still gets the full content in text, and a text-reading downstream
+agent (which does not parse SVG geometry) is never left with a relationship
+that exists only in the picture. This extends the prose-is-authoritative
+rule above: prose governs not only on disagreement but on completeness, so
+adding a diagram is not license to thin the prose it depicts.
+
 ### Layout legibility for hand-authored SVG
 
 The agent designs SVG coordinates without rendering — layouts that look
@@ -508,6 +525,9 @@ Before returning the artifact, scan it for common slips:
 - **`<details>`** inside repeating cards have no `open` attribute.
 - **Diagram labels** are legible — no arrow paths crossing text,
   halo width appropriate for font size.
+- **Diagrams complement prose, not replace it.** Every relationship a
+  diagram conveys is also present in the surrounding IDed prose; no
+  content lives only in an SVG.
 - **No JS framework runtimes** included. Small inline `<script>` for
   active-section TOC tracking or anchor-permalink behavior is the only
   acceptable JS.

--- a/plugins/compound-engineering/skills/ce-plan/references/html-rendering.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/html-rendering.md
@@ -324,6 +324,23 @@ across categories, a bar chart is the right shape; if it's component
 relationships, a topology diagram; if it's process flow across
 participants, a swim lane; etc.
 
+**Conceptual diagrams are not wireframes.** The wireframe affordance below
+is scoped to brainstorm requirements docs about *visual products* and is
+excluded for non-visual systems. That exclusion is about wireframes only —
+a brainstorm about a data model, schema, agent workflow, or migration is
+still free to use a conceptual diagram (a before/after field map, a
+source-of-truth fan-out, a state diagram). Don't let the wireframe
+exclusion suppress a conceptual diagram the content warrants.
+
+**Diagrams complement prose; they never replace it.** A diagram is an
+accelerant placed next to the prose it illustrates, not a substitute. The
+IDed prose stays complete and standalone — a reader who ignores every
+diagram still gets the full content in text, and a text-reading downstream
+agent (which does not parse SVG geometry) is never left with a relationship
+that exists only in the picture. This extends the prose-is-authoritative
+rule above: prose governs not only on disagreement but on completeness, so
+adding a diagram is not license to thin the prose it depicts.
+
 ### Layout legibility for hand-authored SVG
 
 The agent designs SVG coordinates without rendering — layouts that look
@@ -508,6 +525,9 @@ Before returning the artifact, scan it for common slips:
 - **`<details>`** inside repeating cards have no `open` attribute.
 - **Diagram labels** are legible — no arrow paths crossing text,
   halo width appropriate for font size.
+- **Diagrams complement prose, not replace it.** Every relationship a
+  diagram conveys is also present in the surrounding IDed prose; no
+  content lives only in an SVG.
 - **No JS framework runtimes** included. Small inline `<script>` for
   active-section TOC tracking or anchor-permalink behavior is the only
   acceptable JS.


### PR DESCRIPTION
## Summary

Brainstorm requirements docs about non-visual systems — data models, schemas, agent workflows, migrations — had no way to earn a diagram, so they rendered as walls of dry prose even when a before/after field map or a source-of-truth fan-out would carry the idea far faster. `ce-plan` already gave diagrams a home (High-Level Technical Design); `ce-brainstorm`'s section contract had no equivalent, and the one brainstorm visual affordance in `html-rendering.md` — wireframes — explicitly excluded non-visual systems. Those two gaps left conceptual diagrams unreachable for exactly the docs that most benefit from them.

This adds a **Visualizations** affordance to the brainstorm section contract, gated on a named test ("does the picture let a reader grasp the concept faster than the paragraph alone?") with anti-padding so diagrams aren't added for ceremony. It also separates *conceptual diagrams* from *wireframes* in `html-rendering.md`, so the wireframe exclusion stops shadowing legitimate diagrams on non-visual brainstorms.

## Guardrail: diagrams complement prose, never replace it

Encouraging diagrams risks an agent drawing a before/after map and then thinning the prose it depicts. That breaks two things: prose is authoritative when the two disagree, and downstream agents (e.g. `ce-work`) read the artifact as linear text, so a relationship living only in an SVG is invisible to them. The change frames complementarity as an extension of the existing prose-is-authoritative rule and backs it with a post-compose audit check, so it fires reliably instead of sitting as prose the agent skims past.


---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
