### PR TITLE
fix(metadata): align plugin and marketplace metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,11 +11,9 @@
   "plugins": [
     {
       "name": "compound-engineering",
-      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last.",
+      "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
       "author": {
-        "name": "Kieran Klaassen",
-        "url": "https://github.com/kieranklaassen",
-        "email": "kieran@every.to"
+        "name": "Kieran Klaassen and Trevin Chow"
       },
       "homepage": "https://github.com/EveryInc/compound-engineering-plugin",
       "tags": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,7 @@
 {
   "name": "compound-engineering-plugin",
   "owner": {
-    "name": "Kieran Klaassen",
-    "url": "https://github.com/kieranklaassen"
+    "name": "Kieran Klaassen and Trevin Chow"
   },
   "metadata": {
     "description": "Plugin marketplace for Claude Code and Codex extensions",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "compound-engineering",
-      "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
+      "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
       "author": {
         "name": "Kieran Klaassen and Trevin Chow"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,9 @@
 {
   "name": "compound-engineering",
   "version": "3.14.0",
-  "description": "AI-powered development tools for code review, research, design, and workflow automation.",
+  "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
   "author": {
-    "name": "Kieran Klaassen",
-    "email": "kieran@every.to",
-    "url": "https://github.com/kieranklaassen"
+    "name": "Kieran Klaassen and Trevin Chow"
   },
   "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",
   "repository": "https://github.com/EveryInc/compound-engineering-plugin",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
   "version": "3.14.0",
-  "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
+  "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
   "author": {
     "name": "Kieran Klaassen and Trevin Chow"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,14 +9,12 @@
   "repository": "https://github.com/EveryInc/compound-engineering-plugin",
   "license": "MIT",
   "keywords": [
-    "ai-powered",
-    "compound-engineering",
-    "workflow-automation",
+    "brainstorming",
     "code-review",
-    "rails",
-    "ruby",
-    "python",
-    "typescript",
-    "knowledge-management"
+    "compound-engineering",
+    "debugging",
+    "ideation",
+    "workflows",
+    "workflow-automation"
   ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
   "version": "3.14.0",
-  "description": "AI-powered development tools for code review, research, design, and workflow automation.",
+  "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
   "author": {
     "name": "Kieran Klaassen",
     "email": "kieran@every.to",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -38,6 +38,7 @@
       "/ce-code-review my changes"
     ],
     "brandColor": "#C9EFFA",
+    "composerIcon": "./assets/logo.png",
     "logo": "./assets/logo.png",
     "screenshots": []
   }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "compound-engineering",
   "version": "3.14.0",
-  "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
+  "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
   "author": {
     "name": "Kieran Klaassen and Trevin Chow"
   },
@@ -20,7 +20,7 @@
   "skills": "./skills/",
   "interface": {
     "displayName": "Compound Engineering",
-    "shortDescription": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
+    "shortDescription": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
     "longDescription": "Compound Engineering guides AI agents through the full engineering loop: strategy, ideation, requirements, planning, execution, debugging, review, PR feedback, and captured learnings that make future work easier.",
     "developerName": "Kieran Klaassen and Trevin Chow",
     "category": "Coding",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -3,23 +3,19 @@
   "version": "3.14.0",
   "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
   "author": {
-    "name": "Kieran Klaassen",
-    "email": "kieran@every.to",
-    "url": "https://github.com/kieranklaassen"
+    "name": "Kieran Klaassen and Trevin Chow"
   },
   "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",
   "repository": "https://github.com/EveryInc/compound-engineering-plugin",
   "license": "MIT",
   "keywords": [
-    "ai-powered",
-    "compound-engineering",
-    "workflow-automation",
+    "brainstorming",
     "code-review",
-    "rails",
-    "ruby",
-    "python",
-    "typescript",
-    "knowledge-management"
+    "compound-engineering",
+    "debugging",
+    "ideation",
+    "workflows",
+    "workflow-automation"
   ],
   "skills": "./skills/",
   "interface": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "compound-engineering",
       "source": ".",
-      "description": "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last."
+      "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents"
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -13,7 +13,7 @@
     {
       "name": "compound-engineering",
       "source": ".",
-      "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents"
+      "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents"
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "compound-engineering",
   "displayName": "Compound Engineering",
   "version": "3.14.0",
-  "description": "AI-powered development tools for code review, research, design, and workflow automation.",
+  "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
   "author": {
     "name": "Kieran Klaassen",
     "url": "https://github.com/kieranklaassen"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -5,7 +5,6 @@
   "description": "AI-powered development tools for code review, research, design, and workflow automation.",
   "author": {
     "name": "Kieran Klaassen",
-    "email": "kieran@every.to",
     "url": "https://github.com/kieranklaassen"
   },
   "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "compound-engineering",
   "displayName": "Compound Engineering",
   "version": "3.14.0",
-  "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
+  "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
   "author": {
     "name": "Kieran Klaassen and Trevin Chow"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -4,8 +4,7 @@
   "version": "3.14.0",
   "description": "Brainstorming, planning, debugging, and autonomous workflows for AI agents",
   "author": {
-    "name": "Kieran Klaassen",
-    "url": "https://github.com/kieranklaassen"
+    "name": "Kieran Klaassen and Trevin Chow"
   },
   "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",
   "repository": "https://github.com/EveryInc/compound-engineering-plugin",

--- a/src/release/metadata.ts
+++ b/src/release/metadata.ts
@@ -77,10 +77,10 @@ export type CompoundEngineeringCounts = {
 }
 
 const COMPOUND_ENGINEERING_DESCRIPTION =
-  "AI-powered development tools for code review, research, design, and workflow automation."
+  "Brainstorming, planning, debugging, and autonomous workflows for AI agents"
 
 const COMPOUND_ENGINEERING_MARKETPLACE_DESCRIPTION =
-  "AI-powered development tools that get smarter with every use. Make each unit of engineering work easier than the last."
+  "Brainstorming, planning, debugging, and autonomous workflows for AI agents"
 
 function resolveExpectedVersion(
   explicitVersion: string | undefined,

--- a/src/release/metadata.ts
+++ b/src/release/metadata.ts
@@ -77,10 +77,10 @@ export type CompoundEngineeringCounts = {
 }
 
 const COMPOUND_ENGINEERING_DESCRIPTION =
-  "Brainstorming, planning, debugging, and autonomous workflows for AI agents"
+  "Brainstorm, plan, debug, review, and compound learnings with AI agents"
 
 const COMPOUND_ENGINEERING_MARKETPLACE_DESCRIPTION =
-  "Brainstorming, planning, debugging, and autonomous workflows for AI agents"
+  "Brainstorm, plan, debug, review, and compound learnings with AI agents"
 
 function resolveExpectedVersion(
   explicitVersion: string | undefined,

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -125,7 +125,7 @@ describe("release metadata", () => {
     const description = await buildCompoundEngineeringDescription(process.cwd())
 
     expect(description).toBe(
-      "AI-powered development tools for code review, research, design, and workflow automation.",
+      "Brainstorm, plan, debug, review, and compound learnings with AI agents",
     )
   })
 
@@ -216,7 +216,7 @@ describe("release metadata", () => {
       JSON.stringify(
         {
           version: "2.42.0",
-          description: "AI-powered development tools for code review, research, design, and workflow automation.",
+          description: "Brainstorm, plan, debug, review, and compound learnings with AI agents",
         },
         null,
         2,
@@ -240,7 +240,7 @@ describe("release metadata", () => {
 
     const afterContents = JSON.parse(await Bun.file(codexPath).text())
     expect(afterContents.description).toBe(
-      "AI-powered development tools for code review, research, design, and workflow automation.",
+      "Brainstorm, plan, debug, review, and compound learnings with AI agents",
     )
   })
 


### PR DESCRIPTION
## Summary

Plugin and marketplace metadata is now consistent across the shipped Claude, Cursor, and Codex surfaces. The manifests and marketplace entries share the same concise description, use the shared author naming, and avoid exposing personal contact/profile fields where they are not needed.

This also keeps the release metadata sync constants aligned with the published manifests, so future validation preserves the same copy. Codex presentation metadata now has both `logo` and `composerIcon` pointing at the bundled logo asset.

## Validation

- `jq . .claude-plugin/plugin.json .cursor-plugin/plugin.json .codex-plugin/plugin.json .claude-plugin/marketplace.json .cursor-plugin/marketplace.json`
- `bun test tests/release-metadata.test.ts`
- `bun run release:validate`

Note: full `bun test` was attempted locally but this checkout is missing `js-yaml`, which blocks unrelated suites before completion.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
