### PR TITLE
fix(codex): expand plain-language starter prompts

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -33,9 +33,8 @@
     "privacyPolicyURL": "https://every.to/legal",
     "termsOfServiceURL": "https://every.to/legal",
     "defaultPrompt": [
-      "/ce-brainstorm a new feature",
-      "/ce-plan the implementation",
-      "/ce-code-review my changes"
+      "Brainstorm a new feature with me",
+      "Ideate and surprise me!"
     ],
     "brandColor": "#C9EFFA",
     "composerIcon": "./assets/icon.svg",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -34,7 +34,8 @@
     "termsOfServiceURL": "https://every.to/legal",
     "defaultPrompt": [
       "Brainstorm a new feature with me",
-      "Ideate and surprise me!"
+      "Ideate and surprise me!",
+      "Simplify the code in my most-churned file"
     ],
     "brandColor": "#C9EFFA",
     "composerIcon": "./assets/icon.svg",

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For the full catalog and how each skill chains together, see [docs/skills](docs/
 **Finding a direction** -- when you don't have a specific idea yet, ideate first, then carry the strongest survivor into the loop:
 
 ```text
-/ce-ideate "new drawing tools"
+/ce-ideate new drawing tools
 /ce-ideate github issues   # ground ideas in your open issues instead of a prompt
 ```
 
@@ -66,7 +66,7 @@ For the full catalog and how each skill chains together, see [docs/skills](docs/
 **Standard feature loop** -- turn a rough idea into shipped, reviewed code:
 
 ```text
-/ce-brainstorm "make background job retries safer"
+/ce-brainstorm make background job retries safer
 /ce-plan
 /ce-work
 /ce-simplify-code
@@ -78,7 +78,7 @@ For the full catalog and how each skill chains together, see [docs/skills](docs/
 
 ```text
 /ce-simplify-code
-/ce-simplify-code "simplify the code in my most-churned file"
+/ce-simplify-code simplify the code in my most-churned file
 ```
 
 The first pass tightens recent branch changes before review. The targeted pass is useful when one file keeps absorbing unrelated fixes, follow-ups, or merge conflicts.
@@ -86,7 +86,7 @@ The first pass tightens recent branch changes before review. The targeted pass i
 **Debugging a bug** -- when you start from broken behavior instead of a feature:
 
 ```text
-/ce-debug "the checkout webhook sometimes creates duplicate invoices"
+/ce-debug the checkout webhook sometimes creates duplicate invoices
 /ce-code-review
 /ce-compound
 ```
@@ -94,7 +94,7 @@ The first pass tightens recent branch changes before review. The targeted pass i
 **Autonomous** -- hand off a feature and let the agent run the whole pipeline:
 
 ```text
-/ce-brainstorm "describe the feature"
+/ce-brainstorm describe the feature
 /lfg
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For the full catalog and how each skill chains together, see [docs/skills](docs/
 
 ```text
 /ce-ideate new drawing tools
+/ce-ideate surprise me
 /ce-ideate github issues   # ground ideas in your open issues instead of a prompt
 ```
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ For the full catalog and how each skill chains together, see [docs/skills](docs/
 /ce-compound
 ```
 
+**Simplifying code** -- use it after fresh implementation work, or point it at code that keeps slowing changes down:
+
+```text
+/ce-simplify-code
+/ce-simplify-code "simplify the code in my most-churned file"
+```
+
+The first pass tightens recent branch changes before review. The targeted pass is useful when one file keeps absorbing unrelated fixes, follow-ups, or merge conflicts.
+
 **Debugging a bug** -- when you start from broken behavior instead of a feature:
 
 ```text


### PR DESCRIPTION
## Summary

The Codex plugin's starter prompts now use natural-language requests instead of slash-command invocations, so composer suggestions fit Codex's prompt flow rather than assuming command syntax.

The starter set now also includes a concise simplification prompt, and the README Quick Example section spells out the matching slash-command usage: a default `/ce-simplify-code` pass after fresh implementation work and a targeted pass for the most-churned file.

## Verification

`bun run release:validate`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
