### PR TITLE
fix(ce-resolve-pr-feedback): prevent replies landing on wrong PR from GHE node ID mismatch

### DIFF
--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -164,7 +164,7 @@ For `needs-human` verdicts, post the reply but do NOT resolve the thread. Leave 
 0. **Verify the thread ID** before replying. GitHub Enterprise can return inconsistent node IDs for the same thread depending on the query path. Always confirm the ID from `get-pr-comments` resolves to the correct thread using [scripts/get-thread-for-comment](../scripts/get-thread-for-comment) with the comment's numeric URL ID:
 ```bash
 # Extract numeric comment ID from the comment URL (e.g. discussion_r2589700 → 2589700)
-gh api repos/{owner}/{repo}/pulls/comments/COMMENT_ID --jq .node_id
+GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/COMMENT_ID --jq .node_id
 bash scripts/get-thread-for-comment PR_NUMBER COMMENT_NODE_ID OWNER/REPO
 ```
 The returned `id` is the authoritative thread ID to use for reply and resolve. If it differs from what `get-pr-comments` returned, use the one from this script.

--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -161,10 +161,19 @@ For `needs-human` verdicts, post the reply but do NOT resolve the thread. Leave 
 
 ### Review threads
 
+0. **Verify the thread ID** before replying. GitHub Enterprise can return inconsistent node IDs for the same thread depending on the query path. Always confirm the ID from `get-pr-comments` resolves to the correct thread using [scripts/get-thread-for-comment](../scripts/get-thread-for-comment) with the comment's numeric URL ID:
+```bash
+# Extract numeric comment ID from the comment URL (e.g. discussion_r2589700 → 2589700)
+gh api repos/{owner}/{repo}/pulls/comments/COMMENT_ID --jq .node_id
+bash scripts/get-thread-for-comment PR_NUMBER COMMENT_NODE_ID OWNER/REPO
+```
+The returned `id` is the authoritative thread ID to use for reply and resolve. If it differs from what `get-pr-comments` returned, use the one from this script.
+
 1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread):
 ```bash
 echo "REPLY_TEXT" | bash scripts/reply-to-pr-thread THREAD_ID
 ```
