### PR TITLE
fix(ce-code-review): annotate model tier in Stage 3 team announce; reference annotation from Stage 4 dispatch

### DIFF
--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -306,21 +306,25 @@ Stack-specific personas are additive when runtime behavior warrants them. A Hotw
 
 For `ce-deployment-verification-agent`, use the same migration-artifact gate when the change is risky (destructive DDL, backfills, NOT NULL without default, column renames/drops).
 
-Announce the team before spawning:
+Announce the team before spawning. Include the intended model tier for each reviewer — this annotation is the authoritative input Stage 4 reads to apply the dispatch-time override, so it must be present and accurate before any agent is dispatched:
 
 ```
 Review team:
-- correctness (always)
-- testing (always)
-- maintainability (always)
-- project-standards (always)
-- ce-agent-native-reviewer (always)
-- ce-learnings-researcher (always)
-- security -- new endpoint in routes.rb accepts user-provided redirect URL
-- julik-frontend-races -- Stimulus controller with async DOM updates
-- data-migration -- adds migration 20260303_add_index_to_orders
-- ce-deployment-verification-agent -- destructive migration with backfill
+- correctness (always) [session model]
+- testing (always) [mid-tier]
+- maintainability (always) [mid-tier]
+- project-standards (always) [mid-tier]
+- ce-agent-native-reviewer (always) [mid-tier]
+- ce-learnings-researcher (always) [mid-tier]
+- security -- new endpoint in routes.rb accepts user-provided redirect URL [session model]
+- julik-frontend-races -- Stimulus controller with async DOM updates [mid-tier]
+- data-migration -- adds migration 20260303_add_index_to_orders [mid-tier]
+- ce-deployment-verification-agent -- destructive migration with backfill [mid-tier]
 ```
+
+**Model tier rules for the annotation:**
+- `[session model]` — `ce-correctness-reviewer`, `ce-security-reviewer`, `ce-adversarial-reviewer` only.
+- `[mid-tier]` — every other persona and CE agent.
 
 This is progress reporting, not a blocking confirmation.
 
@@ -360,7 +364,12 @@ Pass `{run_id}` to every persona sub-agent so they can write their full analysis
 
 Omit the `mode` parameter when dispatching sub-agents so the user's configured permission settings apply. Do not pass `mode: "auto"`.
 
-**Model override at dispatch time.** Pass the platform's mid-tier model on every dispatch except `ce-correctness-reviewer`, `ce-security-reviewer`, and `ce-adversarial-reviewer`, which inherit the session model (per the Model tiering subsection above). In Claude Code, add `model: "sonnet"` to the `Agent` tool call. In Codex, pass the equivalent mid-tier on `spawn_agent` (e.g., `gpt-5.4-mini` as of April 2026). In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name. Check this on every Agent / `spawn_agent` / `subagent` call in the parallel dispatch; omitting it on Opus sessions silently 3-4x's the cost of a review.
+**Model override at dispatch time — check this before every dispatch call.** Omitting it on Opus sessions silently 3-4x's the cost of a review. For each reviewer, read the `[session model]` / `[mid-tier]` annotation from the Stage 3 team announce and apply it:
+
+- `[session model]` → no override; the reviewer inherits the session model.
+- `[mid-tier]` → in Claude Code, add `model: "claude-sonnet-4-5"` to the `Agent` tool call. In Codex, pass `gpt-5.4-mini` (or current equivalent) on `spawn_agent`. In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name.
+
+The Stage 3 annotation is the single source of truth for model assignment; do not re-derive it from the tiering rules at dispatch time.
 
 **Bounded parallel dispatch.** Respect the current harness's active-subagent limit. Queue selected reviewers, dispatch only as many as the harness accepts, and fill freed slots as reviewers complete. Treat active-agent/thread/concurrency-limit spawn errors as backpressure, not reviewer failure: leave the reviewer queued and retry after a slot frees. Record a reviewer as failed only after a successful dispatch times out/fails, or when dispatch fails for a non-capacity reason.
 

--- a/plugins/compound-engineering/skills/ce-code-review/SKILL.md
+++ b/plugins/compound-engineering/skills/ce-code-review/SKILL.md
@@ -366,8 +366,8 @@ Omit the `mode` parameter when dispatching sub-agents so the user's configured p
 
 **Model override at dispatch time — check this before every dispatch call.** Omitting it on Opus sessions silently 3-4x's the cost of a review. For each reviewer, read the `[session model]` / `[mid-tier]` annotation from the Stage 3 team announce and apply it:
 
