### PR TITLE
fix(ce-simplify-code): name the blocking question tool on the ask-for-scope path

### DIFF
--- a/skills/ce-simplify-code/SKILL.md
+++ b/skills/ce-simplify-code/SKILL.md
@@ -16,7 +16,7 @@ Resolve the simplification scope in this order:
 2. **Otherwise, in a git repository**, default to the diff between the current branch and its base branch (e.g., `git diff origin/main...` or against the configured upstream). This covers the common case of "simplify everything I've added on this feature branch before opening a PR." If the branch has no upstream or base ref, fall back to staged + unstaged changes (`git diff HEAD`).
 3. **Outside a git repository or when no diff is available**, review the most recently modified files mentioned by the user or edited earlier in this conversation.
 
-If none of the above produces a non-empty scope, stop and ask the user what to simplify rather than guessing.
+If none of the above produces a non-empty scope, stop and ask the user what to simplify rather than guessing. Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
 
 ## Step 2: Launch 3 review agents in parallel
 


### PR DESCRIPTION
## What

`ce-simplify-code` Step 1 resolves the simplification scope, and its final fallback is the skill's only user-facing question:

> If none of the above produces a non-empty scope, stop and ask the user what to simplify rather than guessing.

That line didn't name a blocking question tool. This PR names the per-platform tool and adds the standard fallback, so the ask actually blocks instead of risking a non-blocking ask or a silent skip:

> …Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.

## Why

- **Cross-platform reliability.** On a harness where `AskUserQuestion`'s schema isn't loaded (it's deferred in Claude Code) or where the tool is named differently, "stop and ask the user" can degrade to a non-blocking ask or a silently skipped question — exactly the failure the rest of the plugin guards against.
- **Consistency with house style.** ~40 other skills already use this canonical blocking-tool phrasing (e.g. `ce-compound-refresh`, `ce-work`). `ce-simplify-code`'s lone ask-the-user moment was the outlier.

## Scope

One-line change to `skills/ce-simplify-code/SKILL.md`. No frontmatter, manifest, count, or behavior change beyond the ask path. Verbatim reuse of the existing in-repo phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUBgV2MxLsQmui8c84zZrr
