### PR TITLE
fix(lfg): finish cleanly when the repo has no git remote

### DIFF
--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -29,6 +29,8 @@ When invoking any skill referenced below, resolve its name against the available
 
    `mode:agent` is report-only **by design** — it surfaces findings but never edits the tree; LFG applies the eligible ones in step 5. When narrating progress to the user, frame this as "review found X → applied X in step 5," not as "code review did not auto-fix." A report-only review followed by an LFG-applied fix is the intended contract, not a gap.
 
+**Shipping precondition (steps 5–9).** Run `git remote` once before the shipping steps. If it lists **no remote** (e.g. a sandbox/throwaway checkout that has `git init` but no `origin`), shipping is **local-only**: make every commit the steps below call for, but **skip every push, PR create/edit, and CI-watch action** — the pushes in steps 5 and 6, the push and PR creation in step 8, and step 9 in full. A missing remote is a terminal local-only state, not an error: never retry a push or hunt for a remote — make the local commits and proceed to step 10. Run steps 5–9 normally when a remote exists.
+
 5. **Apply and persist review fixes** (REQUIRED after step 4, before residual handoff)
 
    Load `references/review-followup.md` and execute its apply step (mechanical apply + commit/push when changes exist). Do not proceed to the residual handoff, run browser tests, or output DONE while eligible review fixes remain only in the working tree uncommitted.
@@ -55,7 +57,7 @@ When invoking any skill referenced below, resolve its name against the available
       gh pr edit PR_NUMBER --body-file BODY_FILE
       ```
 
-   6. If no open PR exists, create a tracked fallback file at `docs/residual-review-findings/<branch-or-head-sha>.md` containing the composed section and the source PR-review run context. Stage only that file, commit it with `docs(review): record residual review findings`, and push the current branch. If an upstream exists, run `git push`. If no upstream exists, resolve a writable remote dynamically: prefer `origin` when present, otherwise use `git remote` and choose the first configured remote. Then run `git push --set-upstream <remote> HEAD`. This is the durable no-PR sink. Do not output DONE until either the existing PR body has been updated or this fallback file commit has been pushed. If both paths fail, stop and report the failed commands; do not silently proceed.
+   6. If no open PR exists, create a tracked fallback file at `docs/residual-review-findings/<branch-or-head-sha>.md` containing the composed section and the source PR-review run context. Stage only that file, commit it with `docs(review): record residual review findings`, and push the current branch **when a remote is configured** (per the shipping precondition). If an upstream exists, run `git push`. If no upstream exists but a remote is configured, resolve a writable remote dynamically: prefer `origin` when present, otherwise use `git remote` and choose the first configured remote. Then run `git push --set-upstream <remote> HEAD`. If there is no remote at all, do not push — the committed fallback file is the durable sink. This is the durable no-PR sink. Do not output DONE until the residual findings are durable: either the existing PR body has been updated, or this fallback file commit has been made (pushed when a remote exists, committed locally when none). A push that fails when a remote exists is a stop-and-report; never retry a push, or block DONE, when no remote exists.
 
    Never block DONE on tracker filing failures once residuals have been durably recorded. A `no_sink` outcome is success only when the findings are present in the PR body or in the pushed fallback file.
 
@@ -63,7 +65,7 @@ When invoking any skill referenced below, resolve its name against the available
 
 8. Invoke the `ce-commit-push-pr` skill.
 
-   This commits any remaining changes, pushes the branch, and opens a pull request. If step 6 already opened a PR (check with `gh pr view --json number,url,state 2>/dev/null`), skip PR creation but still commit and push any uncommitted changes.
+   This commits any remaining changes, pushes the branch, and opens a pull request. If step 6 already opened a PR (check with `gh pr view --json number,url,state 2>/dev/null`), skip PR creation but still commit and push any uncommitted changes. **Per the shipping precondition, when no remote is configured, do NOT invoke `ce-commit-push-pr` — its commit step pushes unconditionally (`git push -u origin HEAD`), so a literal invocation would still hit the impossible push. Instead commit any remaining changes locally yourself (`git add -A && git commit`) and skip the push and PR creation entirely.**
 
 9. **CI watch and autofix loop** (only when an open PR exists for the current branch)
 

--- a/skills/lfg/references/review-followup.md
+++ b/skills/lfg/references/review-followup.md
@@ -37,7 +37,7 @@ Do not treat `autofix_class` as permission to auto-apply.
 1. Filter `actionable_findings` (or markdown Actionable Findings) with the bar above.
 2. Apply eligible fixes in the working tree in severity order (`#` stable from the review).
 3. Run targeted tests when `requires_verification: true` on any applied finding.
