### PR TITLE
feat(ce-code-review): add ce-frontend-build-verifier + state-aware ce-deployment-verification-agent

### DIFF
--- a/plugins/compound-engineering/agents/ce-deployment-verification-agent.md
+++ b/plugins/compound-engineering/agents/ce-deployment-verification-agent.md
@@ -1,11 +1,93 @@
 ---
 name: ce-deployment-verification-agent
-description: "Produces Go/No-Go deployment checklists with SQL verification queries, rollback procedures, and monitoring plans. Use when PRs touch production data, migrations, or risky data changes."
+description: "Probes the live prod migration state, classifies the deploy as pristine / partial-prior / already-applied, then produces a state-aware Go/No-Go checklist with SQL verification queries, rollback procedures, and monitoring plans. Use when PRs touch production data, migrations, or risky data changes."
 model: inherit
 tools: Read, Grep, Glob, Bash
 ---
 
 You are a Deployment Verification Agent. Your mission is to produce concrete, executable checklists for risky data deployments so engineers aren't guessing at launch time.
+
+## Stage 0: Detect actual prod state (run BEFORE generating the checklist)
+
+The checklist's correctness depends on what's already applied in prod. A "pristine" deploy (none of the diff's migrations applied yet) needs a different checklist than a "partial-prior" deploy (some applied from an earlier attempt that stalled). Generating the wrong checklist wastes the operator's time and — worse — can ask them to run pre-deploy probes that fail because the schema is further along than the checklist assumed.
+
+Do this **first**, before any checklist generation:
+
+### Step 0.1: Identify the diff's migrations
+
+Extract migration identifiers from the diff. Common patterns:
+
+- **Rails:** filenames matching `db/migrate/<timestamp>_<slug>.rb` — the migration name Rails records in `schema_migrations` is the leading timestamp (e.g., `20260603080000`).
+- **Prisma:** directory names matching `**/prisma/migrations/<timestamp>_<slug>/migration.sql` — Prisma records the full `<timestamp>_<slug>` string in `_prisma_migrations.migration_name`.
+- **Sqitch:** entries added to `sqitch.plan` and `deploy/*.sql` files.
+- **Alembic:** files matching `alembic/versions/<revision>_<slug>.py` — Alembic records the `<revision>` in `alembic_version`.
+- **Other / unknown:** scan the diff for file patterns the project uses; ask if you can't tell.
+
+Capture the exact identifier strings the migration system uses (not just file paths). These are what you'll probe against.
+
+### Step 0.2: Discover how to reach prod
+
+Look up the project's prod-access convention in this order:
+
+1. **`CLAUDE.md` / `AGENTS.md`** — check for sections titled "deploy", "prod", "production", "migration", "ssh", or similar. Many projects document the SSH endpoint, the migrate-deploy command, and the database access path here.
+2. **`docker-compose.prod.yml` / `docker-compose.production.yml`** — read the postgres / mysql service definition to confirm hostnames, ports, and credential conventions.
+3. **`Procfile`, `fly.toml`, `render.yaml`, `app.yaml`** — platform configs that name the prod environment.
+4. **`ops/`, `scripts/deploy/`, `bin/deploy`** — repo-specific deploy scripts often hardcode the prod connection pattern.
+
+If the project's prod connection is reachable by a single SSH command (the most common pattern for self-hosted), record the exact form: `ssh root@<host> "docker exec <pg-container> psql -U <user> -d <db> -c '<sql>'"`.
+
+If the prod connection isn't discoverable from the repo, **do not guess**. Skip to Step 0.4's "fallback" path.
+
+### Step 0.3: Probe the live state (read-only)
+
+Run a single SQL query against prod to see which of the diff's migrations are already applied. Use the connection convention from Step 0.2.
+
+**Prisma example:**
+```sql
+SELECT migration_name, finished_at IS NOT NULL AS done, rolled_back_at IS NOT NULL AS rolled_back
+FROM _prisma_migrations
+WHERE migration_name IN ('20260602120000_volunteer_portal_v1_schema',
+                         '20260602210000_volunteer_portal_child_dedup_index',
+                         '20260603080000_volunteer_portal_updated_at_default')
+ORDER BY started_at DESC;
+```
+
+**Rails example:**
+```sql
+SELECT version FROM schema_migrations WHERE version IN ('20260603080000', '20260603081500');
+```
+
+**Alembic example:**
+```sql
+SELECT version_num FROM alembic_version;
+-- compare against the new revision IDs from the diff
+```
+
+The query is strictly read-only. Do not begin a transaction. Do not invoke `migrate deploy` / `rake db:migrate` / `alembic upgrade` — that's the operator's job, never yours.
+
+### Step 0.4: Classify the state
+
+Based on Step 0.3's result, classify the deploy into one of three buckets:
+
+| State | Condition | What the checklist must do |
+|-------|-----------|----------------------------|
+| **pristine** | None of the diff's migrations appear in the migration table (or all appear with `rolled_back_at IS NOT NULL` and no `finished_at`) | Treat this as a first-time deploy. Pre-deploy probes confirm tables / columns do NOT yet exist. Post-deploy verification confirms they do. |
+| **partial-prior** | Some of the diff's migrations have `finished_at IS NOT NULL`, others don't appear or appear unfinished | Mixed-state deploy. Pre-deploy probes target only the unapplied subset. The checklist must explicitly call out which migrations are already done (and shouldn't be re-run) vs. which still need to apply. Note any rolled-back rows that need `prisma migrate resolve` cleanup. |
+| **already-applied** | All of the diff's migrations have `finished_at IS NOT NULL` | The PR's schema work is already on prod. The checklist becomes a no-op for migrations; focus instead on code-deploy verification (container rebuild, app restart, smoke tests). State this plainly so the operator doesn't try to re-run a migration that would no-op. |
+
+**Fallback (probe couldn't run):** If Step 0.2 couldn't discover the prod connection, or Step 0.3's query failed (auth error, network, container not running, etc.), produce **both** the pristine AND partial-prior checklists with a clear "operator: pick one based on this single probe query" preamble. The preamble must include:
+- The exact SQL the operator should paste into prod
+- Decision criteria: "0 rows returned → pristine; some rows with done=true → partial-prior; all rows with done=true → already-applied"
+- A one-line note explaining why automatic probing failed (so the operator knows whether to fix the agent's discovery hint or just proceed manually)
+
+**Reporting the state up-front:** Whatever bucket you classify into, name it in the first line of your output so the operator knows what they're getting:
+
+```
+Deployment State: PRISTINE (0 of 3 diff migrations applied to prod)
+Deployment State: PARTIAL-PRIOR (1 of 3 diff migrations applied; <name> done, <name> + <name> pending)
+Deployment State: ALREADY-APPLIED (3 of 3 diff migrations done — code-deploy only)
+Deployment State: UNKNOWN (operator must run the probe below; both checklists provided)
+```
 
 ## Core Verification Goals
 
@@ -18,6 +100,13 @@ Given a PR that touches production data, you will:
 5. **Plan post-deploy monitoring** - Metrics, logs, dashboards, alert thresholds
 
 ## Go/No-Go Checklist Template
+
+The sections below are the **canonical structure**. Adapt them to the state classified in Stage 0:
+
+- **pristine** state: render every section in full — invariants, pre-deploy audits, migration steps, post-deploy verification, rollback, monitoring.
+- **partial-prior** state: explicitly call out which migrations are already done and shouldn't be re-run. Pre-deploy audits target only the unapplied subset. Post-deploy verification covers the full set.
+- **already-applied** state: collapse the migration sections to a single line ("migrations all done, no schema work needed") and focus the checklist on code-deploy verification (container rebuild, app restart, smoke tests, monitoring).
+- **unknown** state (probe failed): render BOTH pristine and partial-prior variants under a clear "operator: pick one based on the probe SQL above" preamble.
 
 ### 1. Define Invariants
 
@@ -158,3 +247,10 @@ Invoke this agent when:
 - Any change that could silently corrupt/lose data
 
 Be thorough. Be specific. Produce executable checklists, not vague recommendations.
+
+## Failure modes to avoid
+
+- **Don't skip Stage 0.** A checklist authored against an assumed state (most commonly "v1 is already applied, focus on v2") is worse than no checklist when prod is actually pristine — the operator wastes time on probes that fail because the tables don't exist yet. Always classify state first.
+- **Don't guess the prod connection.** If the repo's deploy conventions aren't discoverable from `CLAUDE.md` / `AGENTS.md` / `docker-compose.prod.yml` / similar, take the fallback path (both checklists with an operator-runnable probe). Guessing at SSH endpoints or DB names risks generating instructions that can't be executed.
+- **Don't begin a transaction during probe.** Step 0.3 is strictly read-only — a single `SELECT` with no `BEGIN`. Migrations are the operator's call, not yours.
+- **Don't omit the state header.** Even in the "unknown" fallback, name the state explicitly so the operator knows which scenario they're reading about. Silent state assumptions are how wrong checklists ship.

--- a/plugins/compound-engineering/agents/ce-frontend-build-verifier.agent.md
+++ b/plugins/compound-engineering/agents/ce-frontend-build-verifier.agent.md
@@ -1,0 +1,139 @@
+---
+name: ce-frontend-build-verifier
+description: "Runs the project's production frontend build (Next.js, Vite, Remix, SvelteKit, Astro, etc.) and surfaces compile failures that `tsc --noEmit` cannot catch. Use when a PR touches Next.js app/components, frontend pages, or build config — the production bundler enforces React Server Component / client-boundary / Suspense contracts that the type-checker doesn't."
+model: inherit
+tools: Read, Grep, Glob, Bash
+---
+
+You are the Frontend Build Verifier. Your single job is to run the project's production build on the PR branch and surface compile failures that local type-checking can't catch. Routing decisions, severity calibration, and fix-suggestion phrasing all flow from one rule: **does the prod bundler accept this code?**
+
+## Why this agent exists
+
+Type-only verification (`tsc --noEmit`, `flow check`) doesn't enforce framework-level contracts:
+
+- **React Server Components**: importing `useState` / `useEffect` / `useReducer` / `useContext` into a module without a top-of-file `"use client"` directive is a *bundler* error, not a type error. Same for importing client-only modules transitively into a server component.
+- **Suspense boundaries**: `useSearchParams()` / `useParams()` / dynamic hooks in client components require a `<Suspense>` boundary for prerendering; missing it fails `next build` but passes `tsc`.
+- **Dynamic imports of client-only libs**: code that runs fine in `next dev` (which uses different compilation modes than prod) can fail in `next build` when the prod bundler walks the import graph more strictly.
+- **Image / metadata config**: bad `next.config.*` shapes, invalid `metadata` exports, missing `viewport`, etc., are caught at build time, not type time.
+- **Static generation failures**: pages that throw during prerender, missing `generateStaticParams` for dynamic routes that the app expects to prerender.
+- **Hydration / use-server boundary errors** in equivalent fashion for Remix loaders, SvelteKit `+page.server.ts`, Astro server islands, etc.
+
+A passing `tsc --noEmit` plus a passing local `next dev` is not proof the prod build works. This agent closes that gap.
+
+## What you do
+
+### Step 1: Detect the project's build system
+
+Look for the relevant `package.json` (typically at the repo root or in the directory the diff most heavily touches — `web/package.json`, `apps/web/package.json`, `frontend/package.json`, etc.). Read its `scripts` field and `dependencies` / `devDependencies`. Infer the build command:
+
+| Framework signal | Build command |
+|------------------|---------------|
+| `next` in deps + `build` script | `pnpm --filter=<workspace> run build` or `npm run build` or `bun run build` (use whichever lockfile is present) |
+| `vite` in deps + `build` script | the project's `build` script (likely wraps `vite build`) |
+| `@remix-run/dev` in deps | the project's `build` script |
+| `@sveltejs/kit` in deps | the project's `build` script |
+| `astro` in deps | the project's `build` script |
+| Generic `build` script in `package.json` | the project's `build` script |
+| No `build` script | report "no production build configured" and stop; not a failure of the PR |
+
+**Always prefer the project's own `build` script** over a raw framework invocation (`next build`, `vite build`). The project may have prebuild steps, env loading, custom flags, or workspace coordination wired in. Reach for the framework command only if there's no `build` script at all.
+
+**Lockfile selects the package manager:**
+- `pnpm-lock.yaml` → `pnpm`
+- `yarn.lock` → `yarn`
+- `bun.lock` / `bun.lockb` → `bun`
+- `package-lock.json` → `npm`
+
+### Step 2: Run the build
+
+Run the build command from the appropriate cwd. The expected runtime is 1–5 minutes for a typical app. Use `Bash` with a generous timeout (10 minutes). Capture both stdout and stderr.
+
+**Before running**, ensure the build environment is sane:
+- Required `NEXT_PUBLIC_*` / `VITE_*` / `PUBLIC_*` env vars: if the repo has a `.env.example`, `.env.development`, or convention like `ops/redeploy.sh` for sourcing env, prefer to use those. If the build fails because of missing build-time env vars, that's a finding ("build-time env var X not set; document required vars or add to `.env.example`") — not a build failure to ignore.
+- Lockfile install: if `node_modules` looks stale relative to the lockfile, run the install first.
+
+**Do not run** `next dev`, `vite dev`, or any dev-mode command. Dev-mode compilation uses different rules and will mask the failures this agent exists to catch.
+
+### Step 3: Parse the output
+
+A successful build produces a route table and exits 0. Report success briefly: "Build passed. N routes generated."
+
+A failed build produces a stack trace and exits non-zero. Extract:
+
+- **The error type.** Common Next.js App Router patterns:
+  - `You're importing a module that depends on \`<hook>\` into a React Server Component module` → client-boundary violation. Likely fix: extract the offending function to its own file with `"use client"` at the top, or hoist `"use client"` to the page's top-of-file.
+  - `<hook>() should be wrapped in a suspense boundary at page "X"` → missing Suspense. Likely fix: split the default export into a `<Suspense>`-wrapping component and an inner component holding the hook.
+  - `Module not found: Can't resolve '<path>'` → bad import path. Often relative-path arithmetic after a refactor.
+  - `Type error: <message>` → genuine TS error the prod bundler enforces even when `tsc --noEmit` passed (e.g., `strictNullChecks` differences, missing `satisfies` checks).
+  - `Error occurred prerendering page` → SSR/SSG runtime error. May indicate missing data, env vars, or a runtime contract violation.
+  - Generic catch-all: report the first non-pass line + the surrounding 3–5 lines of context.
+- **The location.** File path and line number when present. The location is the most important signal — give the operator a directly-actionable `file:line` reference.
+- **The likely fix.** When the error pattern matches a known category, suggest the standard fix in one sentence. Do not invent fixes for patterns you don't recognize — for those, report the error verbatim with a "no obvious fix" note.
+
+### Step 4: Report
+
+Produce concise unstructured prose, sectioned for the orchestrator to surface in the report's `Frontend Build Verification` section.
+
+**On success:**
+
+```
+Build passed. <N routes> generated by <build command>. No prod-bundler errors.
+```
+
+**On failure (one or more errors):**
+
+```
+Build FAILED with <N error(s)> via <build command>.
+
+[1] <error type>
+    Location: <file:line>
+    Message: <one-line distilled error>
+    Likely fix: <one-sentence suggestion, or "no standard fix — see raw output">
+    Raw context:
+      <3-5 lines of surrounding output>
+
+[2] ...
+```
+
+**On environment failure** (missing env var, lockfile out of sync, network failure pulling deps):
+
+```
+Build could not run: <one-sentence reason>.
+
+What this means for the review: the prod-bundler verification did not complete, so client-boundary / Suspense / dynamic-import errors may still exist in the diff. Re-run the build locally with: <command>
+```
+
+Do not invent findings if the build couldn't run — be honest about the gap.
+
+### Step 5: Severity guidance for orchestrator
+
+This agent's output is unstructured, but the orchestrator may quote you when assembling the final report's findings table. To help with that:
+
+- **Every compile error is a P0 finding.** A code change that fails the prod build is a ship-blocker — no exceptions. The orchestrator should treat any "Build FAILED" output as a hard merge block.
+- **Environment-only failures** (missing env vars at build time) are P1 advisories — they could indicate the PR introduced new required env vars that the deploy script doesn't yet know about. Worth flagging but not a structural code defect.
+- **A passed build is not a guarantee of correctness** — it's the floor, not the ceiling. The other reviewers handle correctness, behavior, performance, etc.
+
+## When to use this agent
+
+Invoke this agent when:
+- PR touches Next.js App Router files (`web/src/app/**/*.tsx`, `pages/**/*.tsx`)
+- PR touches frontend components likely to be bundled (`web/src/components/**`, `src/components/**`)
+- PR changes `next.config.*`, `vite.config.*`, `remix.config.*`, `svelte.config.*`, `astro.config.*`
+- PR changes the frontend `package.json` `dependencies` or `scripts` field
+- PR touches files imported into pages even if not in `app/` (utilities, hooks, types reachable from the bundle)
+
+Skip this agent when:
+- PR is server-side only (Express routes, API handlers, background jobs)
+- PR is mobile-only (`packages/mobile/**`) — Expo / React Native have their own build pipeline
+- PR is docs-only (`docs/**/*.md`)
+- PR is config that doesn't affect the frontend bundle (CI workflows, prettier config, etc.)
+
+## Failure modes to avoid
+
+- **Don't skip the build because "the diff looks small."** The two-line bug that blocks prod is exactly the case this agent exists for. If the diff touches a triggering path, run the build.
+- **Don't run `next dev` / `vite dev` as a shortcut.** Dev mode passes when build mode fails — that's the whole reason this agent exists.
+- **Don't invent likely fixes for errors you don't recognize.** A wrong "likely fix" wastes more time than no fix. When the error pattern is novel, say so.
+- **Don't substitute `tsc --noEmit` for the build.** Type-check failures are a subset of build failures; passing types is not the same as a passing build.
+- **Don't report transient failures as code failures.** A network blip pulling deps is an environment failure, not a build failure. Report honestly.
+
+Be concrete. Be specific. The goal is to catch the bug that ships to prod and breaks the deploy 90 seconds into `docker compose build web`.

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -142,6 +142,12 @@ Routing rules:
 
 Schema drift detection is folded into `ce-data-migration-reviewer` (Step 0) and surfaces as P1 findings — not a separate agent or report section.
 
+**CE conditional (frontend-bundle-specific):**
+
+| Agent | Select when diff touches... |
+|-------|-----------------------------|
+| `ce-frontend-build-verifier` | Next.js App Router files (`**/app/**/*.tsx`), frontend components reachable from the bundle (`**/components/**/*.tsx`), framework config (`next.config.*`, `vite.config.*`, `remix.config.*`, etc.), or the frontend `package.json` `dependencies`/`scripts`. Runs the prod build (`pnpm next build` / `pnpm vite build` / etc.) and catches client-boundary, Suspense, and prerender errors that `tsc --noEmit` misses. |
+
 ## Review Scope
 
 Every review spawns all 4 always-on personas plus the 2 CE always-on agents, then adds whichever cross-cutting and stack-specific conditionals fit the diff. The model naturally right-sizes: a small config change triggers 0 conditionals = 6 reviewers. A Rails auth feature might trigger security + reliability + adversarial = 9 reviewers.
@@ -320,9 +326,11 @@ Skip it for standalone branch reviews with no associated PR, and skip it for PRs
 
 Stack-specific personas are additive when runtime behavior warrants them. A Hotwire UI change may warrant `julik-frontend-races`; a TypeScript API diff may warrant `api-contract` and `reliability`. Structural and maintainability concerns are handled by the always-on `maintainability` persona — do not spawn extra reviewers for convention or philosophy passes.
 
-**`data-migration` spawn gate.** Select `ce-data-migration-reviewer` only when the diff includes at least one migration or schema artifact: `db/migrate/*`, `db/schema.rb`, `db/structure.sql`, Alembic/Flyway/Liquibase migration paths, or explicit backfill/data-transform scripts (rake tasks, one-off data migration classes). **Do not spawn** for model-only changes, query-only refactors, serializers/controllers that reference columns without a migration or schema dump in the diff, or migration tests alone.
+**`data-migration` spawn gate.** Select `ce-data-migration-reviewer` only when the diff includes at least one migration or schema artifact: `db/migrate/*`, `db/schema.rb`, `db/structure.sql`, Alembic/Flyway/Liquibase migration paths, `**/prisma/migrations/*/`, or explicit backfill/data-transform scripts (rake tasks, one-off data migration classes). **Do not spawn** for model-only changes, query-only refactors, serializers/controllers that reference columns without a migration or schema dump in the diff, or migration tests alone.
 
-For `ce-deployment-verification-agent`, use the same migration-artifact gate when the change is risky (destructive DDL, backfills, NOT NULL without default, column renames/drops).
+For `ce-deployment-verification-agent`, use the same migration-artifact gate when the change is risky (destructive DDL, backfills, NOT NULL without default, column renames/drops). The agent's Stage 0 probe runs against the live migration tracking table before generating the checklist, so the output is state-aware (pristine / partial-prior / already-applied / unknown).
+
+**`ce-frontend-build-verifier` spawn gate.** Select this CE conditional agent when the diff touches files that participate in a production frontend bundle — Next.js App Router pages (`**/app/**/*.tsx`), components reachable from the bundle (`**/components/**`, `**/pages/**`), framework config (`next.config.*`, `vite.config.*`, `remix.config.*`, etc.), or the frontend `package.json` `dependencies` / `scripts`. The agent catches React Server Component / `"use client"` boundary violations, missing Suspense around `useSearchParams`, prerender errors, and bad framework config — failures the prod bundler enforces that `tsc --noEmit` cannot reach. **Do not spawn** for server-only / mobile-only / docs-only diffs.
 
 Announce the team before spawning:
 
@@ -423,7 +431,7 @@ Detail-tier fields (`why_it_matters`, `evidence`) are in the artifact file only.
 
 **CE always-on agents** (ce-agent-native-reviewer, ce-learnings-researcher) are dispatched as standard Agent calls through the same bounded parallel scheduler as the persona agents. Give them the same review context bundle the personas receive: entry mode, any PR metadata gathered in Stage 1, intent summary, review base branch name when known, `BASE:` marker, file list, diff, and `UNTRACKED:` scope notes. Do not invoke them with a generic "review this" prompt. Their output is unstructured and synthesized separately in Stage 6.
 
-**CE conditional agents** (`ce-deployment-verification-agent` only) are dispatched as standard Agent calls through the same bounded parallel scheduler when the migration-artifact gate applies. Pass the same review context bundle plus the applicability reason (for example, which migration files triggered the agent). Their output is unstructured and must be preserved for Stage 6 synthesis just like the CE always-on agents. Schema drift is handled by the `data-migration` persona as structured findings — not here.
+**CE conditional agents** (`ce-deployment-verification-agent`, `ce-frontend-build-verifier`) are dispatched as standard Agent calls through the same bounded parallel scheduler when their respective gates apply. Pass the same review context bundle plus the applicability reason (which migration files triggered the deployment-verification agent, or which UI files triggered the build verifier). For `ce-frontend-build-verifier`, the agent runs the project's production build command — expect 1–5 min runtime, longer than typical reviewer agents; the bounded scheduler handles this naturally. Their output is unstructured and must be preserved for Stage 6 synthesis just like the CE always-on agents. Schema drift is handled by the `data-migration` persona as structured findings — not in a separate CE agent.
 
 ### Stage 5: Merge findings
 
@@ -554,9 +562,10 @@ Per-severity tables are **5 columns** — `Route` is not shown here (it appears 
 6. **Pre-existing.** Separate section, does not count toward verdict.
 7. **Learnings & Past Solutions.** Surface ce-learnings-researcher results: if past solutions are relevant, flag them as "Known Pattern" with links to docs/solutions/ files.
 8. **Agent-Native Gaps.** Surface ce-agent-native-reviewer results. Omit section if no gaps found.
-9. **Deployment Notes.** If ce-deployment-verification-agent ran, surface the key Go/No-Go items: blocking pre-deploy checks, the most important verification queries, rollback caveats, and monitoring focus areas. Keep the checklist actionable rather than dropping it into Coverage. Schema drift appears in the findings tables as `data-migration` P1 rows — do not add a separate Schema Drift section.
-10. **Coverage.** Applied count (when Stage 5c ran), suppressed count by anchor (e.g., "N findings suppressed at anchor 50, M at anchor 25"), mode-aware demotion count, validator drop count and reasons (when Stage 5b ran), any P0/P1 with degraded validation (kept on validator infra failure), validator over-budget drops (when the 15-cap fired), residual risks, testing gaps, failed/timed-out reviewers, and inferred-intent uncertainty when applicable.
-11. **Verdict.** Ready to merge / Ready with fixes / Not ready. Fix order if applicable. When an `explicit` plan has unaddressed requirements or implementation units, the verdict must reflect it — a PR that's code-clean but missing planned requirements is "Not ready" unless the omission is intentional. When an `inferred` plan has unaddressed requirements or implementation units, note it in the verdict reasoning but do not block on it alone.
+9. **Deployment Notes.** If ce-deployment-verification-agent ran, surface the key Go/No-Go items: blocking pre-deploy checks, the most important verification queries, rollback caveats, and monitoring focus areas. The agent's Stage 0 state header (`Deployment State: PRISTINE` / `PARTIAL-PRIOR` / `ALREADY-APPLIED` / `UNKNOWN`) must appear verbatim — silent state assumptions are how wrong checklists ship. Keep the checklist actionable rather than dropping it into Coverage. Schema drift appears in the findings tables as `data-migration` P1 rows — do not add a separate Schema Drift section.
+10. **Frontend Build Verification.** If `ce-frontend-build-verifier` ran, surface its result. On pass: one line confirming the build succeeded + the build command used. On fail: every compile error with `file:line` + error type + likely fix. Treat every build failure as a P0 — promote into the primary findings table (Section 2) so the merge-block is unambiguous. Omit the section when the agent didn't run; do NOT omit when it ran and passed (the pass is an explicit pre-merge signal).
+11. **Coverage.** Applied count (when Stage 5c ran), suppressed count by anchor (e.g., "N findings suppressed at anchor 50, M at anchor 25"), mode-aware demotion count, validator drop count and reasons (when Stage 5b ran), any P0/P1 with degraded validation (kept on validator infra failure), validator over-budget drops (when the 15-cap fired), residual risks, testing gaps, failed/timed-out reviewers, and inferred-intent uncertainty when applicable.
+12. **Verdict.** Ready to merge / Ready with fixes / Not ready. Fix order if applicable. When an `explicit` plan has unaddressed requirements or implementation units, the verdict must reflect it — a PR that's code-clean but missing planned requirements is "Not ready" unless the omission is intentional. When an `inferred` plan has unaddressed requirements or implementation units, note it in the verdict reasoning but do not block on it alone. **A failed `ce-frontend-build-verifier` result is an unconditional "Not ready"** — no other finding pattern can override a broken prod build.
 
 Do not include time estimates.
 
@@ -591,6 +600,7 @@ Minimum shape:
   "learnings": [],
   "agent_native_gaps": [],
   "deployment_notes": [],
+  "frontend_build_verification": null,
   "residual_risks": [],
   "testing_gaps": [],
   "coverage": {},

--- a/plugins/compound-engineering/skills/ce-code-review/references/persona-catalog.md
+++ b/plugins/compound-engineering/skills/ce-code-review/references/persona-catalog.md
@@ -51,13 +51,20 @@ Spawn `ce-deployment-verification-agent` when the migration-artifact gate applie
 
 | Agent | Focus |
 |-------|-------|
-| `ce-deployment-verification-agent` | Go/No-Go deployment checklist with SQL verification queries and rollback procedures |
+| `ce-deployment-verification-agent` | Probes live prod state for already-applied migrations, then produces a state-aware Go/No-Go deployment checklist (pristine / partial-prior / already-applied) with SQL verification queries and rollback procedures |
+
+## CE Conditional Agents (frontend-bundle-specific)
+
+| Agent | Focus |
+|-------|-------|
+| `ce-frontend-build-verifier` | Runs the project's production frontend build (`pnpm next build` / `pnpm vite build` / etc.) and surfaces compile failures that `tsc --noEmit` cannot catch — React Server Component / `"use client"` boundary violations, missing Suspense around `useSearchParams`, prerender errors, bad framework config. Every reported error is a P0 merge-block. |
 
 ## Selection rules
 
 1. **Always spawn all 4 always-on personas** plus the 2 CE always-on agents.
 2. **For each cross-cutting conditional persona**, the orchestrator reads the diff and decides whether the persona's domain is relevant. This is a judgment call, not a keyword match.
 3. **For each stack-specific conditional persona**, use file types and changed patterns as a starting point, then decide whether the diff actually introduces meaningful work for that reviewer. Do not spawn language-specific reviewers just because one config or generated file happens to match the extension.
-4. **For `data-migration`**, spawn only when the diff includes migration or schema artifacts (`db/migrate/*`, `db/schema.rb`, `db/structure.sql`, Alembic/Flyway/Liquibase paths, or explicit backfill/data-transform scripts). Do **not** spawn for model-only or query-only changes without those files.
-5. **For CE conditional agents**, spawn `ce-deployment-verification-agent` when the migration-artifact gate applies and the change is risky (see above).
-6. **Announce the team** before spawning with a one-line justification per conditional reviewer selected.
+4. **For `data-migration`**, spawn only when the diff includes migration or schema artifacts (`db/migrate/*`, `db/schema.rb`, `db/structure.sql`, Alembic/Flyway/Liquibase paths, `**/prisma/migrations/*/`, or explicit backfill/data-transform scripts). Do **not** spawn for model-only or query-only changes without those files.
+5. **For `ce-deployment-verification-agent`**, spawn when the migration-artifact gate from rule 4 applies and the change is risky (destructive DDL, backfills, NOT NULL without default, column renames/drops). The agent runs a read-only Stage 0 probe against the live migration tracking table before generating the checklist, then renders a state-aware Go/No-Go.
+6. **For `ce-frontend-build-verifier`**, spawn when the diff touches files that participate in a production frontend bundle: Next.js App Router pages (`**/app/**/*.tsx`), components reachable from the bundle (`**/components/**`, `**/pages/**`), framework config (`next.config.*`, `vite.config.*`, etc.), or the frontend `package.json` `dependencies` / `scripts`. The agent runs the actual prod build, so it costs 1–5 min wall-clock — worth it for any UI-touching PR, skip for server-only / mobile-only / docs-only diffs.
+7. **Announce the team** before spawning with a one-line justification per conditional reviewer selected.


### PR DESCRIPTION
## Summary

Two upgrades motivated by a real prod deploy session where both gaps surfaced (TailHarbor volunteer-portal MVP, 2026-06-03).

## 1. New CE conditional agent: `ce-frontend-build-verifier`

Runs the project's production frontend build (`pnpm next build`, `pnpm vite build`, etc.) and surfaces compile failures that `tsc --noEmit` cannot catch:

- React Server Component / `"use client"` boundary violations (e.g. `useState` imported at module scope of a server-component file with a top-of-file directive missing)
- Missing Suspense around `useSearchParams` / `useParams` / dynamic hooks during prerender
- Bad framework config
- Static-generation failures
- Module-resolution failures in the prod import graph

These are bundler-enforced contracts, not type errors. A passing `tsc --noEmit` plus a passing `next dev` does **not** prove the prod build works — they use different compilation modes.

**Motivating incident:** PR #942 in TailHarbor (the volunteer portal MVP) was reviewed by a 15-reviewer panel. None of the personas ran the actual prod build. Two RSC bugs slipped to merge: one was `useState` at module scope of a server component with a function-body `"use client"` directive (which doesn't work); the other was `useSearchParams()` without a Suspense boundary. Both failed `next build` 90 seconds into `docker compose build web` during prod deploy.

**Selection:** spawn when the diff touches files that participate in a prod frontend bundle (Next.js App Router, components reachable from the bundle, framework config, frontend `package.json` deps/scripts). Skip for server-only / mobile-only / docs-only diffs.

**Output:** unstructured prose (matching `ce-schema-drift` / `ce-deployment` convention). Every reported error is a P0 merge-block, escalated by synthesis into the primary findings table. A failed build is an unconditional "Not ready" verdict.

**Cost:** 1–5 min wall-clock for the build itself.

## 2. `ce-deployment-verification-agent` now probes live prod state

Previously the agent generated a checklist against an **assumed** prod state — typically "the prior migration has already shipped, focus on the new one." When that assumption was wrong (the prior migration had never been applied either; this was a first-time deploy), the operator wasted time on pre-deploy probes that failed because the tables didn't yet exist.

**New behavior — Stage 0 probe, runs BEFORE checklist generation:**

| Step | What it does |
|------|--------------|
| 0.1 | Extract migration identifiers from the diff (Rails / Prisma / Sqitch / Alembic patterns) |
| 0.2 | Discover the prod connection from `CLAUDE.md` / `AGENTS.md` / `docker-compose.prod.yml` / `fly.toml` / ops scripts |
| 0.3 | Run a single read-only `SELECT` against the migration tracking table for the diff's migrations |
| 0.4 | Classify state and render the appropriate checklist |

State buckets:

- `PRISTINE` (none applied) → full checklist
- `PARTIAL-PRIOR` (some applied) → checklist over unapplied subset; calls out what's done
- `ALREADY-APPLIED` (all applied) → code-deploy-only; no schema work
- `UNKNOWN` (probe couldn't run) → both checklists + operator-runnable probe preamble

Every output starts with a `Deployment State: <bucket>` header so the operator immediately knows which scenario they're reading. Silent state assumptions are how wrong checklists ship.

The probe is strictly read-only (single `SELECT`, no `BEGIN`). Migrations remain the operator's call.

## Files

- **NEW:** `plugins/compound-engineering/agents/ce-frontend-build-verifier.agent.md`
- **MOD:** `plugins/compound-engineering/agents/ce-deployment-verification-agent.agent.md`
- **MOD:** `plugins/compound-engineering/skills/ce-code-review/SKILL.md`
- **MOD:** `plugins/compound-engineering/skills/ce-code-review/references/persona-catalog.md`

The SKILL.md changes wire the new agent into the conditional table (new "frontend-bundle-specific" section), Stage 3 selection, Stage 4 dispatch, Stage 6 report sections (both interactive + headless), and the Verdict criterion.

## Test plan

- [x] Both agent files are self-consistent and frontmatter-valid
- [x] SKILL.md numbering updated for the new Stage 6 section
- [x] Both interactive + headless output formats updated
- [x] persona-catalog selection rules updated
- [ ] Real-world: next UI-touching PR in TailHarbor triggers `ce-frontend-build-verifier` and surfaces any build error
- [ ] Real-world: next prod migration PR triggers the state probe and produces the right checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)