### PR TITLE
fix(config-read): read config via native tool, not $() pre-resolution

### DIFF
--- a/plugins/compound-engineering/AGENTS.md
+++ b/plugins/compound-engineering/AGENTS.md
@@ -274,17 +274,22 @@ When dispatching sub-agents, **omit the `mode` parameter** on the Agent/Task too
 
 Plugin config lives at `.compound-engineering/config.local.yaml` in the repo root. This file is gitignored (machine-local settings), which creates two gotchas:
 
-1. **Path resolution:** Never read the config relative to CWD — the user may invoke a skill from a subdirectory. Always resolve from the repo root. In pre-resolution commands, use `git rev-parse --show-toplevel` to find the root.
+1. **Path resolution:** Never read the config relative to CWD — the user may invoke a skill from a subdirectory. Always resolve from the repo root using `git rev-parse --show-toplevel`.
 
-2. **Worktrees:** Gitignored files are per-worktree. A config file created in the main checkout does not exist in worktrees. Use `--show-toplevel` to find the root:
-   ```
-   !`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
-   ```
-   Outside a git repo, `git rev-parse` emits empty and `cat "/.compound-engineering/config.local.yaml"` fails (permission denied or not found, suppressed by `2>/dev/null`), so the `__NO_CONFIG__` sentinel fires. Note: the previous pattern used `(top=$(...); [ -n "$top" ] && cat "$top/...")` with a semicolon to guard the empty-root case, but `;` is rejected by Claude Code's safety checker as `Unhandled node type: ;` (see Pre-resolution exception above) and must not be used in `!` pre-resolution.
+2. **Worktrees:** Gitignored files are per-worktree. A config file created in the main checkout does not exist in worktrees. `--show-toplevel` returns the current worktree path, so config from the main checkout is not found from a worktree. This is acceptable — config is optional and users who work from worktrees can add a config file there.
 
-   Note: in a worktree, `--show-toplevel` returns the worktree path, so config from the main checkout will not be found. This is acceptable — config is optional and users who work from worktrees can add a config file there. A previous pattern used `git-common-dir` with `${common%/.git}` to derive the main repo root as a fallback, but bash parameter expansion operators are rejected as "Contains expansion" (see Pre-resolution exception above), so that approach is no longer viable without a script.
+**Blessed pattern — pre-resolve only the repo root, then read the file in the skill body:**
+```
+!`git rev-parse --show-toplevel 2>/dev/null || true`
+```
+In the skill body: if the pre-resolved line is an absolute path, use it as `<repo-root>`; if it is empty or still shows a backtick command string, resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool, then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool (Read in Claude Code, read_file in Codex). The runtime fallback is load-bearing: `!` pre-resolution is Claude-Code-only and is **not** translated by the converters (`transformContentForCodex` and the other target writers copy `!`cmd`` through as literal text), so on Codex/Gemini/Pi/OpenCode the line is unresolved and the agent must derive the root itself — otherwise config is silently ignored on every non-Claude platform. Only when the root cannot be resolved (not a git repo) or the file is missing is it "no config" → fall through to defaults; never fail or block on missing config. (This mirrors the `ce-sessions` pre-resolution fallback.)
 
-If neither path has the file, fall through to defaults — never fail or block on missing config.
+**Do NOT read the config contents inside the `!` pre-resolution itself.** Two earlier forms are now rejected and enforced against by `tests/skill-shell-safety.test.ts`:
+
+- `` !`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'` `` aborts skill load on environments whose permission checker rejects `$()` command substitution (reported on Windows / CC 2.1.63 in issue #920).
+- The `(top=$(...); cat "$top/...")` subshell variant is worse: `;` is rejected as `Unhandled node type: ;` (issue #758), even inside a subshell.
+
+The blessed pattern sidesteps both: a bare `git rev-parse` first token has no `$()`, no `;`, and matches common allow rules, while the config contents are read with a native tool at runtime (no skill-load checker involved). A previous worktree fallback that derived the main repo root via `git-common-dir` with `${common%/.git}` is also unavailable — parameter expansion operators are rejected as "Contains expansion" (see Pre-resolution exception above).
 
 ### Quick Validation Command
 

--- a/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-brainstorm/SKILL.md
@@ -67,15 +67,17 @@ Do not proceed until you have a feature description from the user.
 
 Determine `OUTPUT_FORMAT` before any other phase fires. Output mode is **exclusive** — the requirements doc is written as either markdown (`.md`) OR HTML (`.html`), never both. Precedence: CLI arg > config > default (`md`), with a hard pipeline-mode override.
 
-**Read config (pre-resolved at skill load):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Read config.** The repo root is pre-resolved at skill load:
+!`git rev-parse --show-toplevel 2>/dev/null || true`
+
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
 
 Resolution steps:
 
 1. **CLI arg.** Scan `$ARGUMENTS` for a token starting with the literal prefix `output:`. If found, strip it from arguments before treating the remainder as the feature description, and match its value case-insensitively against `md` and `html`.
    - `output:` alone (no value) → no-op, fall through to step 2.
    - `output:<unknown>` (e.g., `output:pdf`) → drop the token, fall through to step 2, and remember to emit a one-line note above the post-generation menu after final resolution: `Ignored unknown output: value '<value>' — using <resolved_format> instead.` where `<resolved_format>` is the value `OUTPUT_FORMAT` actually resolved to after steps 2-4. Do not hardcode `md` in the note — that misleads users when config has set HTML.
-2. **Config.** If step 1 did not resolve and the pre-resolved YAML above has an **active (non-commented)** `brainstorm_output:` key whose value matches `md` or `html` (case-insensitive), use it. Missing, invalid, or commented values fall through silently. Critical: lines starting with `#` are YAML comments and must be ignored — the shipped config template includes commented examples like `# brainstorm_output: html` to document the option, and matching those as active settings would silently force HTML mode on every run without the user having opted in.
+2. **Config.** If step 1 did not resolve and the config file read above has an **active (non-commented)** `brainstorm_output:` key whose value matches `md` or `html` (case-insensitive), use it. Missing, invalid, or commented values fall through silently. Critical: lines starting with `#` are YAML comments and must be ignored — the shipped config template includes commented examples like `# brainstorm_output: html` to document the option, and matching those as active settings would silently force HTML mode on every run without the user having opted in.
 3. **Default.** Otherwise `OUTPUT_FORMAT=md`.
 4. **Pipeline override.** When invoked from LFG or any `disable-model-invocation` context, force `OUTPUT_FORMAT=md` regardless of steps 1-3. Downstream consumers (`ce-plan`, `ce-work`) parse markdown reliably; HTML in pipeline runs is unnecessary friction.
 

--- a/plugins/compound-engineering/skills/ce-ideate/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-ideate/SKILL.md
@@ -67,15 +67,17 @@ Determine `OUTPUT_FORMAT` for the ideation artifact this run might persist. Outp
 
 Unlike `ce-plan` and `ce-brainstorm` (which default to `md`), ce-ideate defaults to **`html`** — ideation artifacts are read mainly by humans weighing candidate directions, and a rich self-contained HTML file (with illustrative diagrams for the top candidates) makes the ideas easier to approach.
 
-**Read config (pre-resolved at skill load):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Read config.** The repo root is pre-resolved at skill load:
+!`git rev-parse --show-toplevel 2>/dev/null || true`
+
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
 
 Resolution steps:
 
 1. **CLI arg.** Scan `$ARGUMENTS` for a token starting with the literal prefix `output:`. If found, strip it from arguments before treating the remainder as the focus hint, and match its value case-insensitively against `md` and `html`.
    - `output:` alone (no value) → no-op, fall through to step 2.
    - `output:<unknown>` (e.g., `output:pdf`) → drop the token, fall through to step 2, and remember to emit a one-line note above the post-ideation menu after final resolution: `Ignored unknown output: value '<value>' — using <resolved_format> instead.` where `<resolved_format>` is the value `OUTPUT_FORMAT` actually resolved to after steps 2-4. Do not hardcode a format in the note — that misleads users when config or the default differs from what you assume.
-2. **Config.** If step 1 did not resolve and the pre-resolved YAML above has an **active (non-commented)** `ideate_output:` key whose value matches `md` or `html` (case-insensitive), use it. Missing, invalid, or commented values fall through silently. Critical: lines starting with `#` are YAML comments and must be ignored — the shipped config template includes a commented example like `# ideate_output: md` to document the option, and matching that as an active setting would silently override the default on every run without the user having opted in.
+2. **Config.** If step 1 did not resolve and the config file read above has an **active (non-commented)** `ideate_output:` key whose value matches `md` or `html` (case-insensitive), use it. Missing, invalid, or commented values fall through silently. Critical: lines starting with `#` are YAML comments and must be ignored — the shipped config template includes a commented example like `# ideate_output: md` to document the option, and matching that as an active setting would silently override the default on every run without the user having opted in.
 3. **Default.** Otherwise `OUTPUT_FORMAT=html`.
 4. **Pipeline override.** When invoked from any pipeline or `disable-model-invocation` context, force `OUTPUT_FORMAT=md` regardless of steps 1-3 — automated downstream consumers parse markdown reliably and HTML in pipeline runs is unnecessary friction.
 

--- a/plugins/compound-engineering/skills/ce-plan/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-plan/SKILL.md
@@ -63,15 +63,17 @@ A plan is ready when an implementer can start confidently without needing the pl
 
 Determine `OUTPUT_FORMAT` before any other phase fires. Output mode is **exclusive** — the plan is written as either markdown (`.md`) OR HTML (`.html`), never both. Precedence: CLI arg > config > default (`md`), with a hard pipeline-mode override.
 
-**Read config (pre-resolved at skill load):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Read config.** The repo root is pre-resolved at skill load:
+!`git rev-parse --show-toplevel 2>/dev/null || true`
+
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
 
 Resolution steps:
 
 1. **CLI arg.** Scan `$ARGUMENTS` for a token starting with the literal prefix `output:`. If found, strip it from arguments before treating the remainder as the feature description, and match its value case-insensitively against `md` and `html`.
    - `output:` alone (no value) → no-op, fall through to step 2.
    - `output:<unknown>` (e.g., `output:pdf`) → drop the token, fall through to step 2, and remember to emit a one-line note above the post-generation menu after final resolution: `Ignored unknown output: value '<value>' — using <resolved_format> instead.` where `<resolved_format>` is the value `OUTPUT_FORMAT` actually resolved to after steps 2-4. Do not hardcode `md` in the note — that misleads users when config has set HTML.
-2. **Config.** If step 1 did not resolve and the pre-resolved YAML above has an **active (non-commented)** `plan_output:` key whose value matches `md` or `html` (case-insensitive), use it. Missing, invalid, or commented values fall through silently. Critical: lines starting with `#` are YAML comments and must be ignored — the shipped config template includes commented examples like `# plan_output: html` to document the option, and matching those as active settings would silently force HTML mode on every run without the user having opted in.
+2. **Config.** If step 1 did not resolve and the config file read above has an **active (non-commented)** `plan_output:` key whose value matches `md` or `html` (case-insensitive), use it. Missing, invalid, or commented values fall through silently. Critical: lines starting with `#` are YAML comments and must be ignored — the shipped config template includes commented examples like `# plan_output: html` to document the option, and matching those as active settings would silently force HTML mode on every run without the user having opted in.
 3. **Default.** Otherwise `OUTPUT_FORMAT=md`.
 4. **Pipeline override.** When invoked from LFG or any `disable-model-invocation` context, force `OUTPUT_FORMAT=md` regardless of steps 1-3. `ce-work` and other automated downstream consumers parse markdown reliably; HTML in pipeline runs is unnecessary friction.
 

--- a/plugins/compound-engineering/skills/ce-product-pulse/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-product-pulse/SKILL.md
@@ -51,12 +51,10 @@ Apply a **15-minute trailing buffer** to the window's upper bound. Many analytic
 
 ### Phase 0: Route by Config State
 
-**Config (pre-resolved):**
-!`(top=$(git rev-parse --show-toplevel 2>/dev/null); [ -n "$top" ] && cat "$top/.compound-engineering/config.local.yaml" 2>/dev/null) || echo '__NO_CONFIG__'`
+**Read config.** The repo root is pre-resolved at skill load:
+!`git rev-parse --show-toplevel 2>/dev/null || true`
 
-If the block above contains YAML key-value pairs, extract values for the `pulse_*` keys listed under "Config keys" below.
-If it shows `__NO_CONFIG__`, the file does not exist — treat this as a first run.
-If it shows an unresolved command string, read `.compound-engineering/config.local.yaml` from the repo root using the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the file does not exist, treat as first run.
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the root cannot be resolved or the file does not exist, treat this as a first run. Otherwise extract values for the `pulse_*` keys listed under "Config keys" below.
 
 **Config keys:**
 - `pulse_product_name` -- string, used in report titles. Required for routing: if unset, skill is unconfigured.

--- a/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-work-beta/SKILL.md
@@ -42,12 +42,10 @@ After extracting tokens from arguments, resolve the delegation state using this 
 2. **Config file** -- extract settings from the config block below. Value `codex` for `work_delegate` activates delegation; `false` deactivates.
 3. **Hard default** -- `false` (delegation off)
 
-**Config (pre-resolved):**
-!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
+**Read config.** The repo root is pre-resolved at skill load:
+!`git rev-parse --show-toplevel 2>/dev/null || true`
 
-If the block above contains YAML key-value pairs, extract values for the keys listed below.
-If it shows `__NO_CONFIG__`, the file does not exist — all settings fall through to defaults.
-If it shows an unresolved command string, read `.compound-engineering/config.local.yaml` from the repo root using the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the file does not exist, all settings fall through to defaults.
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the root cannot be resolved or the file does not exist, all settings fall through to defaults. Otherwise extract values for the keys listed below.
 
 If any setting has an unrecognized value, fall through to the hard default for that setting. For optional settings without a hard default (`work_delegate_model`, `work_delegate_effort`), an unrecognized or unparseable value resolves to **unset** — the corresponding flag is omitted from the `codex exec` invocation so Codex resolves from `~/.codex/config.toml`. Never substitute an invalid value into the CLI flags.
 

--- a/tests/skill-shell-safety.test.ts
+++ b/tests/skill-shell-safety.test.ts
@@ -59,8 +59,12 @@ function findPreResolutionCommands(body: string): { lineNumber: number; command:
   // Scan the entire body so multi-line `!` blocks are also caught. `[^`]*`
   // matches across newlines (line terminators are not special inside JS
   // character classes), so wrapped commands surface here too.
+  // The `(?<!`)` lookbehind skips a `!` that is itself inside an inline-code
+  // span (e.g. prose like "doesn't process `!` pre-resolution — ...; omit"),
+  // which is documentation, not a real `!`-directive — a genuine pre-resolution
+  // `!` is preceded by line-start or whitespace, never by a backtick.
   const found: { lineNumber: number; command: string }[] = []
-  const regex = /!`([^`]*)`/g
+  const regex = /(?<!`)!`([^`]*)`/g
   let match: RegExpExecArray | null
   while ((match = regex.exec(body)) !== null) {
     const lineNumber = body.slice(0, match.index).split(/\r?\n/).length
@@ -144,6 +148,28 @@ function findCommandSubstitutionContents(cmd: string): string[] {
  */
 function hasNestedQuotedStringInCommandSubst(cmd: string): boolean {
   return findCommandSubstitutionContents(cmd).some(s => s.includes('"'))
+}
+
+/**
+ * Returns true when the command contains a `;` command separator outside of
+ * quotes. Claude Code's skill-load safety checker cannot parse `;` as a syntax
+ * node and aborts with "Unhandled node type: ;" before the skill body runs —
+ * even when the `;` sits inside a subshell, e.g. `(top=$(...); cat "$top/f")`
+ * (issue #758; reintroduced and rejected in PR #934). Use `&&`/`||` chaining,
+ * or extract the logic to a script invoked from the skill body. A `;` inside a
+ * quoted string is a literal, not a separator, and is not flagged.
+ */
+function hasSemicolonSeparator(cmd: string): boolean {
+  let inSingleQuote = false
+  let inDoubleQuote = false
+  for (let i = 0; i < cmd.length; i++) {
+    const c = cmd[i]
+    if (!inDoubleQuote && c === "'") { inSingleQuote = !inSingleQuote; continue }
+    if (!inSingleQuote && c === '"') { inDoubleQuote = !inDoubleQuote; continue }
+    if (inSingleQuote || inDoubleQuote) continue
+    if (c === ';') return true
+  }
+  return false
 }
 
 /**
@@ -291,6 +317,28 @@ describe("hasNestedQuotedStringInCommandSubst", () => {
   })
 })
 
+describe("hasSemicolonSeparator", () => {
+  test("flags a `;` inside a subshell (the PR #934 / issue #758 regression)", () => {
+    expect(hasSemicolonSeparator('(top=$(git rev-parse --show-toplevel 2>/dev/null); cat "$top/f") || echo \'__NO_CONFIG__\'')).toBe(true)
+  })
+
+  test("flags a top-level `;` separator", () => {
+    expect(hasSemicolonSeparator("git rev-parse --show-toplevel 2>/dev/null; echo done")).toBe(true)
+  })
+
+  test("does not flag a command with no semicolon", () => {
+    expect(hasSemicolonSeparator("git rev-parse --show-toplevel 2>/dev/null || true")).toBe(false)
+  })
+
+  test("does not flag a `;` inside a single-quoted string", () => {
+    expect(hasSemicolonSeparator("echo 'a; b'")).toBe(false)
+  })
+
+  test("does not flag a `;` inside a double-quoted string", () => {
+    expect(hasSemicolonSeparator('echo "a; b"')).toBe(false)
+  })
+})
+
 describe("hasUnguardedErrorSuppression", () => {
   test("flags single-statement `2>/dev/null` with no fallback", () => {
     expect(hasUnguardedErrorSuppression("git rev-parse --abbrev-ref HEAD 2>/dev/null")).toBe(true)
@@ -404,6 +452,19 @@ describe("skill `!` pre-resolution commands avoid Claude Code denylist", () => {
       expect(
         offenders,
         `Claude Code rejects \`case ... esac\` in \`!\` pre-resolution commands. Use \`if\`/\`then\`/\`else\` or \`&&\`/\`||\` chaining, or \`git rev-parse --path-format=absolute --git-common-dir\` for worktree-stable repo names.\nOffending commands:\n${formatted}`,
