### PR TITLE
fix: slim skill descriptions

### DIFF
--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-brainstorm
-description: 'Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says "let''s brainstorm", "what should we build", or "help me think through X", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm.'
+description: 'Explore vague or ambitious ideas into right-sized requirements. Use when the user wants to brainstorm, think through scope, decide what to build, or needs collaborative product framing before planning.'
 argument-hint: "[feature idea or problem to explore] [output:html]"
 ---
 

--- a/skills/ce-code-review/SKILL.md
+++ b/skills/ce-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-code-review
-description: "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. In interactive mode it applies safe, verified fixes and commits them when the working tree is clean (it never pushes); in mode:agent it reports only and the caller applies. Use when reviewing code changes before creating a PR."
+description: "Structured code review for bugs, regressions, tests, and standards. Use before PRs or when asked for review; interactive mode can fix locally, while mode:agent reports only for pipeline callers."
 argument-hint: "[mode:agent] [blank to review current branch, or provide PR link]"
 ---
 

--- a/skills/ce-commit-push-pr/SKILL.md
+++ b/skills/ce-commit-push-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-commit-push-pr
-description: Commit, push, and open a PR with an adaptive, value-first description that scales in depth with the change. Use when the user says "commit and PR", "ship this", "create a PR", or "open a pull request". Also handles description-only flows ("write a PR description", "rewrite the PR body", "describe this PR") without committing or pushing.
+description: Commit, push, and open a PR. Use when asked to ship/open a PR, or for PR-description-only flows like writing, rewriting, or describing a PR body.
 ---
 
 # Git Commit, Push, and PR

--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-commit
-description: Create a git commit with a clear, value-communicating message. Use when the user says "commit", "commit this", "save my changes", "create a commit", or wants to commit staged or unstaged work. Produces well-structured commit messages that follow repo conventions when they exist, and defaults to conventional commit format otherwise.
+description: Create a git commit with a clear, value-communication message. Use when the user asks to commit/save staged or unstaged changes with a repo-appropriate, value-communicating message.
 ---
 
 # Git Commit

--- a/skills/ce-compound-refresh/SKILL.md
+++ b/skills/ce-compound-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-compound-refresh
-description: Refresh stale learning and pattern docs under docs/solutions/ by reviewing them against the current codebase, then updating, consolidating, or deleting drifted ones. Use when the user asks to "refresh my learnings", "audit docs/solutions/", "clean up stale learnings", or "consolidate overlapping docs", or when ce-compound flags an older doc as superseded. Do not trigger for general refactor, debugging, or code-review work unless the user has explicitly pointed at docs/solutions/.
+description: Refresh docs/solutions learnings against the current codebase. Use when auditing stale, overlapping, superseded, or drifted learnings; avoid general refactor, debugging, or code review unless docs/solutions is explicit.
 argument-hint: "[optional: scope hint — directory, filename, module, or keyword] [mode:headless] "
 ---
 

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-compound
-description: Document a recently solved problem to compound your team's knowledge or CONCEPTS.md, the project's shared domain vocabulary.
+description: Document a recently solved problem or durable project vocabulary in docs/solutions/ or CONCEPTS.md. Use when capturing a learning after work.
 argument-hint: "[optional: brief context] [mode:headless] "
 ---
 

--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-debug
-description: 'Systematically find root causes and fix bugs. Use when debugging errors, investigating test failures, reproducing bugs from issue trackers (GitHub, Linear, Jira), or when stuck on a problem after failed fix attempts. Also use when the user says ''debug this'', ''why is this failing'', ''fix this bug'', ''trace this error'', or pastes stack traces, error messages, or issue references.'
+description: 'Diagnosis loop for bugs and failing behavior. Use for errors, stack traces, regressions, failed tests, issue-tracker bugs, stuck investigations after failed fixes, or asks to debug/fix a bug.'
 argument-hint: "[issue reference, error message, test path, or description of broken behavior]"
 ---
 

--- a/skills/ce-doc-review/SKILL.md
+++ b/skills/ce-doc-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-doc-review
-description: Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.
+description: Review requirements, plans, or specs with role-specific lenses. Use when the user wants to improve an existing planning document.
 argument-hint: "[mode:headless] [path/to/document.md]"
 ---
 

--- a/skills/ce-dogfood-beta/SKILL.md
+++ b/skills/ce-dogfood-beta/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-dogfood-beta
-description: "[BETA] Dogfood the active branch end-to-end as a QA engineer. Diffs the branch against main, builds an exhaustive browser test matrix of every change (full user journeys, not just features), drives the app with agent-browser, then auto-fixes issues, adds regression tests, and commits each fix until the matrix is green. Use when you want a hands-off 'test everything we just built and make it actually work' pass before shipping."
+description: "[BETA] Hands-off end-to-end branch dogfood pass with browser testing, auto-fixes, regression tests, and fix commits."
 disable-model-invocation: true
 argument-hint: "[PR number, branch name, or blank for current branch] [--port PORT]"
 ---

