### PR TITLE
fix(release): bump marketplace catalogs for coding-tutor removal

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -67,6 +67,7 @@
     ".claude-plugin": {
       "release-type": "simple",
       "package-name": "marketplace",
+      "release-as": "1.0.3",
       "extra-files": [
         {
           "type": "json",
@@ -78,6 +79,7 @@
     ".cursor-plugin": {
       "release-type": "simple",
       "package-name": "cursor-marketplace",
+      "release-as": "1.0.2",
       "extra-files": [
         {
           "type": "json",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        # Full history so release:validate can read the base-branch (origin/main)
+        # release-please manifest when checking release-as pins for staleness.
+        with:
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/scripts/release/validate.ts
+++ b/scripts/release/validate.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { execFileSync } from "node:child_process"
 import path from "path"
 import { validateReleasePleaseConfig } from "../../src/release/config"
 import { getCompoundEngineeringCounts, syncReleaseMetadata } from "../../src/release/metadata"
@@ -6,13 +7,33 @@ import { readJson } from "../../src/utils/files"
 
 type ReleasePleaseManifest = Record<string, string>
 
+const MANIFEST_RELATIVE_PATH = ".github/.release-please-manifest.json"
+
+// The release-as staleness check must compare a pin against the version already
+// released on the base branch (main), NOT the working tree: a release-please PR
+// bumps the working-tree manifest to the proposed version, which would make a
+// legitimate pin look stale and block the very release it exists to create.
+// Returns {} when origin/main is unreachable (e.g. a shallow checkout that did
+// not fetch it) so the staleness check no-ops rather than risk a false block.
+function readReleasedManifest(): ReleasePleaseManifest {
+  try {
+    const raw = execFileSync("git", ["show", `origin/main:${MANIFEST_RELATIVE_PATH}`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    return JSON.parse(raw) as ReleasePleaseManifest
+  } catch {
+    return {}
+  }
+}
+
 const releasePleaseConfig = await readJson<{ packages: Record<string, unknown> }>(
   path.join(process.cwd(), ".github", "release-please-config.json"),
 )
 const manifest = await readJson<ReleasePleaseManifest>(
-  path.join(process.cwd(), ".github", ".release-please-manifest.json"),
+  path.join(process.cwd(), ...MANIFEST_RELATIVE_PATH.split("/")),
 )
-const configErrors = validateReleasePleaseConfig(releasePleaseConfig, manifest)
+const configErrors = validateReleasePleaseConfig(releasePleaseConfig, readReleasedManifest())
 const counts = await getCompoundEngineeringCounts(process.cwd())
 const result = await syncReleaseMetadata({
   write: false,

--- a/scripts/release/validate.ts
+++ b/scripts/release/validate.ts
@@ -12,7 +12,7 @@ const releasePleaseConfig = await readJson<{ packages: Record<string, unknown> }
 const manifest = await readJson<ReleasePleaseManifest>(
   path.join(process.cwd(), ".github", ".release-please-manifest.json"),
 )
-const configErrors = validateReleasePleaseConfig(releasePleaseConfig)
+const configErrors = validateReleasePleaseConfig(releasePleaseConfig, manifest)
 const counts = await getCompoundEngineeringCounts(process.cwd())
 const result = await syncReleaseMetadata({
   write: false,

--- a/src/release/config.ts
+++ b/src/release/config.ts
@@ -11,7 +11,10 @@ type ReleasePleaseConfig = {
 }
 
 // Maps a release component path (e.g. ".claude-plugin") to its last-released
-// version, mirroring .github/.release-please-manifest.json.
+// version. Callers pass the manifest as it exists on the base branch (main),
+// NOT the working tree -- on a release-please PR the working-tree manifest is
+// already bumped to the proposed version, which would make a legitimate pin
+// look stale. See validateReleasePleaseConfig and scripts/release/validate.ts.
 type ReleasePleaseManifest = Record<string, string>
 
 // Compares two plain "x.y.z" versions. Returns a negative number when `a` is
@@ -41,19 +44,18 @@ export function validateReleasePleaseConfig(
   for (const [packagePath, packageConfig] of Object.entries(config.packages)) {
     const releaseAs = packageConfig["release-as"]
     if (releaseAs) {
-      // A release-as pin is only legitimate as a one-shot forward override:
-      // it must be strictly ahead of the last-released version so it drives
-      // exactly one release. Once that release ships, release-please advances
-      // the manifest to match the pin (it does not edit the config), so the
-      // pin becomes stale -- and the check below then fails, forcing cleanup.
-      // This is what bit the repo in #674: a pin left behind at-or-below the
-      // released version silently re-pins every subsequent release.
+      // A release-as pin is only legitimate as a one-shot forward override: it
+      // must be strictly ahead of the released version so it drives exactly one
+      // release. Once that release ships, the released version catches up to the
+      // pin, and this check then fails on the next PR -- forcing cleanup. This
+      // is what bit the repo in #674: a pin left behind at-or-below the released
+      // version silently re-pins (freezes) every subsequent release.
+      //
+      // `released` is the base-branch (main) version. If it is unknown (e.g. the
+      // base manifest could not be read), we cannot prove the pin is stale, so
+      // we allow it rather than risk blocking a legitimate release.
       const released = manifest[packagePath]
-      if (released === undefined) {
-        errors.push(
-          `Package "${packagePath}" uses a release-as pin "${releaseAs}" but has no release-please manifest entry to compare against. A pin must be a strict forward bump over the last-released version; remove it or add the manifest entry.`,
-        )
-      } else if (compareReleaseVersions(releaseAs, released) <= 0) {
+      if (released !== undefined && compareReleaseVersions(releaseAs, released) <= 0) {
         errors.push(
           `Package "${packagePath}" uses a stale release-as pin "${releaseAs}" that is not ahead of the released version "${released}". Remove release-as after the pinned release ships so future releases can bump normally.`,
         )

--- a/src/release/config.ts
+++ b/src/release/config.ts
@@ -10,15 +10,54 @@ type ReleasePleaseConfig = {
   packages: Record<string, ReleasePleasePackageConfig>
 }
 
-export function validateReleasePleaseConfig(config: ReleasePleaseConfig): string[] {
+// Maps a release component path (e.g. ".claude-plugin") to its last-released
+// version, mirroring .github/.release-please-manifest.json.
+type ReleasePleaseManifest = Record<string, string>
+
+// Compares two plain "x.y.z" versions. Returns a negative number when `a` is
+// lower than `b`, 0 when equal, positive when higher. Any pre-release suffix is
+// ignored -- release-owned versions in this repo are plain semver.
+function compareReleaseVersions(a: string, b: string): number {
+  const parse = (version: string) =>
+    version
+      .split("-")[0]
+      .split(".")
+      .map((part) => Number.parseInt(part, 10) || 0)
+  const left = parse(a)
+  const right = parse(b)
+  for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+    const diff = (left[index] ?? 0) - (right[index] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
+export function validateReleasePleaseConfig(
+  config: ReleasePleaseConfig,
+  manifest: ReleasePleaseManifest = {},
+): string[] {
   const errors: string[] = []
 
   for (const [packagePath, packageConfig] of Object.entries(config.packages)) {
     const releaseAs = packageConfig["release-as"]
     if (releaseAs) {
-      errors.push(
-        `Package "${packagePath}" uses temporary release-as pin "${releaseAs}". Remove release-as after the pinned release ships so future releases can bump normally.`,
-      )
+      // A release-as pin is only legitimate as a one-shot forward override:
+      // it must be strictly ahead of the last-released version so it drives
+      // exactly one release. Once that release ships, release-please advances
+      // the manifest to match the pin (it does not edit the config), so the
+      // pin becomes stale -- and the check below then fails, forcing cleanup.
+      // This is what bit the repo in #674: a pin left behind at-or-below the
+      // released version silently re-pins every subsequent release.
+      const released = manifest[packagePath]
+      if (released === undefined) {
+        errors.push(
+          `Package "${packagePath}" uses a release-as pin "${releaseAs}" but has no release-please manifest entry to compare against. A pin must be a strict forward bump over the last-released version; remove it or add the manifest entry.`,
+        )
+      } else if (compareReleaseVersions(releaseAs, released) <= 0) {
+        errors.push(
+          `Package "${packagePath}" uses a stale release-as pin "${releaseAs}" that is not ahead of the released version "${released}". Remove release-as after the pinned release ships so future releases can bump normally.`,
+        )
+      }
     }
 
     const changelogPath = packageConfig["changelog-path"]

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -37,6 +37,8 @@ describe("release-please config validation", () => {
     expect(errors).toEqual([])
   })
 
+  // The `manifest` argument is the released (base-branch) version, so an
+  // at-or-below pin means the release already shipped -- the pin is stale.
   test("rejects a stale release-as pin that is not ahead of the released version", () => {
     const errors = validateReleasePleaseConfig(
       {
@@ -59,6 +61,9 @@ describe("release-please config validation", () => {
     expect(errors[1]).toContain("1.0.0")
   })
 
+  // A forward pin is ahead of the released version. This is also the state of an
+  // in-flight release-please PR when compared against the base manifest (the
+  // release has not shipped yet), so it must pass.
   test("allows a forward release-as pin that is ahead of the released version", () => {
     const errors = validateReleasePleaseConfig(
       {
@@ -76,7 +81,10 @@ describe("release-please config validation", () => {
     expect(errors).toEqual([])
   })
 
-  test("rejects a release-as pin with no manifest entry to compare against", () => {
+  // No released baseline (e.g. the base manifest could not be read) means
+  // staleness is unprovable, so the pin is allowed rather than risk blocking a
+  // legitimate release.
+  test("allows a release-as pin when the released version is unknown", () => {
     const errors = validateReleasePleaseConfig({
       packages: {
         ".": {
@@ -85,9 +93,6 @@ describe("release-please config validation", () => {
       },
     })
 
-    expect(errors).toHaveLength(1)
-    expect(errors[0]).toContain('Package "."')
-    expect(errors[0]).toContain("release-as")
-    expect(errors[0]).toContain("3.0.2")
+    expect(errors).toEqual([])
   })
 })

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -37,22 +37,57 @@ describe("release-please config validation", () => {
     expect(errors).toEqual([])
   })
 
-  test("rejects checked-in release-as pins", () => {
+  test("rejects a stale release-as pin that is not ahead of the released version", () => {
+    const errors = validateReleasePleaseConfig(
+      {
+        packages: {
+          ".claude-plugin": { "release-as": "1.0.2" },
+          ".cursor-plugin": { "release-as": "1.0.0" },
+        },
+      },
+      {
+        ".claude-plugin": "1.0.2",
+        ".cursor-plugin": "1.0.1",
+      },
+    )
+
+    expect(errors).toHaveLength(2)
+    expect(errors[0]).toContain('Package ".claude-plugin"')
+    expect(errors[0]).toContain("stale")
+    expect(errors[0]).toContain("1.0.2")
+    expect(errors[1]).toContain('Package ".cursor-plugin"')
+    expect(errors[1]).toContain("1.0.0")
+  })
+
+  test("allows a forward release-as pin that is ahead of the released version", () => {
+    const errors = validateReleasePleaseConfig(
+      {
+        packages: {
+          ".claude-plugin": { "release-as": "1.0.3" },
+          ".cursor-plugin": { "release-as": "1.0.2" },
+        },
+      },
+      {
+        ".claude-plugin": "1.0.2",
+        ".cursor-plugin": "1.0.1",
+      },
+    )
+
+    expect(errors).toEqual([])
+  })
+
+  test("rejects a release-as pin with no manifest entry to compare against", () => {
     const errors = validateReleasePleaseConfig({
       packages: {
         ".": {
           "release-as": "3.0.2",
         },
-        "plugins/compound-engineering": {
-          "release-as": "3.0.2",
-        },
       },
     })
 
-    expect(errors).toHaveLength(2)
+    expect(errors).toHaveLength(1)
     expect(errors[0]).toContain('Package "."')
     expect(errors[0]).toContain("release-as")
-    expect(errors[1]).toContain('Package "plugins/compound-engineering"')
-    expect(errors[1]).toContain("3.0.2")
+    expect(errors[0]).toContain("3.0.2")
   })
 })


### PR DESCRIPTION
## Problem

Code review flagged that commit a10ac3f (`chore(coding-tutor): remove deprecated plugin`, #929) removed coding-tutor from both `.claude-plugin/marketplace.json` and `.cursor-plugin/marketplace.json` — a **marketplace-level change** per release requirement R15 (adding/removing plugins from the catalog) — but the release manifest still leaves `marketplace` at `1.0.2` and `cursor-marketplace` at `1.0.1`.

The catalog contents changed under unchanged versions, and no `marketplace-v*` / `cursor-marketplace-v*` release was cut. The cause: a10ac3f landed as `chore:`, which release-please treats as non-releasing. So the open release PR (#928) bumps `cli`/`compound-engineering` to 3.13.0 but omits both marketplace components.

## Fix

1. **Force the bumps** with forward `release-as` pins — `marketplace` → `1.0.3`, `cursor-marketplace` → `1.0.2`. On the next release-please run these get added to the standing release PR, cutting `marketplace-v1.0.3` and `cursor-marketplace-v1.0.2`.

2. **Refine the over-broad validator guard** (`src/release/config.ts`). It previously rejected *any* `release-as` pin (added in #674 after a stale pin silently re-pinned every release), which made the documented override path un-mergeable. Now a pin is allowed only when it's a strict forward bump over the **released version**, and rejected when it's at-or-below it (stale).

   Crucially, "released version" is read from the **base branch (`origin/main`)**, not the working tree. release-please bumps `.release-please-manifest.json` *inside* the release PR, so comparing against the working tree would flag the pins as stale on the very release PR they exist to create (caught in review — thanks @chatgpt-codex-connector). Comparing against `origin/main` distinguishes an in-flight release (base not yet bumped → allow) from a genuinely stale leftover pin (base already caught up → reject).

   - `scripts/release/validate.ts` reads the base manifest via `git show origin/main:…` and falls back to `{}` (check no-ops) if unreachable, so it never produces a false block.
   - `.github/workflows/ci.yml`'s `test` job uses `fetch-depth: 0` so `origin/main` is available.

### Lifecycle

| State | base (`origin/main`) | pin | result |
|---|---|---|---|
| Fresh-pin PR (this PR) | 1.0.2 / 1.0.1 | 1.0.3 / 1.0.2 | allow (forward) |
| Generated release PR | 1.0.2 / 1.0.1 (not merged yet) | 1.0.3 / 1.0.2 | allow ✅ |
| After release ships | 1.0.3 / 1.0.2 | 1.0.3 / 1.0.2 | **stale → next PR fails until pins removed** |

### Why pins (and not a no-op `fix:` commit)

The catalogs are already content-clean post-removal, so there's no honest content change to anchor a normal releasing commit. A forward pin is the precise "explicit release override" the reviewer offered, and refining the guard makes it the *correct* mechanism rather than a banned one.

## Follow-up (required)

After `marketplace`/`cursor-marketplace` release ships, **remove both `release-as` pins** from `.github/release-please-config.json`. The validator will flag them as stale (by design) until then.

## Testing

- `bun run release:validate` — passes (forward pins accepted against the `origin/main` baseline).
- Simulated the release-PR state locally (working-tree manifest bumped to 1.0.3/1.0.2 while `origin/main` stays at 1.0.2/1.0.1): **no stale error** — the release PR would not be blocked.
- `bun test tests/release-config.test.ts` — 5 pass (forward-allowed, stale-rejected, unknown-baseline-allowed).
- Full suite: 1680 pass / 9 fail; the 9 are pre-existing environment tests (`detectInstalledTools`/CLI install probing local home dirs), identical on clean `main`.