### PR TITLE
fix(skills): enforce content conventions in CI and fix violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,28 @@ jobs:
       - name: Validate release metadata
         run: bun run release:validate
 
+      # Canonical schema check: runs `claude plugin validate` against the
+      # marketplace catalog and each plugin directory (blocking, non-strict).
+      # The CLI must be installed via npm, not bun: `bun x` cannot run this
+      # package (bun blocks its required postinstall and cannot resolve its
+      # `claude` bin name), and `bun run` rewrites `npx` in package.json
+      # scripts to the broken `bun x`, so the script invokes a `claude`
+      # already on PATH instead.
+      #
+      # The validator version is pinned deliberately for reproducible CI: a
+      # floating @latest would track new upstream validation rules
+      # automatically but could break CI without any repo change. Bump the
+      # pin intentionally to adopt new `claude plugin validate` rules (and
+      # revisit --strict below when doing so).
+      #
+      # --strict (warnings-as-errors) should be enabled once this known
+      # warning is fixed:
+      #   plugins/compound-engineering -- 1 warning:
+      #     "root: CLAUDE.md at the plugin root is not loaded as project context. To ship context with your plugin, use a skill (skills/<name>/SKILL.md) instead."
+      - name: Validate plugin schema (claude plugin validate)
+        run: |
+          npm install -g @anthropic-ai/claude-code@2.1.175
+          bun run plugin:validate
+
       - name: Run tests
         run: bun test

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "list": "bun run src/index.ts list",
     "cli:install": "bun run src/index.ts install",
     "test": "bun test",
+    "plugin:validate": "claude plugin validate .claude-plugin/marketplace.json && claude plugin validate plugins/compound-engineering",
     "release:preview": "bun run scripts/release/preview.ts",
     "release:sync-metadata": "bun run scripts/release/sync-metadata.ts --write",
     "release:validate": "bun run scripts/release/validate.ts"