--- a/skills/ce-ideate/SKILL.md
+++ b/skills/ce-ideate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-ideate
-description: "Generate and critically evaluate grounded ideas about a topic. Use when asking what to improve, requesting idea generation, exploring surprising directions, or wanting the AI to proactively suggest strong options before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on X', 'surprise me', 'what would you change', or any request for AI-generated suggestions rather than refining the user's own idea."
+description: "Generate and evaluate grounded ideas. Use when the user asks for ideas, improvements, surprising options, or AI-generated directions before choosing one to develop; use ce-brainstorm to refine the user's own idea."
 argument-hint: "[feature, focus area, or constraint] [output:md]"
 
 ---

--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-optimize
-description: "Run metric-driven iterative optimization loops -- define a measurable goal, run parallel experiments, measure each against hard gates or LLM-as-judge scores, keep improvements, and converge on the best solution. Use when optimizing clustering quality, search relevance, build performance, prompt quality, or any measurable outcome that benefits from systematic experimentation."
+description: "Run metric-driven optimization loops. Use when improving measurable outcomes such as search relevance, clustering quality, build performance, prompt quality, or scored behavior through experiments."
 argument-hint: "[path to optimization spec YAML, or describe the optimization goal]"
 ---
 

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-plan
-description: "Create structured plans for multi-step tasks -- software features, research workflows, events, study plans, or any goal that benefits from breakdown. Also deepens existing plans with interactive sub-agent review. Use when the user says 'plan this', 'create a plan', 'how should we build', 'break this down', or when a brainstorm doc is ready for planning. Use 'deepen the plan' or 'deepening pass' for the deepening flow. For exploratory requests, prefer ce-brainstorm first."
+description: "Create structured plans for multi-step work, including software and non-software tasks. Use when asked to plan, break down implementation, plan from requirements, or deepen an existing plan; prefer ce-brainstorm for exploratory framing."
 argument-hint: "[optional: feature description, requirements doc path, plan path to deepen, or any task to plan] [output:html]"
 ---
 

--- a/skills/ce-polish/SKILL.md
+++ b/skills/ce-polish/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-polish
-description: "Start the dev server, open the feature in a browser, and iterate on improvements together. Manual invocation only — type /ce-polish to run it."
+description: "Start the dev server, inspect the feature in browser, and iterate on polish."
 disable-model-invocation: true
 argument-hint: "[PR number, branch name, or blank for current branch]"
 ---

--- a/skills/ce-product-pulse/SKILL.md
+++ b/skills/ce-product-pulse/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ce-product-pulse
-description: "Generate a time-windowed pulse report on what users experienced and how the product performed - usage, quality, errors, signals worth investigating. Use when the user says 'run a pulse', 'show me the pulse', 'how are we doing', 'weekly recap', 'launch-day check', or passes a time window like '24h' or '7d'. Configures via .compound-engineering/config.local.yaml and saves reports to docs/pulse-reports/."
+description: "Generate time-windowed product pulse reports from configured signals."
+disable-model-invocation: true
 argument-hint: "[lookback window, e.g. '24h', '7d', '1h'; default 24h]"
 allowed-tools:
   - Read

--- a/skills/ce-promote/SKILL.md
+++ b/skills/ce-promote/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ce-promote
-description: "Draft user-facing announcement and marketing copy for a feature that just shipped — an X post or thread, a changelog blurb, a LinkedIn post, an email, a blog intro, or a short demo script. Spiral-agnostic by default; voice-matched via the Spiral CLI when it is installed and authed. Use when the user says 'promote this', 'draft the announcement', 'write the launch copy', 'market this feature', 'announce this feature', 'write the release tweet', or 'ce-promote'."
+description: "Draft launch or promotion copy for a shipped feature."
+disable-model-invocation: true
 argument-hint: "[optional: what shipped and/or channels, e.g. 'a tweet thread and a LinkedIn post']"
 ---
 

--- a/skills/ce-proof/SKILL.md
+++ b/skills/ce-proof/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-proof
-description: Publish, view, comment on, and edit markdown via Proof (proofeditor.ai) — create a shareable doc, read a shared doc, and make comment/suggestion/block edits over its API. Use when the user says "view this in proof", "share to proof", "publish to proof", or wants a shareable markdown surface for a spec, plan, or draft, including publish handoffs from ce-brainstorm, ce-ideate, or ce-plan. Do not trigger on "proof" meaning evidence, math proofs, proof-of-concept, or "proofread this".
+description: Publish, read, comment on, or edit markdown in Proof. Use for Proof links, sharing specs/plans/drafts, or publish handoffs from planning workflows; avoid proofread, math, evidence, or proof-of-concept meanings.
 allowed-tools:
   - Bash
   - Read

