### PR TITLE
feat: add lfg cli command

### DIFF
--- a/docs/plans/2026-06-25-001-feat-lfg-cli-command-plan.md
+++ b/docs/plans/2026-06-25-001-feat-lfg-cli-command-plan.md
@@ -1,0 +1,141 @@
+---
+title: "feat: add lfg CLI command"
+type: feat
+date: 2026-06-25
+---
+
+# feat: add lfg CLI command
+
+## Summary
+
+Add a first-class `lfg` subcommand to the Compound Engineering Bun CLI so users and agents can start the existing `compound-engineering:lfg` pipeline from a terminal while preserving the skill as the source of pipeline behavior.
+
+---
+
+## Problem Frame
+
+`skills/lfg/SKILL.md` is currently invocable as an agent skill, but the plugin CLI in `src/index.ts` only exposes install, conversion, cleanup, listing, and plugin-path operations. Users who discover the plugin from the shell cannot ask the CLI to run the same hands-off planning-to-PR pipeline without manually knowing the Codex skill invocation shape.
+
+---
+
+## Requirements
+
+- R1. The CLI exposes an `lfg` subcommand from the existing `compound-plugin` entrypoint.
+- R2. The command forwards the feature description arguments to the installed Codex skill invocation without reimplementing the pipeline steps in TypeScript.
+- R3. The command preserves the caller's working directory so LFG plans and edits the project where the CLI was launched.
+- R4. The command fails fast with an actionable error when the Codex CLI is unavailable or exits non-zero.
+- R5. The command is documented in CLI help and package scripts so humans and agents can discover it.
+- R6. Automated coverage proves argument forwarding, cwd preservation, and error propagation without needing a real Codex install.
+
+---
+
+## Key Technical Decisions
+
+- **Delegate to Codex skill execution:** The TypeScript CLI should launch `codex exec` with a prompt that explicitly invokes `$compound-engineering:lfg` and includes the user's feature description. This keeps `skills/lfg/SKILL.md` as the source of the orchestration contract and avoids a second pipeline implementation.
+- **Use stdin prompt composition instead of shell quoting:** Build the prompt string in TypeScript and pass it to the child process stdin so arbitrary feature descriptions do not need shell escaping.
+- **Inject the Codex binary for tests:** Read the binary path from an environment variable with a `codex` default so tests can point the command at a stub executable and assert argv, cwd, and stdin deterministically.
+- **Pass through stdio:** Let Codex own progress output. The wrapper's job is process setup, not transcript parsing.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant User as Terminal user or agent
+  participant CE as compound-plugin lfg
+  participant Codex as Codex CLI
+  participant Skill as compound-engineering:lfg skill
+  User->>CE: lfg "feature description"
+  CE->>Codex: codex exec -C original cwd -
+  CE->>Codex: stdin prompt invoking $compound-engineering:lfg
+  Codex->>Skill: load and run pipeline
+  Skill-->>User: LFG transcript and DONE/diagnostics
+```
+
+---
+
+## Implementation Units
+
+### U1. CLI command implementation
+
+**Goal:** Add a reusable command module for `lfg` and register it in the root command table.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- `src/commands/lfg.ts`
+- `src/index.ts`
+
+**Approach:** Create `src/commands/lfg.ts` using the existing `citty` command pattern. Accept a variadic positional argument for the feature description, compose a prompt that starts with `$compound-engineering:lfg` and preserves the full description, then spawn the Codex CLI with `exec -C process.cwd() -`. Use `process.env.COMPOUND_ENGINEERING_CODEX_BIN ?? "codex"` for the binary. Pipe stdout and stderr through to the parent and throw an error that names the failed binary and exit code when the child exits non-zero.
+
+**Patterns to follow:** `src/index.ts` subcommand registration; existing Bun subprocess handling in tests; agent-friendly CLI principles in `docs/solutions/agent-friendly-cli-principles.md`.
+
+**Test scenarios:**
+- Happy path: running `bun run src/index.ts lfg build the thing` invokes the stub Codex binary with `exec`, `-C`, the original cwd, and `-`.
+- Happy path: the stub receives a stdin prompt containing `$compound-engineering:lfg` and the full feature description.
+- Edge case: no feature description still invokes the skill with an empty argument body so the skill can run its own clarification behavior.
+- Failure path: a stub Codex binary exiting non-zero causes the CLI to exit non-zero and includes the child exit code in stderr.
+
+**Verification:** Targeted CLI tests pass without a real Codex install.
+
+### U2. Discoverability and scripts
+
+**Goal:** Make the new command visible through package scripts and help output.
+
+**Requirements:** R5
+
+**Dependencies:** U1
+
+**Files:**
+- `package.json`
+- `tests/cli.test.ts`
+
+**Approach:** Add a root package script such as `lfg: "bun run src/index.ts lfg"`. Rely on `citty` metadata for help text and cover `--help` output with a focused assertion if the existing CLI test style supports it.
+
+**Patterns to follow:** Current package scripts for `list`, `convert`, and `cli:install`; CLI tests in `tests/cli.test.ts`.
+
+**Test scenarios:**
+- Happy path: package metadata exposes an `lfg` script that runs `src/index.ts lfg`.
+- Happy path: top-level CLI help lists `lfg` with a short description.
+
+**Verification:** CLI tests prove discoverability and package metadata is syntactically valid JSON.
+
+---
+
+## Scope Boundaries
+
+- This plan does not rewrite the LFG pipeline in TypeScript.
+- This plan does not change `skills/lfg/SKILL.md` pipeline order or review/CI behavior.
+- This plan does not require Codex plugin installation during tests; stubbing the Codex binary is enough.
+
+### Deferred to Follow-Up Work
+
+- A more general `compound-plugin run-skill <name>` command could be added later if multiple skills need shell wrappers.
+- Machine-readable run summaries can be considered later if Codex exposes a stable output contract for skill runs.
+
+---
+
+## System-Wide Impact
+
+The change adds a new exported CLI contract and a package script, but it keeps the skill registry, converters, plugin manifests, and installed skill contents unchanged. It improves agent access to a high-value workflow without widening the plugin install surface.
+
+---
+
+## Risks & Dependencies
+
+- **Codex CLI invocation drift:** The wrapper depends on `codex exec -C <cwd> -` accepting stdin prompts. Keep the wrapper small and covered by argv tests so future Codex changes have one clear update point.
+- **Pipeline duplication risk:** Reimplementing LFG in TypeScript would create drift from `skills/lfg/SKILL.md`; the design avoids this by delegating to the skill prompt.
+- **External binary availability:** Runtime success depends on Codex being installed and authenticated. The command should report that plainly when the child process cannot start or exits non-zero.
+
+---
+
+## Sources & Research
+
+- Existing skill pipeline: `skills/lfg/SKILL.md`.
+- CLI entrypoint and command registry: `src/index.ts` and `src/commands/*.ts`.
+- Existing CLI tests: `tests/cli.test.ts`.
+- Codex plugin and skill model notes: `docs/specs/codex.md`.
+- Agent-friendly CLI design guidance: `docs/solutions/agent-friendly-cli-principles.md`.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "convert": "bun run src/index.ts convert",
     "cleanup": "bun run src/index.ts cleanup",
     "list": "bun run src/index.ts list",
+    "lfg": "bun run src/index.ts lfg",
     "cli:install": "bun run src/index.ts install",
     "test": "bun test",
     "plugin:validate": "claude plugin validate .claude-plugin/marketplace.json && claude plugin validate .",

--- a/src/commands/lfg.ts
+++ b/src/commands/lfg.ts
@@ -1,0 +1,44 @@
+import { defineCommand } from "citty"
+
+const CODEX_BIN_ENV = "COMPOUND_ENGINEERING_CODEX_BIN"
+
+function buildLfgPrompt(featureDescription: string): string {
+  const trimmed = featureDescription.trim()
+  return [
+    "$compound-engineering:lfg",
+    "",
+    trimmed,
+  ].join("\n").trimEnd()
+}
+
+export default defineCommand({
+  meta: {
+    name: "lfg",
+    description: "Run the Compound Engineering LFG pipeline through Codex",
+  },
+  async run({ rawArgs }) {
+    const codexBin = process.env[CODEX_BIN_ENV] || "codex"
+    const featureDescription = rawArgs.join(" ")
+    const prompt = buildLfgPrompt(featureDescription)
+
+    let proc: Bun.Subprocess<"pipe", "inherit", "inherit">
+    try {
+      proc = Bun.spawn([codexBin, "exec", "-C", process.cwd(), "-"], {
+        stdin: "pipe",
+        stdout: "inherit",
+        stderr: "inherit",
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw new Error(`Failed to start ${codexBin} for compound-engineering:lfg: ${message}`)
+    }
+
+    proc.stdin.write(prompt)
+    proc.stdin.end()
+
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      throw new Error(`${codexBin} exited with code ${exitCode} while running compound-engineering:lfg`)
+    }
+  },
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import convert from "./commands/convert"
 import cleanup from "./commands/cleanup"
 import install from "./commands/install"
 import listCommand from "./commands/list"
+import lfg from "./commands/lfg"
 import pluginPath from "./commands/plugin-path"
 
 const main = defineCommand({
@@ -17,6 +18,7 @@ const main = defineCommand({
     cleanup: () => cleanup,
     convert: () => convert,
     install: () => install,
+    lfg: () => lfg,
     list: () => listCommand,
     "plugin-path": () => pluginPath,
   },

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -95,7 +95,166 @@ function envWithoutOpenCodeConfig(overrides: NodeJS.ProcessEnv = {}): NodeJS.Pro
   return env
 }
 
+async function createCodexStub(tempRoot: string): Promise<string> {
+  const stubPath = path.join(tempRoot, "codex-stub")
+  await fs.writeFile(
+    stubPath,
+    `#!/bin/sh
+printf '%s\n' "$@" > "$CAPTURE_ARGS"
+pwd > "$CAPTURE_CWD"
+cat > "$CAPTURE_STDIN"
+exit "\${CODEX_STUB_EXIT:-0}"
+`,
+  )
+  await fs.chmod(stubPath, 0o755)
+  return stubPath
+}
+
 describe("CLI", () => {
+  test("lfg forwards feature descriptions to the Codex skill", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-lfg-"))
+    const workspaceRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "cli-lfg-workspace-")))
+    const repoRoot = path.join(import.meta.dir, "..")
+    const stubPath = await createCodexStub(tempRoot)
+    const captureArgs = path.join(tempRoot, "args.txt")
+    const captureCwd = path.join(tempRoot, "cwd.txt")
+    const captureStdin = path.join(tempRoot, "stdin.txt")
+
+    const proc = Bun.spawn([
+      "bun",
+      "run",
+      path.join(repoRoot, "src", "index.ts"),
+      "lfg",
+      "add",
+      "cli",
+      "support",
+    ], {
+      cwd: workspaceRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        COMPOUND_ENGINEERING_CODEX_BIN: stubPath,
+        CAPTURE_ARGS: captureArgs,
+        CAPTURE_CWD: captureCwd,
+        CAPTURE_STDIN: captureStdin,
+      },
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    expect((await fs.readFile(captureArgs, "utf8")).trim().split("\n")).toEqual([
+      "exec",
+      "-C",
+      workspaceRoot,
+      "-",
+    ])
+    expect((await fs.readFile(captureCwd, "utf8")).trim()).toBe(workspaceRoot)
+    const prompt = await fs.readFile(captureStdin, "utf8")
+    expect(prompt).toContain("$compound-engineering:lfg")
+    expect(prompt).toContain("add cli support")
+  })
+
+  test("lfg supports an empty feature description", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-lfg-empty-"))
+    const workspaceRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "cli-lfg-empty-workspace-")))
+    const repoRoot = path.join(import.meta.dir, "..")
+    const stubPath = await createCodexStub(tempRoot)
+    const captureStdin = path.join(tempRoot, "stdin.txt")
+
+    const proc = Bun.spawn(["bun", "run", path.join(repoRoot, "src", "index.ts"), "lfg"], {
+      cwd: workspaceRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        COMPOUND_ENGINEERING_CODEX_BIN: stubPath,
+        CAPTURE_ARGS: path.join(tempRoot, "args.txt"),
+        CAPTURE_CWD: path.join(tempRoot, "cwd.txt"),
+        CAPTURE_STDIN: captureStdin,
+      },
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    expect((await fs.readFile(captureStdin, "utf8")).trim()).toBe("$compound-engineering:lfg")
+  })
+
+  test("lfg reports missing Codex binary failures", async () => {
+    const workspaceRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "cli-lfg-missing-workspace-")))
+    const repoRoot = path.join(import.meta.dir, "..")
+    const missingCodex = path.join(workspaceRoot, "missing-codex")
+
+    const proc = Bun.spawn(["bun", "run", path.join(repoRoot, "src", "index.ts"), "lfg", "ship", "it"], {
+      cwd: workspaceRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        COMPOUND_ENGINEERING_CODEX_BIN: missingCodex,
+      },
+    })
+
+    const exitCode = await proc.exited
+    const stderr = await new Response(proc.stderr).text()
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain("Failed to start")
+    expect(stderr).toContain("compound-engineering:lfg")
+    expect(stderr).toContain(missingCodex)
+  })
+
+  test("lfg reports Codex failures", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-lfg-failure-"))
+    const workspaceRoot = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "cli-lfg-failure-workspace-")))
+    const repoRoot = path.join(import.meta.dir, "..")
+    const stubPath = await createCodexStub(tempRoot)
+
+    const proc = Bun.spawn(["bun", "run", path.join(repoRoot, "src", "index.ts"), "lfg", "ship", "it"], {
+      cwd: workspaceRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        COMPOUND_ENGINEERING_CODEX_BIN: stubPath,
+        CODEX_STUB_EXIT: "7",
+        CAPTURE_ARGS: path.join(tempRoot, "args.txt"),
+        CAPTURE_CWD: path.join(tempRoot, "cwd.txt"),
+        CAPTURE_STDIN: path.join(tempRoot, "stdin.txt"),
+      },
+    })
+
+    const exitCode = await proc.exited
+    const stderr = await new Response(proc.stderr).text()
+
+    expect(exitCode).not.toBe(0)
+    expect(stderr).toContain("exited with code 7")
+    expect(stderr).toContain("compound-engineering:lfg")
+  })
+
+  test("lfg is discoverable from command metadata and package scripts", async () => {
+    const repoRoot = path.join(import.meta.dir, "..")
+    const lfgCommand = (await import("../src/commands/lfg")).default as { meta: { name: string; description: string } }
+
+    expect(lfgCommand.meta.name).toBe("lfg")
+    expect(lfgCommand.meta.description).toBe("Run the Compound Engineering LFG pipeline through Codex")
+
+    const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, "package.json"), "utf8")) as { scripts: Record<string, string> }
+    expect(packageJson.scripts.lfg).toBe("bun run src/index.ts lfg")
+  })
+
   test("install converts fixture plugin to OpenCode output", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-opencode-"))
     const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")


### PR DESCRIPTION
## Summary

The Compound Engineering CLI can now launch the existing LFG pipeline directly from the shell. The new `lfg` command delegates to the installed Codex skill instead of duplicating the pipeline, so the skill remains the source of truth while terminal users and agents get a scriptable entrypoint.

## Details

- `compound-plugin lfg ...` forwards the feature description to `codex exec -C <caller cwd> -` so LFG runs against the project where the command was launched.
- The wrapper preserves pass-through Codex output and reports missing or failed Codex invocations with `compound-engineering:lfg` context.
- `bun run lfg` now exposes the same command through package scripts.

## Validation

- `bun test tests/cli.test.ts` — 42 pass
- `bunx tsc --noEmit`
- `bun test` — 1,617 pass
- Manual help check: `bun run src/index.ts --help` lists `lfg`; `bun run src/index.ts lfg --help` shows the subcommand usage.
- Browser testing: skipped because the changed files are CLI, tests, and a plan artifact with no browser-testable route.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
