### PR TITLE
fix(ce-setup): remove unsafe plugin root pre-resolution

### DIFF
--- a/docs/skills/ce-setup.md
+++ b/docs/skills/ce-setup.md
@@ -80,7 +80,7 @@ The skill detects if the obsolete `compound-engineering.local.md` exists at the 
 
 ### 6. Claude Code update hint
 
-When the setup flow can determine that the installed plugin version came from Claude Code plugin metadata, it recommends `/ce-update` for upgrades. Otherwise, `/ce-update` references are omitted. The skill does not use `!` pre-resolution or shell expansion of the Claude plugin root environment variable for this check, because Claude Code can reject those commands at skill-load time.
+When the setup flow can determine that the installed plugin version came from Claude Code plugin metadata, it records that as local detection state and recommends `/ce-update` for upgrades. Otherwise, `/ce-update` references are omitted. The skill does not use `!` pre-resolution or shell expansion of the Claude plugin root environment variable for this check, because Claude Code can reject those commands at skill-load time.
 
 ### 7. Explicit-invocation only
 

--- a/docs/skills/ce-setup.md
+++ b/docs/skills/ce-setup.md
@@ -78,9 +78,9 @@ If verification succeeds, success is reported. If it fails, the project URL is d
 
 The skill detects if the obsolete `compound-engineering.local.md` exists at the repo root. If so, it explains the file is obsolete (review-agent selection is now automatic, machine-local state moved to `.compound-engineering/config.local.yaml`) and asks whether to delete. The user controls the cleanup; the skill doesn't silently delete repo files.
 
-### 6. Pre-resolved plugin root for Claude Code detection
+### 6. Claude Code update hint
 
-The skill uses pre-resolution (`!` backtick at skill load) to capture `${CLAUDE_PLUGIN_ROOT}`. If it resolves to an absolute path, this is Claude Code and the skill recommends `/ce-update` for upgrades. If it doesn't resolve (empty, literal token, or non-Claude harness), `/ce-update` references are omitted. No guessing at platform.
+When the setup flow can determine that the installed plugin version came from Claude Code plugin metadata, it recommends `/ce-update` for upgrades. Otherwise, `/ce-update` references are omitted. The skill does not use `!` pre-resolution or shell expansion of the Claude plugin root environment variable for this check, because Claude Code can reject those commands at skill-load time.
 
 ### 7. Explicit-invocation only
 

--- a/plugins/compound-engineering/skills/ce-setup/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-setup/SKILL.md
@@ -42,9 +42,7 @@ Display the script's output to the user.
 
 ### Step 3: Evaluate Results
 
-**Plugin root (pre-resolved):** !`echo "${CLAUDE_PLUGIN_ROOT}"`
-
-If the line above resolved to an absolute path (starts with `/` and contains no `${`), this is a Claude Code session and `/ce-update` is available. Anything else — empty, the literal `${CLAUDE_PLUGIN_ROOT}` token, or an unresolved command string like `echo "${CLAUDE_PLUGIN_ROOT}"` left in place by a non-Claude harness that doesn't process `!` pre-resolution — means this is not Claude Code; omit any `/ce-update` references from output.
+If Step 1 found a Claude Code plugin root or manifest path while determining the installed plugin version, this is a Claude Code session and `/ce-update` is available. If Step 1 could not determine that the installed plugin came from Claude Code plugin metadata, omit `/ce-update` references from output. Do not use `!` pre-resolution or shell expansion of the Claude plugin root environment variable for this check; Claude Code can reject those commands before the skill body runs.
 
 After the diagnostic report, check whether:
 

--- a/plugins/compound-engineering/skills/ce-setup/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-setup/SKILL.md
@@ -20,6 +20,11 @@ Detect the installed compound-engineering plugin version by reading the plugin m
 
 If a version is found, pass it to the check script via `--version`. Otherwise omit the flag.
 