--- a/skills/ce-resolve-pr-feedback/SKILL.md
+++ b/skills/ce-resolve-pr-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-resolve-pr-feedback
-description: Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.
+description: Resolve PR review feedback. Use when addressing review comments, resolving review threads, or fixing code-review feedback.
 argument-hint: "[PR number, comment URL, or blank for current branch's PR]"
 allowed-tools: Bash(gh *), Bash(git *), Read
 ---

--- a/skills/ce-riffrec-feedback-analysis/SKILL.md
+++ b/skills/ce-riffrec-feedback-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-riffrec-feedback-analysis
-description: Analyze Riffrec feedback captures. Always load for `riffrec-*.zip`, `session.json` + `events.json` + `recording.webm` + `voice.webm` bundles, or requests to capture/share Riffrec sessions.
+description: Analyze Riffrec feedback captures from bundles or standalone recordings. Always load for `riffrec-*.zip`, `session.json` + `events.json` + `recording.webm` + `voice.webm` bundles, `.mp4`/`.mov`/`.webm` videos, `.m4a`/`.mp3`/`.wav` audio, or capture/share requests.
 ---
 
 # Riffrec Feedback Analysis

--- a/skills/ce-riffrec-feedback-analysis/SKILL.md
+++ b/skills/ce-riffrec-feedback-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-riffrec-feedback-analysis
-description: Riffrec product-feedback workflow. ALWAYS load when the user posts a `riffrec-*.zip`, a bundle with `session.json` + `events.json` + `recording.webm` + `voice.webm`, a video/audio recording for product feedback, or asks how to capture and share Riffrec sessions. Routes between setup, quick bug report, and extensive analysis.
+description: Analyze Riffrec feedback captures. Always load for `riffrec-*.zip`, `session.json` + `events.json` + `recording.webm` + `voice.webm` bundles, or requests to capture/share Riffrec sessions.
 ---
 
 # Riffrec Feedback Analysis

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-setup
-description: "Check Compound Engineering health and repo-local config. Reports optional tool capabilities, removes obsolete local config, refreshes the config example, and helps safely gitignore machine-local settings. Use when verifying setup, troubleshooting missing optional tools, or onboarding a repo."
+description: "Check Compound Engineering health and repo-local config."
 disable-model-invocation: true
 ---
 

--- a/skills/ce-simplify-code/SKILL.md
+++ b/skills/ce-simplify-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-simplify-code
-description: "Simplify and refine recently changed code for clarity, reuse, quality, and efficiency while preserving behavior."
+description: "Simplify recently changed code for clarity, reuse, quality, and efficiency while preserving behavior. Use for tidy/refactor passes; use ce-debug for bugs."
 argument-hint: "[blank to simplify current branch changes, or describe what to simplify]"
 ---
 

--- a/skills/ce-strategy/SKILL.md
+++ b/skills/ce-strategy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-strategy
-description: "Create or maintain STRATEGY.md - the product's target problem, approach, users, key metrics, and tracks of work. Use when starting a new product, updating direction, or when prompts like 'write our strategy', 'update the roadmap', 'what are we working on', or 'set up the strategy doc' come up. Also triggers when ce-ideate, ce-brainstorm, or ce-plan need upstream grounding and no strategy doc exists yet."
+description: "Create or update STRATEGY.md. Use when starting a product, changing direction or roadmap, or when ce-ideate, ce-brainstorm, or ce-plan need upstream product grounding."
 argument-hint: "[optional: section to revisit, e.g. 'metrics' or 'approach']"
 ---
 

--- a/skills/ce-test-browser/SKILL.md
+++ b/skills/ce-test-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-test-browser
-description: Run browser tests on pages affected by current PR or branch
+description: Run browser tests for pages affected by the current branch or PR.
 argument-hint: "[PR number, branch name, 'current', or --port PORT]"
 ---
 

--- a/skills/ce-test-xcode/SKILL.md
+++ b/skills/ce-test-xcode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-test-xcode
-description: "Build and test iOS apps on simulator using XcodeBuildMCP. Use after making iOS code changes, before creating a PR, or when verifying app behavior and checking for crashes on simulator."
+description: "Build and test iOS apps on simulator with XcodeBuildMCP."
 argument-hint: "[scheme name or 'current' to use default]"
 disable-model-invocation: true
 ---

--- a/skills/ce-work-beta/SKILL.md
+++ b/skills/ce-work-beta/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-work-beta
-description: "[BETA] Execute work with external delegate support. Same as ce-work but includes experimental Codex delegation mode for token-conserving code implementation."
+description: "[BETA] Execute ce-work with external delegate support."
 disable-model-invocation: true
 argument-hint: "[Plan doc path or description of work. Blank to auto use latest plan doc] [delegate:codex]"
 ---

--- a/skills/ce-work/SKILL.md
+++ b/skills/ce-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-work
-description: Execute work efficiently while maintaining quality and finishing features
+description: Execute a plan or concrete work prompt end-to-end. Use when implementing from docs/plans, a spec path, or a clear build request; use ce-debug for open-ended bugs.
 argument-hint: "[Plan doc path or description of work. Blank to auto use latest plan doc]"
 ---
 

