### PR TITLE
fix: reduce verbosity and remove HTML comments from generated docs

### DIFF
--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -264,6 +264,8 @@ When a doc is warranted, compose it using:
 - `references/brainstorm-sections.md` — section contract (outcomes, hard floor, include-when-material catalog, agency rules, ID conventions).
 - The format-specific rendering reference loaded at Phase 0.0 (`markdown-rendering.md` OR `html-rendering.md`) — how the resolved format presents the sections.
 
+**Write tight.** A section being material is not license to pad it. Hold every kept section to the prose-economy discipline in `references/brainstorm-sections.md`: one idea per sentence, a requirement is intent plus at most one qualifier, defer forks to Outstanding Questions rather than specifying both arms, resolve superseded text in place rather than stacking strata. Before declaring the doc written, run the named test there — could a reader find a contradiction in each section in one pass?
+
 Write to `docs/brainstorms/YYYY-MM-DD-<topic>-requirements.<md|html>` — extension follows `OUTPUT_FORMAT`. Confirm with the absolute path so the reference is clickable.
 
 #### Vocabulary Capture — after the requirements doc (only if CONCEPTS.md already exists)

--- a/plugins/compound-engineering/skills/ce-brainstorm/references/brainstorm-sections.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/brainstorm-sections.md
@@ -52,6 +52,44 @@ brainstorm with sparse content produces a sparse doc; one with rich content
 produces a rich doc. Don't add ceremony to make a slim brainstorm look
 substantial.
 
+## Prose economy
+
+Match-depth-to-content sizes *which* sections appear and how deep each goes.
+This sizes *how the kept prose reads*. A section can be material and still be
+written loosely — the failure mode is a material section padded into a wall of
+text where contradictions hide and a downstream agent loses the thread. Length
+that earns its place is fine; wordiness around that length is not.
+
+Hold every kept section to these:
+
+- **One idea per sentence.** A Summary is a handful of sentences, not one
+  sentence with five semicolons and four parentheticals. If a sentence needs a
+  second parenthetical to stay true, split it.
+- **A requirement is one sentence of intent plus at most one qualifier.** When
+  a requirement would specify two outcomes ("either A or B, planning decides"),
+  state the intent and send the fork to Outstanding Questions — don't write both
+  arms in full inside the requirement.
+- **Cut hedges and intensifiers.** "Critically", "deliberately", "explicitly",
+  "genuinely", "actually", "simply" carry nothing a downstream agent acts on.
+- **Prefer the verb to the nominalization.** "Demote the grid", not "the
+  demotion of the grid is the deliberate change in this brief".
+
+Precision is not padding: keep domain terms, conditionals, and exact thresholds
+verbatim. Economy targets the connective tissue around them, never the precision
+itself.
+
+**Resolve in place; don't stratify.** When a later decision answers a parked
+question or supersedes earlier text, rewrite or remove the original entry —
+don't append a separate "resolutions" layer that leaves the superseded text
+standing, and don't keep superseded prose as strikethrough. Version control
+holds the history. Stacked question/resolution strata double the reading surface
+and hide which text is live.
+
+**Named test, run before the doc is declared written:** could a reader find a
+contradiction in each section in one pass? A sentence carrying more than one
+parenthetical, or a requirement specifying two outcomes, fails the test — split
+it or defer it.
+
 ## Hard floor
 
 When a doc is warranted, these are present.

--- a/plugins/compound-engineering/skills/ce-doc-review/references/open-questions-defer.md
+++ b/plugins/compound-engineering/skills/ce-doc-review/references/open-questions-defer.md
@@ -27,14 +27,12 @@ Date format: ISO 8601 calendar date (`YYYY-MM-DD`). If multiple reviews occur on
 
 ### Step 3: Format and append the entry
 
