### PR TITLE
fix(kimi): add native plugin support

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -44,6 +44,7 @@
         ".cursor/",
         ".windsurf/",
         ".agents/plugins/marketplace.json",
+        ".kimi-plugin/marketplace.json",
         ".claude-plugin/marketplace.json",
         ".cursor-plugin/marketplace.json"
       ],
@@ -66,6 +67,11 @@
         {
           "type": "json",
           "path": ".codex-plugin/plugin.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": ".kimi-plugin/plugin.json",
           "jsonpath": "$.version"
         },
         {

--- a/.kimi-plugin/marketplace.json
+++ b/.kimi-plugin/marketplace.json
@@ -1,0 +1,10 @@
+{
+  "version": "2",
+  "plugins": [
+    {
+      "id": "compound-engineering",
+      "displayName": "Compound Engineering",
+      "source": "https://github.com/EveryInc/compound-engineering-plugin"
+    }
+  ]
+}

--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "compound-engineering",
+  "version": "3.14.3",
+  "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
+  "keywords": [
+    "brainstorming",
+    "code-review",
+    "compound-engineering",
+    "debugging",
+    "ideation",
+    "workflows",
+    "workflow-automation"
+  ],
+  "author": "Kieran Klaassen and Trevin Chow",
+  "homepage": "https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it",
+  "license": "MIT",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Compound Engineering",
+    "shortDescription": "Brainstorm, plan, debug, review, and compound learnings with AI agents",
+    "longDescription": "Compound Engineering guides AI agents through the full engineering loop: strategy, ideation, requirements, planning, execution, debugging, review, PR feedback, and captured learnings that make future work easier.",
+    "developerName": "Kieran Klaassen and Trevin Chow",
+    "websiteURL": "https://github.com/EveryInc/compound-engineering-plugin"
+  }
+}

--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -19,9 +19,12 @@ An internal prompt file owned by one Skill that defines a specialist persona or 
 ## Conversion
 
 ### Target
-A destination coding-agent platform other than Claude Code (OpenCode, Codex, Pi, Antigravity, and others) that a Plugin is converted into and installed onto, each with its own file layout and capability mapping. Also called a target provider.
+A destination coding-agent platform other than Claude Code (OpenCode, Codex, Pi, Antigravity, Kimi Code, and others) that the repo supports through native plugin metadata or a Converter/Writer pair. Also called a target provider when it uses the conversion path.
 
 A Plugin is installed to a Target at one of two scopes: global (user-wide) or per-workspace.
+
+### Native plugin surface
+A platform-provided install contract that can consume this repo's committed plugin manifest or marketplace metadata directly, without generating a converted Bundle. When a Target has a native plugin surface, user-facing support usually belongs in platform metadata, release validation, and docs instead of a new Converter and Writer.
 
 ### Converter
 The step that transforms a parsed Plugin into one Target's in-memory form, mapping tools, permissions, hooks, and model names explicitly rather than by convention.

--- a/README.md
+++ b/README.md
@@ -210,6 +210,22 @@ CODEX_HOME="$HOME/.codex/profiles/work" codex plugin add compound-engineering@co
 
 The marketplace step only makes the plugin available; the plugin install is what activates the native CE skills for that profile.
 
+### Kimi Code CLI
+
+Kimi Code CLI can install Compound Engineering directly from this repository because the repo ships a native `.kimi-plugin/plugin.json` manifest:
+
+```text
+/plugins install https://github.com/EveryInc/compound-engineering-plugin
+```
+
+You can also browse it through Kimi's custom marketplace flow:
+
+```text
+/plugins marketplace https://raw.githubusercontent.com/EveryInc/compound-engineering-plugin/main/.kimi-plugin/marketplace.json
+```
+
+After installing or updating, run `/reload` or start a new Kimi session so the plugin skills are loaded.
+
 ### GitHub Copilot
 
 For **VS Code Copilot Agent Plugins**:
