### PR TITLE
docs(readme): add Codex upgrade steps to Existing Installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,27 @@ agy plugin install ./compound-engineering-plugin/.agy
 
 ### Existing Installs
 
-Compound Engineering moved to a root-native, skills-only layout. An existing marketplace install keeps a **cached** marketplace entry that still points at the old `plugins/compound-engineering` path, so running `/plugin update` on its own reads that stale entry and leaves you on the previous version. On Claude Code, refresh the cached marketplace definition **first**, then update the plugin — order matters:
+Compound Engineering moved to a root-native, skills-only layout. An existing marketplace install keeps a **cached** marketplace snapshot that still points at the old `plugins/compound-engineering` path, so updating the plugin on its own reads that stale snapshot and leaves you on the previous version. Refresh the cached marketplace **first**, then update the plugin — order matters.
+
+**Claude Code**
 
 ```text
 /plugin marketplace update compound-engineering-plugin
 /plugin update compound-engineering
 ```
+
+**Codex CLI**
+
+```bash
+codex plugin marketplace upgrade compound-engineering-plugin
+codex plugin add compound-engineering@compound-engineering-plugin
+```
+
+There is no `codex plugin update`; re-running `add` reinstalls from the refreshed snapshot. For a non-default profile, run both commands against the same `CODEX_HOME`.
+
+**Codex App**
+
+Refresh the marketplace from the **Plugins** panel (remove and re-add the `EveryInc/compound-engineering-plugin` marketplace if there is no refresh control), then reinstall **compound-engineering** and restart Codex.
 
 If you configured a host with a direct path or sparse path under `plugins/compound-engineering`, edit or reinstall that source so it points at the repository root with no sparse path.
 


### PR DESCRIPTION
## Summary

Follow-up to #982, which surfaced the mandatory marketplace refresh for Claude Code but left Codex uncovered. The agentless refactor (#967) moved Codex's catalog path too — `.agents/plugins/marketplace.json` went from `./plugins/compound-engineering` to `./` — so an existing Codex install carries the same **stale cached snapshot** and a plain reinstall keeps users on the previous, agent-based version.

## What changed

- Restructured **Existing Installs** into per-platform blocks (was Claude Code only).
- **Codex CLI** — `codex plugin marketplace upgrade` then re-`add` (there is no `codex plugin update`; re-adding reinstalls from the refreshed snapshot), with a note to run both against the same `CODEX_HOME` for non-default profiles. Verified against the installed `codex` binary.
- **Codex App** — refresh the marketplace from the Plugins panel, then reinstall.

## Scope note

Cursor, Copilot, Droid, and Qwen are likely subject to the same stale-cache class, but their refresh syntax was not verified from this environment, so they are intentionally left out rather than documented from guesswork.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
