### PR TITLE
fix(lfg): run ce-simplify-code before review; clarify report-only contract

### DIFF
--- a/plugins/compound-engineering/skills/lfg/SKILL.md
+++ b/plugins/compound-engineering/skills/lfg/SKILL.md
@@ -10,25 +10,33 @@ When invoking any skill referenced below, resolve its name against the available
 
 1. Invoke the `ce-plan` skill with `$ARGUMENTS`.
 
-   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, invoke `ce-plan` again with `$ARGUMENTS`. Do NOT proceed to step 2 until a written plan exists. **Record the plan file path** — it will be passed to ce-code-review in step 3.
+   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, invoke `ce-plan` again with `$ARGUMENTS`. Do NOT proceed to step 2 until a written plan exists. **Record the plan file path** — it will be passed to ce-code-review in step 4.
 
 2. Invoke the `ce-work` skill.
 
    GATE: STOP. Verify that implementation work was performed - files were created or modified beyond the plan. Do NOT proceed to step 3 if no code changes were made.
 
-3. Invoke the `ce-code-review` skill with `mode:agent plan:<plan-path-from-step-1>`.
+3. Invoke the `ce-simplify-code` skill on the branch diff.
+
+   This runs before review so the code-review in step 4 covers the simplified code. **Skip** this step when the change is docs-only (only markdown/docs paths changed) or trivial (roughly under 10 changed lines). Otherwise let `ce-simplify-code` resolve the branch-diff scope itself; it preserves behavior and runs the test suite.
+
+   Do not commit in this step. `ce-simplify-code` leaves its changes in the working tree; step 4's review scopes the working tree (uncommitted changes included), and step 8's `ce-commit-push-pr` commits whatever remains. Committing here would sweep any still-uncommitted `ce-work` edits into a misleading `refactor` commit and could stall on a tree that never goes clean.
+
+4. Invoke the `ce-code-review` skill with `mode:agent plan:<plan-path-from-step-1>`.
 
    Pass the plan file path from step 1 so ce-code-review can verify requirements completeness. Read the **Actionable Findings** summary the skill emits.
 
-4. **Apply and persist review fixes** (REQUIRED after step 3, before residual handoff)
+   `mode:agent` is report-only **by design** — it surfaces findings but never edits the tree; LFG applies the eligible ones in step 5. When narrating progress to the user, frame this as "review found X → applied X in step 5," not as "code review did not auto-fix." A report-only review followed by an LFG-applied fix is the intended contract, not a gap.
 
-   Load `references/review-followup.md` and execute step 4 there (mechanical apply + commit/push when changes exist). Do not proceed to step 5, run browser tests, or output DONE while eligible review fixes remain only in the working tree uncommitted.
+5. **Apply and persist review fixes** (REQUIRED after step 4, before residual handoff)
 
-5. **Autonomous residual handoff** (only when step 3 reported one or more actionable `downstream-resolver` findings not applied in step 4; skip when it reported `Actionable findings: none.`)
+   Load `references/review-followup.md` and execute its apply step (mechanical apply + commit/push when changes exist). Do not proceed to the residual handoff, run browser tests, or output DONE while eligible review fixes remain only in the working tree uncommitted.
+
+6. **Autonomous residual handoff** (only when step 4 reported one or more actionable `downstream-resolver` findings not applied in step 5; skip when it reported `Actionable findings: none.`)
 
    Do not prompt the user. This step embraces the autopilot contract: residuals must become durable before DONE, but the agent never stops to ask.
 
-   1. Load `references/tracker-defer.md` in **non-interactive mode**. Pass the residual actionable findings from step 3/4 (or the run artifact when the summary was truncated).
+   1. Load `references/tracker-defer.md` in **non-interactive mode**. Pass the residual actionable findings from step 4/5 (or the run artifact when the summary was truncated).
    2. Collect the structured return: `{ filed: [...], failed: [...], no_sink: [...] }`.
    3. Compose a `## Residual Review Findings` markdown section from the structured return:
       - For each item in `filed`: a bullet with severity, file:line, title, and a link to the tracker ticket URL.
@@ -50,15 +58,15 @@ When invoking any skill referenced below, resolve its name against the available
 
    Never block DONE on tracker filing failures once residuals have been durably recorded. A `no_sink` outcome is success only when the findings are present in the PR body or in the pushed fallback file.
 
-6. Invoke the `ce-test-browser` skill with `mode:pipeline`.
+7. Invoke the `ce-test-browser` skill with `mode:pipeline`.
 
-7. Invoke the `ce-commit-push-pr` skill.
+8. Invoke the `ce-commit-push-pr` skill.
 
-   This commits any remaining changes, pushes the branch, and opens a pull request. If step 5 already opened a PR (check with `gh pr view --json number,url,state 2>/dev/null`), skip PR creation but still commit and push any uncommitted changes.
+   This commits any remaining changes, pushes the branch, and opens a pull request. If step 6 already opened a PR (check with `gh pr view --json number,url,state 2>/dev/null`), skip PR creation but still commit and push any uncommitted changes.
 
-8. **CI watch and autofix loop** (only when an open PR exists for the current branch)
+9. **CI watch and autofix loop** (only when an open PR exists for the current branch)
 