@@ -371,6 +387,20 @@ codex plugin add compound-engineering@compound-engineering-plugin
 ```
 
 Use a separate `CODEX_HOME` when you want to keep local testing isolated from your normal Codex profile. The Codex marketplace entry points at the public Git plugin source so root-shaped plugin repos install correctly; use a temporary marketplace catalog with a `source.url` plus `ref` when testing unpublished plugin-content changes end to end.
+
+**Kimi Code CLI**
+
+Inside Kimi Code CLI:
+
+```text
+/plugins install /path/to/compound-engineering-plugin
+```
+
+To test the local marketplace catalog instead, pass the catalog path:
+
+```text
+/plugins marketplace /path/to/compound-engineering-plugin/.kimi-plugin/marketplace.json
+```
 
 **OpenCode**
 

--- a/docs/solutions/integrations/kimi-native-plugin-manifest-support.md
+++ b/docs/solutions/integrations/kimi-native-plugin-manifest-support.md
@@ -1,0 +1,92 @@
+---
+title: "Use native Kimi plugin manifests instead of a converter target"
+date: 2026-06-24
+category: integrations
+module: installer
+problem_type: tooling_decision
+component: tooling
+severity: medium
+applies_when:
+  - "Adding support for a coding-agent platform that can install plugin manifests directly"
+  - "A proposed converter target duplicates a platform-native plugin or marketplace flow"
+  - "Release automation must keep platform manifests in parity with canonical plugin metadata"
+related_components:
+  - release-metadata
+  - release-please
+  - native-plugin-install
+tags:
+  - kimi
+  - native-plugins
+  - marketplace
+  - release-validation
+  - converter-targets
+---
+
+# Use native Kimi plugin manifests instead of a converter target
+
+## Problem
+
+Kimi Code support can look like a normal new target provider at first: add `--to kimi`, write a converter, and emit a Kimi-specific output tree. That is the wrong first move when the platform already has a native plugin manifest and custom marketplace contract.
+
+This came up when [PR #997](https://github.com/EveryInc/compound-engineering-plugin/pull/997) by [@mastepanoski](https://github.com/mastepanoski) proposed Kimi support as a converter target. The useful signal was the demand for Kimi support; the implementation shape duplicated a native install surface.
+
+## Decision
+
+Prefer Kimi's native plugin metadata over a converter target:
+
+- Commit `.kimi-plugin/plugin.json` with the Kimi manifest fields that describe this plugin, including `interface`, `skills`, `sessionStart.skill`, and `skillInstructions`.
+- Commit `.kimi-plugin/marketplace.json` using Kimi marketplace schema version `2`.
+- Keep `.kimi-plugin/plugin.json` in the root release component so release automation bumps it with the canonical plugin version.
+- Treat `.kimi-plugin/marketplace.json` as static catalog metadata, and validate it instead of version-bumping it.
+- Do not add `src/converters/claude-to-kimi.ts`, `src/targets/kimi.ts`, or a `--to kimi` CLI target unless Kimi later documents a separate generated output format that cannot be represented by the native manifest.
+
+## Why This Matters
+
+Native plugin support is a distribution contract, not a format-conversion problem. A converter target would create another generated install path to document, test, version, and clean up, while Kimi users would still need the manifest and marketplace metadata for the normal install flow.
+
+The correct support surface is therefore:
+
+- platform metadata: `.kimi-plugin/plugin.json` and `.kimi-plugin/marketplace.json`
+- release metadata: version parity, required fields, skill path checks, and marketplace schema validation
+- user docs: install and local-development instructions for Kimi's native plugin flow
+- target spec docs: a short spec explaining which Kimi fields are used and which unsupported runtime fields are intentionally absent
+
+## Implementation Pattern
+
+When adding a platform with a native plugin surface, wire it like a first-class release surface:
+
+1. Add the native manifest and marketplace/catalog files expected by the platform.
+2. Put the release-owned manifest file in `.github/release-please-config.json` as an extra file for the canonical component.
+3. Exclude static marketplace files from release component ownership when they do not carry a version.
+4. Add release validation that rejects missing manifests, version drift, missing declared asset paths, marketplace schema drift, and marketplace plugin-list drift.
+5. Update README install docs and `docs/specs/` so future contributors know this is native metadata, not a converter target.
+
+For Kimi specifically, validate at least:
+
+- `.kimi-plugin/plugin.json` exists
+- `name`, `version`, `description`, and `skills` are non-empty
+- `skills` points at an existing directory in the repo
+- the Kimi manifest version equals the root plugin/package version
+- `.kimi-plugin/marketplace.json` has schema `version: "2"`
+- marketplace plugin IDs match the Claude marketplace plugin IDs
+- each marketplace entry has a non-empty `source`
+- root-local marketplace sources such as `"."` or `"./"` are rejected because they are only local-development placeholders
+
+## Warning Signs
+
+Reconsider a proposed new target provider when:
+
+- the platform docs describe a `plugin.json`-style manifest in the source repo
+- the platform supports a custom marketplace or catalog pointing at repository/plugin sources
+- the target would mostly copy existing skills and docs without meaningful tool, permission, hook, or model conversion
+- install docs would need to tell users to run this repo's converter instead of the platform's documented plugin install path
+
+Those are signs the platform support belongs in native metadata and release validation.
+
+## Related
+
+- [Native plugin install strategy](./native-plugin-install-strategy.md)
+- [Plugin versioning requirements](../plugin-versioning-requirements.md)
+- [Adding converter target providers](../adding-converter-target-providers.md)
+- [PR #997: original Kimi support proposal](https://github.com/EveryInc/compound-engineering-plugin/pull/997)
+- [PR #998: native Kimi plugin support](https://github.com/EveryInc/compound-engineering-plugin/pull/998)

--- a/docs/solutions/integrations/native-plugin-install-strategy.md
+++ b/docs/solutions/integrations/native-plugin-install-strategy.md
@@ -21,6 +21,7 @@ tags:
   - copilot
   - droid
   - qwen
+  - kimi
   - antigravity
   - opencode
   - pi
@@ -44,6 +45,7 @@ The install strategy follows from that: prefer each harness's native plugin/pack
 | GitHub Copilot CLI | Native plugin marketplace using the existing Claude plugin metadata | No | Copilot translates the Claude plugin metadata itself. |
 | Factory Droid | Native plugin marketplace pointed at the CE GitHub repository | No | Droid translates Claude Code plugins automatically. |
 | Qwen Code | Native extension install from the CE GitHub repository and existing Claude plugin metadata | No | Qwen translates Claude Code extensions automatically. |
+| Kimi Code CLI | Native plugin install from this repository using `.kimi-plugin/plugin.json` | No | Kimi can install directly from the GitHub repo and can browse the committed `.kimi-plugin/marketplace.json` custom catalog. |
 | OpenCode | Git-backed OpenCode plugin entry in `opencode.json` | No | `.opencode/plugins/compound-engineering.js` registers the CE skills directory directly. |
 | Pi | Git-backed Pi package install from this repository | No | Root `package.json` exposes `.pi/extensions/compound-engineering.ts` and the CE skills directory. `pi-ask-user` is a recommended companion for richer prompts. |
 | Antigravity CLI | Native Antigravity plugin from the committed `.agy/` bundle | No | Clone the repo, then `agy plugin install ./compound-engineering-plugin/.agy`. The `.agy/` bundle holds `plugin.json` plus a `skills -> ../skills` symlink. `agy` still reads `GEMINI.md` as workspace context. |
@@ -116,6 +118,24 @@ agy plugin install ./compound-engineering-plugin/.agy
 ```
 
 `agy` still reads `GEMINI.md` as workspace context (retained despite the Gemini CLI converter target being removed). For local development, point `agy` at the `.agy/` subdirectory of the checkout so it finds `plugin.json`, the `skills` symlink, and `GEMINI.md` together.
