### PR TITLE
feat(lfg): fold compounding into the skill and bring it to parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The first pass tightens recent branch changes before review. The targeted pass i
 /lfg
 ```
 
-`/lfg` runs the loop hands-off: it plans, works through the plan, simplifies, runs code review and applies the fixes, runs browser tests, commits, pushes, opens a PR, then watches CI and repairs failures until it's green. Start it after `/ce-brainstorm` so it plans against real requirements rather than a one-line prompt. It's the autopilot version of the standard loop -- neat when you want to step away and come back to an open, green PR.
+`/lfg` runs the loop hands-off. It first resolves whatever you hand it into a concrete task -- a feature description, a Riffrec bundle, a video/audio recording, or screenshots (recordings and screenshots are analyzed into structured feedback first) -- then plans, works through the plan, simplifies, runs code review and applies the fixes, runs browser tests, dogfoods the changed journeys as a real user, commits, pushes, opens a PR, captures any durable learning into `docs/solutions/` (compound-out), then watches CI and repairs failures until it's green. Start it after `/ce-brainstorm` so it plans against real requirements rather than a one-line prompt. It's the autopilot version of the standard loop -- neat when you want to step away and come back to an open, green PR.
 
 ## Getting Started
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -91,7 +91,7 @@ Invoked when a specific need arises — not part of any chain.
 
 | Skill | Description |
 |-------|-------------|
-| [`/lfg`](./lfg.md) | Run the full hands-off engineering pipeline from planning through a green PR — plan, work, simplify, review, fix, browser-test, ship, and watch CI |
+| [`/lfg`](./lfg.md) | Run the full hands-off engineering pipeline from a feature description, Riffrec bundle, recording, or screenshots through a green PR — plan, work, simplify, review, fix, browser-test, dogfood, ship, compound-out the learning, and watch CI |
 
 ---
 

--- a/docs/skills/lfg.md
+++ b/docs/skills/lfg.md
@@ -2,9 +2,9 @@
 
 > Run the full hands-off engineering pipeline from planning through a green PR.
 
-`lfg` is the **autonomous pipeline** skill. It chains the main Compound Engineering workflow into one long-running run: plan the work, implement it, simplify the result, review it, apply eligible review fixes, run browser tests, commit, push, open a PR, then watch CI and repair failures within a bounded loop.
+`lfg` is the **autonomous pipeline** skill. It first resolves its input into a concrete task — a plain feature description, a Riffrec bundle, a video/audio recording, or one or more screenshots — then chains the main Compound Engineering workflow into one long-running run: plan the work, implement it, simplify the result, review it, apply eligible review fixes, run browser tests, dogfood the changed journeys as a real user, commit, push, open a PR, capture any durable learning into `docs/solutions/` (compound-out), then watch CI and repair failures within a bounded loop.
 
-Use it when you want the full agentic shipping path and are comfortable with the agent taking the work from a feature description to an open PR. It is best after `/ce-brainstorm`, because the pipeline can then plan against real requirements instead of a one-line prompt.
+Use it when you want the full agentic shipping path and are comfortable with the agent taking the work from any of those inputs to an open PR. It is best after `/ce-brainstorm`, because the pipeline can then plan against real requirements instead of a one-line prompt. When the input is a recording, video, or screenshots, `lfg` analyzes it into structured feedback before planning (a **feedback-sourced** run) and writes the PR body from a fixed template so the issue is understandable without watching the original recording.
 
 ---
 
@@ -12,11 +12,11 @@ Use it when you want the full agentic shipping path and are comfortable with the
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Runs the full CE software pipeline from planning through PR and CI watch |
-| When to use it | Software tasks that are ready for autonomous implementation |
-| What it produces | Code changes, commits, usually a PR, and durable residual notes when something cannot be fully resolved |
-| What's next | Review the PR, merge when ready, and run `/ce-compound` if there is reusable learning to capture |
-| Distinguishing | Hard ordering gates, return-to-caller execution, review-fix persistence, browser test pass, bounded CI autofix loop |
+| What does it do? | Resolves its input into a task, then runs the full CE software pipeline from planning through PR and CI watch |
+| When to use it | Software tasks that are ready for autonomous implementation, from a description, Riffrec bundle, recording, or screenshots |
+| What it produces | Code changes, commits, usually a PR, a captured learning when one is durable, and durable residual notes when something cannot be fully resolved |
+| What's next | Review the PR and merge when ready — the compound-out step already captures reusable learning automatically |
+| Distinguishing | Input resolution (description / Riffrec / video / screenshots), hard ordering gates, return-to-caller execution, review-fix persistence, browser test pass, real-user dogfooding, compound-out, bounded CI autofix loop |
 
 ---
 
@@ -30,13 +30,16 @@ Without an explicit pipeline, autonomous runs tend to skip planning, treat revie
 
 `lfg` makes the sequence explicit and gated:
 
-- `/ce-plan` must produce an implementation-ready code plan before work starts
+- The input is resolved into a task first: a Riffrec bundle, video, or audio recording is analyzed by `/ce-riffrec-feedback-analysis` into structured feedback; screenshots are read directly; plain text is used verbatim
+- `/ce-plan` must produce an implementation-ready code plan before work starts (this is also the **compound-in**, where planning research reads prior learnings from `docs/solutions/`)
 - `/ce-work` runs in return-to-caller mode so the pipeline regains control after implementation
 - `/ce-simplify-code` runs before review unless the change is docs-only or trivial
 - `/ce-code-review` reports findings, then `lfg` applies eligible fixes and commits them
 - Residual review findings are made durable in the PR body or a fallback tracked file
-- `/ce-test-browser` runs in pipeline mode
-- `/ce-commit-push-pr` ships remaining changes when a remote exists
+- `/ce-test-browser` runs in pipeline mode, and is skipped when the diff touches no web-ui surface (docs-only or cli/api/library/ios-only changes)
+- The changed user journeys are dogfooded hands-on as a real user (bad input, edge states, navigation), with any breakage fixed at its root and covered by a regression test
+- `/ce-commit-push-pr` ships remaining changes when a remote exists; feedback-sourced runs get a fixed PR-body template
+- `/ce-compound` runs in headless mode as the **compound-out**, capturing any durable learning into `docs/solutions/` (non-blocking — "nothing to capture" is a success) so the next run starts smarter
 - CI is watched for up to three repair iterations on an open PR
 
 The pipeline also has a local-only path: if the repository has no git remote, it commits locally and skips push, PR creation, and CI watch instead of retrying impossible network steps.
@@ -82,21 +85,31 @@ Direct invocation is useful for clear software tasks, but it gives the planner l
 
 ## Reference
 
+Argument hint: `[feature description | riffrec zip | video | screenshots]`
+
 | Argument | Effect |
 |----------|--------|
 | _(empty)_ | Plans from current context, then runs the pipeline if the plan is eligible |
-| `<feature description>` | Passes the description to `/ce-plan`, then runs the pipeline |
+| `<feature description>` | Passes the description verbatim to `/ce-plan`, then runs the pipeline |
+| `<riffrec zip / bundle>` | Analyzes the Riffrec bundle into structured feedback first (feedback-sourced run), then plans and runs the pipeline |
+| `<video / audio recording>` | Analyzes the recording into structured feedback first (feedback-sourced run), then plans and runs the pipeline |
+| `<screenshot image(s)>` | Reads the screenshots to derive what is broken or requested (feedback-sourced run), then plans and runs the pipeline |
 
-Output: code changes, commits, and usually a PR. If there is no configured git remote, output is local commits only. If CI remains red after the bounded repair loop, unresolved failures are recorded durably before the run ends.
+Feedback-sourced runs (recording, video, or screenshots) write the PR body from a fixed template — what the user reported, the problem, how it was reproduced, the fix, a demo, and testing — so the issue is understandable without the original recording.
+
+Output: code changes, commits, usually a PR, and a captured learning in `docs/solutions/` when one is durable. If there is no configured git remote, output is local commits only. If CI remains red after the bounded repair loop, unresolved failures are recorded durably before the run ends.
 
 ---
 
 ## See Also
 
 - [`ce-brainstorm`](./ce-brainstorm.md) — strongest upstream source of requirements
+- [`ce-riffrec-feedback-analysis`](./ce-riffrec-feedback-analysis.md) — analyzes a Riffrec bundle, video, or audio input into structured feedback during input resolution
 - [`ce-plan`](./ce-plan.md) — first required pipeline step
 - [`ce-work`](./ce-work.md) — implementation engine called in return-to-caller mode
 - [`ce-simplify-code`](./ce-simplify-code.md) — pre-review simplification step
 - [`ce-code-review`](./ce-code-review.md) — review gate
 - [`ce-test-browser`](./ce-test-browser.md) — browser validation step
+- [`ce-dogfood`](./ce-dogfood.md) — the diff-scoped real-user dogfooding behavior `lfg` performs after browser tests
 - [`ce-commit-push-pr`](./ce-commit-push-pr.md) — shipping handoff when a remote exists
+- [`ce-compound`](./ce-compound.md) — the compound-out step that captures durable learning into `docs/solutions/`

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -2,20 +2,32 @@
 name: lfg
 description: Run the full hands-off engineering pipeline from planning through a green PR.
 disable-model-invocation: true
-argument-hint: "[feature description]"
+argument-hint: "[feature description | riffrec zip | video | screenshots]"
 ---
 
 CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required step. Do NOT jump ahead to coding or implementation. The plan phase (step 1) MUST be completed and verified BEFORE any work begins. Violating this order produces bad output.
 
 When invoking any skill referenced below, resolve its name against the available-skills list the host platform provides and use that exact entry. Some platforms list skills under a plugin namespace (e.g., `compound-engineering:ce-plan`); others list the bare name. Invoking a short-form guess that isn't in the list will fail — always match a listed entry verbatim before calling the Skill/Task tool.
 
-1. Invoke the `ce-plan` skill with `$ARGUMENTS`.
+**Input resolution (do this before step 1).** `$ARGUMENTS` may be a plain feature description, a path to a Riffrec bundle (`riffrec-*.zip`, or a folder with `session.json` + `events.json` + `recording.webm` + `voice.webm`), a video/audio recording, or one or more screenshots. Resolve it into a concrete task before planning:
 
-   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, invoke `ce-plan` again with `$ARGUMENTS`. Do NOT proceed to step 2 until a written plan exists. **Record the plan file path** — it will be passed to ce-work in step 2 and ce-code-review in step 4.
+- Riffrec bundle, video, or audio: invoke the `ce-riffrec-feedback-analysis` skill on the path to extract structured product feedback — the bugs, UX issues, repro steps, and the user's spoken intent. Use that feedback as the task.
+- Screenshot image(s): view them and derive what is broken or requested. Use that as the task.
+- Plain text: use it verbatim.
+
+Call the result the **resolved task**, and note whether it came from a recording, video, or screenshots — a **feedback-sourced** run, which changes the PR body in step 10. Use the resolved task (not bare `$ARGUMENTS`) wherever a step below passes `$ARGUMENTS`.
+
+1. Invoke the `ce-plan` skill with the resolved task.
+
+   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, invoke `ce-plan` again with the resolved task. Do NOT proceed to step 2 until a written plan exists. **Record the plan file path** — it will be passed to ce-work in step 2 and ce-code-review in step 4.
+
+   This planning step is LFG's **compound-in**: `ce-plan` fans out its institutional-recall researchers (prior learnings in `docs/solutions/`, repo conventions, git history, and best practices), so planning already starts from accumulated knowledge rather than a blank slate. There is no separate research step to run here — let `ce-plan` own it.
 
    Read the plan metadata before continuing. If the plan has `artifact_contract: ce-unified-plan/v1`, proceed only when it has `artifact_readiness: implementation-ready` and `execution: code`. Stop the pipeline for `artifact_readiness: requirements-only`, any unrecognized readiness value, `execution: knowledge-work`, approach-plan outputs, answer-seeking/universal outputs, or invalid progress-like readiness values. LFG never launches `/goal` directly; when goal-mode or dynamic workflows are appropriate, `ce-work` owns that implementation engine choice and must return control to LFG afterward.
 
 2. Invoke the `ce-work` skill with `mode:return-to-caller <plan-path-from-step-1>`.
+
+   If the task is a bug fix (especially a feedback-sourced run), reproduce the bug locally FIRST — set up the minimal local state and trigger the failing behavior — before writing any fix, so the fix targets the confirmed root cause. Prefer building that state synthetically; only pull production data as a last resort, and always anonymize names, emails, and other PII. Do not commit throwaway repro data (e.g., to seed files) unless it has lasting value for the team.
 
    GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Read the structured return and require `status: complete`, the same plan path, changed files, U-IDs attempted/completed when present, verification results, blocker list, behavior-change signal, and `standalone_shipping_skipped: true`. Do NOT proceed to step 3 if no code changes were made or if ce-work did not return control in return-to-caller mode.
 
@@ -23,7 +35,7 @@ When invoking any skill referenced below, resolve its name against the available
 
    This runs before review so the code-review in step 4 covers the simplified code. **Skip** this step when the change is docs-only (only markdown/docs paths changed) or trivial (roughly under 10 changed lines). Otherwise let `ce-simplify-code` resolve the branch-diff scope itself; it preserves behavior and runs the test suite.
 
-   Do not commit in this step. `ce-simplify-code` leaves its changes in the working tree; step 4's review scopes the working tree (uncommitted changes included), and step 8's `ce-commit-push-pr` commits whatever remains. Committing here would sweep any still-uncommitted `ce-work` edits into a misleading `refactor` commit and could stall on a tree that never goes clean.
+   Do not commit in this step. `ce-simplify-code` leaves its changes in the working tree; step 4's review scopes the working tree (uncommitted changes included), and step 10's `ce-commit-push-pr` commits whatever remains. Committing here would sweep any still-uncommitted `ce-work` edits into a misleading `refactor` commit and could stall on a tree that never goes clean.
 
 4. Invoke the `ce-code-review` skill with `mode:agent plan:<plan-path-from-step-1>`.
 
@@ -31,7 +43,7 @@ When invoking any skill referenced below, resolve its name against the available
 
    `mode:agent` is report-only **by design** — it surfaces findings but never edits the tree; LFG applies the eligible ones in step 5. When narrating progress to the user, frame this as "review found X → applied X in step 5," not as "code review did not auto-fix." A report-only review followed by an LFG-applied fix is the intended contract, not a gap.
 
-**Shipping precondition (steps 5–9).** Run `git remote` once before the shipping steps. If it lists **no remote** (e.g. a sandbox/throwaway checkout that has `git init` but no `origin`), shipping is **local-only**: make every commit the steps below call for, but **skip every push, PR create/edit, and CI-watch action** — the pushes in steps 5 and 6, the push and PR creation in step 8, and step 9 in full. A missing remote is a terminal local-only state, not an error: never retry a push or hunt for a remote — make the local commits and proceed to step 10. Run steps 5–9 normally when a remote exists.
+**Shipping precondition (steps 5–11).** Run `git remote` once before the shipping steps. If it lists **no remote** (e.g. a sandbox/throwaway checkout that has `git init` but no `origin`), shipping is **local-only**: make every commit the steps below call for, but **skip every push, PR create/edit, and CI-watch action** — the pushes in steps 5 and 6, the push and PR creation in step 10, and step 11 in full. A missing remote is a terminal local-only state, not an error: never retry a push or hunt for a remote — make the local commits and proceed to step 12. Run steps 5–11 normally when a remote exists.
 
 5. **Apply and persist review fixes** (REQUIRED after step 4, before residual handoff)
 
@@ -65,13 +77,41 @@ When invoking any skill referenced below, resolve its name against the available
 
 7. Invoke the `ce-test-browser` skill with `mode:pipeline`.
 
-8. Invoke the `ce-commit-push-pr` skill.
+8. **Dogfood the change as a real user** (ALWAYS run; do not skip)
 
-   This commits any remaining changes, pushes the branch, and opens a pull request. If step 6 already opened a PR (check with `gh pr view --json number,url,state 2>/dev/null`), skip PR creation but still commit and push any uncommitted changes. **Per the shipping precondition, when no remote is configured, do NOT invoke `ce-commit-push-pr` — its commit step pushes unconditionally (`git push -u origin HEAD`), so a literal invocation would still hit the impossible push. Instead commit any remaining changes locally yourself (`git add -A && git commit`) and skip the push and PR creation entirely.**
+   `ce-dogfood` is `disable-model-invocation` and cannot be invoked from this pipeline, so perform its diff-scoped dogfooding behavior directly. This is hands-on exercise of the changed journeys, distinct from the automated browser tests in step 7.
 
-9. **CI watch and autofix loop** (only when an open PR exists for the current branch)
+   Determine which observable surfaces the branch diff touches (web-ui, ios, cli, api, library, docs), then exercise the CHANGED user journeys the way a real user would — not just the happy path; include bad input, edge states, and back/forward navigation:
 
-   Detect the PR; if none exists or `gh` is unavailable, skip this step entirely and proceed to step 10.
+   - web-ui: start or attach to the running app and drive the affected pages in a real browser.
+   - ios: drive the changed flows on the simulator.
+   - cli: run the changed commands as a user would, including bad input and unusual flag combinations.
+   - api / library: call the changed entrypoints as a consumer would, including misuse.
+
+   Fix any UX or behavior breakage found at its root cause, add a regression test for each fix, and re-check until the changed journeys work. Leave the fixes uncommitted in the working tree — step 10 commits and pushes them. If there is genuinely nothing runnable to exercise (e.g., a pure docs change), state that explicitly and continue.
+
+9. **Capture the learning** (compound-out)
+
+   Invoke the `ce-compound` skill with `mode:headless`, passing a one-line context hint describing what was built or fixed. This is LFG's **compound-out**: it runs non-interactively and writes any durable, non-obvious learning from this run — a debugged root cause, a convention or tooling decision, a workflow insight — into `docs/solutions/`, so the next LFG run's planning research (step 1) starts ahead of this one.
+
+   This step is non-blocking: if `ce-compound` finds nothing durable to capture it ends with `Documentation skipped`, which is a success, not an error. Do not commit here; leave any written learning doc in the working tree for step 10 to commit and push (respecting the shipping precondition).
+
+10. Invoke the `ce-commit-push-pr` skill.
+
+   This commits any remaining changes (including dogfood fixes from step 8 and any learning doc from step 9), pushes the branch, and opens a pull request. If step 6 already opened a PR (check with `gh pr view --json number,url,state 2>/dev/null`), skip PR creation but still commit and push any uncommitted changes. **Per the shipping precondition, when no remote is configured, do NOT invoke `ce-commit-push-pr` — its commit step pushes unconditionally (`git push -u origin HEAD`), so a literal invocation would still hit the impossible push. Instead commit any remaining changes locally yourself (`git add -A && git commit`) and skip the push and PR creation entirely.**
+
+   If this is a feedback-sourced run (see Input resolution), write the PR body from this fixed template so the issue is understandable without watching the original recording:
+
+   - `## What the user reported` — one or two plain-language sentences, then the user's narration as a verbatim Markdown block quote (`>`), and any "before" frames from the analysis.
+   - `## The problem` — the technical root cause.
+   - `## How we reproduced it` — the minimal local state and exact steps.
+   - `## The fix` — what changed and why, kept tight.
+   - `## Demo` — for an observable change, after evidence proving it works (screenshots, terminal output, or a recording).
+   - `## Testing` — the regression test covering this bug, plus any other checks run.
+
+11. **CI watch and autofix loop** (only when an open PR exists for the current branch)
+
+   Detect the PR; if none exists or `gh` is unavailable, skip this step entirely and proceed to step 12.
 
    ```bash
    gh pr view --json number,url,state
@@ -85,7 +125,7 @@ When invoking any skill referenced below, resolve its name against the available
       gh pr checks --watch
       ```
 
