### PR TITLE
docs(skill-authoring): fix self-contradicting script-path rule in plugin AGENTS.md

### DIFF
--- a/plugins/compound-engineering/AGENTS.md
+++ b/plugins/compound-engineering/AGENTS.md
@@ -207,9 +207,9 @@ Design rules for blocking question menus (`AskUserQuestion` / `request_user_inpu
 
 ### Script Path References in Skills
 
-- [ ] In bash code blocks, reference co-located scripts using relative paths (e.g., `bash scripts/my-script ARG`) — not `${CLAUDE_PLUGIN_ROOT}` or other platform-specific variables
-- [ ] All platforms resolve script paths relative to the skill's directory; no env var prefix is needed
-- [ ] Reference the script with a backtick path (e.g., `` `scripts/my-script` ``) so agents can locate it; a markdown link is not needed since the bash code block already provides the invocation
+- [ ] In bash code blocks, invoke co-located scripts through `${CLAUDE_SKILL_DIR:-.}` (e.g., `bash "${CLAUDE_SKILL_DIR:-.}/scripts/my-script" ARG`) — not a bare relative path, and not `${CLAUDE_PLUGIN_ROOT}`. The runtime Bash tool runs from the user's project CWD, not the skill directory, so a bare `bash scripts/my-script` resolves against `<project>/scripts/` and fails — the recurring bug class behind #764, #811, and #898.
+- [ ] On Claude Code `${CLAUDE_SKILL_DIR}` resolves to the skill directory; on other targets it is unset and the `:-.` fallback only keeps the command syntactically valid — it does **not** resolve to the bundled script there, so runtime bundled-script invocation is currently unsolved on Codex/Gemini. Do not gate a skill's core behavior on a runtime bundled-script call when portability to those targets matters. See "Permission gate on extracted scripts" under *Tool Selection in Agents and Skills* below for the `allowed-tools` pinning that pairs with this.
+- [ ] Reference the script with a backtick *read-time* path (e.g., `` `scripts/my-script` ``) so agents can locate it to read it — read-time references do resolve against the skill directory on all platforms; a markdown link is not needed since the bash code block already provides the invocation
 
 ### Cross-Platform Reference Rules
 


### PR DESCRIPTION
Third and final follow-up in the skill-dir-path thread (#935 → #938 → #940 → this). This fixes the **authoring root cause** that keeps reintroducing the bug.

## Problem

`plugins/compound-engineering/AGENTS.md` → *Script Path References in Skills* told authors:

> - In bash code blocks, reference co-located scripts using relative paths (e.g., `bash scripts/my-script ARG`) …
> - **All platforms resolve script paths relative to the skill's directory; no env var prefix is needed**

That directly contradicts the **same file's** *Permission gate on extracted scripts* section (under *Tool Selection in Agents and Skills*), which correctly states:

> Use `${CLAUDE_SKILL_DIR}` for the script path, not bare relative paths. The runtime Bash tool runs from the user's project CWD, not the skill directory — `bash scripts/<name>.sh` fails with "No such file or directory" empirically.

…and contradicts the empirical reality behind #764 (`ce-worktree`), #811 (`ce-code-review`), and #898 (`ce-compound`). This is the upstream authoring rule that made the runtime bug keep recurring.

## Fix

Rewrite the two runtime-invocation bullets to:
- require `${CLAUDE_SKILL_DIR:-.}` for *executing* a bundled script (not a bare path, not `${CLAUDE_PLUGIN_ROOT}`),
- cross-reference the authoritative *Permission gate* section for the paired `allowed-tools` pinning,
- state honestly that on Codex/Gemini the `:-.` fallback only keeps the command syntactically valid and does **not** resolve to the bundled script (consistent with #938 and the Codex investigation behind #940).

The **third bullet is kept and clarified** rather than removed: a backtick *read-time* reference genuinely does resolve against the skill directory on all platforms — that's the *File References in Skills* rule and is correct. The distinction (read-time vs. runtime execution) is exactly what #938 untangled in the repo-root `AGENTS.md`.

Authoring-doc change only.