-- `[session model]` → no override; the reviewer inherits the session model.
-- `[mid-tier]` → in Claude Code, add `model: "claude-sonnet-4-5"` to the `Agent` tool call. In Codex, pass `gpt-5.4-mini` (or current equivalent) on `spawn_agent`. In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name.
+- `[session model]` → no override; the reviewer inherits the session model. This applies to `ce-correctness-reviewer`, `ce-security-reviewer`, and `ce-adversarial-reviewer`.
+- `[mid-tier]` → in Claude Code, add `model: "sonnet"` to the `Agent` tool call. In Codex, pass `gpt-5.4-mini` (or current equivalent) on `spawn_agent`. In Pi, pass the equivalent on `subagent` via the `pi-subagents` extension. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name.
 
 The Stage 3 annotation is the single source of truth for model assignment; do not re-derive it from the tiering rules at dispatch time.
 


### PR DESCRIPTION
This pull request updates the documentation for the code review agent system to clarify and formalize how model tiers are assigned and dispatched to reviewer personas. The changes ensure that model assignment is explicit, consistent, and based on authoritative annotations, reducing ambiguity and potential for costly mistakes.

**Model tier assignment and annotation:**

* The team announcement before spawning reviewers now requires explicit annotation of the intended model tier (`[session model]` or `[mid-tier]`) for each reviewer persona, making the assignment clear and authoritative for subsequent stages.
* Rules for model tier assignment are codified: `[session model]` is used only for `ce-correctness-reviewer`, `ce-security-reviewer`, and `ce-adversarial-reviewer`; all other personas use `[mid-tier]`.

**Dispatch-time model override logic:**

* At dispatch time, the system must read the model tier annotation from the Stage 3 team announce and apply it for each reviewer, rather than re-deriving the assignment from code logic.
* When `[mid-tier]` is specified, the appropriate model override (e.g., `model: "sonnet"` for Claude Code, `gpt-5.4-mini` for Codex) is applied; `[session model]` reviewers inherit the session model with no override. On platforms without a model-override parameter, the override is omitted to ensure compatibility.

These updates make the model assignment process more transparent and less error-prone, particularly in cost-sensitive scenarios.## Problem (fixes #965)

Stage 4's model-override instruction was a prose paragraph buried after structural dispatch concerns (run ID generation, large-diff path writing, bounded parallelism). An orchestrator satisfying all structural requirements could miss the override entirely, defaulting all reviewers to the session model — silently 3-4x'ing cost on Opus sessions with no warning emitted.

Evidence from a 9-reviewer dispatch (2026-06-19): `model: "sonnet"` was not passed to any of the 6 non-critical reviewers despite the orchestrator having read the instruction. All ran on `claude-opus-4.6`.

## Approach

**Make the model assignment a first-class output of Stage 3** (reviewer selection), not a rule the orchestrator must re-apply from memory at each Stage 4 dispatch call.

The Stage 3 team announce now carries `[session model]` / `[mid-tier]` annotations on every reviewer line. Stage 4 reads those annotations mechanically — one lookup per dispatch, no re-derivation of tiering logic.

## Changes

**Stage 3 — team announce block:**
- Each reviewer line now ends with `[session model]` or `[mid-tier]`
- Model tier rules added below the block (which three reviewers get session model; everyone else gets mid-tier)
- Framing updated: the annotation is described as \*\*the authoritative input Stage 4 reads\*\*, not just progress reporting

**Stage 4 — Spawning paragraph:**
- Cost warning (\*"omitting it on Opus sessions silently 3-4x's the cost"\*) moved to the **opening sentence** — before dispatch instructions, not after
- Override instruction now says "read the annotation from the Stage 3 team announce and apply it" rather than re-stating the tiering rules inline
- Added explicit bullet for each annotation value (`[session model]` → no override; `[mid-tier]` → apply mid-tier)
- Added closing line: \*"The Stage 3 annotation is the single source of truth for model assignment; do not re-derive it from the tiering rules at dispatch time."\*

## Why annotation-at-selection beats prose-at-dispatch

The structural dispatch work (generate run ID, write diff, queue reviewers) happens in Stage 4 independent of the tiering prose. When override and dispatch are in the same prose block, the orchestrator can execute dispatch correctly while skipping the override. Moving model assignment to Stage 3 output means the override decision is done before Stage 4 starts — Stage 4 just reads and applies it.