### PR TITLE
fix(release): include refactors in release notes

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -8,6 +8,28 @@
     ".": {
       "release-type": "simple",
       "package-name": "compound-engineering",
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "deps",
+          "section": "Dependencies",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Refactoring",
+          "hidden": false
+        }
+      ],
       "skip-changelog": true,
       "exclude-paths": [
         "SECURITY.md",

--- a/docs/solutions/workflow/manual-release-please-github-releases.md
+++ b/docs/solutions/workflow/manual-release-please-github-releases.md
@@ -66,7 +66,8 @@ The practical fix:
 PR title determines release intent:
 
 - `feat` -> minor
-- `fix`, `perf`, `refactor`, `revert` -> patch
+- `fix`, `perf`, `revert` -> patch
+- `refactor` -> visible in release notes under `Refactoring`, but not release-driving unless breaking or explicitly overridden
 - `!` -> major; do not use without explicit maintainer confirmation
 
 File paths determine component ownership:

--- a/src/release/components.ts
+++ b/src/release/components.ts
@@ -52,7 +52,7 @@ const SCOPES_TO_COMPONENTS: Record<string, ReleaseComponent> = {
 }
 
 const NON_RELEASABLE_TYPES = new Set(["docs", "chore", "test", "ci", "build", "style"])
-const PATCH_TYPES = new Set(["fix", "perf", "refactor", "revert"])
+const PATCH_TYPES = new Set(["fix", "perf", "revert"])
 
 type VersionSources = Record<ReleaseComponent, string>
 

--- a/tests/release-components.test.ts
+++ b/tests/release-components.test.ts
@@ -66,6 +66,7 @@ describe("release intent parsing", () => {
   test("infers bump levels from parsed intent", () => {
     expect(inferBumpFromIntent(parseReleaseIntent("feat: add release preview"))).toBe("minor")
     expect(inferBumpFromIntent(parseReleaseIntent("fix: correct preview output"))).toBe("patch")
+    expect(inferBumpFromIntent(parseReleaseIntent("refactor: reshape plugin layout"))).toBeNull()
     expect(inferBumpFromIntent(parseReleaseIntent("docs: update requirements"))).toBeNull()
     expect(inferBumpFromIntent(parseReleaseIntent("refactor!: break compatibility"))).toBe("major")
   })

--- a/tests/release-config.test.ts
+++ b/tests/release-config.test.ts
@@ -106,4 +106,17 @@ describe("release-please config validation", () => {
 
     expect(config.packages["."]?.["skip-changelog"]).toBe(true)
   })
+
+  test("current root package includes refactors in generated release notes", () => {
+    const configPath = path.join(import.meta.dir, "..", ".github", "release-please-config.json")
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+      packages: Record<string, { "changelog-sections"?: Array<{ type: string; section: string; hidden?: boolean }> }>
+    }
+
+    expect(config.packages["."]?.["changelog-sections"]).toContainEqual({
+      type: "refactor",
+      section: "Refactoring",
+      hidden: false,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Release Please was not showing plain `refactor:` PRs in generated release notes. The root package config relied on default changelog sections, and Release Please only surfaces the default release-driving types unless sections are configured explicitly.

This PR adds an explicit visible `Refactoring` release-note section for the root package, keeps `feat`, `fix`, and `deps` visible, and aligns the local release preview helper so plain `refactor:` is not previewed as a release-driving patch bump.

## Impact

After this lands, the outstanding release PR should be recomputed by the Release PR workflow and include already-merged refactor commits, including #967, under `Refactoring`.

## Validation

- `bun run release:validate`
- `bun test tests/release-config.test.ts tests/release-components.test.ts tests/release-preview.test.ts`
- `bun test`