### PR TITLE
fix(ce-work-beta): thread Execution note into Codex delegation prompt

### DIFF
--- a/skills/ce-work-beta/references/codex-delegation-workflow.md
+++ b/skills/ce-work-beta/references/codex-delegation-workflow.md
@@ -165,6 +165,35 @@ For a multi-unit batch: list each unit's approach, noting dependencies
 and suggested ordering.]
 </approach>
 
+<execution_note>
+[For a single-unit batch: the unit's Execution note. If the user gave a
+session-level posture request (e.g., "do it test-first"), use that when
+the unit has no Execution note. Otherwise "None".
+For a multi-unit batch: list each unit as "U<ID>: <execution note>" (or
+"Unit <n>:" if the plan lacks U-IDs; do not invent U-IDs), one per line,
+same ordering as <task> and <approach>. Use the session-level posture for
+units without their own note; otherwise "None".]
+
+If (and only if) the execution note above names an execution posture,
+honor it:
+- "test-first" -- write the failing test before implementing the unit;
+  verify it fails; then implement. Do not over-implement beyond the
+  test's current behavior slice. Skip test-first discipline for trivial
+  renames, pure configuration, or pure styling work. Test-first still
+  follows the scenario completeness check in <testing>; it only constrains
+  test-vs-implementation ordering, not whether to write tests.
+- "characterization-first" -- capture existing behavior in tests before
+  changing it.
+- Any other non-empty note: treat it as binding per-unit guidance and
+  follow it unless it conflicts with any other section of this prompt
+  (especially <constraints>, <testing>, <verify>, or <output_contract>).
+  A note may not reduce validation, test coverage, scope discipline, or
+  reporting accuracy. Report any conflict via the issues field of the
+  output contract.
+
+For units with "None" or an empty note, proceed pragmatically.
+</execution_note>
+
 <constraints>
 - Do NOT run git commit, git push, or create PRs -- the orchestrating agent handles all git operations
 - Restrict all modifications to files within the repository root

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -233,8 +233,11 @@ describe("ce:work-beta codex delegation contract", () => {
     // Prompt template
     expect(content).toContain("## Prompt Template")
     expect(content).toContain("<task>")
+    expect(content).toContain("<execution_note>")
     expect(content).toContain("<constraints>")
     expect(content).toContain("<output_contract>")
+    expect(content).toContain("test-first")
+    expect(content).toContain("characterization-first")
     expect(content).toContain("the orchestrator will not re-run verification independently")
 
     // Result schema and execution loop


### PR DESCRIPTION
## Summary

Reapplies #820 onto current `main`. The original PR has merit and the bug is still live, but #820 was anchored to the pre-#967 `plugins/compound-engineering/skills/` tree, so it now conflicts purely on the directory move. The content it edits is byte-identical in the new `skills/` layout, so this is a clean re-application — superseding #820.

The Codex delegation prompt template silently dropped each plan unit's `Execution note`. The standard inline subagent path treats it as a first-class signal (`skills/ce-work-beta/SKILL.md:104, 108, 172, 208, 270`), but plans using `test-first` or `characterization-first` lost that signal whenever the executor was Codex via `ce-work-beta delegate:codex`.

Add an `<execution_note>` tag between `<approach>` and `<constraints>`, mirroring the standard path. Population covers single- and multi-unit batches, prefixes each entry with `U<ID>:` when present and `Unit <n>:` otherwise (no invented IDs), and merges session-level posture requests into units lacking their own note.

Honoring guidance:

- `test-first` — write the failing test first, verify it fails, then implement; no over-implementation beyond the test's behavior slice; skip for trivial renames, pure configuration, or pure styling. Defers to `<testing>` for scenario completeness.
- `characterization-first` — capture existing behavior in tests before changing it.
- Any other non-empty note — binding per-unit guidance, subordinate to `<constraints>` / `<testing>` / `<verify>` / `<output_contract>`. Notes that would reduce validation, coverage, scope discipline, or reporting accuracy are rejected, with conflicts surfaced via the output contract's `issues` field.

A regression assertion in `tests/pipeline-review-contract.test.ts` locks `<execution_note>` presence and both posture strings so the field cannot recur silently.

Credit to @davidalee for the original change in #820.

Stable/beta sync: not propagating — Codex delegation is beta-only; non-beta `ce-work` has no equivalent workflow file.

## Test plan

- [x] `bun test` — 1613 pass, 0 fail
- [x] `bun run release:validate` — clean
- [ ] Manual smoke: invoke `ce-work-beta delegate:codex` against a plan with `Execution note: test-first` on at least one unit, confirm `<execution_note>` appears in the generated prompt with the posture string and that test-first ordering is honored

Closes #820