-      If the command exits 0, all checks passed. Break out of the loop and proceed to step 10.
+      If the command exits 0, all checks passed. Break out of the loop and proceed to step 12.
 
       If it exits non-zero, one or more checks failed. Continue to (2).
 
@@ -118,8 +158,8 @@ When invoking any skill referenced below, resolve its name against the available
      gh pr edit PR_NUMBER --body-file BODY_FILE
      ```
 
-   - Do NOT continue looping. The autopilot contract is "make residuals durable, then exit." Proceed to step 10.
+   - Do NOT continue looping. The autopilot contract is "make residuals durable, then exit." Proceed to step 12.
 
-10. Output `<promise>DONE</promise>` when complete
+12. Output `<promise>DONE</promise>` when complete
 
 Start with step 1 now. Remember: plan FIRST, then work. Never skip the plan.

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -77,6 +77,8 @@ Call the result the **resolved task**, and note whether it came from a recording
 
 7. Invoke the `ce-test-browser` skill with `mode:pipeline`.
 
+   **Skip** this step when the branch diff touches no web-ui surface — docs-only changes, or changes confined to cli/api/library/ios — since there are no affected pages to drive (step 8 dogfoods those surfaces hands-on). Otherwise run it; the skill self-scopes to the pages the diff affects.
+
 8. **Dogfood the change as a real user** (ALWAYS run; do not skip)
 
    `ce-dogfood` is `disable-model-invocation` and cannot be invoked from this pipeline, so perform its diff-scoped dogfooding behavior directly. This is hands-on exercise of the changed journeys, distinct from the automated browser tests in step 7.
@@ -95,6 +97,8 @@ Call the result the **resolved task**, and note whether it came from a recording
    Invoke the `ce-compound` skill with `mode:headless`, passing a one-line context hint describing what was built or fixed. This is LFG's **compound-out**: it runs non-interactively and writes any durable, non-obvious learning from this run — a debugged root cause, a convention or tooling decision, a workflow insight — into `docs/solutions/`, so the next LFG run's planning research (step 1) starts ahead of this one.
 
    This step is non-blocking: if `ce-compound` finds nothing durable to capture it ends with `Documentation skipped`, which is a success, not an error. Do not commit here; leave any written learning doc in the working tree for step 10 to commit and push (respecting the shipping precondition).
+
+   In headless mode `ce-compound` may also apply a one-time discoverability edit to an instruction file (`AGENTS.md` or `CONCEPTS.md`) so future agents know to check `docs/solutions/`. Like the learning doc, that edit is left uncommitted and ships in this run's PR via step 10 — that is expected, not stray output; do not revert it.
 
 10. Invoke the `ce-commit-push-pr` skill.
 

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -11,7 +11,7 @@ When invoking any skill referenced below, resolve its name against the available
 
 **Input resolution (do this before step 1).** `$ARGUMENTS` may be a plain feature description, a path to a Riffrec bundle (`riffrec-*.zip`, or a folder with `session.json` + `events.json` + `recording.webm` + `voice.webm`), a video/audio recording, or one or more screenshots. Resolve it into a concrete task before planning:
 
-- Riffrec bundle, video, or audio: invoke the `ce-riffrec-feedback-analysis` skill on the path to extract structured product feedback — the bugs, UX issues, repro steps, and the user's spoken intent. Use that feedback as the task.
+- Riffrec bundle, video, or audio: invoke the `ce-riffrec-feedback-analysis` skill on the path to extract structured product feedback — the bugs, UX issues, repro steps, and the user's spoken intent. Take only that structured feedback artifact as the resolved task and proceed to step 1. Do NOT continue into `ce-brainstorm` or any interactive requirements-confirmation step the analysis would otherwise hand off to (its extensive path does this): LFG is autonomous, and step 1 (`ce-plan`) owns planning. Use that extracted feedback as the task.
 - Screenshot image(s): view them and derive what is broken or requested. Use that as the task.
 - Plain text: use it verbatim.
 
@@ -106,7 +106,7 @@ Call the result the **resolved task**, and note whether it came from a recording
 
    If this is a feedback-sourced run (see Input resolution), write the PR body from this fixed template so the issue is understandable without watching the original recording:
 
-   - `## What the user reported` — one or two plain-language sentences, then the user's narration as a verbatim Markdown block quote (`>`), and any "before" frames from the analysis.
+   - `## What the user reported` — one or two plain-language sentences. When a recording/video/audio transcript is available, follow with the user's narration as a verbatim Markdown block quote (`>`) and any "before" frames from the analysis. For screenshot-only runs (no narration or transcript), describe what the screenshots show instead, and do NOT invent a quote.
    - `## The problem` — the technical root cause.
    - `## How we reproduced it` — the minimal local state and exact steps.
    - `## The fix` — what changed and why, kept tight.

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -15,7 +15,7 @@ When invoking any skill referenced below, resolve its name against the available
 - Screenshot image(s): view them and derive what is broken or requested. Use that as the task.
 - Plain text: use it verbatim.
 