--- a/plugins/compound-engineering/skills/ce-brainstorm/references/handoff.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/references/handoff.md
@@ -82,7 +82,7 @@ Load the `ce-proof` skill in HITL-review mode with:
 - **identity:** `ai:compound-engineering` / `Compound Engineering`
 - **recommended next step:** `ce-plan` (shown in the ce-proof skill's final terminal output)
 
-Follow `references/hitl-review.md` in the ce-proof skill. It uploads the doc, prompts the user for review in Proof's web UI, ingests filtered comment threads, applies agreed edits through the current Proof edit APIs, replies/resolves in-thread, and syncs the final markdown back to the source file atomically on proceed.
+Follow the HITL-review workflow in the ce-proof skill (the ce-proof skill loads its own hitl-review reference). It uploads the doc, prompts the user for review in Proof's web UI, ingests filtered comment threads, applies agreed edits through the current Proof edit APIs, replies/resolves in-thread, and syncs the final markdown back to the source file atomically on proceed.
 
 When the ce-proof skill returns control:
 

--- a/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
+++ b/plugins/compound-engineering/skills/ce-plan/references/plan-handoff.md
@@ -4,7 +4,7 @@ This file contains post-plan-writing instructions: document review, post-generat
 
 ## 5.3.8 Document Review
 
-**Format gate.** This phase runs only when `OUTPUT_FORMAT=md` (resolved in SKILL.md Phase 0.0). `ce-doc-review`'s mutation mechanics are markdown-specific — its walkthrough applies `gated_auto`/`manual` fixes as "single-file markdown changes" via the platform's edit tool, and its Append-to-Open-Questions flow inserts `##`/`###` markdown headings (see `references/walkthrough.md` and `references/open-questions-defer.md` in the ce-doc-review skill). Running those mutators against an HTML artifact would produce malformed output. Until ce-doc-review gains HTML-aware mutation, HTML plans skip this phase entirely.
+**Format gate.** This phase runs only when `OUTPUT_FORMAT=md` (resolved in SKILL.md Phase 0.0). `ce-doc-review`'s mutation mechanics are markdown-specific — its walkthrough applies `gated_auto`/`manual` fixes as "single-file markdown changes" via the platform's edit tool, and its Append-to-Open-Questions flow inserts `##`/`###` markdown headings (see the walkthrough and open-questions-defer references inside the ce-doc-review skill). Running those mutators against an HTML artifact would produce malformed output. Until ce-doc-review gains HTML-aware mutation, HTML plans skip this phase entirely.
 
 **When `OUTPUT_FORMAT=html`:** Skip the ce-doc-review invocation. Capture a synthetic "skipped" envelope so the menu summary line in 5.4 can name the limitation explicitly:
 - `fixes_applied = 0`
@@ -81,7 +81,7 @@ Based on selection (the bare per-option routing is also stated inline in the SKI
   - identity: `ai:compound-engineering` / `Compound Engineering`
   - recommended next step: `/ce-work` (shown in the ce-proof skill's final terminal output)
 
-  Follow `references/hitl-review.md` in the ce-proof skill. It uploads the plan, prompts the user for review in Proof's web UI, ingests filtered comment threads, applies agreed edits through the current Proof edit APIs, replies/resolves in-thread, and syncs the final markdown back to the plan file atomically on proceed.
+  Follow the HITL-review workflow in the ce-proof skill (the ce-proof skill loads its own hitl-review reference). It uploads the plan, prompts the user for review in Proof's web UI, ingests filtered comment threads, applies agreed edits through the current Proof edit APIs, replies/resolves in-thread, and syncs the final markdown back to the plan file atomically on proceed.
 
   Note: the Proof flow only runs when `OUTPUT_FORMAT=md` (the menu only renders this option then). Proof ingests markdown; HTML plans use the local browser option instead.
 

--- a/plugins/compound-engineering/skills/ce-update/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-update/SKILL.md
@@ -37,6 +37,11 @@ bash "${CLAUDE_SKILL_DIR}/scripts/currently-loaded-version.sh"
 bash "${CLAUDE_SKILL_DIR}/scripts/marketplace-name.sh"
 ```
 
+If `${CLAUDE_SKILL_DIR}` is unset or unresolved (the commands above fail with
+`No such file or directory`), the harness does not expose the skill directory —
+this is not a standard Claude Code session. Treat it the same as the
+`__CE_UPDATE_NOT_MARKETPLACE__` case in Step 2: explain and stop.
+
 `scripts/upstream-version.sh` reads `plugin.json` on `main` via `gh api`. It
 prints the version string, or the sentinel `__CE_UPDATE_VERSION_FAILED__` if
 `gh` is unavailable or rate-limited.

--- a/tests/real-plugin-conversion.test.ts
+++ b/tests/real-plugin-conversion.test.ts
@@ -1,0 +1,427 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { existsSync, promises as fs, readdirSync, readFileSync } from "fs"
+import os from "os"
+import path from "path"
+import { parseFrontmatter } from "../src/utils/frontmatter"
+
+// Conversion-drift smoke test.
+//
+// Converts the REAL plugin (plugins/compound-engineering) -- not fixtures --
+// to every implemented target via the CLI, then structurally validates each
+// output tree. Expected counts are
+// re-derived from the source tree (agents/, commands/, skills/ plus
+// `ce_platforms` frontmatter) rather than from the converter code, so drift on
+// either side fails here. Fixture-based behavior (field mappings, deep-merge,
+// legacy cleanup) is covered elsewhere; this file owns whole-tree shape for
+// the shipping plugins.
+//
+// Sandbox safety: every conversion writes only inside a fresh os.tmpdir()
+// root, with HOME redirected into that root and CODEX_HOME /
+// OPENCODE_CONFIG_DIR scrubbed so no target default can escape to the real
+// home directory.
+
+const repoRoot = path.join(import.meta.dir, "..")
+const cliEntry = path.join(repoRoot, "src", "index.ts")
+
+const IMPLEMENTED_TARGETS = ["opencode", "codex", "pi", "gemini", "kiro"] as const
+type Target = (typeof IMPLEMENTED_TARGETS)[number]
+
+const PLUGIN_NAMES = ["compound-engineering"] as const
+type PluginName = (typeof PLUGIN_NAMES)[number]
+
+// Note on skill body size: an "8KB Codex skill body cap" circulates in
+// ecosystem lint tooling (e.g. wshobson/agents harness_portability.py), but it
+// is not in the Codex source (codex-rs/core-skills has no body-size constant)
+// or the official docs. The real Codex limit is an ~8,000-character budget on
+// the injected skills METADATA LIST; full SKILL.md bodies are read from disk
+// on demand. So no body-size check is enforced here. The codex-path
+// description cap is converter-enforced (src/converters/claude-to-codex.ts
+// CODEX_DESCRIPTION_MAX_LENGTH).
+
+// ---------------------------------------------------------------------------
+// Source inventory -- read independently from the plugin source tree.
+// ---------------------------------------------------------------------------
+
+type SourceInventory = {
+  agents: string[]
+  commands: string[]
+  skills: { name: string; cePlatforms?: string[] }[]
+}
+
+function listFileBasenames(dir: string, extension: string): string[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith(extension))
+      .map((entry) => entry.name.slice(0, -extension.length))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function listDirNames(dir: string): string[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+function walkFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...walkFiles(full))
+    } else if (entry.isFile()) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function loadSourceInventory(pluginName: PluginName): SourceInventory {
+  const pluginRoot = path.join(repoRoot, "plugins", pluginName)
+  const agents = listFileBasenames(path.join(pluginRoot, "agents"), ".md")
+  const commands = listFileBasenames(path.join(pluginRoot, "commands"), ".md")
+  const skills: SourceInventory["skills"] = []
+  const skillsRoot = path.join(pluginRoot, "skills")
+  for (const name of listDirNames(skillsRoot)) {
+    const skillFile = path.join(skillsRoot, name, "SKILL.md")
+    let raw: string
+    try {
+      raw = readFileSync(skillFile, "utf8")
+    } catch {
+      continue
+    }
+    const { data } = parseFrontmatter(raw, skillFile)
+    const cePlatforms = Array.isArray(data.ce_platforms) ? (data.ce_platforms as string[]) : undefined
+    skills.push({ name, cePlatforms })
+  }
+  return { agents, commands, skills }
+}
+
+// Mirrors filterSkillsByPlatform (src/types/claude.ts) on purpose: the
+// expected skill list must come from an independent reading of the source
+// frontmatter so a regression in the converter's platform filter (or an
+// undocumented new exclusion) shows up as a set difference here. The only
+// intentional exclusion today is `ce_platforms` (e.g. ce-update is
+// claude-only and is dropped from every converted target).
+function skillsForPlatform(inventory: SourceInventory, target: Target): string[] {
+  return inventory.skills
+    .filter((skill) => !skill.cePlatforms || skill.cePlatforms.includes(target))
+    .map((skill) => skill.name)
+    .sort()
+}
+
+// ---------------------------------------------------------------------------
+// Conversion harness -- one CLI `convert` per (plugin, target), reused by all
+// downstream assertions.
+// ---------------------------------------------------------------------------
+
+type Conversion = {
+  // Directory containing the target's output tree (e.g. <tmp>/codex-home,
+  // <tmp>/gemini-out/.gemini).
+  root: string
+}
+
+const conversions = new Map<string, Conversion>()
+
+function conversionKey(pluginName: PluginName, target: Target): string {
+  return `${pluginName}:${target}`
+}
+
+function getConversion(pluginName: PluginName, target: Target): Conversion {
+  const conversion = conversions.get(conversionKey(pluginName, target))
+  if (!conversion) {
+    throw new Error(
+      `No conversion recorded for ${pluginName} -> ${target}. ` +
+        `The "${pluginName} converts to every implemented target" test must pass first.`,
+    )
+  }
+  return conversion
+}
+
+function targetInvocation(target: Target, tempRoot: string): { args: string[]; root: string } {
+  switch (target) {
+    case "opencode": {
+      // The output basename must not be "opencode"/".opencode" -- that flips
+      // the writer into the flat global layout. Pin --permissions explicitly:
+      // `convert` defaults to broad while `install` defaults to none, and the
+      // opencode.json assertion below depends on the permission block.
+      const out = path.join(tempRoot, "opencode-out")
+      return { args: ["--output", out, "--permissions", "broad"], root: out }
+    }
+    case "codex": {
+      // codex ignores --output entirely (resolveTargetOutputRoot returns the
+      // codex home); without --codex-home it would write to ~/.codex.
+      // --include-skills exercises the full standalone bundle.
+      const out = path.join(tempRoot, "codex-home")
+      return { args: ["--codex-home", out, "--include-skills"], root: out }
+    }
+    case "pi": {
+      // pi also ignores --output. The basename must be ".pi" (or "agent") to
+      // get the flat canonical layout instead of nesting under <home>/.pi/.
+      const out = path.join(tempRoot, "pi-home", ".pi")
+      return { args: ["--pi-home", out], root: out }
+    }
+    case "gemini": {
+      // Without --output gemini defaults to <cwd>/.gemini.
+      const out = path.join(tempRoot, "gemini-out")
+      return { args: ["--output", out], root: path.join(out, ".gemini") }
+    }
+    case "kiro": {
+      // Without --output kiro defaults to <cwd>/.kiro.
+      const out = path.join(tempRoot, "kiro-out")
+      return { args: ["--output", out], root: path.join(out, ".kiro") }
+    }
+  }
+}
+
+async function runConvert(pluginName: PluginName, target: Target, tempRoot: string, fakeHome: string): Promise<void> {
+  const { args, root } = targetInvocation(target, tempRoot)
+  const env: Record<string, string | undefined> = { ...process.env, HOME: fakeHome }
+  // Inherited target overrides would silently redirect writes outside tempRoot.
+  delete env.CODEX_HOME
+  delete env.OPENCODE_CONFIG_DIR
+
+  const proc = Bun.spawn([
+    "bun",
+    "run",
+    cliEntry,
+    "convert",
+    path.join(repoRoot, "plugins", pluginName),
+    "--to",
+    target,
+    ...args,
+  ], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  })
+
+  const exitCode = await proc.exited
+  const stdout = await new Response(proc.stdout).text()
+  const stderr = await new Response(proc.stderr).text()
+
+  if (exitCode !== 0) {
+    throw new Error(
+      `convert ${pluginName} --to ${target} failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`,
+    )
+  }
+
+  conversions.set(conversionKey(pluginName, target), { root })
+}
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(filePath, "utf8")) as Record<string, unknown>
+}
+
+function expectSkillDirsHaveSkillMd(skillsRoot: string, skillNames: string[]): void {
+  for (const name of skillNames) {
+    const skillFile = path.join(skillsRoot, name, "SKILL.md")
+    expect(existsSync(skillFile), `Converted skill dir ${path.join(skillsRoot, name)} is missing SKILL.md`).toBe(true)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-plugin drift tests.
+// ---------------------------------------------------------------------------
+
+// Conversion output is read by tests across several describe blocks, so temp
+// roots are only removed once the whole file has run.
+const tempRoots: string[] = []
+
+afterAll(async () => {
+  await Promise.all(tempRoots.map((root) => fs.rm(root, { recursive: true, force: true })))
+})
+
+for (const pluginName of PLUGIN_NAMES) {
+  const inventory = loadSourceInventory(pluginName)
+
+  describe(`real-plugin conversion drift: ${pluginName}`, () => {
+    test("converts to every implemented target", async () => {
+      const outputRoot = await fs.mkdtemp(path.join(os.tmpdir(), `real-convert-${pluginName}-`))
+      tempRoots.push(outputRoot)
+      const fakeHome = path.join(outputRoot, "home")
+      await fs.mkdir(fakeHome)
+
+      await Promise.all(IMPLEMENTED_TARGETS.map((target) => runConvert(pluginName, target, outputRoot, fakeHome)))
+
+      // Sandbox safety: with explicit output flags, no target may fall back to
+      // a home-relative default (the redirected HOME would catch it).
+      for (const leaked of [".codex", ".pi", ".gemini", ".kiro", ".agents", path.join(".config", "opencode")]) {
+        expect(
+          await exists(path.join(fakeHome, leaked)),
+          `convert leaked ${leaked} into HOME despite explicit output flags`,
+        ).toBe(false)
+      }
+    }, 120_000)
+
+    test("opencode output matches the source inventory", () => {
+      const { root } = getConversion(pluginName, "opencode")
+      const expectedSkills = skillsForPlatform(inventory, "opencode")
+
+      const config = readJson(path.join(root, "opencode.json"))
+      expect(config.$schema).toBe("https://opencode.ai/config.json")
+      expect(config.permission, "--permissions broad was pinned, so opencode.json must carry a permission block").toBeDefined()
+
+      const opencodeRoot = path.join(root, ".opencode")
+      expect(listFileBasenames(path.join(opencodeRoot, "agents"), ".md")).toEqual(inventory.agents)
+      expect(listDirNames(path.join(opencodeRoot, "skills"))).toEqual(expectedSkills)
+      expectSkillDirsHaveSkillMd(path.join(opencodeRoot, "skills"), expectedSkills)
+      expect(listFileBasenames(path.join(opencodeRoot, "commands"), ".md")).toEqual(inventory.commands)
+
+      const manifest = readJson(path.join(opencodeRoot, pluginName, "install-manifest.json"))
+      expect(manifest.version).toBe(1)
+      expect(manifest.pluginName).toBe(pluginName)
+      const groups = manifest.groups as Record<string, string[]>
+      expect(groups.agents.length).toBe(inventory.agents.length)
+      expect(groups.skills.length).toBe(expectedSkills.length)
+      expect(groups.commands.length).toBe(inventory.commands.length)
+    })
+
+    test("codex output matches the source inventory", () => {
+      const { root } = getConversion(pluginName, "codex")
+      // Codex converts commands into prompts AND generated command-skills, so
+      // the skills dir is the platform-filtered skills plus the commands.
+      const expectedSkills = [...new Set([...skillsForPlatform(inventory, "codex"), ...inventory.commands])].sort()
+
+      const agentsMd = readFileSync(path.join(root, "AGENTS.md"), "utf8")
+      expect(agentsMd).toContain("<!-- BEGIN COMPOUND CODEX TOOL MAP -->")
+      expect(agentsMd).toContain("<!-- END COMPOUND CODEX TOOL MAP -->")
+
+      const tomlNames = listFileBasenames(path.join(root, "agents", pluginName), ".toml")
+      expect(tomlNames).toEqual(inventory.agents)
+      for (const name of tomlNames) {
+        const toml = readFileSync(path.join(root, "agents", pluginName, `${name}.toml`), "utf8")
+        for (const key of ["name", "description", "developer_instructions"]) {
+          expect(toml, `${name}.toml is missing the ${key} field`).toMatch(new RegExp(`^${key} = `, "m"))
+        }
+      }
+
+      expect(listDirNames(path.join(root, "skills", pluginName))).toEqual(expectedSkills)
+      expectSkillDirsHaveSkillMd(path.join(root, "skills", pluginName), expectedSkills)
+      expect(listFileBasenames(path.join(root, "prompts"), ".md")).toEqual(inventory.commands)
+
+      const manifest = readJson(path.join(root, pluginName, "install-manifest.json"))
+      expect(manifest.version).toBe(1)
+      expect(manifest.pluginName).toBe(pluginName)
+      expect((manifest.agents as string[]).length).toBe(inventory.agents.length)
+      expect((manifest.skills as string[]).length).toBe(expectedSkills.length)
+      expect((manifest.prompts as string[]).length).toBe(inventory.commands.length)
+    })
+
+    test("pi output matches the source inventory", () => {
+      const { root } = getConversion(pluginName, "pi")
+      const expectedSkills = skillsForPlatform(inventory, "pi")
+
+      const agentsMd = readFileSync(path.join(root, "AGENTS.md"), "utf8")
+      expect(agentsMd).toContain("<!-- BEGIN COMPOUND PI TOOL MAP -->")
+      expect(agentsMd).toContain("<!-- END COMPOUND PI TOOL MAP -->")
+
+      expect(listFileBasenames(path.join(root, "agents"), ".md")).toEqual(inventory.agents)
+      expect(listDirNames(path.join(root, "skills"))).toEqual(expectedSkills)
+      expectSkillDirsHaveSkillMd(path.join(root, "skills"), expectedSkills)
+      expect(listFileBasenames(path.join(root, "prompts"), ".md")).toEqual(inventory.commands)
+
+      const manifest = readJson(path.join(root, pluginName, "install-manifest.json"))
+      expect(manifest.version).toBe(1)
+      expect(manifest.pluginName).toBe(pluginName)
+      expect((manifest.agents as string[]).length).toBe(inventory.agents.length)
+      expect((manifest.skills as string[]).length).toBe(expectedSkills.length)
+      expect((manifest.prompts as string[]).length).toBe(inventory.commands.length)
+    })
+
+    test("gemini output matches the source inventory", () => {
+      const { root } = getConversion(pluginName, "gemini")
+      const expectedSkills = skillsForPlatform(inventory, "gemini")
+
+      expect(listFileBasenames(path.join(root, "agents"), ".md")).toEqual(inventory.agents)
+      expect(listDirNames(path.join(root, "skills"))).toEqual(expectedSkills)
+      expectSkillDirsHaveSkillMd(path.join(root, "skills"), expectedSkills)
+      expect(listFileBasenames(path.join(root, "commands"), ".toml")).toEqual(inventory.commands)
+
+      const manifest = readJson(path.join(root, pluginName, "install-manifest.json"))
+      expect(manifest.version).toBe(1)
+      expect(manifest.pluginName).toBe(pluginName)
+      const groups = manifest.groups as Record<string, string[]>
+      expect(groups.agents.length).toBe(inventory.agents.length)
+      expect(groups.skills.length).toBe(expectedSkills.length)
+      expect(groups.commands.length).toBe(inventory.commands.length)
+    })
+
+    test("kiro output matches the source inventory", async () => {
+      const { root } = getConversion(pluginName, "kiro")
+      // Like codex, kiro turns commands into generated skills.
+      const expectedSkills = [...new Set([...skillsForPlatform(inventory, "kiro"), ...inventory.commands])].sort()
+
+      const agentJsonNames = listFileBasenames(path.join(root, "agents"), ".json")
+      expect(agentJsonNames).toEqual(inventory.agents)
+      for (const name of agentJsonNames) {
+        const agent = readJson(path.join(root, "agents", `${name}.json`))
+        expect(agent.name, `${name}.json must carry its own agent name`).toBe(name)
+        expect(typeof agent.description, `${name}.json must carry a description`).toBe("string")
+      }
+      // Agent prompt bodies are split into a sibling prompts/ dir, one per agent.
+      expect(listFileBasenames(path.join(root, "agents", "prompts"), ".md")).toEqual(inventory.agents)
+
+      expect(listDirNames(path.join(root, "skills"))).toEqual(expectedSkills)
+      expectSkillDirsHaveSkillMd(path.join(root, "skills"), expectedSkills)
+
+      // Steering is built from the plugin's own AGENTS.md, so it exists
+      // exactly when the source plugin ships one.
+      const hasPluginAgentsMd = await exists(path.join(repoRoot, "plugins", pluginName, "AGENTS.md"))
+      expect(
+        await exists(path.join(root, "steering", `${pluginName}.md`)),
+        `steering/${pluginName}.md should exist iff plugins/${pluginName}/AGENTS.md exists`,
+      ).toBe(hasPluginAgentsMd)
+
+      // The kiro writer has no managed install manifest (cleanup is
+      // allow-list based). If one appears, the writer contract changed and
+      // this test should be updated deliberately.
+      expect(await exists(path.join(root, pluginName, "install-manifest.json"))).toBe(false)
+    })
+
+    test("every emitted .json parses and every emitted .md has parseable frontmatter", () => {
+      const errors: string[] = []
+      let scanned = 0
+      for (const target of IMPLEMENTED_TARGETS) {
+        const { root } = getConversion(pluginName, target)
+        for (const file of walkFiles(root)) {
+          if (file.endsWith(".json")) {
+            scanned += 1
+            try {
+              JSON.parse(readFileSync(file, "utf8"))
+            } catch (err) {
+              errors.push(`${target}: ${file}: ${err instanceof Error ? err.message : err}`)
+            }
+          } else if (file.endsWith(".md")) {
+            scanned += 1
+            try {
+              parseFrontmatter(readFileSync(file, "utf8"), file)
+            } catch (err) {
+              errors.push(`${target}: ${file}: ${err instanceof Error ? err.message : err}`)
+            }
+          }
+        }
+      }
+      expect(scanned, "expected the converted trees to contain .json/.md files").toBeGreaterThan(0)
+      expect(errors, `Converted output contains unparseable files:\n${errors.join("\n")}`).toEqual([])
+    })
+  })
+}
+

--- a/tests/skill-conventions.test.ts
+++ b/tests/skill-conventions.test.ts
@@ -36,8 +36,12 @@ import { parseFrontmatter } from "../src/utils/frontmatter"
  * 2. REFERENCE INTEGRITY (AGENTS.md "File References in Skills"): every
  *    skill-local path mentioned in a skill's markdown must exist on disk
  *    INSIDE the skill directory. Candidates are (a) relative markdown link
- *    targets and (b) backtick code spans shaped like `references/...`,
- *    `scripts/...`, or `assets/...`. A candidate passes when it resolves
+ *    targets and (b) `references/...`, `scripts/...`, or `assets/...` path
+ *    tokens inside backtick code spans — whether the span IS the path
+ *    (`scripts/run.sh`) or embeds it in a command (`bash scripts/run.sh ARG`,
+ *    `python3 scripts/foo.py <arg>`), so a deleted or renamed script is
+ *    caught even when mentioned only as an executable command. A candidate
+ *    passes when it resolves
  *    inside the skill directory (anchored at the skill root or at the
  *    containing file's directory) AND exists there. Resolution is contained
  *    BEFORE any existence check: a `..` candidate that escapes the skill is
@@ -201,15 +205,26 @@ function extractMarkdownLinkTargets(markdown: string): Located[] {
   return out
 }
 
-/** Extracts backtick code spans shaped like skill-local file paths. */
+/**
+ * Extracts skill-local path tokens (references/, scripts/, assets/) from
+ * backtick code spans. The span may BE the path (`scripts/run.sh`) or embed
+ * it in a command (`bash scripts/run.sh ARG`, `python3 scripts/foo.py <arg>`):
+ * each whitespace-delimited token matching the path shape is extracted, so a
+ * deleted or renamed script is caught even when mentioned only as an
+ * executable command. The token character class excludes template placeholder
+ * characters, so placeholder-bearing path tokens (`scripts/<name>`) are
+ * skipped by construction while placeholder ARGUMENTS after a clean path
+ * token do not suppress it.
+ */
 function extractLocalPathCodeSpans(markdown: string): Located[] {
   const out: Located[] = []
-  const regex = /`([^`\n]+)`/g
+  const spanRegex = /`([^`\n]+)`/g
+  const pathToken = /^(references|scripts|assets)\/[A-Za-z0-9._/-]+$/
   let match: RegExpExecArray | null
-  while ((match = regex.exec(markdown)) !== null) {
-    const span = match[1]
-    if (/^(references|scripts|assets)\/[A-Za-z0-9._/-]+$/.test(span)) {
-      out.push({ lineNumber: lineNumberAt(markdown, match.index), value: span })
+  while ((match = spanRegex.exec(markdown)) !== null) {
+    const lineNumber = lineNumberAt(markdown, match.index)
+    for (const token of match[1].split(/\s+/)) {
+      if (pathToken.test(token)) out.push({ lineNumber, value: token })
     }
   }
   return out
@@ -563,9 +578,35 @@ describe("extractLocalPathCodeSpans", () => {
     ])
   })
 
-  test("ignores bare filenames, commands with arguments, and home paths", () => {
+  test("extracts path tokens embedded in command spans", () => {
     const sample =
-      "see `walkthrough.md`, run `bash scripts/run.sh ARG`, store in `~/coding-tutor-tutorials/x.md`, use `/tmp/scratch`"
+      "Run `bash scripts/run.sh ARG`, then `python3 scripts/extract.py --out report.json`."
+    expect(extractLocalPathCodeSpans(sample).map((s) => s.value)).toEqual([
+      "scripts/run.sh",
+      "scripts/extract.py",
+    ])
+  })
+
+  test("placeholder arguments do not suppress a clean path token", () => {
+    expect(extractLocalPathCodeSpans("run `python3 scripts/validate.py <output-path>`").map((s) => s.value)).toEqual([
+      "scripts/validate.py",
+    ])
+  })
+
+  test("skips placeholder-bearing path tokens", () => {
+    expect(extractLocalPathCodeSpans("invoked via `bash scripts/<name>`")).toEqual([])
+    expect(extractLocalPathCodeSpans("read `references/${topic}.md`")).toEqual([])
+  })
+
+  test("extracts multiple path tokens from one span", () => {
+    expect(
+      extractLocalPathCodeSpans("run `cp references/template.md assets/copy.md`").map((s) => s.value),
+    ).toEqual(["references/template.md", "assets/copy.md"])
+  })
+
+  test("ignores bare filenames, home paths, and absolute paths", () => {
+    const sample =
+      "see `walkthrough.md`, store in `~/coding-tutor-tutorials/x.md`, use `/tmp/scratch`, ls `the scripts/ dir`"
     expect(extractLocalPathCodeSpans(sample)).toEqual([])
   })
 })
@@ -623,8 +664,9 @@ describe("findSelfContainmentViolations", () => {
 })
 
 describe("extractLocalReferenceCandidates", () => {
-  test("collects relative link targets and path-shaped spans, stripping fragments", () => {
-    const sample = "[guide](references/guide.md#setup)\nRead `references/foo.md` and `scripts/run.sh`."
+  test("collects relative link targets and span path tokens (bare and command-embedded), stripping fragments", () => {
+    const sample =
+      "[guide](references/guide.md#setup)\nRead `references/foo.md` and run `bash scripts/run.sh <ARG>`."
     expect(extractLocalReferenceCandidates(sample).map((c) => c.value)).toEqual([
       "references/guide.md",
       "references/foo.md",

--- a/tests/skill-conventions.test.ts
+++ b/tests/skill-conventions.test.ts
@@ -1,0 +1,732 @@
+import { readdirSync, readFileSync, statSync, type Dirent } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { parseFrontmatter } from "../src/utils/frontmatter"
+
+/**
+ * Convention-enforcement tests for skill content, encoding the repo-root
+ * AGENTS.md rules "File References in Skills" and "Platform-Specific
+ * Variables in Skills", plus the Anthropic skill-spec frontmatter limits.
+ *
+ * Skill directories are enumerated dynamically under plugins/<plugin>/skills/
+ * so new skills (and new plugins) are auto-covered.
+ *
+ * Rule groups:
+ *
+ * 1. SELF-CONTAINMENT (AGENTS.md "File References in Skills"): a skill must
+ *    not reference files outside its own directory tree. Detection policy —
+ *    designed to avoid false positives on documentation examples:
+ *      - Fenced code blocks are stripped before scanning. Teaching samples,
+ *        message templates, and anti-pattern demos live in fences (e.g.,
+ *        ce-demo-reel's `![Before](url-1)` PR template), and fences are where
+ *        skills quote code they are ABOUT rather than files they USE.
+ *      - Markdown link/image targets are treated as real references. A target
+ *        is a violation when it is absolute (`/...`, `~/...`) or when it
+ *        resolves outside the skill directory under BOTH file-relative and
+ *        skill-root-relative anchoring (a `../scripts/x` link from
+ *        `references/` resolves inside the skill and is allowed).
+ *      - Prose/backtick mentions of installed-plugin paths
+ *        (`~/.claude/plugins/...`) are flagged — AGENTS.md names this as a
+ *        broken pattern. Files whose PURPOSE is reading that machine state
+ *        are exempted below with written reasons.
+ *      - Bare absolute paths in prose are NOT flagged: skills legitimately
+ *        discuss `/tmp` scratch conventions and quote `/Users/...` as
+ *        anti-pattern examples (ce-plan, ce-sessions, ce-ideate).
+ *
+ * 2. REFERENCE INTEGRITY (AGENTS.md "File References in Skills"): every
+ *    skill-local path mentioned in a skill's markdown must exist on disk
+ *    INSIDE the skill directory. Candidates are (a) relative markdown link
+ *    targets and (b) backtick code spans shaped like `references/...`,
+ *    `scripts/...`, or `assets/...`. A candidate passes when it resolves
+ *    inside the skill directory (anchored at the skill root or at the
+ *    containing file's directory) AND exists there. Resolution is contained
+ *    BEFORE any existence check: a `..` candidate that escapes the skill is
+ *    a violation even when the target exists in a sibling skill — existence
+ *    elsewhere is exactly what makes it a cross-skill reference. Targets
+ *    containing template placeholder characters (`<`, `>`, `*`, `{`, `$`)
+ *    are skipped.
+ *
+ * 3. FRONTMATTER LIMITS (Anthropic skill spec — hard constraints, with no
+ *    exemption lists because exceeding them breaks real behavior):
+ *      - frontmatter description <= 1024 chars (some harnesses reject longer
+ *        descriptions — also enforced in tests/frontmatter.test.ts).
+ *      - frontmatter name <= 64 chars.
+ *    Deliberately NOT gated here: the 500-line SKILL.md body guidance and any
+ *    byte cap on skill bodies. The line guidance is advice, not a constraint —
+ *    several skills in this plugin are large by design, and gating guidance
+ *    would tax every deliberately-large skill with exemption-list ceremony.
+ *    The "8KB Codex body cap" that circulates in ecosystem lint tooling turned
+ *    out to be folklore: Codex's real limit is an ~8,000-character budget on
+ *    the injected skills metadata LIST, while full SKILL.md bodies are read
+ *    from disk on demand (see the note in tests/real-plugin-conversion.test.ts).
+ *
+ * 4. PLATFORM-VARIABLE FALLBACK (AGENTS.md "Platform-Specific Variables in
+ *    Skills"): skill markdown using harness variables (${CLAUDE_*},
+ *    ${CODEX_*}) must degrade gracefully. Mechanically graceful forms pass
+ *    outright: a shell default (`${VAR:-...}`) or an existence guard
+ *    (`[ -n "$VAR" ]` / `[ -z "$VAR" ]`). Any other use must be explicitly
+ *    acknowledged in PLATFORM_VAR_ACKNOWLEDGED with a written reason naming
+ *    the prose fallback (the AGENTS.md pre-resolution pattern). An earlier
+ *    revision tried to verify the fallback PROSE itself, via a fallback
+ *    keyword list and a line window — that graded English with regexes and
+ *    failed legitimate rewordings, so the editorial judgment now lives in
+ *    the registry: exact matching, immune to prose rewording, vetted by a
+ *    reviewer when the entry is added, kept honest by a stale-entry check.
+ *    Credential-style env vars (e.g., GEMINI_API_KEY) are out of scope —
+ *    they are API requirements, not harness variables.
+ *
+ * Each rule's scanning helpers are unit-tested with in-file fixtures at the
+ * bottom of this file (mutation-resistance layer, matching the house style
+ * of tests/skill-shell-safety.test.ts).
+ */
+
+const REPO_ROOT = process.cwd()
+const PLUGINS_ROOT = path.join(REPO_ROOT, "plugins")
+const AGENTS_MD_REF = `AGENTS.md (repo root)`
+
+// ---------------------------------------------------------------------------
+// Exemptions. Shrinking these lists is welcome; growing them requires written
+// justification in the entry comment — they must not become silent junk
+// drawers. Keys are repo-root-relative paths so same-named skills in
+// different plugins cannot collide.
+// ---------------------------------------------------------------------------
+
+// Rule 1: files allowed to mention installed-plugin paths (~/.claude/plugins/...).
+const INSTALLED_PLUGIN_PATH_EXEMPTIONS = new Map<string, string>([
+  [
+    "plugins/compound-engineering/skills/ce-update/SKILL.md",
+    "ce-update is explicitly Claude-Code-only; its purpose is reasoning about the marketplace cache layout it READS (never edits).",
+  ],
+  [
+    "plugins/compound-engineering/skills/ce-report-bug/SKILL.md",
+    "ce-report-bug reads ~/.claude/plugins/installed_plugins.json to capture the installed plugin version for bug reports — runtime machine-state read, not a skill-content reference.",
+  ],
+])
+
+const DESCRIPTION_CHAR_BUDGET = 1024
+const NAME_CHAR_BUDGET = 64
+
+// ---------------------------------------------------------------------------
+// Skill enumeration
+// ---------------------------------------------------------------------------
+
+type SkillDir = {
+  /** repo-root-relative skill dir, e.g. plugins/compound-engineering/skills/ce-plan */
+  relPath: string
+  absPath: string
+}
+
+function listSkillDirs(): SkillDir[] {
+  const out: SkillDir[] = []
+  let plugins: Dirent[]
+  try {
+    plugins = readdirSync(PLUGINS_ROOT, { withFileTypes: true })
+  } catch {
+    return out
+  }
+  for (const plugin of plugins) {
+    if (!plugin.isDirectory()) continue
+    const skillsRoot = path.join(PLUGINS_ROOT, plugin.name, "skills")
+    let skillEntries: Dirent[]
+    try {
+      skillEntries = readdirSync(skillsRoot, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of skillEntries) {
+      if (!entry.isDirectory()) continue
+      const absPath = path.join(skillsRoot, entry.name)
+      out.push({ relPath: path.relative(REPO_ROOT, absPath), absPath })
+    }
+  }
+  return out
+}
+
+function listMarkdownFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...listMarkdownFiles(full))
+      continue
+    }
+    if (entry.name.endsWith(".md")) out.push(full)
+  }
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Scanning helpers (pure; unit-tested at the bottom of this file)
+// ---------------------------------------------------------------------------
+
+/**
+ * Blanks out fenced code blocks (``` / ~~~, any fence length >= 3) while
+ * preserving line numbers. Outer fences longer than three backticks (e.g.,
+ * ````markdown teaching blocks) correctly swallow shorter inner fences.
+ */
+function stripFencedCodeBlocks(markdown: string): string {
+  const lines = markdown.split("\n")
+  let fence: { char: string; len: number } | null = null
+  const out = lines.map((line) => {
+    const match = line.match(/^\s*(`{3,}|~{3,})/)
+    if (match) {
+      const char = match[1][0]
+      const len = match[1].length
+      if (!fence) {
+        fence = { char, len }
+        return ""
+      }
+      if (fence.char === char && len >= fence.len) fence = null
+      return ""
+    }
+    return fence ? "" : line
+  })
+  return out.join("\n")
+}
+
+type Located = { lineNumber: number; value: string }
+
+function lineNumberAt(text: string, index: number): number {
+  return text.slice(0, index).split("\n").length
+}
+
+/** Extracts markdown link and image targets: [text](target), ![alt](target "title"). */
+function extractMarkdownLinkTargets(markdown: string): Located[] {
+  const out: Located[] = []
+  const regex = /!?\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(markdown)) !== null) {
+    out.push({ lineNumber: lineNumberAt(markdown, match.index), value: match[1] })
+  }
+  return out
+}
+
+/** Extracts backtick code spans shaped like skill-local file paths. */
+function extractLocalPathCodeSpans(markdown: string): Located[] {
+  const out: Located[] = []
+  const regex = /`([^`\n]+)`/g
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(markdown)) !== null) {
+    const span = match[1]
+    if (/^(references|scripts|assets)\/[A-Za-z0-9._/-]+$/.test(span)) {
+      out.push({ lineNumber: lineNumberAt(markdown, match.index), value: span })
+    }
+  }
+  return out
+}
+
+function isExternalLinkTarget(target: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(target) || target.startsWith("#")
+}
+
+function isTemplatePlaceholderPath(target: string): boolean {
+  return /[<>*{}$]/.test(target)
+}
+
+/** Strips a #fragment suffix from a link target. */
+function withoutFragment(target: string): string {
+  const hash = target.indexOf("#")
+  return hash === -1 ? target : target.slice(0, hash)
+}
+
+/**
+ * True when a reference target escapes the skill directory. Absolute and
+ * home-anchored targets always escape. Relative targets escape only when
+ * they resolve outside the skill root from BOTH the containing file's
+ * directory (`fileDirWithinSkill`, posix-relative to the skill root, "" for
+ * SKILL.md itself) and the skill root.
+ */
+function escapesSkillDir(target: string, fileDirWithinSkill: string): boolean {
+  if (target.startsWith("/") || target.startsWith("~")) return true
+  const fromFile = path.posix.normalize(path.posix.join(fileDirWithinSkill, target))
+  const fromRoot = path.posix.normalize(target)
+  const escapes = (p: string) => p === ".." || p.startsWith("../")
+  return escapes(fromFile) && escapes(fromRoot)
+}
+
+const INSTALLED_PLUGIN_PATH_REGEX = /(~|\$HOME)\/\.claude\/plugins\//
+
+type SelfContainmentViolation = { lineNumber: number; detail: string }
+
+/** Rule 1 scanner for one markdown file's content. */
+function findSelfContainmentViolations(
+  markdown: string,
+  fileDirWithinSkill: string,
+): SelfContainmentViolation[] {
+  const stripped = stripFencedCodeBlocks(markdown)
+  const out: SelfContainmentViolation[] = []
+  for (const { lineNumber, value } of extractMarkdownLinkTargets(stripped)) {
+    if (isExternalLinkTarget(value) || isTemplatePlaceholderPath(value)) continue
+    if (escapesSkillDir(withoutFragment(value), fileDirWithinSkill)) {
+      out.push({ lineNumber, detail: `link target escapes the skill directory: ${value}` })
+    }
+  }
+  const lines = stripped.split("\n")
+  for (let i = 0; i < lines.length; i++) {
+    if (INSTALLED_PLUGIN_PATH_REGEX.test(lines[i])) {
+      out.push({
+        lineNumber: i + 1,
+        detail: `installed-plugin path (~/.claude/plugins/...): ${lines[i].trim().slice(0, 120)}`,
+      })
+    }
+  }
+  return out
+}
+
+/** Rule 2 candidate extractor: skill-local paths that must exist on disk. */
+function extractLocalReferenceCandidates(markdown: string): Located[] {
+  const stripped = stripFencedCodeBlocks(markdown)
+  const out: Located[] = []
+  for (const { lineNumber, value } of extractMarkdownLinkTargets(stripped)) {
+    if (isExternalLinkTarget(value) || isTemplatePlaceholderPath(value)) continue
+    const target = withoutFragment(value)
+    if (target === "" || target.startsWith("/") || target.startsWith("~")) continue
+    out.push({ lineNumber, value: target })
+  }
+  for (const span of extractLocalPathCodeSpans(stripped)) {
+    if (isTemplatePlaceholderPath(span.value)) continue
+    out.push(span)
+  }
+  return out
+}
+
+/**
+ * Resolves a Rule 2 candidate against a base directory and returns the
+ * result only when it stays inside the skill directory; otherwise null.
+ * Containment is checked BEFORE any disk access so a `..` candidate that
+ * lands on a real file in a sibling skill is rejected rather than treated
+ * as existing — that is precisely the cross-skill reference Rule 2 exists
+ * to catch.
+ */
+function resolveInsideSkill(skillAbsPath: string, baseDir: string, target: string): string | null {
+  const resolved = path.resolve(baseDir, target)
+  if (resolved === skillAbsPath || resolved.startsWith(skillAbsPath + path.sep)) return resolved
+  return null
+}
+
+// Rule 4 helpers ------------------------------------------------------------
+
+const PLATFORM_VAR_REGEX = /\$\{?((?:CLAUDE|CODEX)_[A-Z][A-Z0-9_]*)/g
+
+type PlatformVarOccurrence = { lineNumber: number; variable: string; graceful: boolean }
+
+/** True when the occurrence on this line uses `${VAR:-...}` or sits in `[ -n/-z "$VAR..." ]`. */
+function isGracefulPlatformVarUse(line: string, variable: string): boolean {
+  const defaultForm = new RegExp(`\\$\\{${variable}:-`)
+  if (defaultForm.test(line)) return true
+  const guardForm = new RegExp(`\\[\\s*-[nz]\\s+"[^"]*\\$\\{?${variable}\\b[^"]*"\\s*\\]`)
+  return guardForm.test(line)
+}
+
+function findPlatformVarOccurrences(markdown: string): PlatformVarOccurrence[] {
+  const out: PlatformVarOccurrence[] = []
+  const lines = markdown.split("\n")
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    let match: RegExpExecArray | null
+    PLATFORM_VAR_REGEX.lastIndex = 0
+    while ((match = PLATFORM_VAR_REGEX.exec(line)) !== null) {
+      out.push({
+        lineNumber: i + 1,
+        variable: match[1],
+        graceful: isGracefulPlatformVarUse(line, match[1]),
+      })
+    }
+  }
+  return out
+}
+
+/**
+ * Acknowledged non-graceful platform-variable uses, keyed
+ * `<repo-relative file>#<VARIABLE>` -> written reason naming the prose
+ * fallback that lives in the file.
+ *
+ * Whether prose constitutes a real fallback is an editorial judgment. An
+ * earlier revision automated it with a fallback-keyword list and a line
+ * window; that failed legitimate rewordings ("if the variable is empty")
+ * and could be satisfied by coincidental keywords. The judgment now happens
+ * once, at review time, when an entry is added here — and the stale-entry
+ * test below forces removal when the underlying use disappears.
+ */
+const PLATFORM_VAR_ACKNOWLEDGED = new Map<string, string>([
+  [
+    "plugins/compound-engineering/skills/ce-setup/SKILL.md#CLAUDE_PLUGIN_ROOT",
+    "AGENTS.md pre-resolution pattern: the prose under the pre-resolved line says exactly what to do when it is empty or an unresolved literal (treat as non-Claude-Code; omit /ce-update references).",
+  ],
+  [
+    "plugins/compound-engineering/skills/ce-update/SKILL.md#CLAUDE_SKILL_DIR",
+    "SKILL.md routes unset/unresolved CLAUDE_SKILL_DIR (scripts failing) to its __CE_UPDATE_NOT_MARKETPLACE__ handling.",
+  ],
+  [
+    "plugins/compound-engineering/skills/ce-worktree/SKILL.md#CLAUDE_SKILL_DIR",
+    "Prose explaining the variable's cross-harness behavior, not a use — every executable use in the file carries the ${CLAUDE_SKILL_DIR:-.} shell default.",
+  ],
+])
+
+/** Rule 4 scanner for one markdown file: every non-graceful occurrence. */
+function findPlatformVarViolations(markdown: string): PlatformVarOccurrence[] {
+  return findPlatformVarOccurrences(markdown).filter((o) => !o.graceful)
+}
+
+// ---------------------------------------------------------------------------
+// Repo scans
+// ---------------------------------------------------------------------------
+
+const skillDirs = listSkillDirs()
+
+describe("skill self-containment (AGENTS.md 'File References in Skills')", () => {
+  for (const skill of skillDirs) {
+    test(`${skill.relPath} has no file references escaping the skill directory`, () => {
+      const offenders: string[] = []
+      for (const filePath of listMarkdownFiles(skill.absPath)) {
+        const fileRel = path.relative(REPO_ROOT, filePath)
+        if (INSTALLED_PLUGIN_PATH_EXEMPTIONS.has(fileRel)) continue
+        const fileDirWithinSkill = path
+          .relative(skill.absPath, path.dirname(filePath))
+          .split(path.sep)
+          .join("/")
+        const content = readFileSync(filePath, "utf8")
+        for (const violation of findSelfContainmentViolations(content, fileDirWithinSkill)) {
+          offenders.push(`  ${fileRel}:${violation.lineNumber} — ${violation.detail}`)
+        }
+      }
+      expect(
+        offenders,
+        `Skills must be self-contained: no \`../\` traversal out of the skill, no absolute paths, no installed-plugin (~/.claude/plugins/...) paths — see ${AGENTS_MD_REF} "File References in Skills". Duplicate shared files into each skill or reference the other skill semantically ("load the ce-X skill"). If the file's purpose is reading installed-plugin machine state, add it to INSTALLED_PLUGIN_PATH_EXEMPTIONS in tests/skill-conventions.test.ts with a written reason.\nOffending references:\n${offenders.join("\n")}`,
+      ).toEqual([])
+    })
+  }
+})
+
+describe("skill reference integrity (AGENTS.md 'File References in Skills')", () => {
+  for (const skill of skillDirs) {
+    test(`${skill.relPath} only mentions skill-local paths that exist on disk`, () => {
+      const missing: string[] = []
+      for (const filePath of listMarkdownFiles(skill.absPath)) {
+        const fileRel = path.relative(REPO_ROOT, filePath)
+        const content = readFileSync(filePath, "utf8")
+        for (const { lineNumber, value } of extractLocalReferenceCandidates(content)) {
+          const containedCandidates = [
+            resolveInsideSkill(skill.absPath, skill.absPath, value),
+            resolveInsideSkill(skill.absPath, path.dirname(filePath), value),
+          ].filter((p): p is string => p !== null)
+          if (containedCandidates.length === 0) {
+            missing.push(`  ${fileRel}:${lineNumber} — ${value} (resolves outside the skill directory)`)
+            continue
+          }
+          const exists = (p: string) => {
+            try {
+              statSync(p)
+              return true
+            } catch {
+              return false
+            }
+          }
+          if (!containedCandidates.some(exists)) {
+            missing.push(`  ${fileRel}:${lineNumber} — ${value}`)
+          }
+        }
+      }
+      expect(
+        missing,
+        `Every references/, scripts/, or assets/ path (and relative markdown link) mentioned in a skill must exist inside that skill's directory — see ${AGENTS_MD_REF} "File References in Skills". A path that exists only in ANOTHER skill is a cross-skill reference: duplicate the file into this skill or replace the file-level pointer with semantic wording ("the <name> reference in the ce-X skill" without a path).\nMissing paths:\n${missing.join("\n")}`,
+      ).toEqual([])
+    })
+  }
+})
+
+describe("skill frontmatter limits (Anthropic skill spec)", () => {
+  for (const skill of skillDirs) {
+    const skillMdPath = path.join(skill.absPath, "SKILL.md")
+    const raw = readFileSync(skillMdPath, "utf8")
+    const { data } = parseFrontmatter(raw, skillMdPath)
+
+    test(`${skill.relPath} frontmatter description is at most ${DESCRIPTION_CHAR_BUDGET} characters (Anthropic skill spec)`, () => {
+      const description = typeof data.description === "string" ? data.description : ""
+      expect(description, `${skill.relPath}/SKILL.md must declare a frontmatter description`).not.toBe("")
+      expect(
+        description.length,
+        `${skill.relPath}/SKILL.md description is ${description.length} characters; the Anthropic skill spec caps descriptions at ${DESCRIPTION_CHAR_BUDGET} and some harnesses reject longer ones.`,
+      ).toBeLessThanOrEqual(DESCRIPTION_CHAR_BUDGET)
+    })
+
+    test(`${skill.relPath} frontmatter name is at most ${NAME_CHAR_BUDGET} characters (Anthropic skill spec)`, () => {
+      const name = typeof data.name === "string" ? data.name : ""
+      expect(name, `${skill.relPath}/SKILL.md must declare a frontmatter name`).not.toBe("")
+      expect(
+        name.length,
+        `${skill.relPath}/SKILL.md name is ${name.length} characters; the Anthropic skill spec caps names at ${NAME_CHAR_BUDGET}.`,
+      ).toBeLessThanOrEqual(NAME_CHAR_BUDGET)
+    })
+  }
+
+  test("installed-plugin path exemption list only names existing files", () => {
+    const stale = [...INSTALLED_PLUGIN_PATH_EXEMPTIONS.keys()].filter((rel) => {
+      try {
+        statSync(path.join(REPO_ROOT, rel))
+        return false
+      } catch {
+        return true
+      }
+    })
+    expect(stale, `Remove stale INSTALLED_PLUGIN_PATH_EXEMPTIONS entries:\n${stale.join("\n")}`).toEqual([])
+  })
+})
+
+describe("platform-variable fallback (AGENTS.md 'Platform-Specific Variables in Skills')", () => {
+  for (const skill of skillDirs) {
+    test(`${skill.relPath} platform variables degrade gracefully or are acknowledged`, () => {
+      const offenders: string[] = []
+      for (const filePath of listMarkdownFiles(skill.absPath)) {
+        const fileRel = path.relative(REPO_ROOT, filePath)
+        const content = readFileSync(filePath, "utf8")
+        for (const { lineNumber, variable } of findPlatformVarViolations(content)) {
+          if (PLATFORM_VAR_ACKNOWLEDGED.has(`${fileRel}#${variable}`)) continue
+          offenders.push(`  ${fileRel}:${lineNumber} — \${${variable}} with no fallback`)
+        }
+      }
+      expect(
+        offenders,
+        `Platform variables (\${CLAUDE_*}, \${CODEX_*}) must not be assumed to resolve — see ${AGENTS_MD_REF} "Platform-Specific Variables in Skills". Prefer relative paths from the skill directory; otherwise use a shell default (\${VAR:-...}) or an existence guard ([ -n "$VAR" ]). If the fallback genuinely lives in prose (the AGENTS.md pre-resolution pattern), write that prose first, then acknowledge the use in PLATFORM_VAR_ACKNOWLEDGED in tests/skill-conventions.test.ts with a reason naming the fallback.\nOffending occurrences:\n${offenders.join("\n")}`,
+      ).toEqual([])
+    })
+  }
+
+  test("acknowledged platform-variable entries match current non-graceful uses", () => {
+    const current = new Set<string>()
+    for (const skill of skillDirs) {
+      for (const filePath of listMarkdownFiles(skill.absPath)) {
+        const fileRel = path.relative(REPO_ROOT, filePath)
+        for (const { variable } of findPlatformVarViolations(readFileSync(filePath, "utf8"))) {
+          current.add(`${fileRel}#${variable}`)
+        }
+      }
+    }
+    const stale = [...PLATFORM_VAR_ACKNOWLEDGED.keys()].filter((key) => !current.has(key))
+    expect(
+      stale,
+      `PLATFORM_VAR_ACKNOWLEDGED entries must correspond to a current non-graceful use — remove stale entries from tests/skill-conventions.test.ts:\n${stale.join("\n")}`,
+    ).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Synthetic fixtures: prove violations are caught and valid content passes
+// (mutation-resistance layer).
+// ---------------------------------------------------------------------------
+
+describe("stripFencedCodeBlocks", () => {
+  test("blanks fenced content while preserving line numbers", () => {
+    const sample = "before\n```bash\n[link](../escape.md)\n```\nafter"
+    const stripped = stripFencedCodeBlocks(sample)
+    expect(stripped.split("\n").length).toBe(5)
+    expect(stripped).not.toContain("../escape.md")
+    expect(stripped).toContain("after")
+  })
+
+  test("an outer four-backtick fence swallows inner three-backtick fences", () => {
+    const sample = "````markdown\n```bash\nrm -rf /\n```\nstill fenced [x](../out.md)\n````\nfree"
+    const stripped = stripFencedCodeBlocks(sample)
+    expect(stripped).not.toContain("../out.md")
+    expect(stripped).toContain("free")
+  })
+
+  test("leaves prose outside fences untouched", () => {
+    const sample = "see `references/foo.md` for details"
+    expect(stripFencedCodeBlocks(sample)).toBe(sample)
+  })
+})
+
+describe("extractMarkdownLinkTargets", () => {
+  test("captures link and image targets with line numbers", () => {
+    const sample = "intro\n[doc](references/a.md) and ![img](assets/b.png)\n"
+    expect(extractMarkdownLinkTargets(sample)).toEqual([
+      { lineNumber: 2, value: "references/a.md" },
+      { lineNumber: 2, value: "assets/b.png" },
+    ])
+  })
+
+  test("captures titles-stripped targets", () => {
+    expect(extractMarkdownLinkTargets('[d](references/a.md "Title")')).toEqual([
+      { lineNumber: 1, value: "references/a.md" },
+    ])
+  })
+})
+
+describe("extractLocalPathCodeSpans", () => {
+  test("matches skill-local references/, scripts/, assets/ spans", () => {
+    const sample = "Read `references/walkthrough.md`, run `scripts/get-pr-comments`, embed `assets/logo.png`."
+    expect(extractLocalPathCodeSpans(sample).map((s) => s.value)).toEqual([
+      "references/walkthrough.md",
+      "scripts/get-pr-comments",
+      "assets/logo.png",
+    ])
+  })
+
+  test("ignores bare filenames, commands with arguments, and home paths", () => {
+    const sample =
+      "see `walkthrough.md`, run `bash scripts/run.sh ARG`, store in `~/coding-tutor-tutorials/x.md`, use `/tmp/scratch`"
+    expect(extractLocalPathCodeSpans(sample)).toEqual([])
+  })
+})
+
+describe("escapesSkillDir", () => {
+  test("flags ../ traversal out of the skill from SKILL.md", () => {
+    expect(escapesSkillDir("../other-skill/references/schema.yaml", "")).toBe(true)
+  })
+
+  test("flags absolute and home-anchored targets", () => {
+    expect(escapesSkillDir("/home/user/plugins/skills/other/file.md", "references")).toBe(true)
+    expect(escapesSkillDir("~/.claude/plugins/cache/m/p/1.0.0/skills/other/file.md", "")).toBe(true)
+  })
+
+  test("allows ../ that stays inside the skill (references/ -> scripts/)", () => {
+    expect(escapesSkillDir("../scripts/get-pr-comments", "references")).toBe(false)
+  })
+
+  test("allows skill-root-relative paths", () => {
+    expect(escapesSkillDir("references/foo.md", "")).toBe(false)
+    expect(escapesSkillDir("references/foo.md", "references")).toBe(false)
+  })
+})
+
+describe("findSelfContainmentViolations", () => {
+  test("catches an escaping markdown link", () => {
+    const violations = findSelfContainmentViolations("line\n[steal](../sibling-skill/SKILL.md)\n", "")
+    expect(violations.length).toBe(1)
+    expect(violations[0].lineNumber).toBe(2)
+  })
+
+  test("catches installed-plugin path mentions in prose", () => {
+    const violations = findSelfContainmentViolations(
+      "Read `~/.claude/plugins/cache/marketplace/plugin/1.0.0/skills/other/file.md` for context.",
+      "",
+    )
+    expect(violations.length).toBe(1)
+  })
+
+  test("ignores documentation examples inside fenced code blocks", () => {
+    const sample = "```\n[bad](../outside.md)\ncat ~/.claude/plugins/installed_plugins.json\n```\n"
+    expect(findSelfContainmentViolations(sample, "")).toEqual([])
+  })
+
+  test("ignores external URLs, anchors, and placeholder templates", () => {
+    const sample =
+      "[a](https://example.com) [b](#section) [c](references/<name>.md) [d](mailto:x@y.z)"
+    expect(findSelfContainmentViolations(sample, "")).toEqual([])
+  })
+
+  test("passes clean skill-local references", () => {
+    const sample = "Read `references/foo.md` and [the guide](references/guide.md#usage)."
+    expect(findSelfContainmentViolations(sample, "")).toEqual([])
+  })
+})
+
+describe("extractLocalReferenceCandidates", () => {
+  test("collects relative link targets and path-shaped spans, stripping fragments", () => {
+    const sample = "[guide](references/guide.md#setup)\nRead `references/foo.md` and `scripts/run.sh`."
+    expect(extractLocalReferenceCandidates(sample).map((c) => c.value)).toEqual([
+      "references/guide.md",
+      "references/foo.md",
+      "scripts/run.sh",
+    ])
+  })
+
+  test("skips fenced templates, placeholders, externals, and absolute targets", () => {
+    const sample =
+      "```\n![Before](url-1)\n```\n[t](references/<topic>.md) [u](https://x.dev) [v](/abs/file.md)"
+    expect(extractLocalReferenceCandidates(sample)).toEqual([])
+  })
+})
+
+describe("resolveInsideSkill", () => {
+  const skillRoot = path.join(
+    PLUGINS_ROOT,
+    "compound-engineering",
+    "skills",
+    "ce-resolve-pr-feedback",
+  )
+
+  test("rejects ../ traversal to a sibling skill even when the target exists there", () => {
+    const sibling = "../ce-plan/references/plan-handoff.md"
+    // The target genuinely exists in the sibling skill — existence outside
+    // the skill must not satisfy Rule 2; it is the cross-skill reference.
+    expect(statSync(path.resolve(skillRoot, sibling)).isFile()).toBe(true)
+    expect(resolveInsideSkill(skillRoot, skillRoot, sibling)).toBeNull()
+  })
+
+  test("rejects obfuscated in-prefix traversal (references/../../other-skill/...)", () => {
+    expect(
+      resolveInsideSkill(skillRoot, skillRoot, "references/../../ce-plan/references/plan-handoff.md"),
+    ).toBeNull()
+  })
+
+  test("accepts in-skill ../ traversal (references/ -> scripts/)", () => {
+    expect(
+      resolveInsideSkill(skillRoot, path.join(skillRoot, "references"), "../scripts/get-pr-comments"),
+    ).toBe(path.join(skillRoot, "scripts", "get-pr-comments"))
+  })
+
+  test("accepts skill-root-relative paths", () => {
+    expect(resolveInsideSkill(skillRoot, skillRoot, "references/targeted-mode.md")).toBe(
+      path.join(skillRoot, "references", "targeted-mode.md"),
+    )
+  })
+})
+
+describe("findPlatformVarOccurrences / isGracefulPlatformVarUse", () => {
+  test("flags a bare ${CLAUDE_PLUGIN_ROOT} as non-graceful", () => {
+    const occurrences = findPlatformVarOccurrences("python3 ${CLAUDE_PLUGIN_ROOT}/scripts/x.py")
+    expect(occurrences).toEqual([
+      { lineNumber: 1, variable: "CLAUDE_PLUGIN_ROOT", graceful: false },
+    ])
+  })
+
+  test("treats ${VAR:-default} as graceful", () => {
+    const occurrences = findPlatformVarOccurrences('bash "${CLAUDE_SKILL_DIR:-.}/scripts/x.sh"')
+    expect(occurrences).toEqual([{ lineNumber: 1, variable: "CLAUDE_SKILL_DIR", graceful: true }])
+  })
+
+  test("treats [ -n \"$VAR\" ] existence guards as graceful", () => {
+    const occurrences = findPlatformVarOccurrences('if [ -n "$CODEX_SANDBOX" ] || [ -n "$CODEX_SESSION_ID" ]; then')
+    expect(occurrences.map((o) => o.graceful)).toEqual([true, true])
+  })
+
+  test("ignores credential-style env vars like GEMINI_API_KEY", () => {
+    expect(findPlatformVarOccurrences("export GEMINI_API_KEY=$GEMINI_API_KEY")).toEqual([])
+  })
+})
+
+describe("findPlatformVarViolations", () => {
+  test("reports every non-graceful occurrence (acknowledgment happens via the registry, not the scanner)", () => {
+    // Verbatim from AGENTS.md "Platform-Specific Variables in Skills" — the
+    // documented pre-resolution pattern. Its fallback lives in prose, which
+    // the scanner deliberately does not judge: the occurrence is reported,
+    // and the real ce-setup use of this pattern is acknowledged in
+    // PLATFORM_VAR_ACKNOWLEDGED instead.
+    const agentsMdCanonicalExample = [
+      '**Plugin version (pre-resolved):** !`jq -r .version "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json"`',
+      "",
+      "If the line above resolved to a semantic version (e.g., `2.42.0`), use it.",
+      "Otherwise (empty, a literal command string, or an error), use the versionless fallback.",
+      "Do not attempt to resolve the version at runtime.",
+    ].join("\n")
+    expect(findPlatformVarViolations(agentsMdCanonicalExample)).toEqual([
+      { lineNumber: 1, variable: "CLAUDE_PLUGIN_ROOT", graceful: false },
+    ])
+  })
+
+  test("reports occurrences inside fenced code blocks too", () => {
+    const sample = [
+      "```bash",
+      "python3 ${CLAUDE_PLUGIN_ROOT}/scripts/x.py",
+      "```",
+    ].join("\n")
+    expect(findPlatformVarViolations(sample).map((v) => v.variable)).toEqual(["CLAUDE_PLUGIN_ROOT"])
+  })
+
+  test("graceful uses are not reported", () => {
+    expect(findPlatformVarViolations('bash "${CLAUDE_SKILL_DIR:-.}/scripts/x.sh"')).toEqual([])
+  })
+})
+

--- a/tests/skill-conventions.test.ts
+++ b/tests/skill-conventions.test.ts
@@ -46,8 +46,28 @@ import { parseFrontmatter } from "../src/utils/frontmatter"
  *    IS the path (`scripts/run.sh`) or embeds it in a command
  *    (`bash scripts/run.sh ARG`, `python3 scripts/foo.py <arg>`), so a
  *    deleted or renamed script is caught even when mentioned only as an
- *    executable command — and (c) the same path tokens inside FENCED code
- *    blocks. (c) is where this rule's fence policy deliberately diverges
+ *    executable command — (c) the same path tokens inside FENCED code
+ *    blocks, and (d) `@`-include targets in prose (`@./references/x.md` —
+ *    inlined at load time, so a deleted target breaks the skill at load).
+ *    For (b) and (c), tokens are unwrapped before the shape gate:
+ *    surrounding quotes and a platform-variable prefix (`${VAR}/`,
+ *    `${VAR:-default}/`, `$VAR/`) are stripped, so the repo's documented
+ *    cross-platform invocation style
+ *    (`bash "${CLAUDE_SKILL_DIR:-.}/scripts/x.sh"` — AGENTS.md
+ *    "Platform-Specific Variables in Skills") yields `scripts/x.sh` as a
+ *    candidate; the variable prefix means "skill-root-relative" by that
+ *    convention, so skill-root anchoring is correct for the remainder.
+ *    Deliberately NOT candidates (per a mechanical audit of every
+ *    references/-, scripts/-, assets/-mentioning line across all skills):
+ *    bare path tokens in prose with no backticks, link, or `@` prefix —
+ *    unmarked prose is where hypothetical teaching examples live, and the
+ *    only real instances (advisory `references/yaml-schema.md` pointers in
+ *    HTML comments inside ce-compound's and ce-compound-refresh's asset
+ *    templates) sit in templates that are instantiated OUTSIDE the skill,
+ *    where the path is context for a future reader, not a runtime
+ *    dependency — and directory-only mentions (`references/` with no
+ *    filename), which name no file to check.
+ *    (c) is where this rule's fence policy deliberately diverges
  *    from Rule 1: fenced bash blocks are where skills put their REAL bundled
  *    script invocations (ce-clean-gone-branches' `bash scripts/clean-gone`),
  *    so stripping fences here would let a deleted or renamed script pass CI
@@ -240,9 +260,31 @@ function extractMarkdownLinkTargets(markdown: string): Located[] {
  */
 const LOCAL_PATH_TOKEN = /^(references|scripts|assets)\/[A-Za-z0-9._/-]+$/
 
-/** Whitespace-delimited tokens of `text` matching the skill-local path shape. */
+/**
+ * Strips the shell wrapping a whitespace token may carry around a skill-local
+ * path: surrounding quotes and a platform-variable prefix (`${VAR}/`,
+ * `${VAR:-default}/`, or `$VAR/`). The repo's documented cross-platform
+ * invocation style (AGENTS.md "Platform-Specific Variables in Skills") writes
+ * bundled-script calls as `bash "${CLAUDE_SKILL_DIR:-.}/scripts/x.sh"`, so
+ * the quote/`$`/`{` characters of the wrapping must not hide the
+ * `scripts/x.sh` remainder from the existence check. Unwrapping happens
+ * BEFORE any placeholder gate sees the token: a real invocation's remainder
+ * is placeholder-free, while a templated remainder (`.../scripts/<name>`)
+ * still fails the token shape by construction.
+ */
+function stripShellWrapping(token: string): string {
+  return token
+    .replace(/^["']/, "")
+    .replace(/["']$/, "")
+    .replace(/^\$(?:\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\}|[A-Za-z_][A-Za-z0-9_]*)\//, "")
+}
+
+/** Whitespace-delimited tokens of `text` whose unwrapped form matches the skill-local path shape. */
 function localPathTokensIn(text: string): string[] {
-  return text.split(/\s+/).filter((token) => LOCAL_PATH_TOKEN.test(token))
+  return text
+    .split(/\s+/)
+    .map(stripShellWrapping)
+    .filter((token) => LOCAL_PATH_TOKEN.test(token))
 }
 
 /**
@@ -259,6 +301,29 @@ function extractLocalPathCodeSpans(markdown: string): Located[] {
   while ((match = spanRegex.exec(markdown)) !== null) {
     const lineNumber = lineNumberAt(markdown, match.index)
     for (const token of localPathTokensIn(match[1])) out.push({ lineNumber, value: token })
+  }
+  return out
+}
+
+/**
+ * Extracts `@`-include targets from prose (the at-include syntax that inlines
+ * a file at load time, e.g. `@./references/persona-catalog.md` in
+ * ce-code-review's "Included References"). These are load-bearing — a deleted
+ * target breaks the skill at load — yet invisible to the other extractors:
+ * no backticks, no markdown-link syntax, and the `@`/`./` prefix fails the
+ * bare token shape. Placeholder-bearing targets are excluded by the token
+ * character class, as everywhere else.
+ */
+function extractAtIncludeTargets(markdown: string): Located[] {
+  const out: Located[] = []
+  const regex = /(?:^|\s)@(\.\/)?((?:references|scripts|assets)\/[A-Za-z0-9._/-]+)/g
+  let match: RegExpExecArray | null
+  while ((match = regex.exec(markdown)) !== null) {
+    // match.index may sit on the leading whitespace; number the line of the @.
+    out.push({
+      lineNumber: lineNumberAt(markdown, match.index + match[0].indexOf("@")),
+      value: match[2],
+    })
   }
   return out
 }
@@ -351,6 +416,9 @@ function extractLocalReferenceCandidates(markdown: string): Located[] {
   for (const span of extractLocalPathCodeSpans(stripped)) {
     if (isTemplatePlaceholderPath(span.value)) continue
     out.push(span)
+  }
+  for (const target of extractAtIncludeTargets(stripped)) {
+    out.push(target)
   }
   for (const token of extractFencedLocalPathTokens(markdown)) {
     if (isTemplatePlaceholderPath(token.value)) continue
@@ -647,9 +715,28 @@ describe("extractLocalPathCodeSpans", () => {
     ])
   })
 
+  test("unwraps quoted and variable-prefixed path tokens (skill-root-relative by convention)", () => {
+    expect(
+      extractLocalPathCodeSpans(
+        'invoke `bash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create <branch>`',
+      ).map((s) => s.value),
+    ).toEqual(["scripts/worktree-manager.sh"])
+    expect(
+      extractLocalPathCodeSpans("run `bash $CLAUDE_SKILL_DIR/scripts/setup.sh`").map((s) => s.value),
+    ).toEqual(["scripts/setup.sh"])
+    expect(
+      extractLocalPathCodeSpans('see `cat "references/guide.md"`').map((s) => s.value),
+    ).toEqual(["references/guide.md"])
+  })
+
   test("skips placeholder-bearing path tokens", () => {
     expect(extractLocalPathCodeSpans("invoked via `bash scripts/<name>`")).toEqual([])
     expect(extractLocalPathCodeSpans("read `references/${topic}.md`")).toEqual([])
+  })
+
+  test("skips variable-prefixed tokens whose remainder is a placeholder", () => {
+    expect(extractLocalPathCodeSpans('run `bash "${CLAUDE_SKILL_DIR:-.}/scripts/<name>"`')).toEqual([])
+    expect(extractLocalPathCodeSpans("read `$CLAUDE_PLUGIN_ROOT/references/${topic}.md`")).toEqual([])
   })
 
   test("extracts multiple path tokens from one span", () => {
@@ -662,6 +749,22 @@ describe("extractLocalPathCodeSpans", () => {
     const sample =
       "see `walkthrough.md`, store in `~/coding-tutor-tutorials/x.md`, use `/tmp/scratch`, ls `the scripts/ dir`"
     expect(extractLocalPathCodeSpans(sample)).toEqual([])
+  })
+})
+
+describe("extractAtIncludeTargets", () => {
+  test("extracts prose at-include targets with and without ./", () => {
+    const sample = "### Persona Catalog\n\n@./references/persona-catalog.md\n\n@references/other.md\n"
+    expect(extractAtIncludeTargets(sample)).toEqual([
+      { lineNumber: 3, value: "references/persona-catalog.md" },
+      { lineNumber: 5, value: "references/other.md" },
+    ])
+  })
+
+  test("skips placeholder-bearing targets and non-path at-tokens", () => {
+    expect(extractAtIncludeTargets("@./references/<topic>.md")).toEqual([])
+    expect(extractAtIncludeTargets("@message = Message.find(params[:id])")).toEqual([])
+    expect(extractAtIncludeTargets("email user@scripts.example.com")).toEqual([])
   })
 })
 
@@ -680,11 +783,24 @@ describe("extractFencedLocalPathTokens", () => {
     ])
   })
 
-  test("skips placeholder-bearing tokens, platform-variable paths, and markdown-link syntax", () => {
+  test("unwraps quoted variable-prefixed invocations (the documented cross-platform style)", () => {
+    const sample = [
+      "```bash",
+      'bash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create <branch-name> [from-branch]',
+      'bash "${CLAUDE_SKILL_DIR}/scripts/upstream-version.sh"',
+      "```",
+    ].join("\n")
+    expect(extractFencedLocalPathTokens(sample).map((t) => t.value)).toEqual([
+      "scripts/worktree-manager.sh",
+      "scripts/upstream-version.sh",
+    ])
+  })
+
+  test("skips placeholder-bearing tokens and markdown-link syntax", () => {
     const sample = [
       "```bash",
       "bash scripts/<name>",
-      'bash "${CLAUDE_SKILL_DIR}/scripts/upstream-version.sh"',
+      'bash "${CLAUDE_SKILL_DIR:-.}/scripts/<generated-name>"',
       "```",
       "```markdown",
       "[guide](references/guide.md)",
@@ -788,6 +904,29 @@ describe("extractLocalReferenceCandidates", () => {
 
   test("skips fenced placeholder-bearing path tokens", () => {
     expect(extractLocalReferenceCandidates("```bash\nbash scripts/<generated-name>\n```")).toEqual([])
+  })
+
+  test("collects prose at-include targets (load-time inlining)", () => {
+    const sample = "### Subagent Template\n\n@./references/subagent-template.md\n"
+    expect(extractLocalReferenceCandidates(sample).map((c) => c.value)).toEqual([
+      "references/subagent-template.md",
+    ])
+  })
+
+  test("variable-prefixed invocations are extracted and anchor at the skill root", () => {
+    // The documented cross-platform style: the variable prefix means
+    // "skill-root-relative" (AGENTS.md "Platform-Specific Variables in
+    // Skills"), so the unwrapped remainder must resolve at the skill root —
+    // demonstrated against the real ce-worktree bundled script.
+    const sample =
+      '```bash\nbash "${CLAUDE_SKILL_DIR:-.}/scripts/worktree-manager.sh" create feat/login\n```'
+    expect(extractLocalReferenceCandidates(sample).map((c) => c.value)).toEqual([
+      "scripts/worktree-manager.sh",
+    ])
+    const skillRoot = path.join(PLUGINS_ROOT, "compound-engineering", "skills", "ce-worktree")
+    const resolved = resolveInsideSkill(skillRoot, skillRoot, "scripts/worktree-manager.sh")
+    expect(resolved).not.toBeNull()
+    expect(statSync(resolved!).isFile()).toBe(true)
   })
 })
 

--- a/tests/skill-conventions.test.ts
+++ b/tests/skill-conventions.test.ts
@@ -19,7 +19,12 @@ import { parseFrontmatter } from "../src/utils/frontmatter"
  *      - Fenced code blocks are stripped before scanning. Teaching samples,
  *        message templates, and anti-pattern demos live in fences (e.g.,
  *        ce-demo-reel's `![Before](url-1)` PR template), and fences are where
- *        skills quote code they are ABOUT rather than files they USE.
+ *        skills quote code they are ABOUT rather than files they USE. This
+ *        fence policy is Rule-1-specific — Rule 2 deliberately differs (see
+ *        below): self-containment looks for ESCAPING references, which in
+ *        fences are overwhelmingly quoted anti-patterns, while reference
+ *        integrity looks for LOCAL paths, which in fences are overwhelmingly
+ *        real script invocations.
  *      - Markdown link/image targets are treated as real references. A target
  *        is a violation when it is absolute (`/...`, `~/...`) or when it
  *        resolves outside the skill directory under BOTH file-relative and
@@ -36,12 +41,22 @@ import { parseFrontmatter } from "../src/utils/frontmatter"
  * 2. REFERENCE INTEGRITY (AGENTS.md "File References in Skills"): every
  *    skill-local path mentioned in a skill's markdown must exist on disk
  *    INSIDE the skill directory. Candidates are (a) relative markdown link
- *    targets and (b) `references/...`, `scripts/...`, or `assets/...` path
- *    tokens inside backtick code spans — whether the span IS the path
- *    (`scripts/run.sh`) or embeds it in a command (`bash scripts/run.sh ARG`,
- *    `python3 scripts/foo.py <arg>`), so a deleted or renamed script is
- *    caught even when mentioned only as an executable command. A candidate
- *    passes when it resolves
+ *    targets outside fences, (b) `references/...`, `scripts/...`, or
+ *    `assets/...` path tokens inside backtick code spans — whether the span
+ *    IS the path (`scripts/run.sh`) or embeds it in a command
+ *    (`bash scripts/run.sh ARG`, `python3 scripts/foo.py <arg>`), so a
+ *    deleted or renamed script is caught even when mentioned only as an
+ *    executable command — and (c) the same path tokens inside FENCED code
+ *    blocks. (c) is where this rule's fence policy deliberately diverges
+ *    from Rule 1: fenced bash blocks are where skills put their REAL bundled
+ *    script invocations (ce-clean-gone-branches' `bash scripts/clean-gone`),
+ *    so stripping fences here would let a deleted or renamed script pass CI
+ *    while the skill fails at runtime. Markdown-link syntax inside fences is
+ *    still NOT a candidate — fenced `[text](references/x.md)` is teaching
+ *    material, and its parentheses/brackets fail the bare-token shape — and
+ *    backticks within fenced lines act as token separators so inline-code
+ *    path mentions in fenced pseudocode tokenize cleanly. A candidate passes
+ *    when it resolves
  *    inside the skill directory (anchored at the skill root or at the
  *    containing file's directory) AND exists there. Resolution is contained
  *    BEFORE any existence check: a `..` candidate that escapes the skill is
@@ -163,32 +178,43 @@ function listMarkdownFiles(dir: string): string[] {
 // Scanning helpers (pure; unit-tested at the bottom of this file)
 // ---------------------------------------------------------------------------
 
+type Located = { lineNumber: number; value: string }
+
 /**
- * Blanks out fenced code blocks (``` / ~~~, any fence length >= 3) while
- * preserving line numbers. Outer fences longer than three backticks (e.g.,
- * ````markdown teaching blocks) correctly swallow shorter inner fences.
+ * Partitions markdown around fenced code blocks (``` / ~~~, any fence length
+ * >= 3): `prose` is the input with fences blanked (line numbers preserved),
+ * `fencedLines` are the in-fence lines with their line numbers. Outer fences
+ * longer than three backticks (e.g., ````markdown teaching blocks) correctly
+ * swallow shorter inner fences. Rule 1 scans only `prose`; Rule 2 scans both
+ * sides — sharing one fence state machine keeps the two policies from
+ * drifting on fence-parsing edge cases.
  */
-function stripFencedCodeBlocks(markdown: string): string {
+function partitionFencedCodeBlocks(markdown: string): { prose: string; fencedLines: Located[] } {
   const lines = markdown.split("\n")
   let fence: { char: string; len: number } | null = null
-  const out = lines.map((line) => {
+  const fencedLines: Located[] = []
+  const prose = lines.map((line, i) => {
     const match = line.match(/^\s*(`{3,}|~{3,})/)
     if (match) {
       const char = match[1][0]
       const len = match[1].length
-      if (!fence) {
-        fence = { char, len }
-        return ""
-      }
-      if (fence.char === char && len >= fence.len) fence = null
+      if (!fence) fence = { char, len }
+      else if (fence.char === char && len >= fence.len) fence = null
       return ""
     }
-    return fence ? "" : line
+    if (fence) {
+      fencedLines.push({ lineNumber: i + 1, value: line })
+      return ""
+    }
+    return line
   })
-  return out.join("\n")
+  return { prose: prose.join("\n"), fencedLines }
 }
 
-type Located = { lineNumber: number; value: string }
+/** Blanks out fenced code blocks while preserving line numbers. */
+function stripFencedCodeBlocks(markdown: string): string {
+  return partitionFencedCodeBlocks(markdown).prose
+}
 
 function lineNumberAt(text: string, index: number): number {
   return text.slice(0, index).split("\n").length
@@ -206,25 +232,49 @@ function extractMarkdownLinkTargets(markdown: string): Located[] {
 }
 
 /**
- * Extracts skill-local path tokens (references/, scripts/, assets/) from
- * backtick code spans. The span may BE the path (`scripts/run.sh`) or embed
- * it in a command (`bash scripts/run.sh ARG`, `python3 scripts/foo.py <arg>`):
- * each whitespace-delimited token matching the path shape is extracted, so a
- * deleted or renamed script is caught even when mentioned only as an
- * executable command. The token character class excludes template placeholder
- * characters, so placeholder-bearing path tokens (`scripts/<name>`) are
- * skipped by construction while placeholder ARGUMENTS after a clean path
- * token do not suppress it.
+ * The skill-local path-token shape (references/, scripts/, assets/). The
+ * character class excludes template placeholder characters, so
+ * placeholder-bearing path tokens (`scripts/<name>`) are skipped by
+ * construction while placeholder ARGUMENTS after a clean path token do not
+ * suppress it.
+ */
+const LOCAL_PATH_TOKEN = /^(references|scripts|assets)\/[A-Za-z0-9._/-]+$/
+
+/** Whitespace-delimited tokens of `text` matching the skill-local path shape. */
+function localPathTokensIn(text: string): string[] {
+  return text.split(/\s+/).filter((token) => LOCAL_PATH_TOKEN.test(token))
+}
+
+/**
+ * Extracts skill-local path tokens from backtick code spans. The span may BE
+ * the path (`scripts/run.sh`) or embed it in a command (`bash scripts/run.sh
+ * ARG`, `python3 scripts/foo.py <arg>`): each whitespace-delimited token
+ * matching the path shape is extracted, so a deleted or renamed script is
+ * caught even when mentioned only as an executable command.
  */
 function extractLocalPathCodeSpans(markdown: string): Located[] {
   const out: Located[] = []
   const spanRegex = /`([^`\n]+)`/g
-  const pathToken = /^(references|scripts|assets)\/[A-Za-z0-9._/-]+$/
   let match: RegExpExecArray | null
   while ((match = spanRegex.exec(markdown)) !== null) {
     const lineNumber = lineNumberAt(markdown, match.index)
-    for (const token of match[1].split(/\s+/)) {
-      if (pathToken.test(token)) out.push({ lineNumber, value: token })
+    for (const token of localPathTokensIn(match[1])) out.push({ lineNumber, value: token })
+  }
+  return out
+}
+
+/**
+ * Extracts skill-local path tokens from INSIDE fenced code blocks (the Rule 2
+ * fence policy — see the header). Backticks within a fenced line are treated
+ * as token separators so inline-code path mentions in fenced pseudocode
+ * (`see \`references/x.md\``) tokenize cleanly; markdown-link syntax never
+ * yields a candidate because its brackets/parentheses fail the token shape.
+ */
+function extractFencedLocalPathTokens(markdown: string): Located[] {
+  const out: Located[] = []
+  for (const { lineNumber, value } of partitionFencedCodeBlocks(markdown).fencedLines) {
+    for (const token of localPathTokensIn(value.replace(/`/g, " "))) {
+      out.push({ lineNumber, value: token })
     }
   }
   return out
@@ -301,6 +351,10 @@ function extractLocalReferenceCandidates(markdown: string): Located[] {
   for (const span of extractLocalPathCodeSpans(stripped)) {
     if (isTemplatePlaceholderPath(span.value)) continue
     out.push(span)
+  }
+  for (const token of extractFencedLocalPathTokens(markdown)) {
+    if (isTemplatePlaceholderPath(token.value)) continue
+    out.push(token)
   }
   return out
 }
@@ -611,6 +665,40 @@ describe("extractLocalPathCodeSpans", () => {
   })
 })
 
+describe("extractFencedLocalPathTokens", () => {
+  test("extracts a real script invocation from a fenced bash block", () => {
+    const sample = "intro\n```bash\nbash scripts/clean-gone\n```\nafter"
+    expect(extractFencedLocalPathTokens(sample)).toEqual([
+      { lineNumber: 3, value: "scripts/clean-gone" },
+    ])
+  })
+
+  test("treats backticks inside fenced lines as token separators", () => {
+    const sample = "```\n(see `references/codex-delegation-workflow.md`)\n```"
+    expect(extractFencedLocalPathTokens(sample).map((t) => t.value)).toEqual([
+      "references/codex-delegation-workflow.md",
+    ])
+  })
+
+  test("skips placeholder-bearing tokens, platform-variable paths, and markdown-link syntax", () => {
+    const sample = [
+      "```bash",
+      "bash scripts/<name>",
+      'bash "${CLAUDE_SKILL_DIR}/scripts/upstream-version.sh"',
+      "```",
+      "```markdown",
+      "[guide](references/guide.md)",
+      "![Before](url-1)",
+      "```",
+    ].join("\n")
+    expect(extractFencedLocalPathTokens(sample)).toEqual([])
+  })
+
+  test("ignores path tokens outside fences (those belong to the code-span extractor)", () => {
+    expect(extractFencedLocalPathTokens("run `scripts/run.sh` in prose")).toEqual([])
+  })
+})
+
 describe("escapesSkillDir", () => {
   test("flags ../ traversal out of the skill from SKILL.md", () => {
     expect(escapesSkillDir("../other-skill/references/schema.yaml", "")).toBe(true)
@@ -678,6 +766,28 @@ describe("extractLocalReferenceCandidates", () => {
     const sample =
       "```\n![Before](url-1)\n```\n[t](references/<topic>.md) [u](https://x.dev) [v](/abs/file.md)"
     expect(extractLocalReferenceCandidates(sample)).toEqual([])
+  })
+
+  test("includes fenced script invocations: an existing script passes, a missing one is caught", () => {
+    // Extraction is what makes a fenced mention visible to the existence
+    // check; resolution + statSync against the real skill then demonstrates
+    // the pass/caught split the repo scan enforces.
+    const sample = "```bash\nbash scripts/clean-gone\nbash scripts/deleted-tool.sh\n```"
+    expect(extractLocalReferenceCandidates(sample).map((c) => c.value)).toEqual([
+      "scripts/clean-gone",
+      "scripts/deleted-tool.sh",
+    ])
+    const skillRoot = path.join(PLUGINS_ROOT, "compound-engineering", "skills", "ce-clean-gone-branches")
+    const existing = resolveInsideSkill(skillRoot, skillRoot, "scripts/clean-gone")
+    const missing = resolveInsideSkill(skillRoot, skillRoot, "scripts/deleted-tool.sh")
+    expect(existing).not.toBeNull()
+    expect(statSync(existing!).isFile()).toBe(true)
+    expect(missing).not.toBeNull()
+    expect(() => statSync(missing!)).toThrow()
+  })
+
+  test("skips fenced placeholder-bearing path tokens", () => {
+    expect(extractLocalReferenceCandidates("```bash\nbash scripts/<generated-name>\n```")).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

The AGENTS.md skill-content rules — self-contained skill directories, platform-variable fallbacks — were documentation only; nothing enforced them, so violations shipped silently and broke at runtime, where skills resolve paths from the user's CWD and install under versioned cache paths. This PR adds deterministic CI gates for those rules (plus conversion-drift and schema checks) and fixes the violations the gates surfaced:

- ce-brainstorm and ce-plan handoff docs pointed at files inside the ce-proof and ce-doc-review skill directories; the handoffs now name the target skill's workflow semantically so it loads its own references.
- ce-update assumed `${CLAUDE_SKILL_DIR}` always resolves; unresolved-variable failures now route to its existing not-a-marketplace-install handling instead of a raw script error.

## The gates

| Gate | What it catches |
|---|---|
| Self-containment (`tests/skill-conventions.test.ts`) | File references escaping a skill's directory: `../` traversal, absolute paths, installed-plugin paths. Fenced code blocks are stripped so documentation examples cannot false-positive. |
| Reference integrity | Skill-local paths mentioned in markdown that do not exist on disk. Containment is checked before existence, so a path that exists only in a sibling skill is still a violation. |
| Frontmatter limits | Descriptions over 1024 chars and names over 64 chars — spec constraints that break skill triggering. |
| Platform-variable fallback | `${CLAUDE_*}`/`${CODEX_*}` uses with no shell default, no existence guard, and no acknowledged prose fallback. |
| Conversion drift (`tests/real-plugin-conversion.test.ts`) | Converter regressions against the real shipping plugin: converts to all 5 implemented targets, validates manifests, frontmatter, JSON, and inventory against the source tree, and asserts nothing leaks into HOME. Runs in about a second inside `bun test`. |
| Schema check (CI step) | `claude plugin validate` against the marketplace catalog and plugin directory — the canonical schema, tracked from upstream with no vendored copy to maintain. |

## Design decisions

- **Constraints, not guidance.** Anthropic's 500-line SKILL.md guidance is deliberately not gated — several skills here are large by design, and gating advice would tax every one of them with exemption-list ceremony. Also investigated and rejected: the "8KB Codex skill body cap" that circulates in ecosystem lint tooling. Neither the Codex source nor its docs contain a body cap; the real limit is an ~8,000-character budget on the injected skills *metadata list*, while full SKILL.md bodies load from disk on demand. Both rationales are recorded in-file so the rules don't get re-added without hitting the reasoning first.
- **Registries, not regexes, for editorial judgment.** An early revision verified platform-variable fallback *prose* with a keyword list and a line window; that graded English with regexes — it failed legitimate rewordings and could pass on coincidental keywords. Non-graceful uses now require an explicit `PLATFORM_VAR_ACKNOWLEDGED` entry with a written reason, kept honest by a stale-entry check.
- **The rules themselves are tested.** Every scanning helper has in-file synthetic positive/negative fixtures proving violations are caught and valid content passes, matching the `skill-shell-safety.test.ts` house style.
- **Pinned validator.** CI installs the validator at a pinned version (2.1.175) for reproducible builds; the workflow comment records the bump policy and the single warning standing between the step and `--strict`.

## Test plan

- `bun test` — full suite green, including the 240 new tests across the two files
- `bun run release:validate` and `bun run plugin:validate` pass
- Negative paths verified during development: planted violations fail each rule group, and the conversion test fails on injected drift

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