-Per deferred finding, append a bullet-point entry with the following fields. The visible content is a reader-friendly summary; an HTML comment on the entry persists the dedup-key fields so Step 4's compound-key check can run reliably across retries and same-day reruns without requiring the entry format itself to carry machine-oriented metadata:
+Per deferred finding, append a reader-facing bullet-point entry. The entry carries no HTML comment — the markdown rendering contract forbids mixed-in HTML, and every field Step 4's dedup needs is reconstructable from the visible entry text:
 
 ```
 - **{title}** — {section} ({severity}, {reviewer}, confidence {confidence})
 
   {why_it_matters}
-
-  <!-- dedup-key: section="{normalized_section}" title="{normalized_title}" evidence="{evidence_fingerprint}" -->
 ```
 
 Fields come from the finding's schema:
@@ -46,19 +44,7 @@ Fields come from the finding's schema:
 - `{confidence}` — the integer anchor (`50`, `75`, or `100`), emitted without a decimal point or percent sign
 - `{why_it_matters}` — the full why_it_matters text, preserving the framing guidance from the subagent template
 
-HTML-comment fields (machine-readable, used by Step 4 dedup):
-
-- `{normalized_section}` — `normalize(section)` (lowercase, punctuation-stripped, whitespace-collapsed)
-- `{normalized_title}` — `normalize(title)` (same normalization)
-- `{evidence_fingerprint}` — first ~120 chars of the finding's first evidence quote, word-boundary-preserving, then sanitized for single-line HTML-comment embedding; empty string when the finding had no evidence. Sanitization (apply in order, before the 120-char slice so the resulting fingerprint stays under the budget):
-  1. Collapse any run of whitespace — including newlines, carriage returns, and tabs — to a single space.
-  2. Strip any occurrence of `-->` (HTML-comment terminator) and any stray `<!--` sequence; replace each with a single space. This prevents the evidence from closing the dedup-key comment prematurely or injecting a nested comment.
-  3. Replace the double-quote character with `\"` (quote escaping, as before).
-  4. Trim leading/trailing whitespace.
-
-  The sanitized fingerprint MUST be a single line with no embedded `-->` so the dedup-key comment stays parseable by Step 4's compound-key reconstruction. When computing the fingerprint for a new finding, apply this sanitization; when reading back from an existing entry, treat the parsed `evidence="..."` value as already-sanitized and compare verbatim.
-
-Do not include `suggested_fix` or the full `evidence` array in the appended entry. Those live in the review run artifact (when applicable) and do not belong in the document's Open Questions section — the entry is a concern summary for the reader returning later, not a full decision packet. The HTML-comment dedup-key line is the minimum machine-oriented metadata required for reliable idempotence and deliberately sits on a single line with simple `key="value"` shape so a retry can parse it without a markdown parser.
+Do not include `suggested_fix` or the full `evidence` array in the appended entry. Those live in the review run artifact (when applicable) and do not belong in the document's Open Questions section — the entry is a concern summary for the reader returning later, not a full decision packet.
 
 ### Step 4: Idempotence on compound-key collisions
 