-   Detect the PR; if none exists or `gh` is unavailable, skip this step entirely and proceed to step 9.
+   Detect the PR; if none exists or `gh` is unavailable, skip this step entirely and proceed to step 10.
 
    ```bash
    gh pr view --json number,url,state
@@ -72,7 +80,7 @@ When invoking any skill referenced below, resolve its name against the available
       gh pr checks --watch
       ```
 
-      If the command exits 0, all checks passed. Break out of the loop and proceed to step 9.
+      If the command exits 0, all checks passed. Break out of the loop and proceed to step 10.
 
       If it exits non-zero, one or more checks failed. Continue to (2).
 
@@ -105,8 +113,8 @@ When invoking any skill referenced below, resolve its name against the available
      gh pr edit PR_NUMBER --body-file BODY_FILE
      ```
 
-   - Do NOT continue looping. The autopilot contract is "make residuals durable, then exit." Proceed to step 9.
+   - Do NOT continue looping. The autopilot contract is "make residuals durable, then exit." Proceed to step 10.
 
-9. Output `<promise>DONE</promise>` when complete
+10. Output `<promise>DONE</promise>` when complete
 
 Start with step 1 now. Remember: plan FIRST, then work. Never skip the plan.

--- a/plugins/compound-engineering/skills/lfg/references/review-followup.md
+++ b/plugins/compound-engineering/skills/lfg/references/review-followup.md
@@ -1,8 +1,8 @@
-# Review followup (LFG step 3–4)
+# Review followup (LFG step 4–5)
 
 `ce-code-review` is review-only. LFG applies eligible fixes itself, then commits.
 
-## Step 3 — invoke review
+## Step 4 — invoke review
 
 ```
 ce-code-review mode:agent plan:<plan-path-from-step-1>
@@ -12,7 +12,7 @@ Read the **Actionable Findings** summary and artifact path. Do not pass `mode:au
 
 Capture parsed JSON (`status`, `actionable_findings`, `findings`, `artifact_path`, `run_id`) or the markdown Actionable Findings section. If `status` is `failed`, stop and surface `reason`.
 
-## Step 4 — apply and persist review fixes
+## Step 5 — apply and persist review fixes
 
 ### What to apply
 
@@ -37,8 +37,8 @@ Do not treat `autofix_class` as permission to auto-apply.
 1. Filter `actionable_findings` (or markdown Actionable Findings) with the bar above.
 2. Apply eligible fixes in the working tree in severity order (`#` stable from the review).
 3. Run targeted tests when `requires_verification: true` on any applied finding.
-4. If `git status --short` shows changes, stage only review-driven files, commit `fix(review): apply review findings`, and push before step 5. To push: if an upstream exists, run `git push`. If no upstream exists (common on a fresh feature branch, since step 7's `ce-commit-push-pr` has not run yet), resolve a writable remote dynamically: prefer `origin` when present, otherwise use `git remote` and choose the first configured remote. Then run `git push --set-upstream <remote> HEAD`. If no eligible fixes were applied, note explicitly and skip commit.
+4. If `git status --short` shows changes, stage only review-driven files, commit `fix(review): apply review findings`, and push before step 6. To push: if an upstream exists, run `git push`. If no upstream exists (common on a fresh feature branch, since step 8's `ce-commit-push-pr` has not run yet), resolve a writable remote dynamically: prefer `origin` when present, otherwise use `git remote` and choose the first configured remote. Then run `git push --set-upstream <remote> HEAD`. If no eligible fixes were applied, note explicitly and skip commit.
 
-## Step 5 — residual handoff
+## Step 6 — residual handoff
 
-Residuals are actionable findings **not** applied in step 4 — not leftovers from in-skill autofix. Use the Actionable Findings summary / artifact from step 3.
+Residuals are actionable findings **not** applied in step 5 — not leftovers from in-skill autofix. Use the Actionable Findings summary / artifact from step 4.


### PR DESCRIPTION
## Why

Running the `lfg` pipeline surfaced two rough edges:

1. **`ce-simplify-code` never ran.** The only place simplification could fire was *inside* `ce-work`, where it's gated on a per-phase condition ("before Phase 3 when the diff is >=30 lines"). On small or single-phase tasks that trigger never fires, so the code that reaches review and the PR was never simplified.
2. **`ce-code-review` "only reported" and looked broken.** A recent change made `mode:agent` report-only *by design* — the caller applies fixes. LFG already does this in its apply step, but the run narrated it as "code review did not auto-fix," making a working contract read like a regression.

## What changed

- **New pipeline step: `ce-simplify-code` runs before code-review**, so review covers the simplified code. It's skipped on docs-only or trivial changes.
- **No commit inside the simplify step.** `ce-code-review` scopes the working tree (`git diff $BASE` includes uncommitted changes), so the simplify pass just leaves its edits in place; `ce-commit-push-pr` commits them later. This avoids two failure modes a reviewer flagged: sweeping still-uncommitted `ce-work` edits into a misleading `refactor` commit, and stalling on a clean-tree gate that a no-op simplify pass can't satisfy.
- **Clarified the report-only contract** in the review step so progress is narrated as "review found X -> applied X," not as a missing auto-fix.
- Renumbered the pipeline steps and synced `references/review-followup.md` to match.

## Notes

All skill-prose changes; no version bump, no count change. `bun test tests/frontmatter.test.ts` (327 pass) and `bun run release:validate` (in sync) both green.