--- a/skills/ce-worktree/SKILL.md
+++ b/skills/ce-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-worktree
-description: Ensure work happens in an isolated git worktree without disturbing the current checkout. Use when starting work that should stay isolated, or when `ce-work` or `ce-code-review` offers a worktree option. Detects existing isolation first, prefers the harness's native worktree tool, and falls back to plain git.
+description: Set up isolated git worktrees. Use when starting isolated work, or when ce-work/ce-code-review offers a worktree option; detect existing isolation first.
 ---
 
 # Worktree Isolation

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: lfg
-description: Run the full autonomous engineering pipeline end-to-end (plan, work, code review, test, commit, push, open PR, watch CI, fix CI failures until green). Use only when the user explicitly requests hands-off execution of a software task and provides a feature description; do not auto-route casual conversation here.
+description: Run the full hands-off engineering pipeline from planning through a green PR.
+disable-model-invocation: true
 argument-hint: "[feature description]"
 ---
 

--- a/src/utils/legacy-cleanup.ts
+++ b/src/utils/legacy-cleanup.ts
@@ -243,8 +243,129 @@ const STALE_PROMPT_FILES = [
 ]
 
 const LEGACY_SKILL_DESCRIPTION_ALIASES: Record<string, string[]> = {
+  "ce-brainstorm": [
+    "Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says \"let's brainstorm\", \"what should we build\", or \"help me think through X\", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm.",
+  ],
+  "ce:brainstorm": [
+    "Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says \"let's brainstorm\", \"what should we build\", or \"help me think through X\", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm.",
+  ],
+  "workflows-brainstorm": [
+    "Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says \"let's brainstorm\", \"what should we build\", or \"help me think through X\", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm.",
+  ],
+  "workflows:brainstorm": [
+    "Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says \"let's brainstorm\", \"what should we build\", or \"help me think through X\", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm.",
+  ],
+  "ce-code-review": [
+    "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. In interactive mode it applies safe, verified fixes and commits them when the working tree is clean (it never pushes); in mode:agent it reports only and the caller applies. Use when reviewing code changes before creating a PR.",
+  ],
+  "ce-review": [
+    "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. In interactive mode it applies safe, verified fixes and commits them when the working tree is clean (it never pushes); in mode:agent it reports only and the caller applies. Use when reviewing code changes before creating a PR.",
+  ],
+  "workflows-review": [
+    "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. In interactive mode it applies safe, verified fixes and commits them when the working tree is clean (it never pushes); in mode:agent it reports only and the caller applies. Use when reviewing code changes before creating a PR.",
+  ],
+  "workflows:review": [
+    "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. In interactive mode it applies safe, verified fixes and commits them when the working tree is clean (it never pushes); in mode:agent it reports only and the caller applies. Use when reviewing code changes before creating a PR.",
+  ],
+  "ce-commit": [
+    "Create a git commit with a clear, value-communicating message. Use when the user says \"commit\", \"commit this\", \"save my changes\", \"create a commit\", or wants to commit staged or unstaged work. Produces well-structured commit messages that follow repo conventions when they exist, and defaults to conventional commit format otherwise.",
+  ],
+  "git-commit": [
+    "Create a git commit with a clear, value-communicating message. Use when the user says \"commit\", \"commit this\", \"save my changes\", \"create a commit\", or wants to commit staged or unstaged work. Produces well-structured commit messages that follow repo conventions when they exist, and defaults to conventional commit format otherwise.",
+  ],
+  "ce-plan": [
+    "Create structured plans for multi-step tasks -- software features, research workflows, events, study plans, or any goal that benefits from breakdown. Also deepens existing plans with interactive sub-agent review. Use when the user says 'plan this', 'create a plan', 'how should we build', 'break this down', or when a brainstorm doc is ready for planning. Use 'deepen the plan' or 'deepening pass' for the deepening flow. For exploratory requests, prefer ce-brainstorm first.",
+  ],
+  "ce:plan": [
+    "Create structured plans for multi-step tasks -- software features, research workflows, events, study plans, or any goal that benefits from breakdown. Also deepens existing plans with interactive sub-agent review. Use when the user says 'plan this', 'create a plan', 'how should we build', 'break this down', or when a brainstorm doc is ready for planning. Use 'deepen the plan' or 'deepening pass' for the deepening flow. For exploratory requests, prefer ce-brainstorm first.",
+  ],
+  "workflows-plan": [
+    "Create structured plans for multi-step tasks -- software features, research workflows, events, study plans, or any goal that benefits from breakdown. Also deepens existing plans with interactive sub-agent review. Use when the user says 'plan this', 'create a plan', 'how should we build', 'break this down', or when a brainstorm doc is ready for planning. Use 'deepen the plan' or 'deepening pass' for the deepening flow. For exploratory requests, prefer ce-brainstorm first.",
+  ],
+  "workflows:plan": [
+    "Create structured plans for multi-step tasks -- software features, research workflows, events, study plans, or any goal that benefits from breakdown. Also deepens existing plans with interactive sub-agent review. Use when the user says 'plan this', 'create a plan', 'how should we build', 'break this down', or when a brainstorm doc is ready for planning. Use 'deepen the plan' or 'deepening pass' for the deepening flow. For exploratory requests, prefer ce-brainstorm first.",
+  ],
+  "git-commit-push-pr": [
+    "Commit, push, and open a PR with an adaptive, value-first description that scales in depth with the change. Use when the user says \"commit and PR\", \"ship this\", \"create a PR\", or \"open a pull request\". Also handles description-only flows (\"write a PR description\", \"rewrite the PR body\", \"describe this PR\") without committing or pushing.",
+  ],
+  "ce-compound": [
+    "Document a recently solved problem to compound your team's knowledge or CONCEPTS.md, the project's shared domain vocabulary.",
+  ],
+  "ce:compound": [
+    "Document a recently solved problem to compound your team's knowledge or CONCEPTS.md, the project's shared domain vocabulary.",
+  ],
+  "workflows-compound": [
+    "Document a recently solved problem to compound your team's knowledge or CONCEPTS.md, the project's shared domain vocabulary.",
+  ],
+  "workflows:compound": [
+    "Document a recently solved problem to compound your team's knowledge or CONCEPTS.md, the project's shared domain vocabulary.",
+  ],
+  "ce-compound-refresh": [
+    "Refresh stale learning and pattern docs under docs/solutions/ by reviewing them against the current codebase, then updating, consolidating, or deleting drifted ones. Use when the user asks to \"refresh my learnings\", \"audit docs/solutions/\", \"clean up stale learnings\", or \"consolidate overlapping docs\", or when ce-compound flags an older doc as superseded. Do not trigger for general refactor, debugging, or code-review work unless the user has explicitly pointed at docs/solutions/.",
+  ],
+  "ce:compound-refresh": [
+    "Refresh stale learning and pattern docs under docs/solutions/ by reviewing them against the current codebase, then updating, consolidating, or deleting drifted ones. Use when the user asks to \"refresh my learnings\", \"audit docs/solutions/\", \"clean up stale learnings\", or \"consolidate overlapping docs\", or when ce-compound flags an older doc as superseded. Do not trigger for general refactor, debugging, or code-review work unless the user has explicitly pointed at docs/solutions/.",
+  ],
+  "ce-doc-review": [
+    "Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.",
+  ],
+  "ce-document-review": [
+    "Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.",
+  ],
+  "document-review": [
+    "Review requirements or plan documents using parallel persona agents that surface role-specific issues. Use when a requirements document or plan document exists and the user wants to improve it.",
+  ],
+  "ce-ideate": [
+    "Generate and critically evaluate grounded ideas about a topic. Use when asking what to improve, requesting idea generation, exploring surprising directions, or wanting the AI to proactively suggest strong options before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on X', 'surprise me', 'what would you change', or any request for AI-generated suggestions rather than refining the user's own idea.",
+  ],
+  "ce:ideate": [
+    "Generate and critically evaluate grounded ideas about a topic. Use when asking what to improve, requesting idea generation, exploring surprising directions, or wanting the AI to proactively suggest strong options before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on X', 'surprise me', 'what would you change', or any request for AI-generated suggestions rather than refining the user's own idea.",
+  ],
+  "ce-polish-beta": [
+    "Start the dev server, open the feature in a browser, and iterate on improvements together. Manual invocation only — type /ce-polish to run it.",
+  ],
+  proof: [
+    "Publish, view, comment on, and edit markdown via Proof (proofeditor.ai) — create a shareable doc, read a shared doc, and make comment/suggestion/block edits over its API. Use when the user says \"view this in proof\", \"share to proof\", \"publish to proof\", or wants a shareable markdown surface for a spec, plan, or draft, including publish handoffs from ce-brainstorm, ce-ideate, or ce-plan. Do not trigger on \"proof\" meaning evidence, math proofs, proof-of-concept, or \"proofread this\".",
+  ],
+  "ce-resolve-pr-feedback": [
+    "Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.",
+  ],
+  "resolve-pr-feedback": [
+    "Resolve PR review feedback by evaluating validity and fixing issues in parallel. Use when addressing PR review comments, resolving review threads, or fixing code review feedback.",
+  ],
+  "ce-work": [
+    "Execute work efficiently while maintaining quality and finishing features",
+  ],
+  "ce:work": [
+    "Execute work efficiently while maintaining quality and finishing features",
+  ],
+  "workflows-work": [
+    "Execute work efficiently while maintaining quality and finishing features",
+  ],
+  "workflows:work": [
+    "Execute work efficiently while maintaining quality and finishing features",
+  ],
+  "ce-work-beta": [
+    "[BETA] Execute work with external delegate support. Same as ce-work but includes experimental Codex delegation mode for token-conserving code implementation.",
+  ],
+  "ce:work-beta": [
+    "[BETA] Execute work with external delegate support. Same as ce-work but includes experimental Codex delegation mode for token-conserving code implementation.",
+  ],
+  "ce-worktree": [
+    "Ensure work happens in an isolated git worktree without disturbing the current checkout. Use when starting work that should stay isolated, or when `ce-work` or `ce-code-review` offers a worktree option. Detects existing isolation first, prefers the harness's native worktree tool, and falls back to plain git.",
+  ],
+  "git-worktree": [
+    "Ensure work happens in an isolated git worktree without disturbing the current checkout. Use when starting work that should stay isolated, or when `ce-work` or `ce-code-review` offers a worktree option. Detects existing isolation first, prefers the harness's native worktree tool, and falls back to plain git.",
+  ],
+  "test-browser": [
+    "Run browser tests on pages affected by current PR or branch",
+  ],
+  "test-xcode": [
+    "Build and test iOS apps on simulator using XcodeBuildMCP. Use after making iOS code changes, before creating a PR, or when verifying app behavior and checking for crashes on simulator.",
+  ],
   setup: [
     "Configure project-level settings for compound-engineering workflows. Currently a placeholder — review agent selection is handled automatically by ce:review.",
+    "Check Compound Engineering health and repo-local config. Reports optional tool capabilities, removes obsolete local config, refreshes the config example, and helps safely gitignore machine-local settings. Use when verifying setup, troubleshooting missing optional tools, or onboarding a repo.",
   ],
 }
 
