### PR TITLE
chore(release): remove stale release-as pins for marketplaces

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -78,7 +78,6 @@
     ".claude-plugin": {
       "release-type": "simple",
       "package-name": "marketplace",
-      "release-as": "1.0.3",
       "extra-files": [
         {
           "type": "json",
@@ -90,7 +89,6 @@
     ".cursor-plugin": {
       "release-type": "simple",
       "package-name": "cursor-marketplace",
-      "release-as": "1.0.2",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

`release:validate` (the `test` CI check) is failing on every open PR, blocking the merge gate repo-wide. The cause is two stale `release-as` pins in `.github/release-please-config.json`: `marketplace` pinned to `1.0.3` and `cursor-marketplace` pinned to `1.0.2`. Both have already shipped at exactly those versions, so the pins are no longer ahead of the released version — the validator flags that as stale and exits non-zero.

A `release-as` pin is a one-shot override to force a specific next version. Once it ships, leaving it in place would force the *next* release to reuse the same version instead of bumping normally. Removing both pins lets release automation resume normal version bumps and turns the `test` check green again.

## Verification

`bun run release:validate` now passes locally:

```
Release metadata is in sync. compound-engineering currently has 0 agents, 27 skills, and 0 MCP servers.
```

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
