### PR TITLE
fix: remove no-op prose and codify authoring rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,18 @@ Behavioral changes to a plugin skill or skill-local persona (anything under `ski
 
 - **Mechanical changes do not have this restriction.** Skill scripts (e.g., `extract-metadata.py`), parser logic, conversion code, and anything `bun test` exercises always run the current source. The caching issue only affects LLM-driven skill prose behavior dispatched through the plugin loader.
 
+## Writing Skill Instructions
+
+Every line of skill prose must change agent behavior. Before keeping a line, apply the deletion test: if removing it would not change the output, it is a no-op — delete it. Agents already write detailed commit messages, try to be thorough, and aim for readable code by default, so generic exhortations to do those things ("be thorough", "be comprehensive", "write clean/readable code", "think carefully", "world-class", "high quality") are no-ops that only add tokens and noise.
+
+A line earns its place when it does one of these:
+
+- States a falsifiable constraint: a threshold, format, path, schema, or ordering.
+- Counters a known default tendency: a negative constraint ("do NOT add comments", "never push to main", "stop after X") or a guard against a shortcut the model would otherwise take.
+- Supplies domain knowledge the agent would not otherwise have.
+
+An adjective is fine **only** when immediately operationalized by a concrete rule (e.g., "keep outputs concise — only enough detail to support the next decision"). The adjective alone is framing; the operationalization is the instruction. Do not append motivational rationale ("the quality of everything depends on this") to a directive that already stands on its own, and do not restate an instruction the same file already gives unless it is deliberate spaced repetition placed where drift occurs.
+
 ## Coding Conventions
 
 - Prefer explicit mappings over implicit magic when converting between platforms.

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -10,7 +10,7 @@ Coordinate multiple subagents working in parallel to document a recently solved 
 
 ## Purpose
 
-Captures problem solutions while context is fresh, creating structured documentation in `docs/solutions/` with YAML frontmatter for searchability and future reference. Uses parallel subagents for maximum efficiency.
+Captures problem solutions while context is fresh, creating structured documentation in `docs/solutions/` with YAML frontmatter for searchability and future reference. Uses parallel subagents.
 
 **Why "compound"?** Each documented solution compounds your team's knowledge. The first time you solve a problem takes research. Document it, and the next occurrence takes minutes. Knowledge compounds.
 

--- a/skills/ce-dogfood-beta/SKILL.md
+++ b/skills/ce-dogfood-beta/SKILL.md
@@ -75,7 +75,7 @@ Because tasks are session-scoped but the report doc is on disk, the report is th
 
 ### Phase 1: Analyze Changes
 
-Pull the full diff against `main` and read it carefully — you cannot test what you don't understand.
+Pull the full diff against `main` and read it.
 
 ```bash
 git diff --name-only main...HEAD     # what changed
@@ -88,7 +88,7 @@ Build a mental model of every change: new features, modified behavior, new route
 
 ### Phase 2: Map the Flows, Then Build the Matrix
 
-The quality of the whole dogfood depends on this phase. Do not jump straight to a flat list of pages. First **understand the user flows the diff touches**, then derive the matrix from them. A matrix built without a flow model tests pages in isolation and misses the journey — the email that "sends" but lands in the wrong thread.
+Do not jump straight to a flat list of pages. First **understand the user flows the diff touches**, then derive the matrix from them. A matrix built without a flow model tests pages in isolation and misses the journey — the email that "sends" but lands in the wrong thread.
 
 #### 2a. Map the user flows (required)
 

--- a/skills/ce-simplify-code/SKILL.md
+++ b/skills/ce-simplify-code/SKILL.md
@@ -4,7 +4,7 @@ description: "Simplify recently changed code for clarity, reuse, quality, and ef
 argument-hint: "[blank to simplify current branch changes, or describe what to simplify]"
 ---
 
-You are an engineer that is an expert at simplifying code with a specific focus on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior. You prioritize readable, explicit code over overly compact solutions.
+Simplify code for clarity, consistency, and maintainability while preserving exact functionality. Prioritize readable, explicit code over overly compact solutions.
 
 Review the changed code for reuse, quality, and efficiency. Fix any issues found. Then verify behavior is preserved by running the project's test suite.
 

--- a/skills/ce-work-beta/SKILL.md
+++ b/skills/ce-work-beta/SKILL.md
@@ -418,9 +418,6 @@ When `delegation_active` is true after argument parsing, read `references/codex-
 
 ### Quality is Built In
 
-- Follow existing patterns
-- Write tests for new code
-- Run linting before pushing
 - Review when Tier 1 is available or Tier 2 criteria match (see `shipping-workflow.md`)
 
 ### Ship Complete Features

--- a/skills/ce-work/SKILL.md
+++ b/skills/ce-work/SKILL.md
@@ -367,9 +367,6 @@ Tier 1 harness-native review may still fix inline; Tier 2 always separates revie
 
 ### Quality is Built In
 
-- Follow existing patterns
-- Write tests for new code
-- Run linting before pushing
 - Review when Tier 1 is available or Tier 2 criteria match (see `shipping-workflow.md`)
 
 ### Ship Complete Features


### PR DESCRIPTION
## Summary

Acting on the observation that agent-authored skills are littered with no-op instructions — generic exhortations the model already follows by default ("be thorough", "read carefully", "for maximum efficiency"), this audits all 27 skills and removes the ones that change no output. Output is unchanged by definition; this is purely tokens and noise reclaimed, plus a rule so the pattern doesn't creep back.

The audit yield was low — these skills are already disciplined, with generic adjectives almost always operationalized by a concrete rule. Only a handful of true no-ops surfaced:

- **ce-dogfood-beta** — dropped "read it carefully — you cannot test what you don't understand" and the "quality of the whole dogfood depends on this phase" pep-talk; the load-bearing instructions stand on their own.
- **ce-compound** — dropped "for maximum efficiency" (the parallel-subagent mechanism is specified concretely elsewhere).
- **ce-simplify-code** — collapsed persona puffery to a plain directive, keeping the load-bearing readable-over-compact preference.
- **ce-work / ce-work-beta** — trimmed the duplicated "Quality is Built In" recap (three bullets restating Phase 2) to the one bullet carrying a real constraint.

It also adds an AGENTS.md **Writing Skill Instructions** section: the deletion test (if removing a line changes no output, delete it), the no-op list, and the three things that earn a line's place — a falsifiable constraint, a counter to a known default tendency, or domain knowledge the agent lacks. Adjectives are allowed only when immediately operationalized.

## Validation

Skill prose and docs only; no frontmatter, count, or release-owned description changes. `bun run release:validate` passes (0 agents, 27 skills, 0 MCP servers, metadata in sync).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
