### PR TITLE
feat(kimi): add Kimi CLI target provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,26 @@ agy plugin install ./compound-engineering-plugin/.agy
 
 `agy` also loads `GEMINI.md` workspace context from the checkout.
 
+### Kimi CLI
+
+[Kimi CLI](https://github.com/MoonshotAI/kimi-cli) discovers Agent Skills from a brand group of directories that **includes `~/.claude/skills/`** (with `merge_all_available_skills` on by default). If you already run Compound Engineering in Claude Code, Kimi picks up its skills automatically — no extra step.
+
+To install directly into Kimi's own root (`~/.kimi`) instead, use the converter CLI from a checkout:
+
+```bash
+git clone https://github.com/EveryInc/compound-engineering-plugin
+cd compound-engineering-plugin && bun install
+bun run cli:install . --to kimi
+```
+
+This writes:
+
+- Skills (plus commands and agents, converted to skills invoked via `/skill:<name>`) to `~/.kimi/skills/<name>/SKILL.md`
+- MCP servers to `~/.kimi/mcp.json`
+- Hooks to `~/.kimi/config.toml` (`[[hooks]]`), with tool-name matchers remapped to Kimi equivalents
+
+Override the destination with `--kimi-home <dir>` (or `$KIMI_HOME`). Kimi has no command-file or auto-discovered agent format, so commands and agents both surface as skills.
+
 ### Existing Installs
 
 Compound Engineering moved to a root-native, skills-only layout. An existing marketplace install keeps a **cached** marketplace snapshot that still points at the old `plugins/compound-engineering` path, so updating the plugin on its own reads that stale snapshot and leaves you on the previous version. Refresh the cached marketplace **first**, then update the plugin — order matters.

--- a/README.md
+++ b/README.md
@@ -298,11 +298,9 @@ agy plugin install ./compound-engineering-plugin/.agy
 
 `agy` also loads `GEMINI.md` workspace context from the checkout.
 
-### Kimi CLI
+### Kimi Code CLI
 
-[Kimi CLI](https://github.com/MoonshotAI/kimi-cli) discovers Agent Skills from a brand group of directories that **includes `~/.claude/skills/`** (with `merge_all_available_skills` on by default). If you already run Compound Engineering in Claude Code, Kimi picks up its skills automatically — no extra step.
-
-To install directly into Kimi's own root (`~/.kimi`) instead, use the converter CLI from a checkout:
+The `kimi` target writes for [Kimi Code CLI](https://www.kimi.com/code/) (binary `kimi`, installed via `code.kimi.com/kimi-code/install.sh` or `npm i -g @moonshot-ai/kimi-code`), the successor to the legacy Python `kimi-cli`. Kimi Code CLI discovers Agent Skills from `~/.kimi-code/skills/` (and `~/.agents/skills/`) — it does **not** scan `~/.claude/skills/`, so the converter writes into Kimi Code's own root. Use the converter CLI from a checkout:
 
 ```bash
 git clone https://github.com/EveryInc/compound-engineering-plugin
@@ -312,11 +310,11 @@ bun run cli:install . --to kimi
 
 This writes:
 
-- Skills (plus commands and agents, converted to skills invoked via `/skill:<name>`) to `~/.kimi/skills/<name>/SKILL.md`
-- MCP servers to `~/.kimi/mcp.json`
-- Hooks to `~/.kimi/config.toml` (`[[hooks]]`), with tool-name matchers remapped to Kimi equivalents
+- Skills (plus commands and agents, converted to skills invoked via `/skill:<name>`) to `~/.kimi-code/skills/<name>/SKILL.md`
+- MCP servers to `~/.kimi-code/mcp.json`
+- Hooks to `~/.kimi-code/config.toml` (`[[hooks]]`); most Claude tool-name matchers (`Bash`, `Read`, `Write`, `Edit`, ...) pass through unchanged, with a few remapped (`WebFetch` → `FetchURL`, `Task` → `Agent`, `TodoWrite` → `TodoList`)
 
-Override the destination with `--kimi-home <dir>` (or `$KIMI_HOME`). Kimi has no command-file or auto-discovered agent format, so commands and agents both surface as skills.
+Override the destination with `--kimi-home <dir>` (or `$KIMI_CODE_HOME`). Kimi has no command-file or auto-discovered agent format, so commands and agents both surface as skills.
 
 ### Existing Installs
 

--- a/docs/specs/kimi.md
+++ b/docs/specs/kimi.md
@@ -1,0 +1,52 @@
+# Kimi CLI Spec (Config, Skills, Commands, Agents, MCP, Hooks)
+
+Last verified: 2026-06-24
+
+## Primary sources
+
+```
+https://github.com/MoonshotAI/kimi-cli
+https://moonshotai.github.io/kimi-cli/en/configuration/config-files.html
+https://moonshotai.github.io/kimi-cli/en/customization/mcp.html
+https://moonshotai.github.io/kimi-cli/en/customization/skills.html
+https://moonshotai.github.io/kimi-cli/en/customization/agents.html
+https://moonshotai.github.io/kimi-cli/en/customization/hooks.html
+https://moonshotai.github.io/kimi-cli/en/customization/plugins.html
+```
+
+## Config location and format
+
+- The main config file is `~/.kimi/config.toml` (TOML; JSON is also accepted, and `~/.kimi/config.json` is auto-migrated to TOML). On first run Kimi creates a default config.
+- Alternate config via `--config-file` / `--config`. Runtime data location is governed separately by `KIMI_SHARE_DIR` and does **not** affect skills discovery.
+- `KIMI_HOME` is not a documented Kimi env var; the converter uses it only to let users override the output root (default `~/.kimi`).
+
+## Skills (Agent Skills)
+
+- A skill is a directory containing `SKILL.md`, optionally with `scripts/`, `references/`, `assets/`. A single flat `<name>.md` is also recognized (name = filename).
+- `SKILL.md` uses YAML front matter; all fields are optional: `name` (1-64 chars, lowercase/digits/hyphens; defaults to dir name), `description` (1-1024 chars), `license`, `compatibility`, `metadata`. Open Agent Skills format — compatible with Claude and Codex.
+- User-level discovery scans a **brand group** (first existing of `~/.kimi/skills/`, `~/.claude/skills/`, `~/.codex/skills/`) and a generic group (`~/.config/agents/skills/` or `~/.agents/skills/`). With `merge_all_available_skills = true` (default) all existing brand dirs are merged (priority kimi > claude > codex).
+- Project-level discovery mirrors this relative to the repo root (nearest `.git`): `.kimi/skills/`, `.claude/skills/`, `.codex/skills/`, `.agents/skills/`. Extra dirs via `--skills-dir` or `extra_skill_dirs`.
+- Because Kimi natively reads `~/.claude/skills/`, an existing Claude Code CE install surfaces in Kimi with no conversion.
+- Skills are scanned at the skills **root** (`<name>/SKILL.md`), so a per-plugin subdirectory is not discovered. The converter therefore writes CE skills **flat** at `~/.kimi/skills/<name>/SKILL.md` and tracks managed names in `~/.kimi/<plugin>/install-manifest.json` for safe upgrade cleanup.
+
+## Commands (slash invocation)
+
+- Kimi has no custom-command-file mechanism. The closest equivalent is `/skill:<name>`, which loads a skill's `SKILL.md` as a prompt (optionally with trailing argument text). `/flow:<name>` runs flow-type skills.
+- The converter maps Claude commands (those without `disableModelInvocation`) to skills, and rewrites known `/command` references in converted content to `/skill:<name>`.
+
+## Agents and subagents
+
+- Custom agents are YAML files loaded via `--agent-file`; tools are Python `module:ClassName` paths; subagents nest inside the YAML. There is no auto-discovered agent directory, and Claude tool names do not map to Kimi tool classes.
+- `${KIMI_AGENTS_MD}` merges `AGENTS.md` from project root to CWD (including `.kimi/AGENTS.md`) into the system prompt.
+- Given the low fidelity of YAML agent conversion, the converter renders Claude agent personas as **skills** (invoked via `/skill:<name>`) rather than Kimi YAML agents.
+
+## MCP (Model Context Protocol)
+
+- MCP servers live in `~/.kimi/mcp.json`, in the standard `{ "mcpServers": { ... } }` format (Claude-compatible). stdio servers use `command`/`args`/`env`; HTTP servers use `url`/`headers`. Managed via `kimi mcp add|list|remove|test`.
+- The converter deep-merges CE servers into `mcp.json`, preserves user-owned keys, and removes previously-written keys recorded in the install manifest.
+
+## Hooks (Beta)
+
+- Hooks are defined as a `[[hooks]]` array in `~/.kimi/config.toml`. Fields: `event` (required), `command` (required, receives JSON on stdin), `matcher` (optional regex; empty matches all), `timeout` (optional, default 30s, fail-open).
+- 13 events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `UserPromptSubmit`, `Stop`, `StopFailure`, `SessionStart`, `SessionEnd`, `SubagentStart`, `SubagentStop`, `PreCompact`, `PostCompact`, `Notification`.
+- Tool-name matchers differ from Claude (`WriteFile`, `StrReplaceFile`, `ReadFile`, `Shell`, `FetchURL`, `SearchWeb`, `Agent`, `SetTodoList`, ...). The converter emits only command-type hooks (prompt/agent hooks are skipped), remaps matcher tokens to Kimi names, drops unsupported events, and wraps its `[[hooks]]` entries in a managed marker block so user config is preserved.

--- a/docs/specs/kimi.md
+++ b/docs/specs/kimi.md
@@ -1,52 +1,58 @@
-# Kimi CLI Spec (Config, Skills, Commands, Agents, MCP, Hooks)
+# Kimi Code CLI Spec (Config, Skills, Commands, Agents, MCP, Hooks)
 
 Last verified: 2026-06-24
+
+## Product note: Kimi Code CLI vs. legacy kimi-cli
+
+The `kimi` target writes for **Kimi Code CLI**, the current terminal agent
+installed via `curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash`
+or `npm install -g @moonshot-ai/kimi-code` (binary name `kimi`). It is the
+successor to the older Python **kimi-cli** (`MoonshotAI/kimi-cli`, docs at
+`moonshotai.github.io/kimi-cli`), which used `~/.kimi` and a different set of
+built-in tool names (`Shell`, `WriteFile`, `StrReplaceFile`, ...). Installing
+Kimi Code CLI migrates the old config and renames the legacy binary to
+`kimi-legacy`. Target this current product, not the legacy one.
 
 ## Primary sources
 
 ```
-https://github.com/MoonshotAI/kimi-cli
-https://moonshotai.github.io/kimi-cli/en/configuration/config-files.html
-https://moonshotai.github.io/kimi-cli/en/customization/mcp.html
-https://moonshotai.github.io/kimi-cli/en/customization/skills.html
-https://moonshotai.github.io/kimi-cli/en/customization/agents.html
-https://moonshotai.github.io/kimi-cli/en/customization/hooks.html
-https://moonshotai.github.io/kimi-cli/en/customization/plugins.html
+https://www.kimi.com/code/docs/en/kimi-code-cli/configuration/config-files.html
+https://www.kimi.com/code/docs/en/kimi-code-cli/customization/skills.html
+https://www.kimi.com/code/docs/en/kimi-code-cli/customization/mcp.html
+https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html
+https://www.kimi.com/code/docs/en/kimi-code-cli/reference/tools.html
+https://github.com/MoonshotAI/kimi-cli  (legacy; "evolving into Kimi Code CLI")
 ```
 
 ## Config location and format
 
-- The main config file is `~/.kimi/config.toml` (TOML; JSON is also accepted, and `~/.kimi/config.json` is auto-migrated to TOML). On first run Kimi creates a default config.
-- Alternate config via `--config-file` / `--config`. Runtime data location is governed separately by `KIMI_SHARE_DIR` and does **not** affect skills discovery.
-- `KIMI_HOME` is not a documented Kimi env var; the converter uses it only to let users override the output root (default `~/.kimi`).
+- The main config file is `~/.kimi-code/config.toml` (TOML), created on first run.
+- `KIMI_CODE_HOME` overrides the data root (config becomes `$KIMI_CODE_HOME/config.toml`).
+- The installer's `KIMI_INSTALL_DIR` (default `$HOME/.kimi-code`) governs where the binary lands; the converter writes the data root, defaulting to `$KIMI_CODE_HOME` or `~/.kimi-code`, overridable with `--kimi-home`.
 
 ## Skills (Agent Skills)
 
-- A skill is a directory containing `SKILL.md`, optionally with `scripts/`, `references/`, `assets/`. A single flat `<name>.md` is also recognized (name = filename).
-- `SKILL.md` uses YAML front matter; all fields are optional: `name` (1-64 chars, lowercase/digits/hyphens; defaults to dir name), `description` (1-1024 chars), `license`, `compatibility`, `metadata`. Open Agent Skills format — compatible with Claude and Codex.
-- User-level discovery scans a **brand group** (first existing of `~/.kimi/skills/`, `~/.claude/skills/`, `~/.codex/skills/`) and a generic group (`~/.config/agents/skills/` or `~/.agents/skills/`). With `merge_all_available_skills = true` (default) all existing brand dirs are merged (priority kimi > claude > codex).
-- Project-level discovery mirrors this relative to the repo root (nearest `.git`): `.kimi/skills/`, `.claude/skills/`, `.codex/skills/`, `.agents/skills/`. Extra dirs via `--skills-dir` or `extra_skill_dirs`.
-- Because Kimi natively reads `~/.claude/skills/`, an existing Claude Code CE install surfaces in Kimi with no conversion.
-- Skills are scanned at the skills **root** (`<name>/SKILL.md`), so a per-plugin subdirectory is not discovered. The converter therefore writes CE skills **flat** at `~/.kimi/skills/<name>/SKILL.md` and tracks managed names in `~/.kimi/<plugin>/install-manifest.json` for safe upgrade cleanup.
+- A skill is a directory containing `SKILL.md` (YAML front matter + Markdown body). Front-matter fields include `name`, `description`, `type` (`prompt` default, `inline`, `flow`), `whenToUse`, `disableModelInvocation`, and `arguments` (exposed as `$<name>` placeholders). Open Agent Skills format — compatible with Claude and Codex skill bodies.
+- User-level discovery scans `$KIMI_CODE_HOME/skills/` (default `~/.kimi-code/skills/`) and `~/.agents/skills/`. Project-level discovery scans `.kimi-code/skills/` and `.agents/skills/` relative to the working directory; project entries override user entries.
+- Unlike legacy kimi-cli, Kimi Code CLI does **not** scan `~/.claude/skills/` or `~/.codex/skills/`. An existing Claude Code install is therefore not auto-discovered; the converter writes skills into the Kimi Code root.
+- Skills are scanned at the skills **root** (`<name>/SKILL.md`), so a per-plugin subdirectory is not discovered. The converter writes CE skills **flat** at `~/.kimi-code/skills/<name>/SKILL.md` and tracks managed names in `~/.kimi-code/<plugin>/install-manifest.json` for safe upgrade cleanup. A target name that collides with an unmanaged (foreign) directory is moved aside to a timestamped backup, never overwritten.
 
 ## Commands (slash invocation)
 
-- Kimi has no custom-command-file mechanism. The closest equivalent is `/skill:<name>`, which loads a skill's `SKILL.md` as a prompt (optionally with trailing argument text). `/flow:<name>` runs flow-type skills.
+- Kimi Code CLI has no custom-command-file mechanism. The closest equivalent is `/skill:<name>`, which loads a skill's `SKILL.md` as a prompt (optionally with trailing argument text). `flow`-type skills run as flows.
 - The converter maps Claude commands (those without `disableModelInvocation`) to skills, and rewrites known `/command` references in converted content to `/skill:<name>`.
 
 ## Agents and subagents
 
-- Custom agents are YAML files loaded via `--agent-file`; tools are Python `module:ClassName` paths; subagents nest inside the YAML. There is no auto-discovered agent directory, and Claude tool names do not map to Kimi tool classes.
-- `${KIMI_AGENTS_MD}` merges `AGENTS.md` from project root to CWD (including `.kimi/AGENTS.md`) into the system prompt.
-- Given the low fidelity of YAML agent conversion, the converter renders Claude agent personas as **skills** (invoked via `/skill:<name>`) rather than Kimi YAML agents.
+- There is no auto-discovered agent directory whose format maps cleanly from Claude agents. The converter renders Claude agent personas as **skills** (invoked via `/skill:<name>`) rather than native Kimi agents.
 
 ## MCP (Model Context Protocol)
 
-- MCP servers live in `~/.kimi/mcp.json`, in the standard `{ "mcpServers": { ... } }` format (Claude-compatible). stdio servers use `command`/`args`/`env`; HTTP servers use `url`/`headers`. Managed via `kimi mcp add|list|remove|test`.
+- MCP servers live in `~/.kimi-code/mcp.json` (or `$KIMI_CODE_HOME/mcp.json`), in the standard `{ "mcpServers": { ... } }` format. Entries with a `command` field are stdio servers (`command`/`args`/`env`/`cwd`); entries with a `url` field are HTTP servers (`url`/`headers`, optional `transport = "sse"` for legacy SSE). Project-level `.kimi-code/mcp.json` overrides user-level.
 - The converter deep-merges CE servers into `mcp.json`, preserves user-owned keys, and removes previously-written keys recorded in the install manifest.
 
-## Hooks (Beta)
+## Hooks
 
-- Hooks are defined as a `[[hooks]]` array in `~/.kimi/config.toml`. Fields: `event` (required), `command` (required, receives JSON on stdin), `matcher` (optional regex; empty matches all), `timeout` (optional, default 30s, fail-open).
-- 13 events: `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `UserPromptSubmit`, `Stop`, `StopFailure`, `SessionStart`, `SessionEnd`, `SubagentStart`, `SubagentStop`, `PreCompact`, `PostCompact`, `Notification`.
-- Tool-name matchers differ from Claude (`WriteFile`, `StrReplaceFile`, `ReadFile`, `Shell`, `FetchURL`, `SearchWeb`, `Agent`, `SetTodoList`, ...). The converter emits only command-type hooks (prompt/agent hooks are skipped), remaps matcher tokens to Kimi names, drops unsupported events, and wraps its `[[hooks]]` entries in a managed marker block so user config is preserved.
+- Hooks are a `[[hooks]]` array in `~/.kimi-code/config.toml`. Fields: `event` (required), `command` (required, receives JSON on stdin), `matcher` (optional regex; empty matches all), `timeout` (optional, 1-600s, default 30s, fail-open). Exit code `0` allows, `2` blocks; only `PreToolUse`, `Stop`, and `UserPromptSubmit` can block.
+- Events: `UserPromptSubmit`, `PreToolUse`, `Stop`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `PermissionResult`, `SessionStart`, `SessionEnd`, `SubagentStart`, `SubagentStop`, `StopFailure`, `Interrupt`, `PreCompact`, `PostCompact`, `Notification`.
+- Tool-name matchers largely match Claude's: `Bash`, `Read`, `Write`, `Edit`, `Grep`, `Glob`, `WebSearch` are identical and pass through unchanged. Only a few differ: `WebFetch -> FetchURL`, `Task -> Agent`, `TodoWrite -> TodoList`, `MultiEdit -> Edit`. The converter emits only command-type hooks (prompt/agent hooks are skipped), drops unsupported events, and wraps its `[[hooks]]` entries in a managed marker block so user config is preserved.

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -45,7 +45,7 @@ export default defineCommand({
     kimiHome: {
       type: "string",
       alias: "kimi-home",
-      description: "Write Kimi output to this Kimi root (default: $KIMI_HOME or ~/.kimi)",
+      description: "Write Kimi output to this Kimi root (default: $KIMI_CODE_HOME or ~/.kimi-code)",
     },
     scope: {
       type: "string",

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -5,7 +5,7 @@ import { loadClaudePlugin } from "../parsers/claude"
 import { targets, validateScope } from "../targets"
 import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
 import { ensureCodexAgentsFile } from "../utils/codex-agents"
-import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
+import { expandHome, resolveCodexHome, resolveKimiHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../utils/resolve-output"
 import { detectInstalledTools } from "../utils/detect-tools"
 
@@ -25,7 +25,7 @@ export default defineCommand({
     to: {
       type: "string",
       default: "opencode",
-      description: "Target format (opencode | codex | pi | antigravity | all)",
+      description: "Target format (opencode | codex | pi | antigravity | kimi | all)",
     },
     output: {
       type: "string",
@@ -41,6 +41,11 @@ export default defineCommand({
       type: "string",
       alias: "pi-home",
       description: "Write Pi output to this Pi root (ex: ~/.pi/agent or ./.pi)",
+    },
+    kimiHome: {
+      type: "string",
+      alias: "kimi-home",
+      description: "Write Kimi output to this Kimi root (default: $KIMI_HOME or ~/.kimi)",
     },
     scope: {
       type: "string",
@@ -85,6 +90,7 @@ export default defineCommand({
     const hasExplicitOutput = Boolean(args.output && String(args.output).trim())
     const codexHome = resolveCodexHome(args.codexHome)
     const piHome = resolveTargetHome(args.piHome, path.join(os.homedir(), ".pi", "agent"))
+    const kimiHome = resolveKimiHome(args.kimiHome)
 
     const options: ClaudeToOpenCodeOptions = {
       agentMode: String(args.agentMode) === "primary" ? "primary" : "subagent",
@@ -127,6 +133,7 @@ export default defineCommand({
           outputRoot,
           codexHome,
           piHome,
+          kimiHome,
           pluginName: plugin.manifest.name,
           hasExplicitOutput,
         })
@@ -158,6 +165,7 @@ export default defineCommand({
       outputRoot,
       codexHome,
       piHome,
+      kimiHome,
       pluginName: plugin.manifest.name,
       hasExplicitOutput,
       scope: resolvedScope,
@@ -194,6 +202,7 @@ export default defineCommand({
         outputRoot,
         codexHome,
         piHome,
+        kimiHome,
         pluginName: plugin.manifest.name,
         hasExplicitOutput,
         scope: handler.defaultScope,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -8,7 +8,7 @@ import { targets, validateScope } from "../targets"
 import { pathExists } from "../utils/files"
 import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
 import { ensureCodexAgentsFile } from "../utils/codex-agents"
-import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
+import { expandHome, resolveCodexHome, resolveKimiHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../utils/resolve-output"
 import { detectInstalledTools } from "../utils/detect-tools"
 
@@ -28,7 +28,7 @@ export default defineCommand({
     to: {
       type: "string",
       default: "opencode",
-      description: "Target format (opencode | codex | pi | antigravity | all)",
+      description: "Target format (opencode | codex | pi | antigravity | kimi | all)",
     },
     output: {
       type: "string",
@@ -44,6 +44,11 @@ export default defineCommand({
       type: "string",
       alias: "pi-home",
       description: "Write Pi output to this Pi root (ex: ~/.pi/agent or ./.pi)",
+    },
+    kimiHome: {
+      type: "string",
+      alias: "kimi-home",
+      description: "Write Kimi output to this Kimi root (default: $KIMI_HOME or ~/.kimi)",
     },
     scope: {
       type: "string",
@@ -95,6 +100,7 @@ export default defineCommand({
       const outputRoot = resolveOutputRoot(args.output)
       const codexHome = resolveCodexHome(args.codexHome)
       const piHome = resolveTargetHome(args.piHome, path.join(os.homedir(), ".pi", "agent"))
+      const kimiHome = resolveKimiHome(args.kimiHome)
       const hasExplicitOutput = Boolean(args.output && String(args.output).trim())
 
       const options: ClaudeToOpenCodeOptions = {
@@ -138,6 +144,7 @@ export default defineCommand({
             outputRoot,
             codexHome,
             piHome,
+            kimiHome,
             pluginName: plugin.manifest.name,
             hasExplicitOutput,
           })
@@ -172,6 +179,7 @@ export default defineCommand({
         outputRoot,
         codexHome,
         piHome,
+        kimiHome,
         pluginName: plugin.manifest.name,
         hasExplicitOutput,
         scope: resolvedScope,
@@ -203,6 +211,7 @@ export default defineCommand({
           outputRoot,
           codexHome,
           piHome,
+          kimiHome,
           pluginName: plugin.manifest.name,
           hasExplicitOutput,
           scope: handler.defaultScope,

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -48,7 +48,7 @@ export default defineCommand({
     kimiHome: {
       type: "string",
       alias: "kimi-home",
-      description: "Write Kimi output to this Kimi root (default: $KIMI_HOME or ~/.kimi)",
+      description: "Write Kimi output to this Kimi root (default: $KIMI_CODE_HOME or ~/.kimi-code)",
     },
     scope: {
       type: "string",

--- a/src/converters/claude-to-kimi.ts
+++ b/src/converters/claude-to-kimi.ts
@@ -180,7 +180,7 @@ function collectReferencedSidecarDirs(agent: ClaudeAgent): KimiGeneratedSkillSid
 }
 
 /**
- * Kimi hooks are `[[hooks]]` shell commands keyed on its own 13 lifecycle
+ * Kimi hooks are `[[hooks]]` shell commands keyed on its own lifecycle
  * events. Claude events Kimi lacks, and prompt/agent-type hook entries (which
  * have no shell command), are dropped during conversion. Warn so the loss is
  * visible rather than silent.

--- a/src/converters/claude-to-kimi.ts
+++ b/src/converters/claude-to-kimi.ts
@@ -1,0 +1,236 @@
+import fs, { type Dirent } from "fs"
+import path from "path"
+import { formatFrontmatter } from "../utils/frontmatter"
+import { type ClaudeAgent, type ClaudeCommand, type ClaudeHooks, type ClaudePlugin, filterSkillsByPlatform } from "../types/claude"
+import type {
+  KimiBundle,
+  KimiGeneratedSkill,
+  KimiGeneratedSkillSidecarDir,
+} from "../types/kimi"
+import type { ClaudeToOpenCodeOptions } from "./claude-to-opencode"
+import {
+  isKimiHookEvent,
+  normalizeKimiName,
+  transformContentForKimi,
+  type KimiInvocationTargets,
+} from "../utils/kimi-content"
+
+export type ClaudeToKimiOptions = ClaudeToOpenCodeOptions
+
+// Kimi skill descriptions are 1-1024 chars.
+const KIMI_DESCRIPTION_MAX_LENGTH = 1024
+
+/**
+ * Convert a Claude plugin into a Kimi CLI bundle.
+ *
+ * Kimi has no native plugin-install flow, so everything is emitted by the
+ * converter. Skills map directly (same open SKILL.md spec). Commands and agents
+ * have no first-class Kimi equivalent, so both become skills the user invokes
+ * via `/skill:<name>`. MCP servers and hooks map to Kimi's own config surfaces.
+ */
+export function convertClaudeToKimi(
+  plugin: ClaudePlugin,
+  _options: ClaudeToKimiOptions,
+): KimiBundle {
+  const platformSkills = filterSkillsByPlatform(plugin.skills, "kimi")
+  const invocableCommands = plugin.commands.filter((command) => !command.disableModelInvocation)
+
+  const skillDirs = platformSkills.map((skill) => ({
+    name: skill.name,
+    sourceDir: skill.sourceDir,
+  }))
+
+  // Reserve every emitted skill name up front so command- and agent-derived
+  // skills never collide with a pass-through skill or with each other.
+  const usedNames = new Set<string>(skillDirs.map((skill) => normalizeKimiName(skill.name)))
+
+  const skillTargets: Record<string, string> = {}
+  for (const skill of platformSkills) {
+    skillTargets[normalizeKimiName(skill.name)] = skill.name
+  }
+
+  const commandSkillNames = new Map<string, string>()
+  for (const command of invocableCommands) {
+    const name = uniqueName(normalizeKimiName(command.name), usedNames)
+    commandSkillNames.set(command.name, name)
+    skillTargets[normalizeKimiName(command.name)] = name
+  }
+
+  const agentSkillNames = new Map<string, string>()
+  const agentTargets: Record<string, string> = {}
+  for (const agent of plugin.agents) {
+    const name = uniqueName(normalizeKimiName(agent.name), usedNames)
+    agentSkillNames.set(agent.name, name)
+    for (const alias of agentAliases(plugin, agent)) {
+      agentTargets[normalizeKimiName(alias)] = name
+    }
+  }
+
+  warnUnsupportedHooks(plugin.hooks)
+
+  const invocationTargets: KimiInvocationTargets = { skillTargets, agentTargets }
+
+  const generatedSkills: KimiGeneratedSkill[] = []
+  for (const command of invocableCommands) {
+    generatedSkills.push(
+      convertCommandSkill(command, commandSkillNames.get(command.name)!, invocationTargets),
+    )
+  }
+  for (const agent of plugin.agents) {
+    generatedSkills.push(
+      convertAgentSkill(agent, agentSkillNames.get(agent.name)!, invocationTargets),
+    )
+  }
+
+  return {
+    pluginName: plugin.manifest.name,
+    skillDirs,
+    generatedSkills,
+    invocationTargets,
+    mcpServers: plugin.mcpServers,
+    hooks: plugin.hooks,
+  }
+}
+
+function convertCommandSkill(
+  command: ClaudeCommand,
+  name: string,
+  invocationTargets: KimiInvocationTargets,
+): KimiGeneratedSkill {
+  const frontmatter: Record<string, unknown> = {
+    name,
+    description: sanitizeDescription(
+      command.description ?? `Converted from Claude command ${command.name}`,
+    ),
+  }
+  const sections: string[] = []
+  if (command.argumentHint) {
+    sections.push(`## Arguments\n${command.argumentHint}`)
+  }
+  if (command.allowedTools && command.allowedTools.length > 0) {
+    sections.push(`## Allowed tools\n${command.allowedTools.map((tool) => `- ${tool}`).join("\n")}`)
+  }
+  sections.push(transformContentForKimi(command.body.trim(), invocationTargets))
+  const body = sections.filter(Boolean).join("\n\n").trim()
+  const content = formatFrontmatter(frontmatter, body.length > 0 ? body : command.body)
+  return { name, content }
+}
+
+function convertAgentSkill(
+  agent: ClaudeAgent,
+  name: string,
+  invocationTargets: KimiInvocationTargets,
+): KimiGeneratedSkill {
+  const frontmatter: Record<string, unknown> = {
+    name,
+    description: sanitizeDescription(
+      agent.description ?? `Converted from Claude agent ${agent.name}`,
+    ),
+  }
+  const sections: string[] = []
+  if (agent.capabilities && agent.capabilities.length > 0) {
+    sections.push(`## Capabilities\n${agent.capabilities.map((c) => `- ${c}`).join("\n")}`)
+  }
+  sections.push(transformContentForKimi(agent.body.trim(), invocationTargets))
+  const body = sections.filter(Boolean).join("\n\n").trim()
+  const content = formatFrontmatter(
+    frontmatter,
+    body.length > 0 ? body : `Instructions converted from the ${agent.name} agent.`,
+  )
+  return { name, content, sidecarDirs: collectReferencedSidecarDirs(agent) }
+}
+
+function agentAliases(plugin: ClaudePlugin, agent: ClaudeAgent): string[] {
+  const category = getAgentCategory(agent)
+  const bare = agent.name.startsWith("ce-") ? agent.name.slice("ce-".length) : ""
+  return [
+    agent.name,
+    bare,
+    category ? `${category}:${agent.name}` : "",
+    category && bare ? `${category}:${bare}` : "",
+    category ? `${plugin.manifest.name}:${category}:${agent.name}` : "",
+    category && bare ? `${plugin.manifest.name}:${category}:${bare}` : "",
+  ].filter(Boolean)
+}
+
+function getAgentCategory(agent: ClaudeAgent): string | null {
+  const parts = agent.sourcePath.split(path.sep)
+  const agentsIndex = parts.lastIndexOf("agents")
+  if (agentsIndex === -1) return null
+  const next = parts[agentsIndex + 1]
+  if (!next || next.endsWith(".md")) return null
+  return next
+}
+
+function collectReferencedSidecarDirs(agent: ClaudeAgent): KimiGeneratedSkillSidecarDir[] {
+  const sourceDir = path.dirname(agent.sourcePath)
+  let entries: Dirent[]
+  try {
+    entries = fs.readdirSync(sourceDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .filter((entry) => agent.body.includes(`${entry.name}/`) || agent.body.includes(`\`${entry.name}\``))
+    .map((entry) => ({
+      sourceDir: path.join(sourceDir, entry.name),
+      targetName: entry.name,
+    }))
+}
+
+/**
+ * Kimi hooks are `[[hooks]]` shell commands keyed on its own 13 lifecycle
+ * events. Claude events Kimi lacks, and prompt/agent-type hook entries (which
+ * have no shell command), are dropped during conversion. Warn so the loss is
+ * visible rather than silent.
+ */
+function warnUnsupportedHooks(hooks?: ClaudeHooks): void {
+  if (!hooks?.hooks) return
+  const droppedEvents = new Set<string>()
+  let droppedNonCommand = 0
+  for (const [event, matchers] of Object.entries(hooks.hooks)) {
+    const hasEntries = matchers.some((matcher) => matcher.hooks.length > 0)
+    if (!isKimiHookEvent(event)) {
+      if (hasEntries) droppedEvents.add(event)
+      continue
+    }
+    for (const matcher of matchers) {
+      for (const entry of matcher.hooks) {
+        if (entry.type !== "command") droppedNonCommand += 1
+      }
+    }
+  }
+
+  const parts: string[] = []
+  if (droppedEvents.size > 0) {
+    parts.push(`unsupported events not converted (${Array.from(droppedEvents).join(", ")})`)
+  }
+  if (droppedNonCommand > 0) {
+    parts.push(`${droppedNonCommand} prompt/agent hook(s) skipped (Kimi hooks run shell commands only)`)
+  }
+  if (parts.length > 0) {
+    console.warn(`Warning: Kimi hook conversion is partial -- ${parts.join("; ")}.`)
+  }
+}
+
+function sanitizeDescription(value: string, maxLength = KIMI_DESCRIPTION_MAX_LENGTH): string {
+  const normalized = value.replace(/\s+/g, " ").trim()
+  if (normalized.length <= maxLength) return normalized
+  const ellipsis = "..."
+  return normalized.slice(0, Math.max(0, maxLength - ellipsis.length)).trimEnd() + ellipsis
+}
+
+function uniqueName(base: string, used: Set<string>): string {
+  if (!used.has(base)) {
+    used.add(base)
+    return base
+  }
+  let index = 2
+  while (used.has(`${base}-${index}`)) {
+    index += 1
+  }
+  const name = `${base}-${index}`
+  used.add(name)
+  return name
+}

--- a/src/targets/index.ts
+++ b/src/targets/index.ts
@@ -3,10 +3,12 @@ import { convertClaudeToOpenCode, type ClaudeToOpenCodeOptions } from "../conver
 import { convertClaudeToCodex } from "../converters/claude-to-codex"
 import { convertClaudeToPi } from "../converters/claude-to-pi"
 import { convertClaudeToAntigravity } from "../converters/claude-to-antigravity"
+import { convertClaudeToKimi } from "../converters/claude-to-kimi"
 import { writeOpenCodeBundle } from "./opencode"
 import { writeCodexBundle } from "./codex"
 import { writePiBundle } from "./pi"
 import { writeAntigravityBundle } from "./antigravity"
+import { writeKimiBundle } from "./kimi"
 
 export type TargetScope = "global" | "workspace"
 
@@ -72,5 +74,14 @@ export const targets: Record<string, TargetHandler> = {
     implemented: true,
     convert: convertClaudeToAntigravity as TargetHandler["convert"],
     write: writeAntigravityBundle as TargetHandler["write"],
+  },
+  kimi: {
+    name: "kimi",
+    implemented: true,
+    convert: convertClaudeToKimi as TargetHandler["convert"],
+    write: ((outputRoot, bundle) =>
+      writeKimiBundle(outputRoot, bundle as Parameters<typeof writeKimiBundle>[1], {
+        outputIsKimiRoot: true,
+      })) as TargetHandler["write"],
   },
 }

--- a/src/targets/kimi.ts
+++ b/src/targets/kimi.ts
@@ -29,7 +29,7 @@ export type KimiInstallManifest = {
 }
 
 export type KimiWriteOptions = {
-  /** When true, `outputRoot` is already the Kimi root (e.g. ~/.kimi). */
+  /** When true, `outputRoot` is already the Kimi root (e.g. ~/.kimi-code). */
   outputIsKimiRoot?: boolean
 }
 
@@ -56,19 +56,26 @@ export async function writeKimiBundle(
     ]),
   )
 
+  // Skill names we previously installed (and may therefore safely overwrite).
+  // Anything else occupying a target name is foreign and is backed up, never
+  // silently deleted, since the skills root is flat and shared.
+  const managedSkills = new Set(manifest?.skills ?? [])
+
   await cleanupRemovedSkills(skillsRoot, manifest, currentSkills)
 
   for (const skill of bundle.skillDirs) {
-    const targetDir = path.join(skillsRoot, sanitizePathName(skill.name))
-    await fs.rm(targetDir, { recursive: true, force: true })
+    const name = sanitizePathName(skill.name)
+    const targetDir = path.join(skillsRoot, name)
+    await clearSkillTarget(targetDir, name, managedSkills)
     await copySkillDir(skill.sourceDir, targetDir, (content) =>
       transformContentForKimi(content, bundle.invocationTargets),
     )
   }
 
   for (const skill of bundle.generatedSkills) {
-    const skillDir = path.join(skillsRoot, sanitizePathName(skill.name))
-    await fs.rm(skillDir, { recursive: true, force: true })
+    const name = sanitizePathName(skill.name)
+    const skillDir = path.join(skillsRoot, name)
+    await clearSkillTarget(skillDir, name, managedSkills)
     await writeText(path.join(skillDir, "SKILL.md"), skill.content + "\n")
     for (const sidecar of skill.sidecarDirs ?? []) {
       await copyDir(sidecar.sourceDir, path.join(skillDir, sidecar.targetName))
@@ -90,7 +97,7 @@ export async function writeKimiBundle(
 
 function resolveKimiRoot(outputRoot: string, options: KimiWriteOptions): string {
   if (options.outputIsKimiRoot) return outputRoot
-  return path.basename(outputRoot) === ".kimi" ? outputRoot : path.join(outputRoot, ".kimi")
+  return path.basename(outputRoot) === ".kimi-code" ? outputRoot : path.join(outputRoot, ".kimi-code")
 }
 
 function sanitizeKimiPathComponent(name: string): string {
@@ -147,6 +154,30 @@ async function writeInstallManifest(kimiRoot: string, manifest: KimiInstallManif
   await writeJson(path.join(kimiRoot, manifest.pluginName, MANAGED_INSTALL_MANIFEST), manifest)
 }
 
+/**
+ * Clear a skill's target directory before (re)writing it. The Kimi skills root
+ * is flat and shared with user-authored skills and other tools, so a name we
+ * ship can collide with a directory this plugin never created. A directory we
+ * previously managed (recorded in the prior install manifest) is removed; any
+ * other existing directory is moved aside to a timestamped backup so a
+ * collision never silently destroys foreign data.
+ */
+async function clearSkillTarget(
+  targetDir: string,
+  name: string,
+  managedSkills: Set<string>,
+): Promise<void> {
+  if (managedSkills.has(name)) {
+    await fs.rm(targetDir, { recursive: true, force: true })
+    return
+  }
+  if (!(await pathExists(targetDir))) return
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
+  const backupPath = `${targetDir}.bak.${timestamp}`
+  await fs.rename(targetDir, backupPath)
+  console.log(`Backed up unmanaged Kimi skill directory to ${backupPath}`)
+}
+
 async function cleanupRemovedSkills(
   skillsRoot: string,
   manifest: KimiInstallManifest | null,
@@ -163,7 +194,7 @@ async function cleanupRemovedSkills(
   }
 }
 
-// ── MCP servers (~/.kimi/mcp.json) ─────────────────────────
+// ── MCP servers (~/.kimi-code/mcp.json) ────────────────────
 
 type McpJson = { mcpServers?: Record<string, ClaudeMcpServer> } & Record<string, unknown>
 
@@ -217,20 +248,18 @@ async function readJsonSafe(filePath: string): Promise<McpJson | null> {
   }
 }
 
-// ── Hooks (~/.kimi/config.toml [[hooks]]) ──────────────────
+// ── Hooks (~/.kimi-code/config.toml [[hooks]]) ─────────────
 
+// Claude tool names -> Kimi Code CLI tool names (used as hook `matcher`
+// tokens). Kimi Code CLI's built-in tool names largely match Claude's
+// (Bash, Read, Write, Edit, Grep, Glob, WebSearch), so those pass through
+// unchanged via the `?? trimmed` fallback in remapMatcher; only the few that
+// genuinely differ are listed here.
 const KIMI_TOOL_NAMES: Record<string, string> = {
-  Write: "WriteFile",
-  Edit: "StrReplaceFile",
-  MultiEdit: "StrReplaceFile",
-  Read: "ReadFile",
-  Bash: "Shell",
-  Grep: "Grep",
-  Glob: "Glob",
+  MultiEdit: "Edit",
   WebFetch: "FetchURL",
-  WebSearch: "SearchWeb",
   Task: "Agent",
-  TodoWrite: "SetTodoList",
+  TodoWrite: "TodoList",
 }
 
 async function writeHooksConfig(kimiRoot: string, hooks?: ClaudeHooks): Promise<void> {

--- a/src/targets/kimi.ts
+++ b/src/targets/kimi.ts
@@ -1,0 +1,317 @@
+import fs from "fs/promises"
+import path from "path"
+import {
+  backupFile,
+  copyDir,
+  copySkillDir,
+  ensureDir,
+  isSafeManagedPath,
+  pathExists,
+  sanitizePathName,
+  writeJson,
+  writeJsonSecure,
+  writeText,
+  writeTextSecure,
+} from "../utils/files"
+import type { KimiBundle } from "../types/kimi"
+import type { ClaudeHooks, ClaudeMcpServer } from "../types/claude"
+import { isKimiHookEvent, transformContentForKimi } from "../utils/kimi-content"
+
+const MANAGED_INSTALL_MANIFEST = "install-manifest.json"
+const HOOKS_START_MARKER = "# BEGIN Compound Engineering plugin hooks -- do not edit this block"
+const HOOKS_END_MARKER = "# END Compound Engineering plugin hooks"
+
+export type KimiInstallManifest = {
+  version: 1
+  pluginName: string
+  skills: string[]
+  mcpServers: string[]
+}
+
+export type KimiWriteOptions = {
+  /** When true, `outputRoot` is already the Kimi root (e.g. ~/.kimi). */
+  outputIsKimiRoot?: boolean
+}
+
+export async function writeKimiBundle(
+  outputRoot: string,
+  bundle: KimiBundle,
+  options: KimiWriteOptions = {},
+): Promise<void> {
+  const kimiRoot = resolveKimiRoot(outputRoot, options)
+  await ensureDir(kimiRoot)
+
+  const pluginName = bundle.pluginName ? sanitizeKimiPathComponent(bundle.pluginName) : undefined
+  const manifest = pluginName ? await readInstallManifest(kimiRoot, pluginName) : null
+
+  // Skills are written FLAT into <kimiRoot>/skills/<name>/ -- Kimi discovers
+  // skills by scanning the skills root directly, so a per-plugin subdirectory
+  // (as Codex uses) would be invisible. Cleanup is driven entirely by the
+  // install manifest's recorded skill names, never by sweeping the shared dir.
+  const skillsRoot = path.join(kimiRoot, "skills")
+  const currentSkills = Array.from(
+    new Set([
+      ...bundle.skillDirs.map((skill) => sanitizePathName(skill.name)),
+      ...bundle.generatedSkills.map((skill) => sanitizePathName(skill.name)),
+    ]),
+  )
+
+  await cleanupRemovedSkills(skillsRoot, manifest, currentSkills)
+
+  for (const skill of bundle.skillDirs) {
+    const targetDir = path.join(skillsRoot, sanitizePathName(skill.name))
+    await fs.rm(targetDir, { recursive: true, force: true })
+    await copySkillDir(skill.sourceDir, targetDir, (content) =>
+      transformContentForKimi(content, bundle.invocationTargets),
+    )
+  }
+
+  for (const skill of bundle.generatedSkills) {
+    const skillDir = path.join(skillsRoot, sanitizePathName(skill.name))
+    await fs.rm(skillDir, { recursive: true, force: true })
+    await writeText(path.join(skillDir, "SKILL.md"), skill.content + "\n")
+    for (const sidecar of skill.sidecarDirs ?? []) {
+      await copyDir(sidecar.sourceDir, path.join(skillDir, sidecar.targetName))
+    }
+  }
+
+  const mcpNames = await writeMcpJson(kimiRoot, bundle.mcpServers ?? {}, manifest)
+  await writeHooksConfig(kimiRoot, bundle.hooks)
+
+  if (pluginName) {
+    await writeInstallManifest(kimiRoot, {
+      version: 1,
+      pluginName,
+      skills: currentSkills,
+      mcpServers: mcpNames,
+    })
+  }
+}
+
+function resolveKimiRoot(outputRoot: string, options: KimiWriteOptions): string {
+  if (options.outputIsKimiRoot) return outputRoot
+  return path.basename(outputRoot) === ".kimi" ? outputRoot : path.join(outputRoot, ".kimi")
+}
+
+function sanitizeKimiPathComponent(name: string): string {
+  return sanitizePathName(name).replace(/[\\/]/g, "-")
+}
+
+// ── Install manifest ───────────────────────────────────────
+
+async function readInstallManifest(
+  kimiRoot: string,
+  pluginName: string,
+): Promise<KimiInstallManifest | null> {
+  const manifestPath = path.join(kimiRoot, pluginName, MANAGED_INSTALL_MANIFEST)
+  try {
+    const raw = await fs.readFile(manifestPath, "utf8")
+    const parsed = JSON.parse(raw) as Partial<KimiInstallManifest>
+    if (parsed.version === 1 && parsed.pluginName === pluginName && Array.isArray(parsed.skills)) {
+      const mcpServers = Array.isArray(parsed.mcpServers) ? parsed.mcpServers : []
+      return {
+        version: 1,
+        pluginName,
+        skills: filterSafeManifestEntries(parsed.skills, kimiRoot, manifestPath, "skills"),
+        mcpServers: mcpServers.filter((name) => typeof name === "string"),
+      }
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn(`Ignoring unreadable Kimi install manifest at ${manifestPath}.`)
+    }
+  }
+  return null
+}
+
+function filterSafeManifestEntries(
+  entries: unknown[],
+  kimiRoot: string,
+  manifestPath: string,
+  group: string,
+): string[] {
+  const safe: string[] = []
+  for (const entry of entries) {
+    if (isSafeManagedPath(kimiRoot, entry)) {
+      safe.push(entry)
+    } else {
+      console.warn(
+        `Dropping unsafe Kimi install-manifest entry in ${manifestPath} (group "${group}"): ${JSON.stringify(entry)}`,
+      )
+    }
+  }
+  return safe
+}
+
+async function writeInstallManifest(kimiRoot: string, manifest: KimiInstallManifest): Promise<void> {
+  await writeJson(path.join(kimiRoot, manifest.pluginName, MANAGED_INSTALL_MANIFEST), manifest)
+}
+
+async function cleanupRemovedSkills(
+  skillsRoot: string,
+  manifest: KimiInstallManifest | null,
+  currentSkills: string[],
+): Promise<void> {
+  if (!manifest) return
+  const current = new Set(currentSkills)
+  for (const skillName of manifest.skills) {
+    if (current.has(skillName)) continue
+    // Defense in depth: entries are already filtered on read, but re-check
+    // before issuing any fs.rm against the shared skills root.
+    if (!isSafeManagedPath(skillsRoot, skillName)) continue
+    await fs.rm(path.join(skillsRoot, skillName), { recursive: true, force: true })
+  }
+}
+
+// ── MCP servers (~/.kimi/mcp.json) ─────────────────────────
+
+type McpJson = { mcpServers?: Record<string, ClaudeMcpServer> } & Record<string, unknown>
+
+async function writeMcpJson(
+  kimiRoot: string,
+  servers: Record<string, ClaudeMcpServer>,
+  manifest: KimiInstallManifest | null,
+): Promise<string[]> {
+  const mcpPath = path.join(kimiRoot, "mcp.json")
+  const existing = await readJsonSafe(mcpPath)
+  const ourNames = Object.keys(servers)
+
+  // Start from existing user content; drop only servers we previously owned
+  // that are no longer present, then layer ours on top.
+  const merged: Record<string, ClaudeMcpServer> = { ...(existing?.mcpServers ?? {}) }
+  for (const name of manifest?.mcpServers ?? []) {
+    if (!ourNames.includes(name)) delete merged[name]
+  }
+  for (const [name, server] of Object.entries(servers)) {
+    merged[name] = server
+  }
+
+  // Nothing to write and no file to clean up.
+  if (existing === null && Object.keys(merged).length === 0) return ourNames
+
+  const next: McpJson = { ...(existing ?? {}) }
+  if (Object.keys(merged).length > 0) {
+    next.mcpServers = merged
+  } else {
+    delete next.mcpServers
+  }
+
+  const nextContent = JSON.stringify(next, null, 2) + "\n"
+  const existingContent = existing !== null ? JSON.stringify(existing, null, 2) + "\n" : null
+  if (nextContent !== existingContent) {
+    if (existing !== null) {
+      const backupPath = await backupFile(mcpPath)
+      if (backupPath) console.log(`Backed up existing Kimi MCP config to ${backupPath}`)
+    }
+    await writeJsonSecure(mcpPath, next)
+  }
+  return ourNames
+}
+
+async function readJsonSafe(filePath: string): Promise<McpJson | null> {
+  try {
+    const content = await fs.readFile(filePath, "utf8")
+    return JSON.parse(content) as McpJson
+  } catch {
+    return null
+  }
+}
+
+// ── Hooks (~/.kimi/config.toml [[hooks]]) ──────────────────
+
+const KIMI_TOOL_NAMES: Record<string, string> = {
+  Write: "WriteFile",
+  Edit: "StrReplaceFile",
+  MultiEdit: "StrReplaceFile",
+  Read: "ReadFile",
+  Bash: "Shell",
+  Grep: "Grep",
+  Glob: "Glob",
+  WebFetch: "FetchURL",
+  WebSearch: "SearchWeb",
+  Task: "Agent",
+  TodoWrite: "SetTodoList",
+}
+
+async function writeHooksConfig(kimiRoot: string, hooks?: ClaudeHooks): Promise<void> {
+  const configPath = path.join(kimiRoot, "config.toml")
+  const existing = await readFileSafe(configPath)
+  const hooksToml = renderKimiHooksToml(hooks)
+  const merged = mergeKimiConfig(existing, hooksToml)
+  if (merged === null) return
+  if (merged === existing) return
+  if (existing) {
+    const backupPath = await backupFile(configPath)
+    if (backupPath) console.log(`Backed up existing Kimi config to ${backupPath}`)
+  }
+  await writeTextSecure(configPath, merged)
+}
+
+export function renderKimiHooksToml(hooks?: ClaudeHooks): string | null {
+  if (!hooks?.hooks) return null
+  const blocks: string[] = []
+  for (const [event, matchers] of Object.entries(hooks.hooks)) {
+    if (!isKimiHookEvent(event)) continue
+    for (const matcher of matchers) {
+      for (const entry of matcher.hooks) {
+        // Kimi hooks are shell commands only; prompt/agent hooks have no
+        // shell-command equivalent and are skipped.
+        if (entry.type !== "command" || !entry.command) continue
+        const lines = ["[[hooks]]", `event = ${tomlString(event)}`]
+        const remapped = remapMatcher(matcher.matcher)
+        if (remapped) lines.push(`matcher = ${tomlString(remapped)}`)
+        lines.push(`command = ${tomlString(entry.command)}`)
+        if (typeof entry.timeout === "number") lines.push(`timeout = ${entry.timeout}`)
+        blocks.push(lines.join("\n"))
+      }
+    }
+  }
+  return blocks.length > 0 ? blocks.join("\n\n") : null
+}
+
+function remapMatcher(matcher?: string): string {
+  const raw = (matcher ?? "").trim()
+  if (!raw || raw === "*") return ""
+  return raw
+    .split("|")
+    .map((token) => {
+      const trimmed = token.trim()
+      return KIMI_TOOL_NAMES[trimmed] ?? trimmed
+    })
+    .join("|")
+}
+
+export function mergeKimiConfig(existing: string, hooksToml: string | null): string | null {
+  const blockPattern = new RegExp(
+    `${escapeForRegex(HOOKS_START_MARKER)}[\\s\\S]*?${escapeForRegex(HOOKS_END_MARKER)}\\n?`,
+    "g",
+  )
+  const stripped = existing.replace(blockPattern, "")
+  const removedManagedBlock = stripped !== existing
+
+  if (!hooksToml) {
+    if (!existing) return null
+    return removedManagedBlock ? stripped.trimEnd() + "\n" : existing
+  }
+
+  const managedBlock = [HOOKS_START_MARKER, hooksToml.trim(), HOOKS_END_MARKER, ""].join("\n")
+  const base = stripped.trimEnd()
+  return base ? `${base}\n\n${managedBlock}` : managedBlock
+}
+
+async function readFileSafe(filePath: string): Promise<string> {
+  try {
+    return await fs.readFile(filePath, "utf8")
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+    return ""
+  }
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value)
+}
+
+function escapeForRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}

--- a/src/types/kimi.ts
+++ b/src/types/kimi.ts
@@ -1,0 +1,33 @@
+import type { ClaudeMcpServer, ClaudeHooks } from "./claude"
+import type { KimiInvocationTargets } from "../utils/kimi-content"
+
+export type KimiSkillDir = {
+  name: string
+  sourceDir: string
+}
+
+export type KimiGeneratedSkillSidecarDir = {
+  sourceDir: string
+  targetName: string
+}
+
+export type KimiGeneratedSkill = {
+  name: string
+  content: string
+  sidecarDirs?: KimiGeneratedSkillSidecarDir[]
+}
+
+export type KimiBundle = {
+  pluginName?: string
+  /** Pass-through Claude skills copied verbatim (with content transform). */
+  skillDirs: KimiSkillDir[]
+  /**
+   * Skills generated from Claude commands and agents. Kimi has no command-file
+   * or auto-discovered agent-directory concept, so both surface as skills that
+   * the user invokes with `/skill:<name>`.
+   */
+  generatedSkills: KimiGeneratedSkill[]
+  invocationTargets?: KimiInvocationTargets
+  mcpServers?: Record<string, ClaudeMcpServer>
+  hooks?: ClaudeHooks
+}

--- a/src/utils/detect-tools.ts
+++ b/src/utils/detect-tools.ts
@@ -50,6 +50,10 @@ const detectableTools: DetectableTool[] = [
     detectPaths: (home) => [path.join(home, ".pi")],
   },
   {
+    name: "kimi",
+    detectPaths: (home) => [path.join(home, ".kimi")],
+  },
+  {
     name: "droid",
     detectPaths: (home) => [path.join(home, ".factory")],
   },

--- a/src/utils/detect-tools.ts
+++ b/src/utils/detect-tools.ts
@@ -51,7 +51,10 @@ const detectableTools: DetectableTool[] = [
   },
   {
     name: "kimi",
-    detectPaths: (home) => [path.join(home, ".kimi")],
+    // Kimi Code CLI (the current product) uses ~/.kimi-code; the legacy
+    // kimi-cli root ~/.kimi is kept as a fallback so migrated installs still
+    // register as detected.
+    detectPaths: (home) => [path.join(home, ".kimi-code"), path.join(home, ".kimi")],
   },
   {
     name: "droid",

--- a/src/utils/kimi-content.ts
+++ b/src/utils/kimi-content.ts
@@ -1,0 +1,140 @@
+export type KimiInvocationTargets = {
+  /**
+   * Normalized name -> Kimi skill name. Covers pass-through skills as well as
+   * skills generated from Claude commands, so a `/command` reference can be
+   * rewritten to the `/skill:<name>` form Kimi understands.
+   */
+  skillTargets: Record<string, string>
+  /** Normalized agent name -> Kimi skill name (agents convert to skills). */
+  agentTargets?: Record<string, string>
+}
+
+export type KimiTransformOptions = {
+  /**
+   * What to do with a slash reference that matches no known skill target.
+   * `preserve` keeps it verbatim (default — it is likely a Kimi built-in
+   * command or a filesystem path); `skill` rewrites it to `/skill:<name>`.
+   */
+  unknownSlashBehavior?: "preserve" | "skill"
+}
+
+/**
+ * Transform Claude Code content to Kimi CLI-compatible content.
+ *
+ * Handles the syntax differences that matter for Kimi:
+ * 1. Task agent calls: `Task agent-name(args)` -> `Use the \`agent-name\` skill to: args`
+ * 2. Slash command references: known commands/skills -> `/skill:<name>`
+ * 3. Agent references: `@agent-name` -> the `agent-name` skill
+ * 4. Claude config paths: `.claude/` -> `.kimi/`
+ */
+export function transformContentForKimi(
+  body: string,
+  targets?: KimiInvocationTargets,
+  options: KimiTransformOptions = {},
+): string {
+  let result = body
+  const skillTargets = targets?.skillTargets ?? {}
+  const agentTargets = targets?.agentTargets ?? {}
+  const unknownSlashBehavior = options.unknownSlashBehavior ?? "preserve"
+
+  const taskPattern = /^(\s*-?\s*)Task\s+([a-z][a-z0-9:-]*)\(([^)]*)\)/gm
+  result = result.replace(taskPattern, (_match, prefix: string, agentName: string, args: string) => {
+    const target = resolveTarget(agentName, agentTargets, skillTargets)
+    const trimmedArgs = args.trim()
+    const skillName = target ?? normalizeKimiName(finalSegment(agentName))
+    return trimmedArgs
+      ? `${prefix}Use the \`${skillName}\` skill to: ${trimmedArgs}`
+      : `${prefix}Use the \`${skillName}\` skill`
+  })
+
+  const slashCommandPattern = /(?<![:\w>}\]\)])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+  result = result.replace(slashCommandPattern, (match, commandName: string) => {
+    if (commandName.includes("/")) return match
+    if (["dev", "tmp", "etc", "usr", "var", "bin", "home"].includes(commandName)) return match
+
+    const normalizedName = normalizeKimiName(commandName)
+    const target = skillTargets[normalizedName]
+    if (target) return `/skill:${target}`
+    if (unknownSlashBehavior === "skill") return `/skill:${normalizedName}`
+    return match
+  })
+
+  result = result
+    .replace(/~\/\.claude\//g, "~/.kimi/")
+    .replace(/\.claude\//g, ".kimi/")
+
+  const agentRefPattern = /@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))/gi
+  result = result.replace(agentRefPattern, (_match, agentName: string) => {
+    const target = resolveTarget(agentName, agentTargets, skillTargets)
+    return `the \`${target ?? normalizeKimiName(agentName)}\` skill`
+  })
+
+  return result
+}
+
+function resolveTarget(
+  value: string,
+  agentTargets: Record<string, string>,
+  skillTargets: Record<string, string>,
+): string | null {
+  const parts = value.split(":").filter(Boolean)
+  const candidates = [
+    normalizeKimiName(value),
+    parts.length >= 2 ? normalizeKimiName(parts.slice(-2).join(":")) : "",
+    parts.length >= 1 ? normalizeKimiName(parts[parts.length - 1]) : "",
+  ].filter(Boolean)
+
+  for (const candidate of candidates) {
+    if (agentTargets[candidate]) return agentTargets[candidate]
+  }
+  for (const candidate of candidates) {
+    if (skillTargets[candidate]) return skillTargets[candidate]
+  }
+  return null
+}
+
+function finalSegment(value: string): string {
+  return value.includes(":") ? value.split(":").pop()! : value
+}
+
+/**
+ * Kimi's 13 supported hook lifecycle events. Claude events outside this set
+ * (e.g. PermissionRequest, Setup) have no Kimi equivalent and are dropped.
+ * Shared by the converter (to warn) and the writer (to render).
+ */
+export const KIMI_HOOK_EVENTS = new Set<string>([
+  "PreToolUse",
+  "PostToolUse",
+  "PostToolUseFailure",
+  "UserPromptSubmit",
+  "Stop",
+  "StopFailure",
+  "SessionStart",
+  "SessionEnd",
+  "SubagentStart",
+  "SubagentStop",
+  "PreCompact",
+  "PostCompact",
+  "Notification",
+])
+
+export function isKimiHookEvent(event: string): boolean {
+  return KIMI_HOOK_EVENTS.has(event)
+}
+
+/**
+ * Normalize a name into a valid Kimi skill name: 1-64 chars, lowercase
+ * letters, digits, and hyphens only.
+ */
+export function normalizeKimiName(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return "item"
+  const normalized = trimmed
+    .toLowerCase()
+    .replace(/[\\/]+/g, "-")
+    .replace(/[:\s]+/g, "-")
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return normalized || "item"
+}

--- a/src/utils/kimi-content.ts
+++ b/src/utils/kimi-content.ts
@@ -25,7 +25,7 @@ export type KimiTransformOptions = {
  * 1. Task agent calls: `Task agent-name(args)` -> `Use the \`agent-name\` skill to: args`
  * 2. Slash command references: known commands/skills -> `/skill:<name>`
  * 3. Agent references: `@agent-name` -> the `agent-name` skill
- * 4. Claude config paths: `.claude/` -> `.kimi/`
+ * 4. Claude config paths: `.claude/` -> `.kimi-code/`
  */
 export function transformContentForKimi(
   body: string,
@@ -60,8 +60,8 @@ export function transformContentForKimi(
   })
 
   result = result
-    .replace(/~\/\.claude\//g, "~/.kimi/")
-    .replace(/\.claude\//g, ".kimi/")
+    .replace(/~\/\.claude\//g, "~/.kimi-code/")
+    .replace(/\.claude\//g, ".kimi-code/")
 
   const agentRefPattern = /@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))/gi
   result = result.replace(agentRefPattern, (_match, agentName: string) => {
@@ -98,21 +98,24 @@ function finalSegment(value: string): string {
 }
 
 /**
- * Kimi's 13 supported hook lifecycle events. Claude events outside this set
- * (e.g. PermissionRequest, Setup) have no Kimi equivalent and are dropped.
- * Shared by the converter (to warn) and the writer (to render).
+ * Kimi Code CLI's supported hook lifecycle events. Claude events outside this
+ * set have no Kimi equivalent and are dropped. Shared by the converter (to
+ * warn) and the writer (to render).
  */
 export const KIMI_HOOK_EVENTS = new Set<string>([
+  "UserPromptSubmit",
   "PreToolUse",
+  "Stop",
   "PostToolUse",
   "PostToolUseFailure",
-  "UserPromptSubmit",
-  "Stop",
-  "StopFailure",
+  "PermissionRequest",
+  "PermissionResult",
   "SessionStart",
   "SessionEnd",
   "SubagentStart",
   "SubagentStop",
+  "StopFailure",
+  "Interrupt",
   "PreCompact",
   "PostCompact",
   "Notification",

--- a/src/utils/resolve-home.ts
+++ b/src/utils/resolve-home.ts
@@ -20,3 +20,8 @@ export function resolveCodexHome(value: unknown): string {
   const defaultPath = process.env.CODEX_HOME?.trim() || path.join(os.homedir(), ".codex")
   return resolveTargetHome(value, path.resolve(expandHome(defaultPath)))
 }
+
+export function resolveKimiHome(value: unknown): string {
+  const defaultPath = process.env.KIMI_HOME?.trim() || path.join(os.homedir(), ".kimi")
+  return resolveTargetHome(value, path.resolve(expandHome(defaultPath)))
+}

--- a/src/utils/resolve-home.ts
+++ b/src/utils/resolve-home.ts
@@ -22,6 +22,6 @@ export function resolveCodexHome(value: unknown): string {
 }
 
 export function resolveKimiHome(value: unknown): string {
-  const defaultPath = process.env.KIMI_HOME?.trim() || path.join(os.homedir(), ".kimi")
+  const defaultPath = process.env.KIMI_CODE_HOME?.trim() || path.join(os.homedir(), ".kimi-code")
   return resolveTargetHome(value, path.resolve(expandHome(defaultPath)))
 }

--- a/src/utils/resolve-output.ts
+++ b/src/utils/resolve-output.ts
@@ -7,13 +7,15 @@ export function resolveTargetOutputRoot(options: {
   outputRoot: string
   codexHome: string
   piHome: string
+  kimiHome: string
   pluginName?: string
   hasExplicitOutput: boolean
   scope?: TargetScope
 }): string {
-  const { targetName, outputRoot, codexHome, piHome, hasExplicitOutput } = options
+  const { targetName, outputRoot, codexHome, piHome, kimiHome, hasExplicitOutput } = options
   if (targetName === "codex") return codexHome
   if (targetName === "pi") return piHome
+  if (targetName === "kimi") return kimiHome
   if (targetName === "antigravity") {
     const base = hasExplicitOutput ? outputRoot : process.cwd()
     return path.join(base, ".agy")

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -193,6 +193,57 @@ describe("CLI", () => {
     }
   })
 
+  test("install converts fixture plugin to Kimi output", async () => {
+    const kimiHome = await fs.mkdtemp(path.join(os.tmpdir(), "cli-kimi-"))
+    const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")
+    const repoRoot = path.join(import.meta.dir, "..")
+
+    const proc = Bun.spawn([
+      "bun",
+      "run",
+      path.join(repoRoot, "src", "index.ts"),
+      "install",
+      fixtureRoot,
+      "--to",
+      "kimi",
+      "--kimi-home",
+      kimiHome,
+    ], {
+      cwd: repoRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    expect(stdout).toContain("Installed compound-engineering")
+
+    // Pass-through skill, agent-as-skill, and command-as-skill all land flat
+    // in <root>/skills/<name>/SKILL.md.
+    expect(await exists(path.join(kimiHome, "skills", "skill-one", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(kimiHome, "skills", "repo-research-analyst", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(kimiHome, "skills", "security-sentinel", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(kimiHome, "skills", "workflows-review", "SKILL.md"))).toBe(true)
+
+    // claude-only skill (ce_platforms: [claude]) is excluded from the kimi target.
+    expect(await exists(path.join(kimiHome, "skills", "claude-only-skill"))).toBe(false)
+
+    // Manifest records the managed skill set.
+    expect(await exists(path.join(kimiHome, "compound-engineering", "install-manifest.json"))).toBe(true)
+
+    // Hooks land in config.toml with remapped tool-name matchers.
+    const config = await fs.readFile(path.join(kimiHome, "config.toml"), "utf8")
+    expect(config).toContain("[[hooks]]")
+    expect(config).toContain('event = "PreToolUse"')
+    expect(config).toContain('matcher = "Shell"')
+  })
+
   test("cleanup backs up legacy Codex artifacts on demand", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-cleanup-codex-"))
     const codexRoot = path.join(tempRoot, ".codex")

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -237,11 +237,12 @@ describe("CLI", () => {
     // Manifest records the managed skill set.
     expect(await exists(path.join(kimiHome, "compound-engineering", "install-manifest.json"))).toBe(true)
 
-    // Hooks land in config.toml with remapped tool-name matchers.
+    // Hooks land in config.toml. Kimi Code CLI shares Claude's Bash tool name,
+    // so the PreToolUse matcher passes through unchanged.
     const config = await fs.readFile(path.join(kimiHome, "config.toml"), "utf8")
     expect(config).toContain("[[hooks]]")
     expect(config).toContain('event = "PreToolUse"')
-    expect(config).toContain('matcher = "Shell"')
+    expect(config).toContain('matcher = "Bash"')
   })
 
   test("cleanup backs up legacy Codex artifacts on demand", async () => {

--- a/tests/detect-tools.test.ts
+++ b/tests/detect-tools.test.ts
@@ -38,6 +38,9 @@ describe("detectInstalledTools", () => {
 
     const pi = results.find((t) => t.name === "pi")
     expect(pi?.detected).toBe(false)
+
+    const kimi = results.find((t) => t.name === "kimi")
+    expect(kimi?.detected).toBe(false)
   })
 
   test("returns all tools with detected=false when no directories exist", async () => {
@@ -47,7 +50,7 @@ describe("detectInstalledTools", () => {
 
     const results = await detectInstalledTools(tempHome, tempCwd)
 
-    expect(results.length).toBe(7)
+    expect(results.length).toBe(8)
     for (const tool of results) {
       expect(tool.detected).toBe(false)
       expect(tool.reason).toBe("not found")
@@ -61,12 +64,17 @@ describe("detectInstalledTools", () => {
     await fs.mkdir(path.join(tempHome, ".config", "opencode"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".factory"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".pi"), { recursive: true })
+    await fs.mkdir(path.join(tempHome, ".kimi"), { recursive: true })
 
     const results = await detectInstalledTools(tempHome, tempCwd)
 
     expect(results.find((t) => t.name === "opencode")?.detected).toBe(true)
     expect(results.find((t) => t.name === "droid")?.detected).toBe(true)
     expect(results.find((t) => t.name === "pi")?.detected).toBe(true)
+
+    const kimi = results.find((t) => t.name === "kimi")
+    expect(kimi?.detected).toBe(true)
+    expect(kimi?.reason).toContain(".kimi")
   })
 
   test("detects antigravity at ~/.gemini/antigravity-cli", async () => {

--- a/tests/detect-tools.test.ts
+++ b/tests/detect-tools.test.ts
@@ -64,7 +64,7 @@ describe("detectInstalledTools", () => {
     await fs.mkdir(path.join(tempHome, ".config", "opencode"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".factory"), { recursive: true })
     await fs.mkdir(path.join(tempHome, ".pi"), { recursive: true })
-    await fs.mkdir(path.join(tempHome, ".kimi"), { recursive: true })
+    await fs.mkdir(path.join(tempHome, ".kimi-code"), { recursive: true })
 
     const results = await detectInstalledTools(tempHome, tempCwd)
 
@@ -74,7 +74,7 @@ describe("detectInstalledTools", () => {
 
     const kimi = results.find((t) => t.name === "kimi")
     expect(kimi?.detected).toBe(true)
-    expect(kimi?.reason).toContain(".kimi")
+    expect(kimi?.reason).toContain(".kimi-code")
   })
 
   test("detects antigravity at ~/.gemini/antigravity-cli", async () => {

--- a/tests/kimi-converter.test.ts
+++ b/tests/kimi-converter.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, spyOn, test } from "bun:test"
+import { convertClaudeToKimi } from "../src/converters/claude-to-kimi"
+import { parseFrontmatter } from "../src/utils/frontmatter"
+import type { ClaudeHooks, ClaudePlugin } from "../src/types/claude"
+
+const fixturePlugin: ClaudePlugin = {
+  root: "/tmp/plugin",
+  manifest: { name: "fixture", version: "1.0.0" },
+  agents: [
+    {
+      name: "ce-security-reviewer",
+      description: "Security-focused agent",
+      capabilities: ["Threat modeling", "OWASP"],
+      body: "Focus on vulnerabilities. Use the `.claude/` rules.",
+      sourcePath: "/tmp/plugin/agents/review/ce-security-reviewer.md",
+    },
+  ],
+  commands: [
+    {
+      name: "workflows:plan",
+      description: "Planning command",
+      argumentHint: "[FOCUS]",
+      allowedTools: ["Read"],
+      body: "Plan the work. Then run /workflows:plan again.",
+      sourcePath: "/tmp/plugin/commands/workflows/plan.md",
+    },
+    {
+      name: "hidden",
+      description: "Should be skipped",
+      disableModelInvocation: true,
+      body: "Hidden body.",
+      sourcePath: "/tmp/plugin/commands/hidden.md",
+    },
+  ],
+  skills: [
+    {
+      name: "existing-skill",
+      description: "Existing skill",
+      sourceDir: "/tmp/plugin/skills/existing-skill",
+      skillPath: "/tmp/plugin/skills/existing-skill/SKILL.md",
+    },
+  ],
+  hooks: undefined,
+  mcpServers: {
+    local: { command: "echo", args: ["hello"] },
+  },
+}
+
+const options = { agentMode: "subagent" as const, inferTemperature: false, permissions: "none" as const }
+
+describe("convertClaudeToKimi", () => {
+  test("passes through skills and carries MCP + plugin name", () => {
+    const bundle = convertClaudeToKimi(fixturePlugin, options)
+
+    expect(bundle.pluginName).toBe("fixture")
+    expect(bundle.skillDirs).toEqual([
+      { name: "existing-skill", sourceDir: "/tmp/plugin/skills/existing-skill" },
+    ])
+    expect(bundle.mcpServers).toEqual({ local: { command: "echo", args: ["hello"] } })
+  })
+
+  test("converts invocable commands to skills and skips model-disabled ones", () => {
+    const bundle = convertClaudeToKimi(fixturePlugin, options)
+    const names = bundle.generatedSkills.map((s) => s.name)
+
+    // workflows:plan -> workflows-plan command skill, plus the agent skill.
+    expect(names).toContain("workflows-plan")
+    expect(names).not.toContain("hidden")
+  })
+
+  test("converts agents to skills with capabilities section", () => {
+    const bundle = convertClaudeToKimi(fixturePlugin, options)
+    const agentSkill = bundle.generatedSkills.find((s) => s.name === "ce-security-reviewer")
+    expect(agentSkill).toBeDefined()
+
+    const { data, body } = parseFrontmatter(agentSkill!.content)
+    expect(data.name).toBe("ce-security-reviewer")
+    expect(data.description).toBe("Security-focused agent")
+    expect(body).toContain("## Capabilities")
+    expect(body).toContain("- Threat modeling")
+    // .claude/ paths are rewritten to .kimi/
+    expect(body).toContain(".kimi/")
+    expect(body).not.toContain(".claude/")
+  })
+
+  test("rewrites slash command references to /skill:<name>", () => {
+    const bundle = convertClaudeToKimi(fixturePlugin, options)
+    const cmdSkill = bundle.generatedSkills.find((s) => s.name === "workflows-plan")
+    expect(cmdSkill!.content).toContain("/skill:workflows-plan")
+  })
+
+  test("builds invocation targets covering skills, commands, and agents", () => {
+    const bundle = convertClaudeToKimi(fixturePlugin, options)
+    expect(bundle.invocationTargets?.skillTargets["existing-skill"]).toBe("existing-skill")
+    expect(bundle.invocationTargets?.skillTargets["workflows-plan"]).toBe("workflows-plan")
+    // agent aliases include the bare (ce-stripped) and category-qualified forms
+    expect(bundle.invocationTargets?.agentTargets?.["ce-security-reviewer"]).toBe("ce-security-reviewer")
+    expect(bundle.invocationTargets?.agentTargets?.["security-reviewer"]).toBe("ce-security-reviewer")
+  })
+
+  test("warns about unsupported hook events and prompt/agent hooks", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      const hooks: ClaudeHooks = {
+        hooks: {
+          // Unsupported event -> warned.
+          PermissionRequest: [{ matcher: "Bash", hooks: [{ type: "command", command: "x" }] }],
+          // Supported event but prompt/agent entries -> warned, not converted.
+          PostToolUse: [
+            { matcher: "Write", hooks: [{ type: "prompt", prompt: "p" }, { type: "agent", agent: "a" }] },
+          ],
+        },
+      }
+      convertClaudeToKimi({ ...fixturePlugin, hooks }, options)
+      expect(warn).toHaveBeenCalled()
+      const message = warn.mock.calls.map((c) => String(c[0])).join("\n")
+      expect(message).toContain("PermissionRequest")
+      expect(message).toContain("shell commands only")
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  test("does not warn when there are no hooks", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      convertClaudeToKimi(fixturePlugin, options)
+      const hookWarning = warn.mock.calls
+        .map((c) => String(c[0]))
+        .find((m) => m.includes("Kimi hook conversion"))
+      expect(hookWarning).toBeUndefined()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  test("respects ce_platforms filtering", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      skills: [
+        { name: "kimi-only", sourceDir: "/tmp/a", skillPath: "/tmp/a/SKILL.md", ce_platforms: ["kimi"] },
+        { name: "codex-only", sourceDir: "/tmp/b", skillPath: "/tmp/b/SKILL.md", ce_platforms: ["codex"] },
+      ],
+    }
+    const bundle = convertClaudeToKimi(plugin, options)
+    const names = bundle.skillDirs.map((s) => s.name)
+    expect(names).toContain("kimi-only")
+    expect(names).not.toContain("codex-only")
+  })
+})

--- a/tests/kimi-converter.test.ts
+++ b/tests/kimi-converter.test.ts
@@ -78,8 +78,8 @@ describe("convertClaudeToKimi", () => {
     expect(data.description).toBe("Security-focused agent")
     expect(body).toContain("## Capabilities")
     expect(body).toContain("- Threat modeling")
-    // .claude/ paths are rewritten to .kimi/
-    expect(body).toContain(".kimi/")
+    // .claude/ paths are rewritten to .kimi-code/
+    expect(body).toContain(".kimi-code/")
     expect(body).not.toContain(".claude/")
   })
 
@@ -103,8 +103,9 @@ describe("convertClaudeToKimi", () => {
     try {
       const hooks: ClaudeHooks = {
         hooks: {
-          // Unsupported event -> warned.
-          PermissionRequest: [{ matcher: "Bash", hooks: [{ type: "command", command: "x" }] }],
+          // Unsupported event -> warned. (Use a synthetic name: Kimi Code CLI
+          // supports every real Claude hook event, including PermissionRequest.)
+          MadeUpEvent: [{ matcher: "Bash", hooks: [{ type: "command", command: "x" }] }],
           // Supported event but prompt/agent entries -> warned, not converted.
           PostToolUse: [
             { matcher: "Write", hooks: [{ type: "prompt", prompt: "p" }, { type: "agent", agent: "a" }] },
@@ -114,7 +115,7 @@ describe("convertClaudeToKimi", () => {
       convertClaudeToKimi({ ...fixturePlugin, hooks }, options)
       expect(warn).toHaveBeenCalled()
       const message = warn.mock.calls.map((c) => String(c[0])).join("\n")
-      expect(message).toContain("PermissionRequest")
+      expect(message).toContain("MadeUpEvent")
       expect(message).toContain("shell commands only")
     } finally {
       warn.mockRestore()

--- a/tests/kimi-writer.test.ts
+++ b/tests/kimi-writer.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from "bun:test"
+import { promises as fs } from "fs"
+import path from "path"
+import os from "os"
+import { mergeKimiConfig, renderKimiHooksToml, writeKimiBundle } from "../src/targets/kimi"
+import type { KimiBundle } from "../src/types/kimi"
+import type { ClaudeHooks } from "../src/types/claude"
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function makeSourceSkill(content: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "kimi-src-"))
+  await fs.writeFile(path.join(dir, "SKILL.md"), content, "utf8")
+  return dir
+}
+
+function baseBundle(overrides: Partial<KimiBundle> = {}): KimiBundle {
+  return {
+    pluginName: "fixture",
+    skillDirs: [],
+    generatedSkills: [],
+    invocationTargets: { skillTargets: {}, agentTargets: {} },
+    ...overrides,
+  }
+}
+
+describe("writeKimiBundle", () => {
+  test("writes skills flat into <root>/skills and records a manifest", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kimi-root-"))
+    const src = await makeSourceSkill("---\nname: existing\ndescription: x\n---\n\nUse .claude/rules here.\n")
+
+    await writeKimiBundle(root, baseBundle({
+      skillDirs: [{ name: "existing", sourceDir: src }],
+      generatedSkills: [{ name: "from-command", content: "---\nname: from-command\ndescription: y\n---\n\nbody" }],
+    }), { outputIsKimiRoot: true })
+
+    expect(await exists(path.join(root, "skills", "existing", "SKILL.md"))).toBe(true)
+    expect(await exists(path.join(root, "skills", "from-command", "SKILL.md"))).toBe(true)
+
+    // Content transform applied to pass-through skill.
+    const passthrough = await fs.readFile(path.join(root, "skills", "existing", "SKILL.md"), "utf8")
+    expect(passthrough).toContain(".kimi/rules")
+    expect(passthrough).not.toContain(".claude/rules")
+
+    const manifest = JSON.parse(await fs.readFile(path.join(root, "fixture", "install-manifest.json"), "utf8"))
+    expect(manifest.skills.sort()).toEqual(["existing", "from-command"])
+  })
+
+  test("removes managed skills that disappear on re-install but leaves foreign skills", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kimi-root-"))
+
+    // Foreign skill the user (or another tool) placed in the shared dir.
+    await fs.mkdir(path.join(root, "skills", "user-skill"), { recursive: true })
+    await fs.writeFile(path.join(root, "skills", "user-skill", "SKILL.md"), "x", "utf8")
+
+    await writeKimiBundle(root, baseBundle({
+      generatedSkills: [{ name: "temp", content: "---\nname: temp\n---\n\nbody" }],
+    }), { outputIsKimiRoot: true })
+    expect(await exists(path.join(root, "skills", "temp"))).toBe(true)
+
+    // Second install no longer ships "temp".
+    await writeKimiBundle(root, baseBundle(), { outputIsKimiRoot: true })
+    expect(await exists(path.join(root, "skills", "temp"))).toBe(false)
+    // Foreign skill is untouched.
+    expect(await exists(path.join(root, "skills", "user-skill"))).toBe(true)
+  })
+
+  test("merges MCP servers into mcp.json preserving user entries", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kimi-root-"))
+    await fs.writeFile(
+      path.join(root, "mcp.json"),
+      JSON.stringify({ mcpServers: { userServer: { command: "user" } } }, null, 2),
+      "utf8",
+    )
+
+    await writeKimiBundle(root, baseBundle({
+      mcpServers: { local: { command: "echo", args: ["hi"] } },
+    }), { outputIsKimiRoot: true })
+
+    const mcp = JSON.parse(await fs.readFile(path.join(root, "mcp.json"), "utf8"))
+    expect(mcp.mcpServers.userServer).toEqual({ command: "user" })
+    expect(mcp.mcpServers.local).toEqual({ command: "echo", args: ["hi"] })
+
+    // Re-install without our server removes ours, keeps the user's.
+    await writeKimiBundle(root, baseBundle(), { outputIsKimiRoot: true })
+    const mcp2 = JSON.parse(await fs.readFile(path.join(root, "mcp.json"), "utf8"))
+    expect(mcp2.mcpServers.userServer).toEqual({ command: "user" })
+    expect(mcp2.mcpServers.local).toBeUndefined()
+  })
+
+  test("writes hooks into config.toml inside a managed block", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kimi-root-"))
+    const hooks: ClaudeHooks = {
+      hooks: {
+        PostToolUse: [
+          { matcher: "Write|Edit", hooks: [{ type: "command", command: "prettier --write" }] },
+        ],
+      },
+    }
+    await writeKimiBundle(root, baseBundle({ hooks }), { outputIsKimiRoot: true })
+
+    const config = await fs.readFile(path.join(root, "config.toml"), "utf8")
+    expect(config).toContain("[[hooks]]")
+    expect(config).toContain('event = "PostToolUse"')
+    // Claude tool names are remapped to Kimi equivalents.
+    expect(config).toContain('matcher = "WriteFile|StrReplaceFile"')
+    expect(config).toContain('command = "prettier --write"')
+  })
+})
+
+describe("renderKimiHooksToml", () => {
+  test("returns null when there are no command hooks", () => {
+    expect(renderKimiHooksToml(undefined)).toBeNull()
+    expect(
+      renderKimiHooksToml({ hooks: { Stop: [{ hooks: [{ type: "prompt", prompt: "hi" }] }] } }),
+    ).toBeNull()
+  })
+
+  test("emits timeout and drops empty matchers", () => {
+    const toml = renderKimiHooksToml({
+      hooks: {
+        Stop: [{ matcher: "*", hooks: [{ type: "command", command: "check.sh", timeout: 10 }] }],
+      },
+    })
+    expect(toml).toContain('event = "Stop"')
+    expect(toml).toContain("timeout = 10")
+    expect(toml).not.toContain("matcher =")
+  })
+
+  test("skips events Kimi does not support", () => {
+    expect(
+      renderKimiHooksToml({ hooks: { NonExistentEvent: [{ hooks: [{ type: "command", command: "x" }] }] } }),
+    ).toBeNull()
+  })
+})
+
+describe("mergeKimiConfig", () => {
+  test("returns null for empty config and no hooks", () => {
+    expect(mergeKimiConfig("", null)).toBeNull()
+  })
+
+  test("appends a managed block while preserving user config", () => {
+    const merged = mergeKimiConfig("merge_all_available_skills = true\n", '[[hooks]]\nevent = "Stop"')
+    expect(merged).toContain("merge_all_available_skills = true")
+    expect(merged).toContain("BEGIN Compound Engineering plugin hooks")
+    expect(merged).toContain('event = "Stop"')
+  })
+
+  test("replaces a prior managed block instead of duplicating", () => {
+    const first = mergeKimiConfig("user = 1\n", '[[hooks]]\nevent = "Stop"')!
+    const second = mergeKimiConfig(first, '[[hooks]]\nevent = "PreToolUse"')!
+    expect(second).toContain('event = "PreToolUse"')
+    expect(second).not.toContain('event = "Stop"')
+    expect((second.match(/BEGIN Compound Engineering plugin hooks/g) ?? []).length).toBe(1)
+  })
+
+  test("strips the managed block when hooks are removed", () => {
+    const withHooks = mergeKimiConfig("user = 1\n", '[[hooks]]\nevent = "Stop"')!
+    const stripped = mergeKimiConfig(withHooks, null)!
+    expect(stripped).toContain("user = 1")
+    expect(stripped).not.toContain("BEGIN Compound Engineering plugin hooks")
+  })
+})

--- a/tests/kimi-writer.test.ts
+++ b/tests/kimi-writer.test.ts
@@ -46,7 +46,7 @@ describe("writeKimiBundle", () => {
 
     // Content transform applied to pass-through skill.
     const passthrough = await fs.readFile(path.join(root, "skills", "existing", "SKILL.md"), "utf8")
-    expect(passthrough).toContain(".kimi/rules")
+    expect(passthrough).toContain(".kimi-code/rules")
     expect(passthrough).not.toContain(".claude/rules")
 
     const manifest = JSON.parse(await fs.readFile(path.join(root, "fixture", "install-manifest.json"), "utf8"))
@@ -70,6 +70,30 @@ describe("writeKimiBundle", () => {
     expect(await exists(path.join(root, "skills", "temp"))).toBe(false)
     // Foreign skill is untouched.
     expect(await exists(path.join(root, "skills", "user-skill"))).toBe(true)
+  })
+
+  test("backs up an unmanaged skill dir instead of clobbering it on name collision", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "kimi-root-"))
+
+    // A foreign skill (no install manifest yet) occupies a name we then ship.
+    await fs.mkdir(path.join(root, "skills", "shared-name"), { recursive: true })
+    await fs.writeFile(path.join(root, "skills", "shared-name", "SKILL.md"), "foreign", "utf8")
+    await fs.writeFile(path.join(root, "skills", "shared-name", "user-data.txt"), "keep me", "utf8")
+
+    await writeKimiBundle(root, baseBundle({
+      generatedSkills: [{ name: "shared-name", content: "---\nname: shared-name\n---\n\nours" }],
+    }), { outputIsKimiRoot: true })
+
+    // Our content is written...
+    const written = await fs.readFile(path.join(root, "skills", "shared-name", "SKILL.md"), "utf8")
+    expect(written).toContain("ours")
+
+    // ...and the foreign directory was preserved in a timestamped backup.
+    const entries = await fs.readdir(path.join(root, "skills"))
+    const backup = entries.find((name) => name.startsWith("shared-name.bak."))
+    expect(backup).toBeDefined()
+    const preserved = await fs.readFile(path.join(root, "skills", backup!, "user-data.txt"), "utf8")
+    expect(preserved).toBe("keep me")
   })
 
   test("merges MCP servers into mcp.json preserving user entries", async () => {
@@ -109,8 +133,8 @@ describe("writeKimiBundle", () => {
     const config = await fs.readFile(path.join(root, "config.toml"), "utf8")
     expect(config).toContain("[[hooks]]")
     expect(config).toContain('event = "PostToolUse"')
-    // Claude tool names are remapped to Kimi equivalents.
-    expect(config).toContain('matcher = "WriteFile|StrReplaceFile"')
+    // Kimi Code CLI shares Claude's Write/Edit tool names, so they pass through.
+    expect(config).toContain('matcher = "Write|Edit"')
     expect(config).toContain('command = "prettier --write"')
   })
 })

--- a/tests/resolve-output.test.ts
+++ b/tests/resolve-output.test.ts
@@ -8,7 +8,7 @@ const baseOptions = {
   outputRoot: "/tmp/output",
   codexHome: path.join(os.homedir(), ".codex"),
   piHome: path.join(os.homedir(), ".pi", "agent"),
-  kimiHome: path.join(os.homedir(), ".kimi"),
+  kimiHome: path.join(os.homedir(), ".kimi-code"),
   hasExplicitOutput: false,
 }
 
@@ -87,28 +87,28 @@ describe("resolveCodexHome", () => {
 })
 
 describe("resolveKimiHome", () => {
-  const originalKimiHome = process.env.KIMI_HOME
+  const originalKimiHome = process.env.KIMI_CODE_HOME
 
   afterEach(() => {
     if (originalKimiHome === undefined) {
-      delete process.env.KIMI_HOME
+      delete process.env.KIMI_CODE_HOME
     } else {
-      process.env.KIMI_HOME = originalKimiHome
+      process.env.KIMI_CODE_HOME = originalKimiHome
     }
   })
 
-  test("defaults to ~/.kimi when KIMI_HOME is unset", () => {
-    delete process.env.KIMI_HOME
-    expect(resolveKimiHome(undefined)).toBe(path.join(os.homedir(), ".kimi"))
+  test("defaults to ~/.kimi-code when KIMI_CODE_HOME is unset", () => {
+    delete process.env.KIMI_CODE_HOME
+    expect(resolveKimiHome(undefined)).toBe(path.join(os.homedir(), ".kimi-code"))
   })
 
-  test("uses KIMI_HOME when no explicit --kimi-home is provided", () => {
-    process.env.KIMI_HOME = "/tmp/custom-kimi-profile"
+  test("uses KIMI_CODE_HOME when no explicit --kimi-home is provided", () => {
+    process.env.KIMI_CODE_HOME = "/tmp/custom-kimi-profile"
     expect(resolveKimiHome(undefined)).toBe("/tmp/custom-kimi-profile")
   })
 
-  test("lets explicit --kimi-home override KIMI_HOME", () => {
-    process.env.KIMI_HOME = "/tmp/custom-kimi-profile"
+  test("lets explicit --kimi-home override KIMI_CODE_HOME", () => {
+    process.env.KIMI_CODE_HOME = "/tmp/custom-kimi-profile"
     expect(resolveKimiHome("/tmp/explicit-kimi")).toBe("/tmp/explicit-kimi")
   })
 })

--- a/tests/resolve-output.test.ts
+++ b/tests/resolve-output.test.ts
@@ -1,13 +1,14 @@
 import { afterEach, describe, expect, test } from "bun:test"
 import os from "os"
 import path from "path"
-import { resolveCodexHome } from "../src/utils/resolve-home"
+import { resolveCodexHome, resolveKimiHome } from "../src/utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../src/utils/resolve-output"
 
 const baseOptions = {
   outputRoot: "/tmp/output",
   codexHome: path.join(os.homedir(), ".codex"),
   piHome: path.join(os.homedir(), ".pi", "agent"),
+  kimiHome: path.join(os.homedir(), ".kimi"),
   hasExplicitOutput: false,
 }
 
@@ -20,6 +21,11 @@ describe("resolveTargetOutputRoot", () => {
   test("pi returns piHome", () => {
     const result = resolveTargetOutputRoot({ ...baseOptions, targetName: "pi" })
     expect(result).toBe(baseOptions.piHome)
+  })
+
+  test("kimi returns kimiHome", () => {
+    const result = resolveTargetOutputRoot({ ...baseOptions, targetName: "kimi" })
+    expect(result).toBe(baseOptions.kimiHome)
   })
 
   test("opencode with explicit output returns outputRoot as-is", () => {
@@ -77,6 +83,33 @@ describe("resolveCodexHome", () => {
     process.env.CODEX_HOME = "/tmp/custom-codex-profile"
 
     expect(resolveCodexHome("/tmp/explicit-codex")).toBe("/tmp/explicit-codex")
+  })
+})
+
+describe("resolveKimiHome", () => {
+  const originalKimiHome = process.env.KIMI_HOME
+
+  afterEach(() => {
+    if (originalKimiHome === undefined) {
+      delete process.env.KIMI_HOME
+    } else {
+      process.env.KIMI_HOME = originalKimiHome
+    }
+  })
+
+  test("defaults to ~/.kimi when KIMI_HOME is unset", () => {
+    delete process.env.KIMI_HOME
+    expect(resolveKimiHome(undefined)).toBe(path.join(os.homedir(), ".kimi"))
+  })
+
+  test("uses KIMI_HOME when no explicit --kimi-home is provided", () => {
+    process.env.KIMI_HOME = "/tmp/custom-kimi-profile"
+    expect(resolveKimiHome(undefined)).toBe("/tmp/custom-kimi-profile")
+  })
+
+  test("lets explicit --kimi-home override KIMI_HOME", () => {
+    process.env.KIMI_HOME = "/tmp/custom-kimi-profile"
+    expect(resolveKimiHome("/tmp/explicit-kimi")).toBe("/tmp/explicit-kimi")
   })
 })
 


### PR DESCRIPTION
## Summary

Adds a `kimi` converter target so Claude Code plugins can be installed into [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) via `convert`/`install --to kimi`. Follows the 6-phase target-provider pattern in `docs/solutions/adding-converter-target-providers.md` (codex is the closest analog).

### Mapping (Kimi surfaces)
- **Skills** — pass through to **flat** `~/.kimi/skills/<name>/SKILL.md`. Kimi scans the skills root directly, so a per-plugin subdir (as codex uses) would be invisible. Managed names are tracked in `~/.kimi/<plugin>/install-manifest.json` for safe upgrade cleanup.
- **Commands & agents** — Kimi has no command-file or auto-discovered agent format, so both convert to **skills** invoked via `/skill:<name>`.
- **MCP servers** — deep-merge into `~/.kimi/mcp.json` (Claude-compatible `mcpServers` format), preserving user keys; previously-written keys are removed on reinstall via the manifest.
- **Hooks** — emit `[[hooks]]` into `~/.kimi/config.toml` inside a managed marker block, remapping matcher tool names (`Write`→`WriteFile`, `Edit`→`StrReplaceFile`, `Bash`→`Shell`, …). Unsupported events and prompt/agent hooks are dropped **with a stderr warning** (per the doc's "warn on dropped features" rule).
- **Content transform** — `.claude/`→`.kimi/`, `/cmd`→`/skill:<name>`, `@agent`/`Task agent(...)`→"the \`<skill>\` skill".

### Wiring
- New: `src/types/kimi.ts`, `src/utils/kimi-content.ts`, `src/converters/claude-to-kimi.ts`, `src/targets/kimi.ts`.
- Registered in `src/targets/index.ts`; `--kimi-home` flag (`$KIMI_HOME`→`~/.kimi`) in `install.ts`/`convert.ts`; `resolveKimiHome`; `resolveTargetOutputRoot` kimi case; `~/.kimi` detection in `detect-tools.ts`.
- Docs: `docs/specs/kimi.md`, README "Kimi CLI" section.

> Note: Kimi natively reads `~/.claude/skills/` (brand group, `merge_all_available_skills` on by default), so existing Claude Code CE users already get the skills in Kimi for free — this target is for installing directly into `~/.kimi`.

### Notes
- No `cleanup --target kimi` path, matching the antigravity precedent (not in `cleanupTargets`); the writer self-cleans stale artifacts via its manifest on reinstall.

## Test plan
- [x] `bun test` — full suite green (1627 pass)
- [x] New `tests/kimi-converter.test.ts` + `tests/kimi-writer.test.ts` (flat skills, manifest cleanup, MCP merge, hooks block, content transform, hook-drop warning)
- [x] CLI integration test (`install --to kimi` on the sample-plugin fixture)
- [x] `bun run release:validate` — in sync
- [x] Manual smoke test against the real plugin: 27 skills written flat, correct manifest, hook-drop warning fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)