### PR TITLE
fix(ce-sessions): emit repo root path instead of basename subshell

### DIFF
--- a/plugins/compound-engineering/skills/ce-sessions/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-sessions/SKILL.md
@@ -20,9 +20,9 @@ Search session history across Claude Code, Codex, and Cursor and synthesize find
 
 If the line above resolved to a plain branch name (like `feat/my-branch`), use it for branch filtering and pass it to the synthesis subagent. If it still contains a backtick command string or is empty, derive the branch at runtime instead.
 
-**Repo name (pre-resolved):** !`basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || true`
+**Repo root (pre-resolved):** !`git rev-parse --show-toplevel 2>/dev/null || true`
 
-If the line above resolved to a plain repo folder name, use it for session discovery. Otherwise derive at runtime.
+If the line above resolved to a path, take its last path component as the repo folder name and use that for session discovery. If it is empty or still contains a backtick command string, derive the repo name at runtime instead.
 
 ## Note: 2026
 


### PR DESCRIPTION
Before this fix, running `/ce-sessions` (or `/ce-compound` with session history enabled) failed immediately: Claude Code's permission check rejected the skill's pre-resolved repo-name line and the SKILL.md preamble never rendered.

The cause was `basename "$(git rev-parse --show-toplevel)"` — wrapping a command substitution in double quotes produces a `string` node the permission checker can't statically analyze (issue #709, the class this repo's own `AGENTS.md` documents as forbidden). The fix emits the raw repo root via a single `git rev-parse --show-toplevel` (the same single-command shape the working branch line above it already uses) and has the agent take the last path component for the repo folder name.

Note for reviewers: `tests/skill-shell-safety.test.ts` did not catch this. Its detector flags a double-quote *inside* the `$()` (`basename "$(dirname "$common")"`) but not a double-quote *wrapping* the `$()` (`basename "$(...)"`). Broadening it would also flag the `cat "$(git rev-parse --show-toplevel)/..."` config-read pattern `AGENTS.md` documents as safe, so this PR leaves the detector alone — the coverage gap is noted but not closed here.

Closes #867

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)