@@ -67,14 +53,14 @@ If an entry with the same compound key already exists under the same `### From Y
 - The same review session re-routes the same finding to Defer a second time (rare but possible via best-judgment-the-rest after a walk-through Defer)
 - The orchestrator retries after a partial failure
 
-**Compound key for dedup:** `normalize(section) + normalize(title) + evidence_fingerprint`, reconstructed from each existing entry's `<!-- dedup-key: ... -->` HTML comment (see Step 3 entry format). For a new finding about to append, compute the same fields from the finding's schema data; for existing entries, parse them out of the HTML comment. Match on all three fields.
+**Compound key for dedup:** `normalize(section) + normalize(title) + why_fingerprint`. All three reconstruct from the visible entry, so no hidden metadata is needed:
 
-- `normalize(section)` and `normalize(title)` use the same normalization as synthesis step 3.3 dedup (lowercase, strip punctuation, collapse whitespace)
-- `evidence_fingerprint` is the first ~120 characters of the finding's first evidence quote, sanitized per Step 3 (whitespace collapsed to single spaces, `-->` and stray `<!--` stripped, quotes escaped). The same slice is used in the decision primer — see `SKILL.md` under "Decision primer". When no evidence is available on the new finding, fall back to section+title alone. When an existing entry's HTML comment has `evidence=""`, treat the entry as evidence-less and also fall back to section+title for that comparison. If an existing entry's dedup-key comment is malformed (e.g., a newline or `-->` sequence split the comment across lines in a pre-sanitization entry), treat that entry under the legacy-fallback rule below rather than attempting a partial reconstruction.
+- `normalize(section)` and `normalize(title)` use the same normalization as synthesis step 3.3 dedup (lowercase, strip punctuation, collapse whitespace). For a new finding, compute from the schema; for an existing entry, parse `{title}` (the bold leader) and `{section}` (the text between the em-dash and the opening `(`) out of the rendered bullet.
+- `why_fingerprint` is the first ~120 characters of the entry's `{why_it_matters}` prose, word-boundary-preserving, with any run of whitespace collapsed to a single space. Because why_it_matters renders verbatim in the entry, the same fingerprint recomputes from the visible bullet on any retry or reread. When why_it_matters is empty, fall back to `normalize(section) + normalize(title)` alone.
 
-Title-only dedup is not sufficient: two different findings in the same document (even in the same review date) can legitimately share a short title if their sections and evidence differ. Using only `{title}` would silently drop one of them — losing user-visible backlog context. The compound key mirrors the R29/R30 matching predicate (`section + title + evidence-substring overlap`) so cross-round and intra-round dedup behave consistently.
+Title-only dedup is not sufficient: two different findings in the same document (even on the same review date) can legitimately share a short title if their sections or rationale differ. Using only `{title}` would silently drop one — losing user-visible backlog context. Matching on section and the why-fingerprint keeps distinct findings distinct, and stays close to the R29/R30 matching predicate (`section + title + evidence-substring overlap`) so cross-round and intra-round dedup behave consistently.
 
-**Legacy entries without dedup-key comments:** entries written before this format (if any survive in the wild) lack the HTML comment. When Step 4 encounters such an entry, fall back to title-only comparison for that entry — imperfect, but strictly better than duplicate-appending. This is a backwards-compat behavior for legacy data, not a sanctioned format.
+**Pre-existing entries with a `dedup-key` HTML comment:** entries written by the prior format carry a trailing `<!-- dedup-key: ... -->` comment. Ignore it for matching — the visible-text key above is authoritative — and strip the comment if the entry is otherwise edited. Do not write new ones.
 
 On collision, record the no-op in the completion report's Coverage section so the user sees the duplicate was suppressed. Cross-subsection collisions (same compound key, different dates) are not deduplicated — each review is allowed to re-raise the same concern.
 
@@ -137,8 +123,6 @@ Starting document state:
 
   The alias exists without documented external consumers...
 
-  <!-- dedup-key: section="risks" title="alias compatibilitytheater concern" evidence="the alias exists without documented external consumers" -->
-
 ```
 
 After appending two findings in a 2026-04-18 session:
@@ -156,8 +140,6 @@ After appending two findings in a 2026-04-18 session:
 
   The alias exists without documented external consumers...
 
-  <!-- dedup-key: section="risks" title="alias compatibilitytheater concern" evidence="the alias exists without documented external consumers" -->
-
 ### From 2026-04-18 review
 
 - **Unit 2/3 merge judgment call** — Scope Boundaries (P2, scope-guardian, confidence 75)
@@ -165,13 +147,9 @@ After appending two findings in a 2026-04-18 session:
   The two units update consumer sites that deploy together. Splitting
   adds dependency tracking without enabling independent delivery.
 
-  <!-- dedup-key: section="scope boundaries" title="unit 23 merge judgment call" evidence="the two units update consumer sites that deploy together" -->
-
 - **Strawman alternatives on migration strategy** — Unit 3 Files (P2, coherence, confidence 75)
 
   The fix options list (a) through (c) as alternatives, but (b) and (c)
   are "accept the regression" framings that don't solve the problem the
   finding describes.
-
-  <!-- dedup-key: section="unit 3 files" title="strawman alternatives on migration strategy" evidence="the fix options list a through c as alternatives but b and c" -->
 ```

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -697,6 +697,8 @@ Extension follows `OUTPUT_FORMAT` from Phase 0.0 — `.md` when markdown, `.html
 
 Compose the plan using the content from `references/plan-sections.md` and the format-specific principles from the rendering reference loaded at Phase 0.0 (`markdown-rendering.md` OR `html-rendering.md`).
 
+**Write tight.** A section being material is not license to pad it. Hold every kept section to the prose-economy discipline in `references/plan-sections.md`: one idea per sentence, a requirement or unit is intent plus at most one qualifier, defer forks to Open Questions rather than specifying both arms, resolve superseded text in place rather than stacking strata. Before declaring the plan written, run the named test there — could the implementer find a contradiction in each section in one pass?
+
 **HTML composition timing.** When `OUTPUT_FORMAT=html`, Phase 5.3 deepening runs before this write completes its final form, but `ce-doc-review` is skipped in HTML mode (its mutation mechanics are markdown-only today — see Phase 5.3.8 format gate in `references/plan-handoff.md`). The HTML artifact reflects deepening synthesis but not doc-review autofixes; this is a known gap until ce-doc-review gains HTML-aware mutation.
 
 Confirm (use absolute path so the reference is clickable in modern terminals):

--- a/plugins/compound-engineering/skills/ce-plan/references/deepening-workflow.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/deepening-workflow.md
@@ -224,7 +224,10 @@ Strengthen only the selected sections. Keep the plan coherent and preserve its o
 
 **In interactive mode:** Only integrate findings the user accepted in 5.3.6b. If some findings from different agents touch the same section, reconcile them coherently but do not reintroduce rejected findings.
 
+Deepening may tighten, not only grow. A section can be strengthened by cutting as well as adding — collapse multi-idea sentences, drop hedges, and delete superseded text outright rather than leaving it as strikethrough or stacking a separate "resolutions" layer on top of it. A shorter, contradiction-free section is a stronger one. This is distinct from "rewrite the entire plan from scratch" below, which stays forbidden.
+
 Allowed changes:
+- Tighten prose in a strengthened section: cut hedges, split sentences carrying more than one idea, and remove superseded text in place (version control holds the history)
 - Clarify or strengthen decision rationale
 - Tighten requirements trace or origin fidelity
 - Reorder or split implementation units when sequencing is weak — but **never renumber existing U-IDs**. Reordering preserves U-IDs in their new order (e.g., U1, U3, U5 reordered is correct; renumbering to U1, U2, U3 is not). Splitting keeps the original U-ID on the original concept and assigns the next unused number to the new unit. Renumbering breaks ce-work blocker and verification references that were written against the original IDs

--- a/plugins/compound-engineering/skills/ce-plan/references/plan-sections.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/plan-sections.md
@@ -157,6 +157,44 @@ The agent also picks per artifact:
 - Whether HTD has one diagram, several, or none — and whether visualizations
   live in HTD or embedded in other sections
 
+## Prose economy
+
+"Include when material" sizes *which* sections appear; this sizes *how the kept
+prose reads*. A section can be material and still be written loosely — the
+failure mode is a material section padded into a wall of text where
+contradictions hide and the implementing agent loses the thread. A deep plan
+earns length through coverage (more units, more traced requirements, real
+risks), never through wordiness around that coverage.
+
+Hold every kept section to these:
+
+- **One idea per sentence.** A Summary is a handful of sentences, not one
+  sentence with five semicolons and four parentheticals. A KTD's rationale is
+  the load-bearing reason, not every reason.
+- **A requirement or unit is one sentence of intent plus at most one
+  qualifier.** When it would specify two outcomes ("either A or B, the
+  implementer decides"), state the intent and send the fork to Open Questions —
+  don't write both arms in full inside the item.
+- **Cut hedges and intensifiers.** "Critically", "deliberately", "explicitly",
+  "genuinely", "actually", "simply" carry nothing the implementer acts on.
+- **Prefer the verb to the nominalization.** "Demote the grid", not "the
+  demotion of the grid is the deliberate change in this plan".
+
+Precision is not padding: keep file paths, IDs, conditionals, and exact
+thresholds verbatim. Economy targets the connective tissue around them, never
+the precision itself.
+
+**Resolve in place; don't stratify.** When deepening, a doc-review pass, or a
+later decision supersedes earlier text, rewrite or remove the original — don't
+leave it standing as strikethrough or stack a separate "resolutions" layer on
+top of it. Version control holds the history. Stacked strata double the reading
+surface and hide which text is live.
+
+**Named test, run before the plan is declared written:** could the implementer
+find a contradiction in each section in one pass? A sentence carrying more than
+one parenthetical, or an item specifying two outcomes, fails the test — split it
+or defer it.
+
 ## Plan metadata fields
 
 Every plan carries a small set of stable metadata fields that downstream


### PR DESCRIPTION
## Summary

Three skills generate or review our requirements and plan documents — `ce-brainstorm`, `ce-plan`, and `ce-doc-review` — and their output came out complete but bloated. That matters more than style, because these documents have two consumers: the human approving them and the downstream agent that reads them as input. Wordiness taxes both — it burns tokens on every read, slows human review, and lets errors hide inside walls of text where neither a reviewer nor a consuming agent reliably catches them. The root cause was a gap in the skills' contracts: they specified *which* sections a document needs but never *how tightly to write them*, so "this section is needed" became "write it at length."

This PR adds the missing discipline. The same documents now come out lean — shorter sentences, requirements that state intent rather than enumerate every branch, and no review scar-tissue or stray HTML in the deliverable — with no loss of coverage.

## What changed

- **Prose economy (`ce-brainstorm`, `ce-plan`).** A new section in each skill's section contract, with a load-bearing pointer in `SKILL.md` so it fires from the always-loaded body: one idea per sentence; a requirement is intent plus at most one qualifier; defer forks rather than writing both arms; resolve superseded text in place instead of stacking strata. Plus a named pre-write test — *could a reader find a contradiction in each section in one pass?*
- **Deepening can tighten (`ce-plan`).** The deepening workflow was additive-only, so a deep pass could only grow a plan. It can now cut: collapse multi-idea sentences, drop hedges, and delete superseded text in place.
- **No HTML in deferred findings (`ce-doc-review`).** Re-derive the Defer dedup key from the visible entry (`section + title + a fingerprint of the rendered why_it_matters`) instead of a hidden `<!-- dedup-key -->` comment. Idempotence holds without polluting the document; pre-existing comments are ignored for matching and stripped on edit.

## Validation

A cross-model smoke test (Codex + Claude) plus a 20-run A/B eval (old contract vs new, 5 runs per arm per skill, deterministic grader). Separations were clean across all five runs per arm, so these are reliable rather than single-run luck:

| Signal (mean, N=5 per arm) | before | after | change |
|---|---|---|---|
| Longest sentence in the Summary — ce-plan | 69 w | 43 w | **−38%** |
| Longest sentence in the Summary — ce-brainstorm | 57 w | 38 w | **−33%** |
| Hedged "both-arms" requirements per run — ce-plan | 0.8 | 0.0 | **gone** |
| HTML comments in deferred review findings | present | none | **gone** |
| Requirement coverage (topics + R-count) | baseline | equal | **no loss** |

The savings are in readability and structure: the longest sentence in a document shrinks by about a third, and the two worst defect classes drop to zero — with coverage held flat.

## What this does not do

- It tightens *how* the prose reads, not *how much* there is — total word counts are roughly flat. Oversized documents in practice grow that way through the deepening and review pipeline stacking text on top; the deepening "tighten" path and the HTML removal start on that layer, but a whole-document size reduction is a downstream effect, not separately measured here.
- One mild residual: `ce-brainstorm` occasionally under-names a secondary quality requirement (mobile legibility), within N=5 noise — flagged, not blocking.

All changes are markdown skill content; `bun test` (443) and `release:validate` pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
