### PR TITLE
fix(ce-sessions): detect Claude sessions after metadata preambles

### DIFF
--- a/plugins/compound-engineering/skills/ce-sessions/scripts/extract-errors.py
+++ b/plugins/compound-engineering/skills/ce-sessions/scripts/extract-errors.py
@@ -88,7 +88,9 @@ def handle_codex(obj):
                 stats["errors_found"] += 1
 
 
-# Auto-detect platform from first few lines, then process all
+# Auto-detect platform, then process all lines. Current Claude Code sessions
+# can front-load more than ten metadata records before the first message, so
+# scan until a decisive record appears instead of capping detection early.
 detected = None
 buffer = []
 
@@ -99,7 +101,7 @@ for line in sys.stdin:
     buffer.append(line)
     stats["lines"] += 1
 
-    if not detected and len(buffer) <= 10:
+    if not detected:
         try:
             obj = json.loads(line)
             if obj.get("type") in ("user", "assistant"):

--- a/plugins/compound-engineering/skills/ce-sessions/scripts/extract-skeleton.py
+++ b/plugins/compound-engineering/skills/ce-sessions/scripts/extract-skeleton.py
@@ -319,7 +319,9 @@ def handle_cursor(obj):
                 pending_tools.append({"ts": "", "name": name, "target": target})
 
 
-# Auto-detect platform from first few lines, then process all
+# Auto-detect platform, then process all lines. Current Claude Code sessions
+# can front-load more than ten metadata records before the first message, so
+# scan until a decisive record appears instead of capping detection early.
 detected = None
 buffer = []
 
@@ -330,7 +332,7 @@ for line in sys.stdin:
     buffer.append(line)
     stats["lines"] += 1
 
-    if not detected and len(buffer) <= 10:
+    if not detected:
         try:
             obj = json.loads(line)
             if obj.get("type") in ("user", "assistant"):

--- a/tests/session-history-scripts.test.ts
+++ b/tests/session-history-scripts.test.ts
@@ -361,6 +361,65 @@ describe("extract-skeleton", () => {
     )
   })
 
+  test("detects Claude sessions after long metadata preambles", async () => {
+    const lines = [
+      "last-prompt",
+      "custom-title",
+      "agent-name",
+      "mode",
+      "permission-mode",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+    ].map((type, index) =>
+      JSON.stringify({
+        type,
+        timestamp: `2026-06-17T10:00:${String(index).padStart(2, "0")}.000Z`,
+      })
+    )
+
+    lines.push(
+      JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content: "please summarize this current Claude session",
+        },
+        timestamp: "2026-06-17T10:00:12.000Z",
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "I found the relevant session history and summarized it.",
+            },
+          ],
+        },
+        timestamp: "2026-06-17T10:00:13.000Z",
+      })
+    )
+
+    const { stdout, exitCode } = await runScript(
+      "extract-skeleton.py",
+      [],
+      lines.join("\n")
+    )
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain("[user] please summarize this current Claude session")
+    expect(stdout).toContain("[assistant] I found the relevant session history")
+    const meta = JSON.parse(stdout.trim().split("\n").at(-1)!)
+    expect(meta.user).toBe(1)
+    expect(meta.assistant).toBe(1)
+    expect(meta.parse_errors).toBe(0)
+  })
+
   test("extracts Claude tool calls with targets", async () => {
     const fixture = await Bun.file(
       path.join(FIXTURES_DIR, "claude-session.jsonl")

--- a/tests/session-history-scripts.test.ts
+++ b/tests/session-history-scripts.test.ts
@@ -729,6 +729,57 @@ describe("extract-errors", () => {
     expect(stdout).toContain("String to replace not found")
   })
 
+  test("extracts Claude errors after long metadata preambles", async () => {
+    const lines = [
+      "last-prompt",
+      "custom-title",
+      "agent-name",
+      "mode",
+      "permission-mode",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+    ].map((type, index) =>
+      JSON.stringify({
+        type,
+        timestamp: `2026-06-17T10:00:${String(index).padStart(2, "0")}.000Z`,
+      })
+    )
+
+    lines.push(
+      JSON.stringify({
+        type: "user",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "toolu_1",
+              is_error: true,
+              content: "Permission denied while reading session history",
+            },
+          ],
+        },
+        timestamp: "2026-06-17T10:00:12.000Z",
+      })
+    )
+
+    const { stdout, exitCode } = await runScript(
+      "extract-errors.py",
+      [],
+      lines.join("\n")
+    )
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain("[error] Permission denied while reading session history")
+    const meta = JSON.parse(stdout.trim().split("\n").at(-1)!)
+    expect(meta.errors_found).toBe(1)
+    expect(meta.parse_errors).toBe(0)
+  })
+
   test("Claude errors are summarized, not raw", async () => {
     const fixture = await Bun.file(
       path.join(FIXTURES_DIR, "claude-session.jsonl")


### PR DESCRIPTION
## Summary

- removes the 10-line cap from `extract-skeleton.py` platform detection
- keeps scanning until a decisive Claude/Codex/Cursor record appears
- adds a regression test for Claude session files with more than ten metadata records before the first message

Closes #923

## Validation

- `bun test tests/session-history-scripts.test.ts` — 50 pass
- `bun run release:validate` — release metadata in sync
- `git diff --check upstream/main...HEAD` — pass

## Duplicate check

Checked open PRs for `#923`, `extract-skeleton`, `detection cap`, and `first 10 lines`; no direct duplicate found. Broad ce-sessions PRs were unrelated.