### PR TITLE
fix(opencode): generate slash-command stubs for each skill

### DIFF
--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -25,7 +25,7 @@ import {
 import { moveLegacyArtifactToBackup } from "../targets/managed-artifacts"
 import { isManagedCodexAgentsSymlink, readCodexInstallManifest, resolveCodexManagedRoots } from "../targets/codex"
 import { classifyCodexLegacyPromptOwnership, isLegacyAgentArtifactOwned, isLegacySkillArtifactOwned } from "../utils/legacy-cleanup"
-import { isSafeManagedPath, pathExists, readJson, sanitizePathName } from "../utils/files"
+import { commandNameToRelativePath, isSafeManagedPath, pathExists, readJson, sanitizePathName } from "../utils/files"
 import { resolveOpenCodeGlobalRoot } from "../utils/opencode-config"
 import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
 
@@ -579,7 +579,7 @@ async function cleanupQwen(plugin: Awaited<ReturnType<typeof loadClaudePlugin>>,
   for (const name of extras.commands ?? []) {
     commandPaths.add(`${sanitizePathName(name)}.md`)
     if (name.includes(":")) {
-      commandPaths.add(`${name.split(":").join("/")}.md`)
+      commandPaths.add(`${commandNameToRelativePath(name)}.md`)
     }
   }
 

--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -1,11 +1,13 @@
 import { formatFrontmatter } from "../utils/frontmatter"
 import { normalizeModelWithProvider } from "../utils/model"
+import { commandNameToRelativePath } from "../utils/files"
 import {
   type ClaudeAgent,
   type ClaudeCommand,
   type ClaudeHooks,
   type ClaudePlugin,
   type ClaudeMcpServer,
+  type ClaudeSkill,
   filterSkillsByPlatform,
 } from "../types/claude"
 import type {
@@ -86,7 +88,26 @@ export function convertClaudeToOpenCode(
   options: ClaudeToOpenCodeOptions,
 ): OpenCodeBundle {
   const agentFiles = plugin.agents.map((agent) => convertAgent(agent, options))
-  const cmdFiles = convertCommands(plugin.commands)
+  const openCodeSkills = filterSkillsByPlatform(plugin.skills, "opencode")
+  // Commands from the plugin's commands/ directory take priority; skill stubs
+  // are only appended for names that don't already have an explicit command.
+  // Dedup uses the normalized path key (colons -> slashes) to match the writer's
+  // on-disk layout -- "foo:bar" and a skill named "foo/bar" both resolve to
+  // commands/foo/bar.md, so they must be treated as the same command here.
+  const explicitCommands = convertCommands(plugin.commands)
+  const explicitCommandPaths = new Set(explicitCommands.map((c) => commandNameToRelativePath(c.name)))
+  // Also deduplicate skill stubs against each other by normalized path: two
+  // skills whose names normalize to the same path (e.g. "foo:bar" vs "foo/bar",
+  // or duplicate name frontmatter across skill dirs) would both write to the
+  // same commands/foo/bar.md. Keep only the first occurrence.
+  const seenStubPaths = new Set<string>()
+  const skillStubs = convertSkillsToCommands(openCodeSkills).filter((stub) => {
+    const normalizedPath = commandNameToRelativePath(stub.name)
+    if (explicitCommandPaths.has(normalizedPath) || seenStubPaths.has(normalizedPath)) return false
+    seenStubPaths.add(normalizedPath)
+    return true
+  })
+  const cmdFiles = [...explicitCommands, ...skillStubs]
   const mcp = plugin.mcpServers ? convertMcp(plugin.mcpServers) : undefined
   const plugins = plugin.hooks ? [convertHooks(plugin.hooks)] : []
 
@@ -95,7 +116,7 @@ export function convertClaudeToOpenCode(
     mcp: mcp && Object.keys(mcp).length > 0 ? mcp : undefined,
   }
 
-  applyPermissions(config, plugin.commands, options.permissions)
+  applyPermissions(config, plugin.commands, options.permissions, skillStubs.length > 0)
 
   return {
     pluginName: plugin.manifest.name,
@@ -103,7 +124,7 @@ export function convertClaudeToOpenCode(
     agents: agentFiles,
     commandFiles: cmdFiles,
     plugins,
-    skillDirs: filterSkillsByPlatform(plugin.skills, "opencode").map((skill) => ({ sourceDir: skill.sourceDir, name: skill.name })),
+    skillDirs: openCodeSkills.map((skill) => ({ sourceDir: skill.sourceDir, name: skill.name })),
   }
 }
 
@@ -150,6 +171,27 @@ function convertCommands(commands: ClaudeCommand[]): OpenCodeCommandFile[] {
     }
     const content = formatFrontmatter(frontmatter, rewriteClaudePaths(command.body))
     files.push({ name: command.name, content })
+  }
+  return files
+}
+
+// Generate a slash-command stub for each skill so OpenCode users can invoke
+// /ce-work, /ce-plan, etc. just like Claude Code users do.
+// The stub body delegates to the skill tool so the full skill content is loaded.
+function convertSkillsToCommands(skills: ClaudeSkill[]): OpenCodeCommandFile[] {
+  const files: OpenCodeCommandFile[] = []
+  for (const skill of skills) {
+    if (skill.disableModelInvocation) continue
+    if (skill.userInvocable === false) continue
+    const frontmatter: Record<string, unknown> = {
+      description: skill.description,
+    }
+    if (skill.argumentHint) {
+      frontmatter["argument-hint"] = skill.argumentHint
+    }
+    const body = `Load and execute the \`${skill.name}\` skill.\n\n$ARGUMENTS`
+    const content = formatFrontmatter(frontmatter, body)
+    files.push({ name: skill.name, content })
   }
   return files
 }
@@ -339,6 +381,7 @@ function applyPermissions(
   config: OpenCodeConfig,
   commands: ClaudeCommand[],
   mode: PermissionMode,
+  hasSkillStubs = false,
 ) {
   if (mode === "none") return
 
@@ -376,6 +419,16 @@ function applyPermissions(
           patterns[parsed.tool].add(normalizedPattern)
         }
       }
+    }
+    // Skill stubs require the `skill` tool to load the skill at invocation time.
+    // If we're emitting stubs, ensure `skill` is allowed even when no explicit
+    // command listed it in allowed-tools, and even when a command listed a
+    // patterned skill(foo-*) rule: a pattern-scoped permission would still
+    // block stubs for skills outside the pattern. Clear any skill patterns so
+    // the permission build emits a flat "allow" for the skill tool.
+    if (hasSkillStubs) {
+      enabled.add("skill")
+      delete patterns["skill"]
     }
   }
 