+      ).toEqual([])
+    })
+
+    test(`${rel} pre-resolution commands contain no \`;\` command separator (issue #758)`, () => {
+      const offenders = preResolutionCommands.filter(({ command }) =>
+        hasSemicolonSeparator(command),
+      )
+      const formatted = offenders
+        .map(({ lineNumber, command }) => `  line ${lineNumber}: ${command}`)
+        .join("\n")
+      expect(
+        offenders,
+        `Claude Code's skill-load checker cannot parse \`;\` and aborts with "Unhandled node type: ;" — even inside a subshell. Use \`&&\`/\`||\` chaining, or extract the logic to a script invoked from the skill body.\nOffending commands:\n${formatted}`,
       ).toEqual([])
     })
 


### PR DESCRIPTION
## Summary

Skills that read `.compound-engineering/config.local.yaml` did so with a `!` pre-resolution command embedding `$()` command substitution:

```
!`cat "$(git rev-parse --show-toplevel 2>/dev/null)/.compound-engineering/config.local.yaml" 2>/dev/null || echo '__NO_CONFIG__'`
```

On environments whose **skill-load** permission checker rejects `$()` (reported on Windows / Claude Code 2.1.63 in #920: *"Command contains $() command substitution"*), this aborts skill load **before the body runs** — the skill is unusable.

## Why not the obvious rewrite

This supersedes #934, which "fixed" #920 by moving to a semicolon subshell `(top=$(...); cat "$top/...") || echo '__NO_CONFIG__'`. That **reintroduces** the crash #758 already fixed: Claude Code's loader cannot parse `;` (`Unhandled node type: ;`), even inside a subshell. It traded one load-time crash for another, and passed CI only because the shell-safety suite had **no semicolon check**.

No inline pre-resolution can fix #920, because finding the repo root requires `$()` — exactly what that environment rejects.

## Approach

Pre-resolve **only the repo root** (no `$()`, no `;`), then read the config with the **native file-read tool** in the skill body:

```
!`git rev-parse --show-toplevel 2>/dev/null || true`
```

This mirrors the existing `ce-sessions` root-pre-resolution pattern and aligns with the repo's "prefer native tools over shell" rule. A bare `git rev-parse` first token has no substitution and matches common allow rules, so the skill-load checker can't reject it; the config contents are read at runtime where no load-time checker applies.

Applied to **ce-plan, ce-brainstorm, ce-ideate, ce-work-beta, ce-product-pulse** (ce-product-pulse was additionally on the broken `;` form).

## Cross-platform fallback (Codex-reviewed)

`!` pre-resolution is **Claude-Code-only** — the converters (`transformContentForCodex` and the other target writers) copy `!`cmd`` lines through as **literal text**, so on Codex/Gemini/Pi/OpenCode the line is never executed. The skill body therefore resolves the root **at runtime** (`git rev-parse --show-toplevel` via the shell tool) when the pre-resolved value is empty or still a command string, so config loads on every platform instead of silently defaulting outside Claude. This matches the `ce-sessions` fallback. (Without it, non-Claude users' config would be silently ignored.)

## Test gap closed

- Add a `;`-separator enforcement test (`hasSemicolonSeparator`) to `tests/skill-shell-safety.test.ts`, wired into the per-skill enforcement loop — this is the check whose absence let #934 pass CI. Verified it flags both the #934 and #758 forms.
- Fix a false-positive in `findPreResolutionCommands`: it matched `` `!` `` inside inline-code prose and scanned the following sentence as a command. Added a `(?<!`)` lookbehind so only genuine `!`-directives are extracted.

## Authoring guidance

Update `plugins/compound-engineering/AGENTS.md` "Reading Config Files from Skills" to bless the root-pre-resolve + native-read pattern, document the converter behavior + runtime fallback, and explain why the prior `$()` and `;` forms are rejected.

## Testing

- `bun test tests/skill-shell-safety.test.ts` — 116 pass, 0 fail (incl. new semicolon cases).
- `bun test tests/frontmatter.test.ts` — 327 pass, 0 fail.
- `bun run release:validate` — in sync.
- Pre-existing CLI/install failures on this machine are environment-specific and unrelated (confirmed identical on a clean tree).

Closes #920. Supersedes #934.