### PR TITLE
docs(ce-simplify-code): document /lfg invocation and utility-skill framing

### DIFF
--- a/docs/skills/ce-simplify-code.md
+++ b/docs/skills/ce-simplify-code.md
@@ -4,9 +4,11 @@
 
 `ce-simplify-code` is the **refinement** skill. It does the homework that's easy to skip after writing code: searches for existing utilities your new code accidentally duplicates, flags hacky patterns and dead code, surfaces missed efficiency wins. Three parallel reviewer agents work the same diff from different angles — Reuse, Quality, Efficiency — and the orchestrator applies their findings, then verifies behavior is preserved.
 
+It's a **utility skill** — point it at whatever you want refined. With no argument it resolves the branch diff; given a file path or a description ("the function I just wrote") it scopes to exactly that. That makes it the natural cleanup pass for AI-generated code, which is its highest-yield use. Agents reliably write more code than a problem needs: industry analysis of hundreds of millions of changed lines shows duplicated and copy-pasted code climbing sharply since coding assistants went mainstream, while refactoring — moving and reusing existing code — has fallen by more than half. The reason is structural, not a model defect: an agent optimizes each fragment locally to *look* well-engineered without the whole-system context to notice that the helper already exists, that the abstraction is single-use, or that the comment restates the code. The result works but carries duplication, single-use wrappers, defensive over-engineering, and tutorial-style comments. `ce-simplify-code` exists to strip that back to what the change actually requires.
+
 The premise is that simplification preserves exact functionality. The skill enforces this by running typecheck, lint, and scoped tests after fixes. **It refuses to relax assertions, weaken type signatures, or skip tests to make checks pass** — that defeats the guarantee.
 
-The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /ce-plan → /ce-work`. `ce-simplify-code` runs as a quality gate inside `/ce-work` Phase 3 (for diffs ≥30 changed lines), and is directly invocable for refining a feature branch before you open a PR.
+The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /ce-plan → /ce-work`. `ce-simplify-code` runs automatically as a quality gate inside `/ce-work` Phase 3 (for diffs ≥30 changed lines) and as step 3 of the autonomous `/lfg` loop (before review, skipped for docs-only or trivial changes), and is directly invocable for refining a feature branch before you open a PR.
 
 ---
 
@@ -105,7 +107,12 @@ Skip `ce-simplify-code` when:
 
 ## Use as Part of the Workflow
 
-`ce-simplify-code` is called automatically by `/ce-work` Phase 3 when a diff is ≥30 changed lines — it runs before the harness-native or `/ce-code-review` review tier so reviewers see the simplified diff. It's also commonly invoked manually before `/ce-commit-push-pr`, when you want a refinement pass on a branch you've been building over multiple sessions.
+`ce-simplify-code` is invoked automatically by two workflows, always **before** the review step so reviewers see the simplified diff:
+
+- **`/ce-work` Phase 3** — runs when a diff is ≥30 changed lines, ahead of the harness-native or `/ce-code-review` review tier.
+- **`/lfg` step 3** — the autonomous build loop runs it on the branch diff after the build step and before code review. It's skipped only for docs-only changes (markdown/docs paths) or trivial ones (roughly under 10 changed lines), and it leaves its edits uncommitted so the loop's later commit step sweeps them up with the rest of the work.
+
+It's also commonly invoked manually before `/ce-commit-push-pr`, when you want a refinement pass on a branch you've been building over multiple sessions.
 
 The flow when manually invoked typically looks like:
 
@@ -120,7 +127,7 @@ write code → /ce-simplify-code → /ce-commit-push-pr
 The skill works just as well outside the chain:
 
 - **Pre-PR refinement** — `/ce-simplify-code` on a feature branch before opening a PR
-- **Post-AI cleanup** — when an LLM generated code that ships but feels over-engineered
+- **Post-AI cleanup** — point it at code an agent just generated to strip the duplication, single-use wrappers, and over-engineering agents tend to leave behind; this is its highest-yield use
 - **Targeted refinement** — `/ce-simplify-code "the changes I made to NotificationDispatcher"` honors a user-named scope
 - **Single-file pass** — `/ce-simplify-code app/services/notification_dispatcher.rb`
 
@@ -153,12 +160,13 @@ The skill won't relax assertions, weaken type signatures, or skip tests to paper
 It can be, but in practice the moment to find an existing utility is when you're searching for it, not when you're writing the feature. A separate refinement pass with parallel cross-cutting search catches things the original write didn't.
 
 **Does it run for tiny diffs?**
-By default it runs against whatever scope it resolves, but the yield on tiny diffs (a couple of lines) is low. Inside `ce-work`, the skill is gated by the ≥30-line threshold for that reason.
+By default it runs against whatever scope it resolves, but the yield on tiny diffs (a couple of lines) is low. The automated callers gate on size for that reason: `ce-work` runs it only for diffs ≥30 changed lines, and `/lfg` skips it for docs-only or trivial (roughly under 10 changed lines) changes.
 
 ---
 
 ## See Also
 
 - [`ce-work`](./ce-work.md) — calls this skill in Phase 3 for diffs of significant size
+- `lfg` — the autonomous build loop runs this skill as step 3, before its review step
 - [`ce-commit-push-pr`](./ce-commit-push-pr.md) — usual next step after a refinement pass
 - [`ce-code-review`](./ce-code-review.md) — the deeper code review skill; `ce-simplify-code` is a complement, not a substitute


### PR DESCRIPTION
The `ce-simplify-code` doc previously only mentioned its automatic invocation inside `/ce-work` Phase 3, leaving the `/lfg` loop's use of it undocumented. The doc now reflects that `/lfg` runs the skill as step 3 (before review, skipped for docs-only or trivial changes), so readers understand both automated callers and their size gates.

It also reframes `ce-simplify-code` as a utility skill you can point at any scope, and names its highest-yield use — cleaning up AI-generated code, which tends toward duplication, single-use wrappers, and over-engineering. The framing is grounded in industry findings on rising code duplication and falling reuse since coding assistants went mainstream (stated, not cited).

Docs-only change to a single Markdown file; no behavior affected.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