+Check that the returned comment URL contains the correct `OWNER/REPO` and PR number before proceeding.
 
 2. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread):
 ```bash

--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
@@ -29,7 +29,7 @@ if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
     exit 1
 fi
 
-# Output is a JSON object with three keys:
+# Output is a JSON object with four keys:
 #   review_threads   - unresolved inline review threads, edge-wrapped as
 #                      [{ node: { id, isResolved, isOutdated, path, line, ...,
 #                                 comments: { nodes: [...] } } }]
@@ -37,6 +37,9 @@ fi
 #                      and known CI/status bots)
 #   review_bodies    - review submissions with non-empty body text (same
 #                      filtering as pr_comments)
+#   cross_invocation - cross-invocation awareness envelope:
+#     signal: true when both resolved and unresolved threads exist (multi-round review)
+#     resolved_threads: last 10 resolved threads by recency, for cluster analysis input
 #
 # Pagination (issue #798): each top-level connection -- reviewThreads,
 # comments, reviews -- is fetched in its own paginated query because
@@ -146,6 +149,12 @@ jq -n \
   [$reviews[].data.repository.pullRequest.reviews.nodes[]] as $all_reviews |
   ["codecov"] as $ci_bot_logins |
   [$all_threads[] | select(.isResolved == false)] as $unresolved |
+  ([$all_threads[]
+    | select(.isResolved == true)
+    | { thread_id: .id, path: .path, line: .line,
+        first_comment_body: .comments.nodes[0].body,
+        last_comment_at: ([.comments.nodes[].createdAt] | sort | last) }]
+    | sort_by(.last_comment_at) | .[-10:] | reverse) as $resolved |
   {
     review_threads: [$unresolved[] | { node: . }],
     pr_comments: [$all_comments[]
@@ -155,5 +164,9 @@ jq -n \
     review_bodies: [$all_reviews[]
       | select(.body != null and .body != "")
       | select(.author.login != $author.login)
-      | select(.author.login as $l | $ci_bot_logins | index($l) | not)]
+      | select(.author.login as $l | $ci_bot_logins | index($l) | not)],
+    cross_invocation: {
+      signal: (($resolved | length) > 0 and ($unresolved | length) > 0),
+      resolved_threads: $resolved
+    }
   }'

--- a/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
+++ b/plugins/compound-engineering/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
@@ -29,7 +29,7 @@ if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
     exit 1
 fi
 
-# Output is a JSON object with four keys:
+# Output is a JSON object with three keys:
 #   review_threads   - unresolved inline review threads, edge-wrapped as
 #                      [{ node: { id, isResolved, isOutdated, path, line, ...,
 #                                 comments: { nodes: [...] } } }]
@@ -37,9 +37,6 @@ fi
 #                      and known CI/status bots)
 #   review_bodies    - review submissions with non-empty body text (same
 #                      filtering as pr_comments)
-#   cross_invocation - cross-invocation awareness envelope:
-#     signal: true when both resolved and unresolved threads exist (multi-round review)
-#     resolved_threads: last 10 resolved threads by recency, for cluster analysis input
 #
 # Pagination (issue #798): each top-level connection -- reviewThreads,
 # comments, reviews -- is fetched in its own paginated query because
@@ -149,12 +146,6 @@ jq -n \
   [$reviews[].data.repository.pullRequest.reviews.nodes[]] as $all_reviews |
   ["codecov"] as $ci_bot_logins |
   [$all_threads[] | select(.isResolved == false)] as $unresolved |
-  ([$all_threads[]
-    | select(.isResolved == true)
-    | { thread_id: .id, path: .path, line: .line,
-        first_comment_body: .comments.nodes[0].body,
-        last_comment_at: ([.comments.nodes[].createdAt] | sort | last) }]
-    | sort_by(.last_comment_at) | .[-10:] | reverse) as $resolved |
   {
     review_threads: [$unresolved[] | { node: . }],
     pr_comments: [$all_comments[]
@@ -164,9 +155,5 @@ jq -n \
     review_bodies: [$all_reviews[]
       | select(.body != null and .body != "")
       | select(.author.login != $author.login)
-      | select(.author.login as $l | $ci_bot_logins | index($l) | not)],
-    cross_invocation: {
-      signal: (($resolved | length) > 0 and ($unresolved | length) > 0),
-      resolved_threads: $resolved
-    }
+      | select(.author.login as $l | $ci_bot_logins | index($l) | not)]
   }'


### PR DESCRIPTION
## What went wrong

While resolving review feedback on a PR hosted on GitHub Enterprise, the skill
posted a reply to the wrong PR — in a completely different repository. The reply
was intended for a thread on a feature PR, but it appeared on an unrelated
infrastructure PR instead.

The root cause: `get-pr-comments` fetches thread node IDs via one GraphQL query
path; `get-thread-for-comment` fetches the same thread via a different path.
On GHE, these two paths returned node IDs that differed by a single character
for the same thread (e.g. `...M3p2Mg==` vs `...Mzp2Mg==`). The ID from
`get-pr-comments` silently resolved to a thread on a different repo, so the
reply mutation landed there instead.

## Fix

**`references/full-mode.md`** — added a verification step (step 0) in the reply
flow: before calling `reply-to-pr-thread`, cross-check the thread ID from
`get-pr-comments` against `get-thread-for-comment` using the comment's numeric
URL ID. If they differ, the ID from `get-thread-for-comment` is authoritative.
Also set `GH_REPO=OWNER/REPO` on the `gh api` verification call so the
`{owner}/{repo}` placeholder resolves against the target repo explicitly, not
from the current git remote (which may point to a fork or unrelated checkout).

**`scripts/get-pr-comments`** — reverted the `cross_invocation` envelope added
in the initial commit. The cluster analysis that would consume it is out of scope
for this fix; shipping unused output invited the "nothing reads this" review
finding that appeared on this PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude_Sonnet_4.6_%28200K%29](https://img.shields.io/badge/Claude_Sonnet_4.6_%28200K%29-D97757?logo=claude&logoColor=white)