-4. If `git status --short` shows changes, stage only review-driven files, commit `fix(review): apply review findings`, and push before step 6. To push: if an upstream exists, run `git push`. If no upstream exists (common on a fresh feature branch, since step 8's `ce-commit-push-pr` has not run yet), resolve a writable remote dynamically: prefer `origin` when present, otherwise use `git remote` and choose the first configured remote. Then run `git push --set-upstream <remote> HEAD`. If no eligible fixes were applied, note explicitly and skip commit.
+4. If `git status --short` shows changes, stage only review-driven files, commit `fix(review): apply review findings`, and push before step 6 **when a remote is configured** (per LFG's shipping precondition). To push: if an upstream exists, run `git push`. If no upstream exists but a remote is configured (common on a fresh feature branch), resolve a writable remote dynamically: prefer `origin` when present, otherwise use `git remote` and choose the first configured remote. Then run `git push --set-upstream <remote> HEAD`. If there is no remote at all, do not push — the local commit suffices. If no eligible fixes were applied, note explicitly and skip commit.
 
 ## Step 6 — residual handoff
 

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -680,7 +680,12 @@ describe("ce-code-review contract", () => {
     expect(lfg).toContain("choose the first configured remote")
     expect(lfg).toContain("git push --set-upstream <remote> HEAD")
     expect(lfg).not.toContain("git push --set-upstream origin HEAD")
-    expect(lfg).toContain("Do not output DONE until either the existing PR body has been updated or this fallback file commit has been pushed.")
+    expect(lfg).toContain("Do not output DONE until the residual findings are durable")
+
+    // Shipping precondition: a remote-less repo (e.g. a sandbox/throwaway checkout)
+    // finishes locally instead of deadlocking on an impossible push.
+    expect(lfg).toContain("Shipping precondition")
+    expect(lfg).toContain("skip every push, PR create/edit, and CI-watch action")
 
     // Autopilot contract: never prompt, but require a durable sink before DONE.
     expect(lfg).toContain("Do not prompt the user")


### PR DESCRIPTION
## Summary

`/lfg` can now finish cleanly in a repo that has **no git remote**. Previously the shipping tail assumed a remote, an open PR, and (effectively) GitHub — so in a remote-less repo a literal-minded agent had no valid way to satisfy "DONE only after push" and would spin instead of completing.

## The bug

The shipping tail (steps 5–9) unconditionally pushes the branch, opens a PR, and watches CI, and step 6 says *"Do not output DONE until … this fallback file commit has been pushed. If both paths fail, stop and report."* In a repo with **no remote**, a push is impossible by definition, so that instruction is unsatisfiable.

This is reachable whenever `/lfg` runs in a sandboxed or throwaway checkout that has `git init` but no `origin`. An agent that reasons flexibly recognizes "the commit is local; add a remote to publish" and finishes; an agent that follows the steps literally cannot reconcile "DONE only after push" with an impossible push and gets stuck in the shipping tail.

## The fix

One **shipping precondition** at the top of the tail: run `git remote` once; if there's no remote, shipping is **local-only** — make the commits the steps call for, skip every push / PR-create / PR-edit / CI-watch action, and proceed to `DONE` without retrying or hunting for a remote. Two small consistency edits (step 6's fallback-file sink, and `references/review-followup.md`'s apply-commit) so a literal agent can't hit a sub-instruction that contradicts the precondition.

Behavior-only (Markdown skill prose). **Normal runs are unchanged** — when a remote exists, steps 5–9 run exactly as before. The only changed path is the no-remote case, which previously deadlocked.

## Validation

- `bun run release:validate` → in sync (27 skills, no count/description drift).
- Markdown-only change; the guard is centralized so it overrides every push site in the tail regardless of which one a given agent reaches first.

A live re-run in a no-remote repo to confirm the deadlock is gone wasn't executed here; the fix is a localized prose guard validated structurally.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