+
+## Kimi Code CLI
+
+Kimi Code CLI has a native plugin surface, so CE should not maintain a Kimi converter target for normal installation. The root `.kimi-plugin/plugin.json` declares the CE skills directory with `skills: "./skills/"` and carries display metadata through Kimi's `interface` object.
+
+Direct install:
+
+```text
+/plugins install https://github.com/EveryInc/compound-engineering-plugin
+```
+
+Marketplace install:
+
+```text
+/plugins marketplace https://raw.githubusercontent.com/EveryInc/compound-engineering-plugin/main/.kimi-plugin/marketplace.json
+```
+
+The Kimi marketplace catalog uses schema version `"2"` and entries with `id` plus `source`. It has no release-owned marketplace version, so release automation bumps only `.kimi-plugin/plugin.json` through the root `compound-engineering` component. `bun run release:validate` enforces Kimi manifest and marketplace parity with the Claude source manifest/catalog.
 
 ## Bun Package Posture
 

--- a/docs/specs/kimi.md
+++ b/docs/specs/kimi.md
@@ -6,6 +6,7 @@ Last verified: 2026-06-24
 
 ```
 https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html
+https://www.kimi.com/code/docs/en/kimi-code-cli/customization/agents.html
 ```
 
 ## Plugin manifests
@@ -69,3 +70,17 @@ Marketplace browsing:
 ```
 
 After installing, enabling, disabling, or removing a plugin, Kimi requires `/reload` or a new session for changes to apply.
+
+## Instruction files
+
+Kimi uses `AGENTS.md` for global and project instructions, not a `KIMI.md` file.
+
+Documented locations include:
+
+| Scope | Location |
+| --- | --- |
+| Global Kimi-specific | `$KIMI_CODE_HOME/AGENTS.md`, defaulting to `~/.kimi-code/AGENTS.md` |
+| Generic cross-tool | `~/.agents/AGENTS.md` |
+| Project | `.kimi-code/AGENTS.md` or `AGENTS.md` under the project tree |
+
+This repo should not add a root `KIMI.md` compatibility shim unless Kimi documents support for that filename. The existing root `AGENTS.md` is already the canonical project instruction file for Kimi-compatible project context.

--- a/docs/specs/kimi.md
+++ b/docs/specs/kimi.md
@@ -1,0 +1,71 @@
+# Kimi Code CLI Spec (Plugins and Skills)
+
+Last verified: 2026-06-24
+
+## Primary sources
+
+```
+https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html
+```
+
+## Plugin manifests
+
+Kimi Code CLI plugins are directories or zip files with a manifest at one of:
+
+```text
+<plugin_root>/kimi.plugin.json
+<plugin_root>/.kimi-plugin/plugin.json
+```
+
+When both exist, `kimi.plugin.json` takes precedence. Compound Engineering uses `.kimi-plugin/plugin.json` to match the repo's other platform-specific manifest directories.
+
+Supported fields include:
+
+| Field | CE usage |
+| --- | --- |
+| `name` | Required plugin id, set to `compound-engineering` |
+| `version` | Root plugin version, bumped by release-please |
+| `description`, `keywords`, `author`, `homepage`, `license` | Shared display metadata |
+| `interface.displayName` | Marketplace/plugin manager display name |
+| `interface.shortDescription` | Short plugin-manager copy |
+| `interface.longDescription` | Longer plugin-manager copy |
+| `interface.developerName` | Human-readable developer name |
+| `interface.websiteURL` | Repository URL |
+| `skills` | `./skills/`, resolved inside the plugin root |
+
+CE does not currently declare `sessionStart.skill`, `skillInstructions`, or `mcpServers` for Kimi. Unsupported runtime fields such as `tools`, `commands`, `hooks`, `apps`, `inject`, and `configFile` are diagnostics-only in Kimi and should not be used for CE behavior.
+
+## Marketplace catalog
+
+Kimi also supports a custom marketplace JSON source. The catalog schema uses:
+
+```json
+{
+  "version": "2",
+  "plugins": [
+    {
+      "id": "compound-engineering",
+      "displayName": "Compound Engineering",
+      "source": "https://github.com/EveryInc/compound-engineering-plugin"
+    }
+  ]
+}
+```
+
+The marketplace catalog has no release-owned `metadata.version` equivalent. Treat `.kimi-plugin/marketplace.json` as static parity data, not a separate release component. `release:validate` checks that its plugin ids match the Claude marketplace plugin names and that entries use installable sources.
+
+## Install commands
+
+Direct install from GitHub:
+
+```text
+/plugins install https://github.com/EveryInc/compound-engineering-plugin
+```
+
+Marketplace browsing:
+
+```text
+/plugins marketplace https://raw.githubusercontent.com/EveryInc/compound-engineering-plugin/main/.kimi-plugin/marketplace.json
+```
+
+After installing, enabling, disabling, or removing a plugin, Kimi requires `/reload` or a new session for changes to apply.

--- a/src/release/components.ts
+++ b/src/release/components.ts
@@ -22,6 +22,7 @@ const FILE_COMPONENT_MAP: Array<{ component: ReleaseComponent; prefixes: string[
       ".claude-plugin/plugin.json",
       ".cursor-plugin/plugin.json",
       ".codex-plugin/",
+      ".kimi-plugin/plugin.json",
       ".opencode/",
       ".pi/",
       "AGENTS.md",
@@ -182,6 +183,7 @@ export async function loadCurrentVersions(cwd = process.cwd()): Promise<VersionS
   const root = await readJson<RootPackageJson>(`${cwd}/package.json`)
   const ce = await readJson<PluginManifest>(`${cwd}/.claude-plugin/plugin.json`)
   const antigravity = await readJson<PluginManifest>(`${cwd}/.agy/plugin.json`)
+  const kimi = await readJson<PluginManifest>(`${cwd}/.kimi-plugin/plugin.json`)
   const marketplace = await readJson<MarketplaceManifest>(`${cwd}/.claude-plugin/marketplace.json`)
   const cursorMarketplace = await readJson<MarketplaceManifest>(`${cwd}/.cursor-plugin/marketplace.json`)
 
@@ -191,6 +193,10 @@ export async function loadCurrentVersions(cwd = process.cwd()): Promise<VersionS
 
   if (root.version !== antigravity.version) {
     throw new Error(`package.json version ${root.version} does not match .agy/plugin.json version ${antigravity.version}`)
+  }
+
+  if (root.version !== kimi.version) {
+    throw new Error(`package.json version ${root.version} does not match .kimi-plugin/plugin.json version ${kimi.version}`)
   }
 
   return {

--- a/src/release/metadata.ts
+++ b/src/release/metadata.ts
@@ -26,6 +26,13 @@ type CodexPluginManifest = {
   skills?: string
 }
 
+type KimiPluginManifest = {
+  name: string
+  version: string
+  description?: string
+  skills?: string
+}
+
 type AntigravityManifest = {
   version: string
 }
@@ -51,6 +58,15 @@ type CodexMarketplaceManifest = {
       path?: string
       url?: string
     }
+  }>
+}
+
+type KimiMarketplaceManifest = {
+  version: string
+  plugins: Array<{
+    id: string
+    displayName?: string
+    source?: string
   }>
 }
 
@@ -161,6 +177,34 @@ export async function buildCompoundEngineeringMarketplaceDescription(_root: stri
   return COMPOUND_ENGINEERING_MARKETPLACE_DESCRIPTION
 }
 
+async function validateDeclaredSkillsPath(
+  manifestPath: string,
+  pluginName: string,
+  platformName: string,
+  skills: string | undefined,
+  errors: string[],
+): Promise<void> {
+  if (skills === undefined) {
+    errors.push(`${manifestPath} (${pluginName}): missing required field "skills". ${platformName} plugins must declare a skills path (e.g., "./skills/").`)
+    return
+  }
+
+  const pluginDir = path.dirname(path.dirname(manifestPath))
+  const skillsDir = path.resolve(pluginDir, skills)
+  try {
+    const stat = await fs.stat(skillsDir)
+    if (!stat.isDirectory()) {
+      errors.push(`${manifestPath} declares skills: "${skills}" but ${skillsDir} is not a directory`)
+    }
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      errors.push(`${manifestPath} declares skills: "${skills}" but ${skillsDir} does not exist`)
+    } else {
+      throw err
+    }
+  }
+}
+
 export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<MetadataSyncResult> {
   const root = options.root ?? process.cwd()
   const write = options.write ?? false
@@ -175,6 +219,7 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
   const compoundClaudePath = path.join(root, ".claude-plugin", "plugin.json")
   const compoundCursorPath = path.join(root, ".cursor-plugin", "plugin.json")
   const compoundAntigravityPath = path.join(root, ".agy", "plugin.json")
+  const compoundKimiPath = path.join(root, ".kimi-plugin", "plugin.json")
   const marketplaceClaudePath = path.join(root, ".claude-plugin", "marketplace.json")
   const marketplaceCursorPath = path.join(root, ".cursor-plugin", "marketplace.json")
 
@@ -281,6 +326,7 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
   // write would create a second authority for the same field.
   const compoundCodexPath = path.join(root, ".codex-plugin", "plugin.json")
   const marketplaceCodexPath = path.join(root, ".agents", "plugins", "marketplace.json")
+  const marketplaceKimiPath = path.join(root, ".kimi-plugin", "marketplace.json")
 
   const codexPluginTargets: Array<{
     claudePath: string
@@ -330,24 +376,7 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
     // skills for each plugin (and `--to codex` defaults to agents-only), so a
     // missing `skills` field silently produces a broken install with no skills
     // registered. Enforce presence, then verify the directory exists.
-    if (codex.skills === undefined) {
-      errors.push(`${codexPath} (${expectedName}): missing required field "skills". Codex plugins must declare a skills path (e.g., "./skills/").`)
-    } else {
-      const pluginDir = path.dirname(path.dirname(codexPath))
-      const skillsDir = path.resolve(pluginDir, codex.skills)
-      try {
-        const stat = await fs.stat(skillsDir)
-        if (!stat.isDirectory()) {
-          errors.push(`${codexPath} declares skills: "${codex.skills}" but ${skillsDir} is not a directory`)
-        }
-      } catch (err: unknown) {
-        if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-          errors.push(`${codexPath} declares skills: "${codex.skills}" but ${skillsDir} does not exist`)
-        } else {
-          throw err
-        }
-      }
-    }
+    await validateDeclaredSkillsPath(codexPath, expectedName, "Codex", codex.skills, errors)
 
     updates.push({ path: codexPath, changed: codexChanged })
     if (write && codexChanged) await writeJson(codexPath, codex)
@@ -377,6 +406,74 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       errors.push(`${marketplaceCodexPath} is missing but ${marketplaceClaudePath} exists. Codex marketplace parity required.`)
       updates.push({ path: marketplaceCodexPath, changed: false })
+    } else {
+      throw err
+    }
+  }
+
+  // Kimi manifests. Kimi Code CLI supports root-native plugin manifests at
+  // `.kimi-plugin/plugin.json`; like Codex, its marketplace catalog has no
+  // release-owned metadata version, so the plugin version is detect-only here
+  // and release-please owns the write via the root component's extra-files.
+  let kimi: KimiPluginManifest
+  let kimiManifestMissing = false
+  try {
+    kimi = await readJson<KimiPluginManifest>(compoundKimiPath)
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      kimiManifestMissing = true
+      errors.push(`${compoundKimiPath} is missing but ${compoundClaudePath} exists. Kimi manifest parity required.`)
+      updates.push({ path: compoundKimiPath, changed: false })
+      kimi = { name: "compound-engineering", version: compoundClaude.version }
+    } else {
+      throw err
+    }
+  }
+
+  if (kimi.name !== "compound-engineering") {
+    errors.push(`${compoundKimiPath}: name "${kimi.name}" does not match expected "compound-engineering"`)
+  }
+
+  let kimiChanged = false
+  if (kimi.version !== compoundClaude.version) {
+    kimiChanged = true
+  }
+  if (compoundClaude.description !== undefined && kimi.description !== compoundClaude.description) {
+    kimi.description = compoundClaude.description
+    kimiChanged = true
+  }
+  await validateDeclaredSkillsPath(compoundKimiPath, "compound-engineering", "Kimi", kimi.skills, errors)
+  updates.push({ path: compoundKimiPath, changed: kimiChanged })
+  if (write && kimiChanged && !kimiManifestMissing) await writeJson(compoundKimiPath, kimi)
+
+  try {
+    const marketplaceKimi = await readJson<KimiMarketplaceManifest>(marketplaceKimiPath)
+    if (marketplaceKimi.version !== "2") {
+      errors.push(`${marketplaceKimiPath}: version "${marketplaceKimi.version}" does not match expected Kimi marketplace schema version "2"`)
+    }
+    const claudeNames = [...marketplaceClaude.plugins.map((p) => p.name)].sort()
+    const kimiIds = [...marketplaceKimi.plugins.map((p) => p.id)].sort()
+    if (claudeNames.join("|") !== kimiIds.join("|")) {
+      errors.push(
+        `${marketplaceKimiPath}: plugin list [${kimiIds.join(", ")}] does not match ${marketplaceClaudePath} [${claudeNames.join(", ")}]`,
+      )
+    }
+    for (const plugin of marketplaceKimi.plugins) {
+      if (typeof plugin.source !== "string" || plugin.source.trim() === "") {
+        errors.push(
+          `${marketplaceKimiPath}: plugin "${plugin.id}" is missing required field "source". Kimi marketplace entries must point to a local path, zip URL, or GitHub URL.`,
+        )
+      } else if (plugin.source === "./" || plugin.source === ".") {
+        errors.push(
+          `${marketplaceKimiPath}: plugin "${plugin.id}" uses source "${plugin.source}". Use a GitHub URL so Kimi can install the root-native plugin from a published marketplace catalog.`,
+        )
+      }
+    }
+    updates.push({ path: marketplaceKimiPath, changed: false })
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      errors.push(`${marketplaceKimiPath} is missing but ${marketplaceClaudePath} exists. Kimi marketplace parity required.`)
+      updates.push({ path: marketplaceKimiPath, changed: false })
     } else {
       throw err
     }

--- a/tests/release-components.test.ts
+++ b/tests/release-components.test.ts
@@ -45,6 +45,17 @@ describe("release component detection", () => {
     expect(components.get("marketplace")).toEqual([])
     expect(components.get("compound-engineering")).toEqual([])
   })
+
+  test("maps Kimi plugin manifest to root plugin component but leaves marketplace static", () => {
+    const components = detectComponentsFromFiles([
+      ".kimi-plugin/plugin.json",
+      ".kimi-plugin/marketplace.json",
+    ])
+
+    expect(components.get("compound-engineering")).toEqual([".kimi-plugin/plugin.json"])
+    expect(components.get("marketplace")).toEqual([])
+    expect(components.get("cursor-marketplace")).toEqual([])
+  })
 })
 
 describe("release intent parsing", () => {

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -25,6 +25,7 @@ async function makeFixtureRoot(): Promise<string> {
   await mkdir(path.join(root, ".claude-plugin"), { recursive: true })
   await mkdir(path.join(root, ".cursor-plugin"), { recursive: true })
   await mkdir(path.join(root, ".codex-plugin"), { recursive: true })
+  await mkdir(path.join(root, ".kimi-plugin"), { recursive: true })
   await mkdir(path.join(root, ".agents", "plugins"), { recursive: true })
 
   await writeFile(
@@ -64,6 +65,19 @@ async function makeFixtureRoot(): Promise<string> {
       2,
     ),
   )
+  await writeFile(
+    path.join(root, ".kimi-plugin", "plugin.json"),
+    JSON.stringify(
+      {
+        name: "compound-engineering",
+        version: "2.42.0",
+        description: "old",
+        skills: "./skills/",
+      },
+      null,
+      2,
+    ),
+  )
   await mkdir(path.join(root, ".agy"), { recursive: true })
   await writeFile(
     path.join(root, ".agy", "plugin.json"),
@@ -75,6 +89,23 @@ async function makeFixtureRoot(): Promise<string> {
       {
         name: "compound-engineering-plugin",
         plugins: [{ name: "compound-engineering" }],
+      },
+      null,
+      2,
+    ),
+  )
+  await writeFile(
+    path.join(root, ".kimi-plugin", "marketplace.json"),
+    JSON.stringify(
+      {
+        version: "2",
+        plugins: [
+          {
+            id: "compound-engineering",
+            displayName: "Compound Engineering",
+            source: "https://github.com/EveryInc/compound-engineering-plugin",
+          },
+        ],
       },
       null,
       2,
@@ -160,6 +191,27 @@ describe("release metadata", () => {
     // Crucially: write: true did NOT bump the Codex version to match Claude.
     // release-please owns version writes via extra-files; syncReleaseMetadata detects but does not correct.
     const afterContents = JSON.parse(await Bun.file(codexPath).text())
+    expect(afterContents.version).toBe("2.41.0")
+  })
+
+  test("reports Kimi plugin.json version drift without auto-correcting", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".kimi-plugin", "plugin.json"),
+      JSON.stringify(
+        { name: "compound-engineering", version: "2.41.0", skills: "./skills/" },
+        null,
+        2,
+      ),
+    )
+    const result = await syncReleaseMetadata({ root, write: true })
+    const kimiPath = path.join(root, ".kimi-plugin", "plugin.json")
+    const kimiUpdate = result.updates.find((u) => u.path === kimiPath)
+
+    expect(kimiUpdate).toBeDefined()
+    expect(kimiUpdate!.changed).toBe(true)
+
+    const afterContents = JSON.parse(await Bun.file(kimiPath).text())
     expect(afterContents.version).toBe("2.41.0")
   })
 
@@ -253,6 +305,15 @@ describe("release metadata", () => {
     expect(result.errors.some((err) => err.includes(".codex-plugin/plugin.json is missing"))).toBe(true)
   })
 
+  test("reports missing Kimi manifest as a structural error", async () => {
+    const root = await makeFixtureRoot()
+    await Bun.$`rm ${path.join(root, ".kimi-plugin", "plugin.json")}`.quiet()
+
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(result.errors.some((err) => err.includes(".kimi-plugin/plugin.json is missing"))).toBe(true)
+  })
+
   test("reports Codex plugin.json name mismatch as structural error", async () => {
     const root = await makeFixtureRoot()
     await writeFile(
@@ -285,6 +346,24 @@ describe("release metadata", () => {
       result.errors.some(
         (err) =>
           err.includes("compound-engineering") &&
+          err.includes("missing required field") &&
+          err.includes("skills"),
+      ),
+    ).toBe(true)
+  })
+
+  test("reports missing skills field on Kimi manifest as structural error", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".kimi-plugin", "plugin.json"),
+      JSON.stringify({ name: "compound-engineering", version: "2.42.0" }, null, 2),
+    )
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes(".kimi-plugin/plugin.json") &&
           err.includes("missing required field") &&
           err.includes("skills"),
       ),
@@ -386,7 +465,102 @@ describe("release metadata", () => {
     ).toBe(true)
   })
 
-  test("happy path: fixture with matching Codex manifests produces no Codex errors", async () => {
+  test("reports Kimi marketplace plugin-list mismatch as structural error", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".kimi-plugin", "marketplace.json"),
+      JSON.stringify(
+        {
+          version: "2",
+          plugins: [],
+        },
+        null,
+        2,
+      ),
+    )
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some(
+        (err) => err.includes(".kimi-plugin/marketplace.json") && err.includes("does not match"),
+      ),
+    ).toBe(true)
+  })
+
+  test("reports Kimi marketplace schema version mismatch as structural error", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".kimi-plugin", "marketplace.json"),
+      JSON.stringify(
+        {
+          version: "1",
+          plugins: [{ id: "compound-engineering" }],
+        },
+        null,
+        2,
+      ),
+    )
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some(
+        (err) => err.includes(".kimi-plugin/marketplace.json") && err.includes('schema version "2"'),
+      ),
+    ).toBe(true)
+  })
+
+  test("reports Kimi marketplace root-local plugin source as structural error", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".kimi-plugin", "marketplace.json"),
+      JSON.stringify(
+        {
+          version: "2",
+          plugins: [{ id: "compound-engineering", source: "./" }],
+        },
+        null,
+        2,
+      ),
+    )
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes(".kimi-plugin/marketplace.json") &&
+          err.includes("compound-engineering") &&
+          err.includes('source "./"'),
+      ),
+    ).toBe(true)
+  })
+
+  test("reports Kimi marketplace missing plugin source as structural error", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".kimi-plugin", "marketplace.json"),
+      JSON.stringify(
+        {
+          version: "2",
+          plugins: [{ id: "compound-engineering" }],
+        },
+        null,
+        2,
+      ),
+    )
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some(
+        (err) =>
+          err.includes(".kimi-plugin/marketplace.json") &&
+          err.includes("compound-engineering") &&
+          err.includes("missing required field") &&
+          err.includes("source"),
+      ),
+    ).toBe(true)
+  })
+
+  test("happy path: fixture with matching native manifests produces no native plugin errors", async () => {
     const root = await makeFixtureRoot()
     // Align Claude <-> Codex versions and descriptions so there's no drift.
     await writeFile(
@@ -408,9 +582,12 @@ describe("release metadata", () => {
     )
 
     const result = await syncReleaseMetadata({ root, write: false })
-    const codexErrors = result.errors.filter(
-      (err) => err.includes(".codex-plugin") || err.includes(".agents/plugins"),
+    const nativePluginErrors = result.errors.filter(
+      (err) =>
+        err.includes(".codex-plugin") ||
+        err.includes(".agents/plugins") ||
+        err.includes(".kimi-plugin"),
     )
-    expect(codexErrors).toEqual([])
+    expect(nativePluginErrors).toEqual([])
   })
 })

--- a/tests/release-preview.test.ts
+++ b/tests/release-preview.test.ts
@@ -51,6 +51,8 @@ describe("release preview", () => {
 
     await writeFile(path.join(root, "package.json"), JSON.stringify({ version: "3.13.1" }))
     await writeFile(path.join(root, ".claude-plugin", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
+    await mkdir(path.join(root, ".kimi-plugin"), { recursive: true })
+    await writeFile(path.join(root, ".kimi-plugin", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
     await mkdir(path.join(root, ".agy"), { recursive: true })
     await writeFile(path.join(root, ".agy", "plugin.json"), JSON.stringify({ version: "3.13.0" }))
     await writeFile(
@@ -63,6 +65,30 @@ describe("release preview", () => {
     )
 
     await expect(loadCurrentVersions(root)).rejects.toThrow(".agy/plugin.json version 3.13.0")
+    await Bun.$`rm -rf ${root}`.quiet()
+  })
+
+  test("rejects Kimi plugin version drift from the root plugin version", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "release-preview-"))
+    await mkdir(path.join(root, ".claude-plugin"), { recursive: true })
+    await mkdir(path.join(root, ".cursor-plugin"), { recursive: true })
+    await mkdir(path.join(root, ".kimi-plugin"), { recursive: true })
+    await mkdir(path.join(root, ".agy"), { recursive: true })
+
+    await writeFile(path.join(root, "package.json"), JSON.stringify({ version: "3.13.1" }))
+    await writeFile(path.join(root, ".claude-plugin", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
+    await writeFile(path.join(root, ".kimi-plugin", "plugin.json"), JSON.stringify({ version: "3.13.0" }))
+    await writeFile(path.join(root, ".agy", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
+    await writeFile(
+      path.join(root, ".claude-plugin", "marketplace.json"),
+      JSON.stringify({ metadata: { version: "3.13.1" } }),
+    )
+    await writeFile(
+      path.join(root, ".cursor-plugin", "marketplace.json"),
+      JSON.stringify({ metadata: { version: "3.13.1" } }),
+    )
+
+    await expect(loadCurrentVersions(root)).rejects.toThrow(".kimi-plugin/plugin.json version 3.13.0")
     await Bun.$`rm -rf ${root}`.quiet()
   })
 })


### PR DESCRIPTION
## Summary

Kimi users can now install Compound Engineering through Kimi Code CLI's native plugin surface instead of needing a generated converter target. This keeps the Kimi install path aligned with the repo's current native-plugin strategy: the repo publishes a Kimi manifest, a Kimi custom marketplace catalog, release automation owns the plugin version, and validation prevents the Kimi metadata from drifting out of parity.

This supersedes the approach in EveryInc/compound-engineering-plugin#997. Credit to @mastepanoski for the original Kimi CLI support proposal and implementation work that surfaced the need; this PR keeps that install goal but routes it through Kimi's supported `plugin.json` manifest path.

## What changed

| Area | Outcome |
| --- | --- |
| Native Kimi plugin | Adds `.kimi-plugin/plugin.json` with Kimi-supported metadata and `skills: "./skills/"`. |
| Kimi marketplace | Adds `.kimi-plugin/marketplace.json` using Kimi marketplace schema version `2`. |
| Release process | Adds Kimi plugin version bumping to the root release component while keeping the Kimi marketplace static. |
| Validation | Fails `release:validate` on Kimi manifest drift, missing skills, bad marketplace schema, plugin-list mismatch, or missing/invalid marketplace source. |
| Docs | Documents direct Kimi install, custom marketplace browsing, and the Kimi spec/strategy. |

## Design decisions

- Kimi is not added as a Bun converter/install target because Kimi Code CLI natively supports plugin manifests at `.kimi-plugin/plugin.json`.
- The Kimi marketplace does not get a release-please component because its catalog schema has no `metadata.version` equivalent.
- Kimi's plugin version is treated like Codex and Antigravity: release-please owns the write through the root `compound-engineering` component, while `release:validate` detects drift.

## Validation

- `bun test` -> `1612 pass, 0 fail`
- `bun run release:validate` -> release metadata in sync

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is repository metadata, release validation, and documentation only; activation is validated through local tests and Kimi users will exercise the published manifest after merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