+Also keep two local state values for later summary text:
+
+- `claude_code_plugin_detected`: true only when the version came from Claude Code plugin metadata or a Claude Code plugin manifest path.
+- `claude_code_plugin_source`: the plugin root or manifest path when known; otherwise empty.
+
 ### Step 2: Run the Health Check Script
 
 Before running the script, display: "Compound Engineering -- checking your environment..."
@@ -42,7 +47,7 @@ Display the script's output to the user.
 
 ### Step 3: Evaluate Results
 
-If Step 1 found a Claude Code plugin root or manifest path while determining the installed plugin version, this is a Claude Code session and `/ce-update` is available. If Step 1 could not determine that the installed plugin came from Claude Code plugin metadata, omit `/ce-update` references from output. Do not use `!` pre-resolution or shell expansion of the Claude plugin root environment variable for this check; Claude Code can reject those commands before the skill body runs.
+If `claude_code_plugin_detected` is true, this is a Claude Code session and `/ce-update` is available. If it is false or unknown, omit `/ce-update` references from output. Do not use `!` pre-resolution or shell expansion of the Claude plugin root environment variable for this check; Claude Code can reject those commands before the skill body runs.
 
 After the diagnostic report, check whether:
 
@@ -64,7 +69,7 @@ If everything is installed, no repo-local cleanup is needed, and `.compound-engi
     Run /ce-setup anytime to re-check.
 ```
 
-If this is a Claude Code session (the **Plugin root** above resolved to a non-empty path), append to the message: "Run /ce-update to grab the latest plugin version."
+If `claude_code_plugin_detected` is true, append to the message: "Run /ce-update to grab the latest plugin version."
 
 Stop here.
 
@@ -159,4 +164,4 @@ Display a brief summary:
     Run /ce-setup anytime to re-check.
 ```
 
-If this is a Claude Code session (per platform detection in Step 3), append: "Run /ce-update to grab the latest plugin version."
+If `claude_code_plugin_detected` is true, append: "Run /ce-update to grab the latest plugin version."

--- a/tests/skill-conventions.test.ts
+++ b/tests/skill-conventions.test.ts
@@ -582,10 +582,6 @@ function findPlatformVarOccurrences(markdown: string): PlatformVarOccurrence[] {
  */
 const PLATFORM_VAR_ACKNOWLEDGED = new Map<string, string>([
   [
-    "plugins/compound-engineering/skills/ce-setup/SKILL.md#CLAUDE_PLUGIN_ROOT",
-    "AGENTS.md pre-resolution pattern: the prose under the pre-resolved line says exactly what to do when it is empty or an unresolved literal (treat as non-Claude-Code; omit /ce-update references).",
-  ],
-  [
     "plugins/compound-engineering/skills/ce-update/SKILL.md#CLAUDE_SKILL_DIR",
     "SKILL.md routes unset/unresolved CLAUDE_SKILL_DIR (scripts failing) to its __CE_UPDATE_NOT_MARKETPLACE__ handling.",
   ],
@@ -1189,4 +1185,3 @@ describe("findPlatformVarViolations", () => {
     expect(findPlatformVarViolations(sample).map((v) => v.variable)).toEqual(["CLAUDE_SKILL_DIR"])
   })
 })
-


### PR DESCRIPTION
## Summary

- removes the `!` pre-resolution command that expands the Claude plugin root env var at skill load
- keeps the `/ce-update` hint only when setup can determine the plugin came from Claude Code plugin metadata
- removes the now-stale platform-variable acknowledgment and updates the generated skill docs

Closes #954

## Validation

- `bun test tests/skill-conventions.test.ts tests/legacy-cleanup.test.ts tests/skills/ce-setup-check-health.test.ts` — 276 pass
- `bun run release:validate` — release metadata in sync
- `git diff --check upstream/main...HEAD` — pass

## Duplicate check

Checked open PRs for `#954`, `ce-setup`, `CLAUDE_PLUGIN_ROOT`, plugin root expansion, and pre-resolution; no direct duplicate found.