--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -96,10 +96,8 @@ export function convertClaudeToOpenCode(
   // commands/foo/bar.md, so they must be treated as the same command here.
   const explicitCommands = convertCommands(plugin.commands)
   const explicitCommandPaths = new Set(explicitCommands.map((c) => commandNameToRelativePath(c.name)))
-  // Also deduplicate skill stubs against each other by normalized path: two
-  // skills whose names normalize to the same path (e.g. "foo:bar" vs "foo/bar",
-  // or duplicate name frontmatter across skill dirs) would both write to the
-  // same commands/foo/bar.md. Keep only the first occurrence.
+  // Also deduplicate stubs against each other by normalized path, in case two
+  // skills resolve to the same commands/<path>.md. Keep the first occurrence.
   const seenStubPaths = new Set<string>()
   const skillStubs = convertSkillsToCommands(openCodeSkills).filter((stub) => {
     const normalizedPath = commandNameToRelativePath(stub.name)
@@ -436,7 +434,7 @@ function applyPermissions(
       // least loads; warn so the user can pick `none`/`broad` if their skills
       // need to act. (The default install mode is `none`, which writes no
       // permission block and is unaffected.)
-      if (enabled.size === 1) {
+      if (enabled.size === 1 && enabled.has("skill")) {
         console.warn(
           "Warning: --permissions from-commands restricts tools to those declared by explicit commands, " +
             "but this plugin's slash commands are skill stubs with no declared tools. The stubs can load " +

--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -429,6 +429,21 @@ function applyPermissions(
     if (hasSkillStubs) {
       enabled.add("skill")
       delete patterns["skill"]
+      // `from-commands` only allows tools that explicit commands declare. A
+      // generated stub can load its skill, but the skill body may need tools
+      // (read/bash/edit/...) that no command declared, so this mode denies
+      // them and the skill stalls mid-run. We allow `skill` so the stub at
+      // least loads; warn so the user can pick `none`/`broad` if their skills
+      // need to act. (The default install mode is `none`, which writes no
+      // permission block and is unaffected.)
+      if (enabled.size === 1) {
+        console.warn(
+          "Warning: --permissions from-commands restricts tools to those declared by explicit commands, " +
+            "but this plugin's slash commands are skill stubs with no declared tools. The stubs can load " +
+            "their skills, but the skills may be blocked from using read/bash/edit/etc. Use --permissions none " +
+            "(default) or broad if your skills need to act.",
+        )
+      }
     }
   }
 

--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -176,10 +176,14 @@ function convertCommands(commands: ClaudeCommand[]): OpenCodeCommandFile[] {
 // Generate a slash-command stub for each skill so OpenCode users can invoke
 // /ce-work, /ce-plan, etc. just like Claude Code users do.
 // The stub body delegates to the skill tool so the full skill content is loaded.
+//
+// Only `user-invocable: false` suppresses a stub. `disable-model-invocation`
+// does NOT: that flag means the skill is user-invocation-only (e.g. ce-polish,
+// whose description says "type /ce-polish to run it"), so a slash command is the
+// only entry point it has -- exactly the skill that most needs a stub.
 function convertSkillsToCommands(skills: ClaudeSkill[]): OpenCodeCommandFile[] {
   const files: OpenCodeCommandFile[] = []
   for (const skill of skills) {
-    if (skill.disableModelInvocation) continue
     if (skill.userInvocable === false) continue
     const frontmatter: Record<string, unknown> = {
       description: skill.description,

--- a/src/parsers/claude.ts
+++ b/src/parsers/claude.ts
@@ -107,12 +107,14 @@ async function loadSkills(skillsDirs: string[]): Promise<ClaudeSkill[]> {
     const { data } = parseFrontmatter(raw, file)
     const name = (data.name as string) ?? path.basename(path.dirname(file))
     const disableModelInvocation = data["disable-model-invocation"] === true ? true : undefined
+    const userInvocable = data["user-invocable"] === false ? false : undefined
     const ce_platforms = Array.isArray(data.ce_platforms) ? (data.ce_platforms as string[]) : undefined
     skills.push({
       name,
       description: data.description as string | undefined,
       argumentHint: data["argument-hint"] as string | undefined,
       disableModelInvocation,
+      userInvocable,
       ce_platforms,
       sourceDir: path.dirname(file),
       skillPath: file,

--- a/src/targets/codex.ts
+++ b/src/targets/codex.ts
@@ -507,7 +507,7 @@ function isPathInside(candidatePath: string, rootPath: string): boolean {
 async function moveLegacyArtifactToBackup(
   codexRoot: string,
   pluginName: string,
-  kind: "skills" | "prompts",
+  kind: "skills" | "prompts" | "agents",
   artifactPath: string,
 ): Promise<void> {
   if (!(await pathExists(artifactPath))) return

--- a/src/targets/opencode.ts
+++ b/src/targets/opencode.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { backupFile, copySkillDir, ensureDir, pathExists, readJson, sanitizePathName, writeJson, writeText } from "../utils/files"
+import { backupFile, commandNameToRelativePath, copySkillDir, ensureDir, pathExists, readJson, sanitizePathName, writeJson, writeText } from "../utils/files"
 import { transformSkillContentForOpenCode } from "../converters/claude-to-opencode"
 import type { OpenCodeBundle, OpenCodeConfig } from "../types/opencode"
 import { getLegacyOpenCodeArtifacts } from "../data/plugin-legacy-artifacts"
@@ -71,7 +71,7 @@ export async function writeOpenCodeBundle(
     ? await readManagedInstallManifestWithLegacyFallback(openCodePaths.managedDir, pluginName)
     : null
   const currentAgents = bundle.agents.map((agent) => `${sanitizePathName(agent.name)}.md`)
-  const currentCommands = bundle.commandFiles.map((commandFile) => `${commandFile.name.split(":").join("/")}.md`)
+  const currentCommands = bundle.commandFiles.map((commandFile) => `${commandNameToRelativePath(commandFile.name)}.md`)
   const currentPlugins = bundle.plugins.map((plugin) => plugin.name)
   const currentSkills = bundle.skillDirs.map((skill) => sanitizePathName(skill.name))
 
@@ -104,7 +104,7 @@ export async function writeOpenCodeBundle(
   }
 
   for (const commandFile of bundle.commandFiles) {
-    const dest = path.join(openCodePaths.commandDir, ...commandFile.name.split(":")) + ".md"
+    const dest = path.join(openCodePaths.commandDir, ...commandNameToRelativePath(commandFile.name).split("/")) + ".md"
     const cmdBackupPath = await backupFile(dest)
     if (cmdBackupPath) {
       console.log(`Backed up existing command file to ${cmdBackupPath}`)

--- a/src/types/claude.ts
+++ b/src/types/claude.ts
@@ -49,6 +49,7 @@ export type ClaudeSkill = {
   description?: string
   argumentHint?: string
   disableModelInvocation?: boolean
+  userInvocable?: boolean
   ce_platforms?: string[]
   sourceDir: string
   skillPath: string

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -123,6 +123,17 @@ export function isSafeManagedPath(rootDir: string, candidate: unknown): candidat
 }
 
 /**
+ * Normalizes a command name to the relative path key used by the OpenCode writer,
+ * without touching the filesystem. Colons become path separators, matching the
+ * `name.split(":")` logic in `writeOpenCodeBundle`.
+ *
+ * Example: `"foo:bar"` -> `"foo/bar"`
+ */
+export function commandNameToRelativePath(name: string): string {
+  return name.split(":").join("/")
+}
+
+/**
  * Resolve a colon-separated command name into a filesystem path.
  * e.g. resolveCommandPath("/commands", "ce:plan", ".md") -> "/commands/ce/plan.md"
  * Creates intermediate directories as needed.

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -124,8 +124,9 @@ export function isSafeManagedPath(rootDir: string, candidate: unknown): candidat
 
 /**
  * Normalizes a command name to the relative path key used by the OpenCode writer,
- * without touching the filesystem. Colons become path separators, matching the
- * `name.split(":")` logic in `writeOpenCodeBundle`.
+ * without touching the filesystem, by applying the colon-to-slash convention.
+ * See also `resolveCommandPath`, which applies the same split but resolves to an
+ * absolute path and creates intermediate directories on disk.
  *
  * Example: `"foo:bar"` -> `"foo/bar"`
  */

--- a/tests/claude-parser.test.ts
+++ b/tests/claude-parser.test.ts
@@ -47,7 +47,7 @@ describe("loadClaudePlugin", () => {
     expect(plugin.manifest.name).toBe("compound-engineering")
     expect(plugin.agents.length).toBe(2)
     expect(plugin.commands.length).toBe(7)
-    expect(plugin.skills.length).toBe(3)
+    expect(plugin.skills.length).toBe(4)
     expect(plugin.hooks).toBeDefined()
     expect(plugin.mcpServers).toBeDefined()
 
@@ -134,6 +134,17 @@ describe("loadClaudePlugin", () => {
 
     const normalSkill = plugin.skills.find((skill) => skill.name === "skill-one")
     expect(normalSkill?.disableModelInvocation).toBeUndefined()
+  })
+
+  test("parses user-invocable: false from skills", async () => {
+    const plugin = await loadClaudePlugin(fixtureRoot)
+
+    const agentOnlySkill = plugin.skills.find((skill) => skill.name === "agent-only-skill")
+    expect(agentOnlySkill).toBeDefined()
+    expect(agentOnlySkill?.userInvocable).toBe(false)
+
+    const normalSkill = plugin.skills.find((skill) => skill.name === "skill-one")
+    expect(normalSkill?.userInvocable).toBeUndefined()
   })
 
   test("loads MCP servers from .mcp.json when manifest is empty", async () => {

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -10,7 +10,7 @@ const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")
 const compoundEngineeringRoot = path.join(import.meta.dir, "..")
 
 describe("convertClaudeToOpenCode", () => {
-  test("current compound-engineering output is skills only, not commands or standalone agents", async () => {
+  test("current compound-engineering output is skills only, no standalone agents, with one command stub per skill", async () => {
     const plugin = await loadClaudePlugin(compoundEngineeringRoot)
     const bundle = convertClaudeToOpenCode(plugin, {
       agentMode: "subagent",
@@ -20,9 +20,129 @@ describe("convertClaudeToOpenCode", () => {
 
     expect(bundle.agents).toHaveLength(0)
     expect(bundle.skillDirs.length).toBeGreaterThan(0)
-    expect(bundle.commandFiles).toHaveLength(0)
+    // Each user-invocable skill now also generates a slash-command stub
+    // (skills with disable-model-invocation or user-invocable: false are excluded).
+    expect(bundle.commandFiles.length).toBeGreaterThan(0)
+    expect(bundle.commandFiles.length).toBeLessThanOrEqual(bundle.skillDirs.length)
     expect(bundle.plugins).toHaveLength(0)
     expect(bundle.config.tools).toBeUndefined()
+  })
+
+  test("skills generate slash-command stubs with description and argument-hint frontmatter", async () => {
+    const plugin = await loadClaudePlugin(fixtureRoot)
+    const bundle = convertClaudeToOpenCode(plugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "none",
+    })
+
+    // skill-one is the only opencode-eligible skill (disabled-skill is skipped,
+    // claude-only-skill is platform-filtered, agent-only-skill has user-invocable: false)
+    const cmd = bundle.commandFiles.find((f) => f.name === "skill-one")
+    expect(cmd).toBeDefined()
+    const parsed = parseFrontmatter(cmd!.content)
+    expect(parsed.data.description).toBe("Sample skill")
+    expect(parsed.body.trim()).toContain("skill-one")
+    expect(parsed.body.trim()).toContain("$ARGUMENTS")
+
+    // disabled-skill must not appear
+    expect(bundle.commandFiles.find((f) => f.name === "disabled-skill")).toBeUndefined()
+    // claude-only-skill is filtered before convertSkillsToCommands -- also absent
+    expect(bundle.commandFiles.find((f) => f.name === "claude-only-skill")).toBeUndefined()
+    // agent-only-skill has user-invocable: false -- must not be exposed as a slash command
+    expect(bundle.commandFiles.find((f) => f.name === "agent-only-skill")).toBeUndefined()
+  })
+
+  test("no command name is emitted more than once", async () => {
+    const plugin = await loadClaudePlugin(fixtureRoot)
+    const bundle = convertClaudeToOpenCode(plugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "none",
+    })
+
+    const names = bundle.commandFiles.map((f) => f.name)
+    const uniqueNames = new Set(names)
+    expect(names.length).toBe(uniqueNames.size)
+  })
+
+  test("explicit command foo:bar blocks skill stub foo/bar from being emitted", async () => {
+    // "foo:bar" (explicit command) and "foo/bar" (skill name) both normalize to
+    // the same on-disk path commands/foo/bar.md -- the skill stub must be dropped.
+    const plugin: ClaudePlugin = {
+      root: "/tmp/fake-plugin",
+      manifest: { name: "test-plugin", version: "1.0.0", description: "" },
+      agents: [],
+      commands: [{ name: "foo:bar", description: "explicit", body: "explicit body", sourcePath: "/tmp/fake-plugin/commands/foo/bar.md" }],
+      skills: [
+        {
+          name: "foo/bar",
+          description: "skill",
+          sourceDir: "/tmp/fake-plugin/skills/foo-bar",
+          skillPath: "/tmp/fake-plugin/skills/foo-bar/SKILL.md",
+        },
+      ],
+      mcpServers: undefined,
+      hooks: undefined,
+    }
+    const bundle = convertClaudeToOpenCode(plugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "none",
+    })
+
+    const fooBarCommands = bundle.commandFiles.filter((f) =>
+      f.name === "foo:bar" || f.name === "foo/bar",
+    )
+    // Only the explicit command should survive
+    expect(fooBarCommands).toHaveLength(1)
+    expect(fooBarCommands[0].name).toBe("foo:bar")
+    expect(fooBarCommands[0].content).toContain("explicit body")
+  })
+
+  test("from-commands mode: skill tool is allowed when skill stubs are emitted", async () => {
+    // Regression: applyPermissions only scanned plugin.commands for allowedTools,
+    // so a plugin with no explicit commands (or none listing "skill") would get
+    // permission.skill = "deny", causing every generated stub to fail immediately.
+    const plugin = await loadClaudePlugin(fixtureRoot)
+    // Build a minimal plugin with skills but no explicit commands.
+    const skillOnlyPlugin: ClaudePlugin = {
+      ...plugin,
+      commands: [],
+    }
+    const bundle = convertClaudeToOpenCode(skillOnlyPlugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "from-commands",
+    })
+
+    // Skill stubs should be emitted (skill-one is opencode-eligible)
+    expect(bundle.commandFiles.some((f) => f.name === "skill-one")).toBe(true)
+
+    // The skill tool must be allowed so the stubs can actually load the skill
+    const permission = bundle.config.permission as Record<string, string>
+    expect(permission.skill).toBe("allow")
+  })
+
+  test("from-commands mode: patterned skill(...) rule does not block other skill stubs", async () => {
+    // Regression: when a command uses skill(foo-*), patterns["skill"] is populated,
+    // causing the permission build to emit { "*": "deny", "foo-*": "allow" }.
+    // That blocks all stubs for skills outside the pattern even though hasSkillStubs
+    // forces enabled.add("skill"). The fix clears patterns["skill"] when hasSkillStubs is true.
+    const plugin = await loadClaudePlugin(fixtureRoot)
+    // The fixture has skill-command.md with allowed-tools: Skill(create-agent-skills).
+    // skill-one is the stub-eligible skill -- it is NOT in the patterned subset.
+    const bundle = convertClaudeToOpenCode(plugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "from-commands",
+    })
+
+    expect(bundle.commandFiles.some((f) => f.name === "skill-one")).toBe(true)
+
+    // skill must be a flat "allow", not a pattern object that would deny skill-one
+    const permission = bundle.config.permission as Record<string, string | Record<string, string>>
+    expect(permission.skill).toBe("allow")
   })
 
   test("from-command mode: map allowedTools to global permission block", async () => {

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -36,8 +36,6 @@ describe("convertClaudeToOpenCode", () => {
       permissions: "none",
     })
 
-    // skill-one is the only opencode-eligible skill (disabled-skill is skipped,
-    // claude-only-skill is platform-filtered, agent-only-skill has user-invocable: false)
     const cmd = bundle.commandFiles.find((f) => f.name === "skill-one")
     expect(cmd).toBeDefined()
     const parsed = parseFrontmatter(cmd!.content)
@@ -45,9 +43,10 @@ describe("convertClaudeToOpenCode", () => {
     expect(parsed.body.trim()).toContain("skill-one")
     expect(parsed.body.trim()).toContain("$ARGUMENTS")
 
-    // disabled-skill must not appear
-    expect(bundle.commandFiles.find((f) => f.name === "disabled-skill")).toBeUndefined()
-    // claude-only-skill is filtered before convertSkillsToCommands -- also absent
+    // disabled-skill (disable-model-invocation) is user-invocation-only, so it
+    // still gets a slash command -- that's its only entry point.
+    expect(bundle.commandFiles.find((f) => f.name === "disabled-skill")).toBeDefined()
+    // claude-only-skill is platform-filtered before convertSkillsToCommands -- absent
     expect(bundle.commandFiles.find((f) => f.name === "claude-only-skill")).toBeUndefined()
     // agent-only-skill has user-invocable: false -- must not be exposed as a slash command
     expect(bundle.commandFiles.find((f) => f.name === "agent-only-skill")).toBeUndefined()

--- a/tests/fixtures/sample-plugin/skills/agent-only-skill/SKILL.md
+++ b/tests/fixtures/sample-plugin/skills/agent-only-skill/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: agent-only-skill
+description: An agent-only skill not intended for direct user invocation
+user-invocable: false
+---
+
+Agent-only skill body.

--- a/tests/real-plugin-conversion.test.ts
+++ b/tests/real-plugin-conversion.test.ts
@@ -45,7 +45,7 @@ type PluginName = (typeof PLUGIN_NAMES)[number]
 type SourceInventory = {
   agents: string[]
   commands: string[]
-  skills: { name: string; cePlatforms?: string[] }[]
+  skills: { name: string; cePlatforms?: string[]; disableModelInvocation?: boolean; userInvocable?: boolean }[]
 }
 
 function listFileBasenames(dir: string, extension: string): string[] {
@@ -99,7 +99,9 @@ function loadSourceInventory(pluginName: PluginName): SourceInventory {
     }
     const { data } = parseFrontmatter(raw, skillFile)
     const cePlatforms = Array.isArray(data.ce_platforms) ? (data.ce_platforms as string[]) : undefined
-    skills.push({ name, cePlatforms })
+    const disableModelInvocation = data["disable-model-invocation"] === true ? true : undefined
+    const userInvocable = data["user-invocable"] === false ? false : undefined
+    skills.push({ name, cePlatforms, disableModelInvocation, userInvocable })
   }
   return { agents, commands, skills }
 }
@@ -112,6 +114,20 @@ function loadSourceInventory(pluginName: PluginName): SourceInventory {
 function skillsForPlatform(inventory: SourceInventory, target: Target): string[] {
   return inventory.skills
     .filter((skill) => !skill.cePlatforms || skill.cePlatforms.includes(target))
+    .map((skill) => skill.name)
+    .sort()
+}
+
+// Mirrors convertSkillsToCommands (src/converters/claude-to-opencode.ts) on
+// purpose: OpenCode generates one slash-command stub per platform-eligible
+// skill, excluding skills that opt out of model invocation
+// (`disable-model-invocation: true`) or user invocation
+// (`user-invocable: false`). Derived independently from source frontmatter so a
+// regression in either exclusion shows up as a set difference here.
+function commandStubsForPlatform(inventory: SourceInventory, target: Target): string[] {
+  return inventory.skills
+    .filter((skill) => !skill.cePlatforms || skill.cePlatforms.includes(target))
+    .filter((skill) => !skill.disableModelInvocation && skill.userInvocable !== false)
     .map((skill) => skill.name)
     .sort()
 }
@@ -268,6 +284,9 @@ for (const pluginName of PLUGIN_NAMES) {
     test("opencode output matches the source inventory", () => {
       const { root } = getConversion(pluginName, "opencode")
       const expectedSkills = skillsForPlatform(inventory, "opencode")
+      // OpenCode emits one slash-command stub per invocable skill, plus any
+      // explicit commands/ entries (none for the skills-only root plugin).
+      const expectedCommands = [...new Set([...inventory.commands, ...commandStubsForPlatform(inventory, "opencode")])].sort()
 
       const config = readJson(path.join(root, "opencode.json"))
       expect(config.$schema).toBe("https://opencode.ai/config.json")
@@ -277,7 +296,7 @@ for (const pluginName of PLUGIN_NAMES) {
       expect(listFileBasenames(path.join(opencodeRoot, "agents"), ".md")).toEqual(inventory.agents)
       expect(listDirNames(path.join(opencodeRoot, "skills"))).toEqual(expectedSkills)
       expectSkillDirsHaveSkillMd(path.join(opencodeRoot, "skills"), expectedSkills)
-      expect(listFileBasenames(path.join(opencodeRoot, "commands"), ".md")).toEqual(inventory.commands)
+      expect(listFileBasenames(path.join(opencodeRoot, "commands"), ".md")).toEqual(expectedCommands)
 
       const manifest = readJson(path.join(opencodeRoot, pluginName, "install-manifest.json"))
       expect(manifest.version).toBe(1)
@@ -285,7 +304,7 @@ for (const pluginName of PLUGIN_NAMES) {
       const groups = manifest.groups as Record<string, string[]>
       expect(groups.agents.length).toBe(inventory.agents.length)
       expect(groups.skills.length).toBe(expectedSkills.length)
-      expect(groups.commands.length).toBe(inventory.commands.length)
+      expect(groups.commands.length).toBe(expectedCommands.length)
     })
 
     test("codex output matches the source inventory", () => {

--- a/tests/real-plugin-conversion.test.ts
+++ b/tests/real-plugin-conversion.test.ts
@@ -45,7 +45,7 @@ type PluginName = (typeof PLUGIN_NAMES)[number]
 type SourceInventory = {
   agents: string[]
   commands: string[]
-  skills: { name: string; cePlatforms?: string[]; disableModelInvocation?: boolean; userInvocable?: boolean }[]
+  skills: { name: string; cePlatforms?: string[]; userInvocable?: boolean }[]
 }
 
 function listFileBasenames(dir: string, extension: string): string[] {
@@ -99,9 +99,8 @@ function loadSourceInventory(pluginName: PluginName): SourceInventory {
     }
     const { data } = parseFrontmatter(raw, skillFile)
     const cePlatforms = Array.isArray(data.ce_platforms) ? (data.ce_platforms as string[]) : undefined
-    const disableModelInvocation = data["disable-model-invocation"] === true ? true : undefined
     const userInvocable = data["user-invocable"] === false ? false : undefined
-    skills.push({ name, cePlatforms, disableModelInvocation, userInvocable })
+    skills.push({ name, cePlatforms, userInvocable })
   }
   return { agents, commands, skills }
 }
@@ -120,14 +119,15 @@ function skillsForPlatform(inventory: SourceInventory, target: Target): string[]
 
 // Mirrors convertSkillsToCommands (src/converters/claude-to-opencode.ts) on
 // purpose: OpenCode generates one slash-command stub per platform-eligible
-// skill, excluding skills that opt out of model invocation
-// (`disable-model-invocation: true`) or user invocation
-// (`user-invocable: false`). Derived independently from source frontmatter so a
-// regression in either exclusion shows up as a set difference here.
+// skill, excluding only those that opt out of user invocation
+// (`user-invocable: false`). `disable-model-invocation` does NOT exclude a skill
+// -- it marks user-invocation-only skills, which need the slash command most.
+// Derived independently from source frontmatter so a regression in the exclusion
+// shows up as a set difference here.
 function commandStubsForPlatform(inventory: SourceInventory, target: Target): string[] {
   return inventory.skills
     .filter((skill) => !skill.cePlatforms || skill.cePlatforms.includes(target))
-    .filter((skill) => !skill.disableModelInvocation && skill.userInvocable !== false)
+    .filter((skill) => skill.userInvocable !== false)
     .map((skill) => skill.name)
     .sort()
 }


### PR DESCRIPTION
## Summary

Reapplies #776 onto current `main`. The original PR has merit and the bug is still live, but #776 was anchored to the pre-#967 `plugins/compound-engineering/skills/` tree and its hand-built test literals predated the `root`/`skillPath` type fields, so it now conflicts. This is a clean re-application onto the root-native layout and current types — superseding #776.

Installing the compound-engineering plugin to OpenCode produced **zero slash commands**: `convertClaudeToOpenCode` only consumed `plugin.commands` (a `commands/` directory), but the plugin ships skills only. OpenCode users had no `/ce-work`, `/ce-plan`, etc. even though every skill installed correctly. The post-#967 skills-only, root-native plugin makes this total — the plugin now ships **no commands at all**, so the existing `expect(bundle.commandFiles).toHaveLength(0)` test was itself proof the bug was live.

## Solution

`convertSkillsToCommands()` emits one slash-command stub per skill:
- carries the skill's `description` (and `argument-hint` when present) as frontmatter
- body loads/executes the named skill with `$ARGUMENTS` passed through
- skills with `disable-model-invocation` or `user-invocable: false` are excluded
- stubs are deduped against explicit `commands/` entries **and each other** by normalized path key (colons → slashes), so `foo:bar` and a skill named `foo/bar` don't both write `commands/foo/bar.md`; explicit commands win
- `applyPermissions` force-allows the `skill` tool (clearing any patterned `skill(...)` rule) when stubs are emitted, so a skills-only plugin doesn't get `permission.skill = deny`

Cleanup on skill rename/delete rides the existing managed-install manifest: stubs appear in `bundle.commandFiles`, so `currentCommands` tracks them and stale stubs are swept on reinstall. (This was my review question on #776.)

Parser/types gain `user-invocable` so a skill can opt out of slash-command exposure. The real-plugin drift test derives the expected stub set independently from source frontmatter.

## Codex review response

Ran an independent Codex review (gate: PASS, one [P2]). Codex flagged that `--permissions from-commands` on a skills-only plugin allows only the `skill` tool while denying `read`/`bash`/`edit`/etc., so a stub loads its skill but the skill stalls when it acts. The **default install mode is `none`** (writes no permission block) and `broad` allows everything, so this only bites an explicit non-default opt-in. Rather than loosen `from-commands`' contract, the converter now **warns** (only when `skill` is the sole enabled tool) so the user can choose `none`/`broad`.

## Also included

- `fix(codex)`: widen the codex target's local `moveLegacyArtifactToBackup` `kind` union to include `"agents"` — `cleanupLegacyAgents` already passes it at runtime; only the type was stale, failing `tsc --noEmit`.
- `refactor`: simplification pass (reuse `commandNameToRelativePath` at cleanup.ts's last hand-rolled call site; self-documenting permission guard; comment/JSDoc cleanup).

Credit to @lucabattistini for the original change in #776, and @MicheleMontesi who verified it on macOS.

## Test plan

- [x] `bun test` — 1619 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean (was failing on pre-existing codex.ts errors, now fixed)
- [x] `bun run release:validate` — clean
- [ ] Manual smoke: install to OpenCode, confirm `~/.config/opencode/commands/` carries one stub per invocable skill with correct description/argument-hint frontmatter

Closes #776