-Call the result the **resolved task**, and note whether it came from a recording, video, or screenshots — a **feedback-sourced** run, which changes the PR body in step 10. Use the resolved task (not bare `$ARGUMENTS`) wherever a step below passes `$ARGUMENTS`.
+Call the result the **resolved task**, and note whether it came from a recording, video, or screenshots — a **feedback-sourced** run, which changes the PR body in step 10. Pass the resolved task to step 1; carry the feedback-sourced flag through to step 10.
 
 1. Invoke the `ce-plan` skill with the resolved task.
 


### PR DESCRIPTION
## Summary

`/lfg` was linear and amnesiac: every run started from zero and ended teaching the next one nothing. This PR folds the **compounding** loop directly into the linear `/lfg` skill and brings the skill up to parity on the capabilities it was missing — entirely inside the skill, with no harness-specific dependency.

> **Re-scoped from the original PR.** This branch was rebased onto the current root-native repo layout (the skill moved to `skills/lfg/` and the plugin went skills-only in #967). The original `.claude/workflows/lfg.js` cloud workflow has been **dropped** — it was not a distributable plugin artifact, re-implemented the whole pipeline as a second surface that had already drifted from the skill, and directly invoked top-level researcher agents that no longer exist (they're now `references/agents/` *inside* `ce-plan`). The valuable idea — compounding — is now expressed in the skill itself.

## What's new

**Compounding, in the skill:**

- **Compound IN** — planning already fans out `ce-plan`'s institutional-recall researchers (prior learnings in `docs/solutions/`, repo conventions, git history, best practices), so a run starts from accumulated knowledge instead of a blank slate. Made explicit on step 1; no duplicate research step.
- **Compound OUT** — a new `ce-compound mode:headless` step captures the durable, non-obvious learning from the run into `docs/solutions/` so the next run's planning starts ahead. Non-blocking (`Documentation skipped` is a success); the learning doc ships via the commit step.

**Skill parity** — the capabilities `/lfg` was missing:

- A **Dogfood** step that exercises the changed journeys as a real user before shipping (inlines `ce-dogfood`'s diff-scoped behavior — it's `disable-model-invocation`, so it's inlined, not invoked).
- **Feedback as input** — pass a Riffrec bundle, video/audio, or screenshots instead of a typed description; `/lfg` analyzes it via `ce-riffrec-feedback-analysis` before planning.
- **Reproduce-before-fix** for bug fixes, with synthetic, anonymized state.
- A fixed **PR-body template** for feedback-sourced runs.

## Changed since the original PR

- Dropped `.claude/workflows/lfg.js` (840 lines).
- Re-applied the warranted skill edits onto main's current 10-step structure (which already gained `ce-simplify-code`, `ce-work mode:return-to-caller`, the `artifact_contract` readiness gate, and the no-remote shipping precondition).
- `ce-dogfood-beta` → `ce-dogfood` (promoted to stable in #1022).
- Dropped the `ce-demo-reel` demo-capture instruction — no such skill exists on main.

## Testing

`bun test` (1687 pass) and `bun run release:validate` pass. The LLM-behavior changes to the skill are not exercised by `bun test`; validate those via the skill-creator eval workflow or a fresh session, per the repo's plugin-caching rule.