### PR TITLE
chore(model): refresh MiniMax examples to current M3 flagship

### DIFF
--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -34,7 +34,7 @@ export function resolveClaudeFamilyAlias(model: string): string {
  * "claude-sonnet-4-6" -> "anthropic/claude-sonnet-4-6"
  * "gpt-5.4"           -> "openai/gpt-5.4"
  * "gemini-2.0"        -> "google/gemini-2.0"
- * "minimax-m2.7"      -> "minimax/minimax-m2.7"
+ * "minimax-m3"        -> "minimax/minimax-m3"
  * "anthropic/foo"     -> "anthropic/foo" (unchanged)
  */
 export function addProviderPrefix(model: string): string {

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -41,8 +41,9 @@ describe("addProviderPrefix", () => {
   })
 
   test("prefixes MiniMax models with minimax/", () => {
+    expect(addProviderPrefix("minimax-m3")).toBe("minimax/minimax-m3")
     expect(addProviderPrefix("minimax-m2.7")).toBe("minimax/minimax-m2.7")
-    expect(addProviderPrefix("minimax-m2.5-highspeed")).toBe("minimax/minimax-m2.5-highspeed")
+    expect(addProviderPrefix("MiniMax-M3")).toBe("minimax/MiniMax-M3")
     expect(addProviderPrefix("MiniMax-M2.7")).toBe("minimax/MiniMax-M2.7")
   })
 


### PR DESCRIPTION
## Summary

Refresh the illustrative `MiniMax` references in the model normalization utility so the JSDoc example and unit tests track the current M3 generation rather than older M2.x examples.

## Changes

- `src/utils/model.ts`: update the `addProviderPrefix` JSDoc example from `minimax-m2.7` to `minimax-m3`.
- `tests/model-utils.test.ts`: drop the deprecated `minimax-m2.5-highspeed` case, add coverage for `minimax-m3` and `MiniMax-M3` (verifies the case-insensitive matcher still handles uppercase variants), and keep the existing `M2.7` cases as a still-supported alternative.

## Why

The matcher itself does not need to change (the `^minimax-/i` regex already handles any model in the family), but the advertised example and test fixtures had drifted to an older generation. Pointing them at M3 keeps the surface aligned with the current flagship and removes a deprecated `M2.5-highspeed` reference.

## Testing

- `bun test tests/model-utils.test.ts` -> 13 pass / 0 fail
- `bun test` (full suite) -> 1395 pass / 0 fail
- `bun run release:validate` -> ok