@@ -270,6 +391,7 @@ const LEGACY_SKILL_DESCRIPTION_ALIASES: Record<string, string[]> = {
  */
 const LEGACY_PROMPT_DESCRIPTION_ALIASES: Record<string, string[]> = {
   "ce-plan.md": [
+    "Create structured plans for multi-step tasks -- software features, research workflows, events, study plans, or any goal that benefits from breakdown. Also deepens existing plans with interactive sub-agent review. Use when the user says 'plan this', 'create a plan', 'how should we build', 'break this down', or when a brainstorm doc is ready for planning. Use 'deepen the plan' or 'deepening pass' for the deepening flow. For exploratory requests, prefer ce-brainstorm first.",
     "Create structured plans for any multi-step task -- software features, research workflows, events, study plans, or any goal that benefits from structured breakdown. Also deepen existing plans with interactive review of sub-agent findings. Use for plan creation when the user says 'plan this', 'create a plan', 'write a tech plan', 'plan the implementation', 'how should we build', 'what's the approach for', 'break this down', 'plan a trip', 'create a study plan', or when a brainstorm/requirements document is ready for planning. Use for plan deepening when the user says 'deepen the plan', 'deepen my plan', 'deepening pass', or uses 'deepen' in reference to a plan.",
     "Create structured plans for any multi-step task -- software features, research workflows, events, study plans, or any goal that benefits from structured breakdown. Also deepen existing plans with interactive review of sub-agent findings.",
     "Transform feature descriptions or requirements into implementation plans grounded in repo patterns and research.",
@@ -283,18 +405,22 @@ const LEGACY_PROMPT_DESCRIPTION_ALIASES: Record<string, string[]> = {
     "[BETA] Execute work with external delegate support. Same as ce:work but includes experimental Codex delegation mode for token-conserving code implementation.",
   ],
   "ce-brainstorm.md": [
+    "Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says \"let's brainstorm\", \"what should we build\", or \"help me think through X\", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm.",
     "Explore requirements and approaches through collaborative dialogue before writing a right-sized requirements document and planning implementation. Use for feature ideas, problem framing, when the user says 'let's brainstorm', or when they want to think through options before deciding what to build. Also use when a user describes a vague or ambitious feature request, asks 'what should we build', 'help me think through X', presents a problem with multiple valid solutions, or seems unsure about scope or direction — even if they don't explicitly ask to brainstorm.",
   ],
   "ce-ideate.md": [
     "Generate and critically evaluate grounded ideas about a topic. Use when asking what to improve, requesting idea generation, exploring surprising directions, or wanting the AI to proactively suggest strong options before brainstorming one in depth. Triggers on phrases like 'what should I improve', 'give me ideas', 'ideate on X', 'surprise me', 'what would you change', or any request for AI-generated suggestions rather than refining the user's own idea.",
   ],
   "ce-compound.md": [
+    "Document a recently solved problem to compound your team's knowledge or CONCEPTS.md, the project's shared domain vocabulary.",
     "Document a recently solved problem to compound your team's knowledge",
   ],
   "ce-compound-refresh.md": [
+    "Refresh stale learning and pattern docs under docs/solutions/ by reviewing them against the current codebase, then updating, consolidating, or deleting drifted ones. Use when the user asks to \"refresh my learnings\", \"audit docs/solutions/\", \"clean up stale learnings\", or \"consolidate overlapping docs\", or when ce-compound flags an older doc as superseded. Do not trigger for general refactor, debugging, or code-review work unless the user has explicitly pointed at docs/solutions/.",
     "Refresh stale or drifting learnings and pattern docs in docs/solutions/ by reviewing, updating, consolidating, replacing, or deleting them against the current codebase. Use after refactors, migrations, dependency upgrades, or when a retrieved learning feels outdated or wrong. Also use when reviewing docs/solutions/ for accuracy, when a recently solved problem contradicts an existing learning, when pattern docs no longer reflect current code, or when multiple docs seem to cover the same topic and might benefit from consolidation.",
   ],
   "ce-review.md": [
+    "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. In interactive mode it applies safe, verified fixes and commits them when the working tree is clean (it never pushes); in mode:agent it reports only and the caller applies. Use when reviewing code changes before creating a PR.",
     "Structured code review using tiered persona agents, confidence-gated findings, and a merge/dedup pipeline. Use when reviewing code changes before creating a PR.",
   ],
 }

--- a/tests/legacy-cleanup.test.ts
+++ b/tests/legacy-cleanup.test.ts
@@ -192,6 +192,39 @@ describe("cleanupStaleSkillDirs", () => {
     expect(await exists(path.join(root, "ce:plan-beta"))).toBe(false)
   })
 
+  test("removes workflow skill dirs whose shipped descriptions drifted", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "cleanup-workflow-drifted-desc-"))
+    const oldBrainstormDescription =
+      "Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says \"let's brainstorm\", \"what should we build\", or \"help me think through X\", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm."
+    const oldPlanDescription =
+      "Create structured plans for multi-step tasks -- software features, research workflows, events, study plans, or any goal that benefits from breakdown. Also deepens existing plans with interactive sub-agent review. Use when the user says 'plan this', 'create a plan', 'how should we build', 'break this down', or when a brainstorm doc is ready for planning. Use 'deepen the plan' or 'deepening pass' for the deepening flow. For exploratory requests, prefer ce-brainstorm first."
+
+    await createDir(
+      path.join(root, "ce:brainstorm"),
+      skillContent("ce:brainstorm", oldBrainstormDescription),
+    )
+    await createDir(
+      path.join(root, "workflows-brainstorm"),
+      skillContent("workflows-brainstorm", oldBrainstormDescription),
+    )
+    await createDir(
+      path.join(root, "workflows-plan"),
+      skillContent("workflows-plan", oldPlanDescription),
+    )
+    await createDir(
+      path.join(root, "workflows:plan"),
+      skillContent("workflows:plan", oldPlanDescription),
+    )
+
+    const removed = await cleanupStaleSkillDirs(root)
+
+    expect(removed).toBe(4)
+    expect(await exists(path.join(root, "ce:brainstorm"))).toBe(false)
+    expect(await exists(path.join(root, "workflows-brainstorm"))).toBe(false)
+    expect(await exists(path.join(root, "workflows-plan"))).toBe(false)
+    expect(await exists(path.join(root, "workflows:plan"))).toBe(false)
+  })
+
   test("returns 0 when directory does not exist", async () => {
     const removed = await cleanupStaleSkillDirs("/tmp/nonexistent-cleanup-dir-12345")
     expect(removed).toBe(0)
@@ -642,13 +675,24 @@ describe("cleanupStalePrompts", () => {
         "[BETA] Execute work with external delegate support. Same as ce:work but includes experimental Codex delegation mode for token-conserving code implementation.",
       ),
     )
+    // Previous ce-brainstorm description as parsed from YAML frontmatter. The
+    // source used a single-quoted YAML scalar, but parseFrontmatter returns the
+    // apostrophe as `let's`; cleanup fingerprints must match the parsed value.
+    await createFile(
+      path.join(root, "ce-brainstorm.md"),
+      promptWrapperContent(
+        "ce-brainstorm",
+        "Explore requirements and approaches through collaborative dialogue, then write a right-sized requirements document. Use when the user says \"let's brainstorm\", \"what should we build\", or \"help me think through X\", presents a vague or ambitious feature request, or seems unsure about scope or direction -- even without explicitly asking to brainstorm.",
+      ),
+    )
 
     const removed = await cleanupStalePrompts(root)
 
-    expect(removed).toBe(3)
+    expect(removed).toBe(4)
     expect(await exists(path.join(root, "ce-plan.md"))).toBe(false)
     expect(await exists(path.join(root, "ce-work.md"))).toBe(false)
     expect(await exists(path.join(root, "ce-work-beta.md"))).toBe(false)
+    expect(await exists(path.join(root, "ce-brainstorm.md"))).toBe(false)
   })
 
   test("preserves wrappers whose description was never shipped by compound-engineering", async () => {

--- a/tests/skill-conventions.test.ts
+++ b/tests/skill-conventions.test.ts
@@ -142,6 +142,39 @@ const INSTALLED_PLUGIN_PATH_EXEMPTIONS = new Map<string, string>([])
 const DESCRIPTION_CHAR_BUDGET = 1024
 const NAME_CHAR_BUDGET = 64
 
+const EXPECTED_USER_INVOKED_SKILLS = new Set([
+  "ce-dogfood-beta",
+  "ce-polish",
+  "ce-product-pulse",
+  "ce-promote",
+  "ce-setup",
+  "ce-test-xcode",
+  "ce-work-beta",
+  "lfg",
+])
+
+const REQUIRED_MODEL_INVOKED_CALLEES = new Set([
+  "ce-brainstorm",
+  "ce-code-review",
+  "ce-commit",
+  "ce-commit-push-pr",
+  "ce-compound",
+  "ce-compound-refresh",
+  "ce-debug",
+  "ce-doc-review",
+  "ce-ideate",
+  "ce-optimize",
+  "ce-plan",
+  "ce-proof",
+  "ce-resolve-pr-feedback",
+  "ce-riffrec-feedback-analysis",
+  "ce-simplify-code",
+  "ce-strategy",
+  "ce-test-browser",
+  "ce-work",
+  "ce-worktree",
+])
+
 // ---------------------------------------------------------------------------
 // Skill enumeration
 // ---------------------------------------------------------------------------
@@ -636,6 +669,39 @@ describe("skill reference integrity (AGENTS.md 'File References in Skills')", ()
 })
 
 describe("skill frontmatter limits (Anthropic skill spec)", () => {
+  test("skill invocation classification matches the intended model/user split", () => {
+    const actualUserInvoked = new Set<string>()
+    const actualModelInvoked = new Set<string>()
+    for (const skill of skillDirs) {
+      const skillMdPath = path.join(skill.absPath, "SKILL.md")
+      const raw = readFileSync(skillMdPath, "utf8")
+      const { data } = parseFrontmatter(raw, skillMdPath)
+      const name = typeof data.name === "string" ? data.name : path.basename(skill.absPath)
+      if (data["disable-model-invocation"] === true) {
+        actualUserInvoked.add(name)
+      } else {
+        actualModelInvoked.add(name)
+      }
+    }
+
+    const missingUserInvoked = [...EXPECTED_USER_INVOKED_SKILLS].filter((name) => !actualUserInvoked.has(name))
+    const unexpectedUserInvoked = [...actualUserInvoked].filter((name) => !EXPECTED_USER_INVOKED_SKILLS.has(name))
+    const disabledRequiredCallees = [...REQUIRED_MODEL_INVOKED_CALLEES].filter((name) => !actualModelInvoked.has(name))
+
+    expect(
+      missingUserInvoked,
+      `These skills should be user-invoked only via disable-model-invocation: true:\n${missingUserInvoked.join("\n")}`,
+    ).toEqual([])
+    expect(
+      unexpectedUserInvoked,
+      `Unexpected user-invoked skills. If intentional, update EXPECTED_USER_INVOKED_SKILLS and verify no model-routed caller depends on them:\n${unexpectedUserInvoked.join("\n")}`,
+    ).toEqual([])
+    expect(
+      disabledRequiredCallees,
+      `These skills must remain model-invoked because pipelines or sibling skills call them:\n${disabledRequiredCallees.join("\n")}`,
+    ).toEqual([])
+  })
+
   for (const skill of skillDirs) {
     const skillMdPath = path.join(skill.absPath, "SKILL.md")
     const raw = readFileSync(skillMdPath, "utf8")


### PR DESCRIPTION
## Summary

Skill descriptions now cost about 52% fewer tokens across the Compound Engineering catalog, while keeping pipeline-critical skills model-invoked and moving hands-off or report-style entrypoints to explicit user invocation.

| Surface | Before | After | Savings |
|---|---:|---:|---:|
| All skill descriptions | ~2,054 tokens | ~988 tokens | 51.9% |
| Model-visible descriptions | ~1,751 tokens | ~846 tokens | 51.7% |
| Model-invoked skills | 22 | 19 | - |

## Details

- Slims all 27 skill frontmatter descriptions around routing intent instead of prose-heavy examples.
- Marks `lfg`, `ce-promote`, and `ce-product-pulse` as user-invoked only.
- Keeps `ce-worktree` and `ce-proof` model-invoked so sibling skills and pipeline flows can still call them.
- Preserves Riffrec routing for standalone video/audio recordings as well as full Riffrec bundles.
- Adds a convention test that locks the intended user/model-invoked split.
- Backfills legacy cleanup fingerprints so users upgrading from previous descriptions do not keep stale duplicate skill or prompt entrypoints.

## Validation

- `bun test tests/legacy-cleanup.test.ts`
- `bun test tests/cli.test.ts --test-name-pattern "cleanup"`
- `bun test tests/skill-conventions.test.ts`
- `bun test tests/converter.test.ts tests/real-plugin-conversion.test.ts tests/frontmatter.test.ts`
- `bun run release:validate`
- `git diff --check`
- `bun test` full suite: 1603 pass

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
