### PR TITLE
fix(ce-commit-push-pr): append PR body so zsh noclobber can't blank it

### DIFF
--- a/skills/ce-commit-push-pr/SKILL.md
+++ b/skills/ce-commit-push-pr/SKILL.md
@@ -119,7 +119,7 @@ Then continue with the rest of the reference (Steps A through G) to compose the 
 The body **must** be written to a temp file and passed via `--body-file <path>`. Never use `--body-file -`, stdin pipes, heredoc-to-stdin, or `--body "$(cat ...)"` — wrappers and stdin handling can silently produce an empty PR body while `gh` still exits 0 and returns a URL.
 
 ```bash
-BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/ce-pr-body.XXXXXX") && cat > "$BODY_FILE" <<'__CE_PR_BODY_END__'
+BODY_FILE=$(mktemp "${TMPDIR:-/tmp}/ce-pr-body.XXXXXX") && cat >> "$BODY_FILE" <<'__CE_PR_BODY_END__'
 <the composed body markdown goes here, verbatim>
 __CE_PR_BODY_END__
 ```


### PR DESCRIPTION
## Summary

Under zsh with `noclobber` set, this skill's recommended snippet silently published an **empty PR body** — `gh` still exited 0 and returned a valid URL, so the failure was invisible unless you re-read the PR. `mktemp` creates the temp file empty, then `cat >` redirected onto the now-existing file; `noclobber` refuses `>` to an existing file, discarding the heredoc. Switching to `cat >>` (append) writes the body regardless of clobber settings — equivalent for the already-empty file, and identical in bash and zsh.

This is the exact silent-empty-body failure the section's own warning (line 119) exists to prevent.

Fixes #1003

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
