### PR TITLE
fix(ce-resolve-pr-feedback): fail loudly when repo auto-detection fails

### DIFF
--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
@@ -15,12 +15,17 @@ if [ -n "$2" ]; then
     OWNER=$(echo "$2" | cut -d/ -f1)
     REPO=$(echo "$2" | cut -d/ -f2)
 else
-    OWNER=$(gh repo view --json owner -q .owner.login 2>/dev/null)
-    REPO=$(gh repo view --json name -q .name 2>/dev/null)
+    # `|| true` is load-bearing: under `set -e`, a failed command substitution
+    # in an assignment aborts the script immediately. Run outside a git repo,
+    # `gh repo view` exits 1, its stderr is swallowed by `2>/dev/null`, and the
+    # script would die here with rc=1 and no output -- making the friendly error
+    # below unreachable. Keep `|| true` so detection failure falls through to it.
+    OWNER=$(gh repo view --json owner -q .owner.login 2>/dev/null || true)
+    REPO=$(gh repo view --json name -q .name 2>/dev/null || true)
 fi
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
-    echo "Error: Could not detect repository. Pass OWNER/REPO as second argument."
+    echo "Error: could not resolve owner/repo. Run get-pr-comments from inside the target git repository, or pass OWNER/REPO as the second argument (e.g., get-pr-comments $PR_NUMBER EveryInc/cora)." >&2
     exit 1
 fi
 

--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
@@ -19,12 +19,17 @@ if [ -n "$3" ]; then
     OWNER=$(echo "$3" | cut -d/ -f1)
     REPO=$(echo "$3" | cut -d/ -f2)
 else
-    OWNER=$(gh repo view --json owner -q .owner.login 2>/dev/null)
-    REPO=$(gh repo view --json name -q .name 2>/dev/null)
+    # `|| true` is load-bearing: under `set -e`, a failed command substitution
+    # in an assignment aborts the script immediately. Run outside a git repo,
+    # `gh repo view` exits 1, its stderr is swallowed by `2>/dev/null`, and the
+    # script would die here with rc=1 and no output -- making the friendly error
+    # below unreachable. Keep `|| true` so detection failure falls through to it.
+    OWNER=$(gh repo view --json owner -q .owner.login 2>/dev/null || true)
+    REPO=$(gh repo view --json name -q .name 2>/dev/null || true)
 fi
 
 if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
-    echo "Error: Could not detect repository. Pass OWNER/REPO as third argument."
+    echo "Error: could not resolve owner/repo. Run get-thread-for-comment from inside the target git repository, or pass OWNER/REPO as the third argument (e.g., get-thread-for-comment $PR_NUMBER $COMMENT_NODE_ID EveryInc/cora)." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

When `get-pr-comments` (or `get-thread-for-comment`) ran from outside the target git repo — e.g. an agent invoking it from the plugin-cache directory — it exited 1 with **zero output and no error message**. A downstream agent read that silent failure as "this PR has no review feedback" and moved on, leaving real review threads unanswered.

The cause was a `set -e` interaction: `gh repo view` auto-detection failed, `2>/dev/null` swallowed its stderr, and the failed command substitution aborted the script *before* the existing "could not detect repository" check could run — making that handler unreachable dead code. The fix appends `|| true` so a detection failure falls through to the handler, routes the diagnostic to stderr (stdout stays a clean JSON contract), and makes the message actionable by naming both remedies: run from inside the repo, or pass `OWNER/REPO` (an escape hatch that already existed but was undiscoverable). Malformed-response paths — bad PR or repo — were already loud via unsuppressed `gh api graphql` errors and stay that way.

| Scenario | Before | After |
|---|---|---|
| Outside the repo, no args | silent rc=1, empty output | rc=1, empty stdout, clear stderr naming both fixes |
| Outside the repo, explicit `OWNER/REPO` | worked | unchanged |
| Inside the repo (auto-detect) | worked | unchanged |

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
