### PR TITLE
fix(ce-code-review): annotate model tier in Stage 3 team announce; read it at Stage 4 dispatch

### DIFF
--- a/skills/ce-code-review/SKILL.md
+++ b/skills/ce-code-review/SKILL.md
@@ -306,21 +306,23 @@ Stack-specific personas are additive when runtime behavior warrants them. A Hotw
 
 For `deployment-verification-agent`, use the same migration-artifact gate when the change is risky (destructive DDL, backfills, NOT NULL without default, column renames/drops).
 
-Announce the team before spawning:
+Announce the team before spawning. Tag each reviewer with its model tier (`[session model]` or `[mid-tier]`) — this annotation is the authoritative input Stage 4 reads to apply the dispatch-time override, so it must be present and accurate before any agent is dispatched:
 
 ```
 Review team:
-- correctness (always)
-- testing (always)
-- maintainability (always)
-- project-standards (always)
-- agent-native-reviewer (always)
-- learnings-researcher (always)
-- security -- new endpoint in routes.rb accepts user-provided redirect URL
-- julik-frontend-races -- Stimulus controller with async DOM updates
-- data-migration -- adds migration 20260303_add_index_to_orders
-- deployment-verification-agent -- destructive migration with backfill
+- correctness (always) [session model]
+- testing (always) [mid-tier]
+- maintainability (always) [mid-tier]
+- project-standards (always) [mid-tier]
+- agent-native-reviewer (always) [mid-tier]
+- learnings-researcher (always) [mid-tier]
+- security -- new endpoint in routes.rb accepts user-provided redirect URL [session model]
+- julik-frontend-races -- Stimulus controller with async DOM updates [mid-tier]
+- data-migration -- adds migration 20260303_add_index_to_orders [mid-tier]
+- deployment-verification-agent -- destructive migration with backfill [mid-tier]
 ```
+
+Tag `[session model]` only for `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer`; every other persona and CE agent gets `[mid-tier]` (see Model tiering below for the rationale).
 
 This is progress reporting, not a blocking confirmation.
 
@@ -360,7 +362,12 @@ Pass `{run_id}` to every persona sub-agent so they can write their full analysis
 
 Omit the `mode` parameter when dispatching sub-agents so the user's configured permission settings apply. Do not pass `mode: "auto"`.
 
-**Model override at dispatch time.** Pass the platform's mid-tier model on every dispatch except `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer`, which inherit the session model (per the Model tiering subsection above). In Claude Code, that is the Sonnet class. In Codex, use the current mini/mid-tier model exposed by `spawn_agent` when known. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name. Check this on every Agent / `spawn_agent` / subagent call in the parallel dispatch; omitting it on a top-tier parent session can multiply review cost.
+**Model override at dispatch time — check this before every dispatch call.** Omitting it on a top-tier parent session (e.g. Opus) silently multiplies review cost. For each reviewer, read the `[session model]` / `[mid-tier]` tag from the Stage 3 team announce and apply it — do not re-derive the tier from the rules at dispatch time:
+
+- `[session model]` → no override; the reviewer inherits the session model. This covers `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer`.
+- `[mid-tier]` → pass the platform's mid-tier model. In Claude Code, that is the Sonnet class. In Codex, use the current mini/mid-tier model exposed by `spawn_agent` when known. On platforms where the dispatch primitive has no model-override parameter or the available model names are unknown, omit the override — a working review on the parent model beats a broken dispatch on an unrecognized name.
+
+The Stage 3 annotation is the single source of truth for model assignment; apply it on every Agent / `spawn_agent` / subagent call in the parallel dispatch.
 
 **Bounded parallel dispatch.** Respect the current harness's active-subagent limit. Queue selected reviewers, dispatch only as many as the harness accepts, and fill freed slots as reviewers complete. Treat active-agent/thread/concurrency-limit spawn errors as backpressure, not reviewer failure: leave the reviewer queued and retry after a slot frees. Record a reviewer as failed only after a successful dispatch times out/fails, or when dispatch fails for a non-capacity reason.
 


### PR DESCRIPTION
## Summary

In `ce-code-review`, which model each reviewer runs on is now decided once — when the review team is selected — instead of being a rule the orchestrator has to remember to re-apply at each dispatch call. Previously the "use the cheaper mid-tier model for non-critical reviewers" instruction lived only as a prose paragraph at dispatch time, after the structural mechanics (run ID, diff staging, parallelism). An orchestrator could satisfy every structural step and skip the override, defaulting all reviewers to the session model — silently 3-4x'ing the cost of a review on Opus sessions, with no warning (fixes #965).

## Approach

Make the model tier a first-class output of reviewer selection (Stage 3), so dispatch (Stage 4) becomes mechanical: read the tag, apply it.

- **Stage 3 team announce** — every reviewer line now carries a `[session model]` or `[mid-tier]` tag, framed as the authoritative input Stage 4 reads. A one-line rule states that only `correctness-reviewer`, `security-reviewer`, and `adversarial-reviewer` get session model; everyone else gets mid-tier.
- **Stage 4 dispatch** — the cost warning now leads the paragraph, and the instruction says "read the tag from the Stage 3 announce and apply it" (with a bullet per tag value) instead of restating the tiering rule inline where it was easy to walk past.

## Relationship to #966

This re-implements the design from community PR #966 (by @sraj5gilead), which could not be merged as submitted: it targeted a path that doesn't exist in this repo (`plugins/compound-engineering/skills/...` vs `skills/...`), conflicted with `main`, and was authored against a stale version of the file using outdated reviewer names and platform references no longer present on `main`. The diagnosis and the annotate-at-selection idea are theirs; this PR applies them against current `main` with correct paths and naming.

## Validation

Tested with the `skill-creator` eval workflow (the path that loads `SKILL.md` from disk, bypassing in-session plugin caching). 3 realistic review scenarios — a mixed redirect+migration+frontend diff, a tiny pure refactor, and a large JWT/auth change — were each run against this branch and against `origin/main`, 3 repetitions per cell (18 runs total). Prompts were deliberately model-agnostic (no mention of models, tiers, cost, or "sonnet") to test whether the skill makes the orchestrator *remember* the override rather than follow a hint.

| Scenario | Version | Emits tier tags | Applies mid-tier override | Critical reviewers on session model |
|---|---|---|---|---|
| mixed-concerns | this branch | 3/3 | 3/3 | 3/3 |
| mixed-concerns | `main` | 0/3 | 3/3 | 3/3 |
| small-refactor | this branch | 3/3 | 3/3 | 3/3 |
| small-refactor | `main` | 0/3 | 3/3 | 3/3 |
| large-auth | this branch | 3/3 | 3/3 | 3/3 |
| large-auth | `main` | 0/3 | 3/3 | 3/3 |

Takeaways: the new Stage 3 annotation works and is accurate (9/9 on this branch, 0/9 on `main` as expected), with no regression to override application or critical-reviewer handling. Honest limitation: both versions applied overrides correctly in all 18 runs, so this harness does **not** quantitatively prove the reliability fix — the #965 failure happens under live multi-agent dispatch pressure (real spawning, parallelism, backpressure), which a sub-agent cannot reproduce because it cannot spawn nested agents. The strongest evidence for the fix remains the original #965 incident; the eval confirms the change is correctly authored, accurate, and safe.

`bun run release:validate` passes (prose-only edit to one skill file; no count/metadata changes).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
