### PR TITLE
docs(opencode): use versionless placeholder for pinned-install example

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -10,11 +10,11 @@ Add Compound Engineering to the `plugin` array in your global or project `openco
 
 Restart OpenCode after changing the config. The OpenCode plugin registers the Compound Engineering skills directory directly; no Bun installer or generated skill copy is required.
 
-To pin a release, add a tag:
+To pin a release, add a tag. Replace `X.Y.Z` with the release you want — see the [releases page](https://github.com/EveryInc/compound-engineering-plugin/releases) for available tags:
 
 ```json
 {
-  "plugin": ["compound-engineering@git+https://github.com/EveryInc/compound-engineering-plugin.git#compound-engineering-v3.13.1"]
+  "plugin": ["compound-engineering@git+https://github.com/EveryInc/compound-engineering-plugin.git#compound-engineering-vX.Y.Z"]
 }
 ```
 


### PR DESCRIPTION
The OpenCode pinned-install example hardcoded `compound-engineering-v3.13.1`, a release-owned version that drifts behind every release-please bump — anyone copying it after a release would pin an outdated tag and miss newer fixes. The example now uses a `vX.Y.Z` placeholder with a pointer to the releases page, so it demonstrates the pinning syntax without ever going stale.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
