### PR TITLE
fix: Codex marketplace install

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "compound-engineering",
       "source": {
-        "source": "local",
-        "path": "./"
+        "source": "url",
+        "url": "https://github.com/EveryInc/compound-engineering-plugin.git"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The Codex app install is self-contained for Compound Engineering. Specialist rev
 
 ### Codex CLI
 
-Register the marketplace, then install the plugin through Codex's TUI.
+Register the marketplace, then install the plugin.
 
 1. **Register the marketplace with Codex:**
 
@@ -156,7 +156,13 @@ Register the marketplace, then install the plugin through Codex's TUI.
    codex plugin marketplace add EveryInc/compound-engineering-plugin
    ```
 
-2. **Install the plugin through Codex's TUI:** launch `codex`, run `/plugins`, find the **Compound Engineering** marketplace, select the **compound-engineering** plugin, and choose **Install**. Restart Codex after install completes. Codex CLI can register marketplaces, but it does not currently expose a plugin-install subcommand for plugins from an added marketplace -- the `/plugins` TUI install is required for CE skills.
+2. **Install the plugin:**
+
+   ```bash
+   codex plugin add compound-engineering@compound-engineering-plugin
+   ```
+
+   You can also launch `codex`, run `/plugins`, find the **Compound Engineering** marketplace, select the **compound-engineering** plugin, and choose **Install**. Restart Codex after install completes.
 
 The native Codex plugin install is self-contained for Compound Engineering. Specialist reviewer and research behavior lives inside the skills as local prompt assets; no separate custom-agent install step is required.
 
@@ -164,10 +170,10 @@ For a non-default Codex profile, run every Codex-related step against the same `
 
 ```bash
 CODEX_HOME="$HOME/.codex/profiles/work" codex plugin marketplace add EveryInc/compound-engineering-plugin
-CODEX_HOME="$HOME/.codex/profiles/work" codex
+CODEX_HOME="$HOME/.codex/profiles/work" codex plugin add compound-engineering@compound-engineering-plugin
 ```
 
-Inside Codex, run `/plugins`, select **Compound Engineering**, then install **compound-engineering**. The marketplace step only makes the plugin available; the TUI install is what activates the native CE skills for that profile.
+The marketplace step only makes the plugin available; the plugin install is what activates the native CE skills for that profile.
 
 ### GitHub Copilot
 
@@ -314,10 +320,10 @@ In the app's **Add plugin marketplace** form, use this checkout as the source:
 
 ```bash
 codex plugin marketplace add "$PWD"
-codex
+codex plugin add compound-engineering@compound-engineering-plugin
 ```
 
-Then run `/plugins`, select **Compound Engineering**, and install **compound-engineering**. Use a separate `CODEX_HOME` when you want to keep local testing isolated from your normal Codex profile.
+Use a separate `CODEX_HOME` when you want to keep local testing isolated from your normal Codex profile. The Codex marketplace entry points at the public Git plugin source so root-shaped plugin repos install correctly; use a temporary marketplace catalog with a `source.url` plus `ref` when testing unpublished plugin-content changes end to end.
 
 **OpenCode**
 

--- a/src/release/metadata.ts
+++ b/src/release/metadata.ts
@@ -46,6 +46,11 @@ type CodexMarketplaceManifest = {
   name: string
   plugins: Array<{
     name: string
+    source?: {
+      source?: string
+      path?: string
+      url?: string
+    }
   }>
 }
 
@@ -359,6 +364,13 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
       errors.push(
         `${marketplaceCodexPath}: plugin list [${codexNames.join(", ")}] does not match ${marketplaceClaudePath} [${claudeNames.join(", ")}]`,
       )
+    }
+    for (const plugin of marketplaceCodex.plugins) {
+      if (plugin.source?.source === "local" && plugin.source.path === "./") {
+        errors.push(
+          `${marketplaceCodexPath}: plugin "${plugin.name}" uses source.path "./"; Codex does not enumerate marketplace entries that point back at the marketplace root. Use a plugin subdirectory path or a Git URL source.`,
+        )
+      }
     }
     updates.push({ path: marketplaceCodexPath, changed: false })
   } catch (err: unknown) {

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -352,6 +352,39 @@ describe("release metadata", () => {
     ).toBe(true)
   })
 
+  test("reports Codex marketplace root-local plugin source as structural error", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".agents", "plugins", "marketplace.json"),
+      JSON.stringify(
+        {
+          name: "compound-engineering-plugin",
+          plugins: [
+            {
+              name: "compound-engineering",
+              source: {
+                source: "local",
+                path: "./",
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    )
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes(".agents/plugins/marketplace.json") &&
+          err.includes("compound-engineering") &&
+          err.includes('source.path "./"'),
+      ),
+    ).toBe(true)
+  })
+
   test("happy path: fixture with matching Codex manifests produces no Codex errors", async () => {
     const root = await makeFixtureRoot()
     // Align Claude <-> Codex versions and descriptions so there's no drift.


### PR DESCRIPTION
## Summary

- Change the Codex marketplace entry to point at the root plugin repo via Git URL instead of `source.path: "./"`.
- Add release metadata validation that rejects root-local Codex marketplace plugin sources, which Codex registers but does not enumerate as installable plugins.
- Update README Codex CLI install docs to use `codex plugin add compound-engineering@compound-engineering-plugin`.

## Root Cause

Codex can add a marketplace whose entry points back at the marketplace root, but it does not list that entry as an available plugin. The prior `.agents/plugins/marketplace.json` used `source: local` with `path: "./"`, so users saw a generic marketplace add failure or an empty plugin list.

## Validation

- `bun run release:validate`
- `bun test` (`1582 pass, 0 fail`)
- Disposable Codex smoke test:
  - `CODEX_HOME=$(mktemp -d) codex plugin marketplace add "$PWD"`
  - `codex plugin list --available --json` lists `compound-engineering@compound-engineering-plugin`
  - `codex plugin add compound-engineering@compound-engineering-plugin --json` installs version `3.13.1`