### PR TITLE
fix(skills): anchor bundled-script calls to the loaded skill dir

### DIFF
--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -251,7 +251,7 @@ mkdir -p .context/compound-engineering/ce-optimize/<spec-name>/
 
 **This phase is a HARD GATE. The user must approve baseline and parallel readiness before Phase 2.**
 
-**Bundled scripts.** Phases 1 and 3 call helper scripts that ship in this skill's `scripts/` directory (`measure.sh`, `parallel-probe.sh`, `experiment-worktree.sh`). The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. `SKILL_DIR` is the directory you loaded this `ce-optimize` SKILL.md from; shell state does not persist between Bash tool calls, so **prepend the assignment to every script call below, in the same command**:
+**Bundled scripts.** Phases 1 and 3 call helper scripts that ship in this skill's `scripts/` directory (`measure.sh`, `parallel-probe.sh`, `experiment-worktree.sh`). The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. Every runnable block below already sets `SKILL_DIR` inline (shell state does not persist between Bash tool calls, so each block must carry it); just replace the `<absolute path …>` placeholder with the directory you loaded this `ce-optimize` SKILL.md from before running. The shape:
 
 ```bash
 SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
@@ -276,6 +276,7 @@ Filter the output against the scope paths. If any in-scope files have uncommitte
 **If user provides a measurement harness** (the `measurement.command` already exists):
 1. Run it once via the measurement script:
    ```bash
+   SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
    bash "$SKILL_DIR/scripts/measure.sh" "<measurement.command>" <timeout_seconds> "<measurement.working_directory or .>"
    ```
 2. Validate the JSON output:
@@ -319,6 +320,7 @@ If primary type is `judge`, also run the judge evaluation on baseline output to 
 
 Run the parallelism probe script:
 ```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
 bash "$SKILL_DIR/scripts/parallel-probe.sh" "<project_directory>" "<measurement.command>" "<measurement.working_directory>" <shared_files...>
 ```
 
@@ -328,6 +330,7 @@ Read the JSON output. Present any blockers to the user with suggested mitigation
 
 Count existing worktrees:
 ```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
 bash "$SKILL_DIR/scripts/experiment-worktree.sh" count
 ```
 
@@ -444,11 +447,12 @@ If the backlog is non-empty but no runnable hypotheses remain because everything
 
 For each hypothesis in the batch, dispatch according to `execution.mode`. In `serial` mode, run exactly one experiment to completion before selecting the next hypothesis. In `parallel` mode, dispatch the full batch concurrently.
 
-The bundled-script calls below use `$SKILL_DIR` (the loaded `ce-optimize` skill directory; see the Bundled scripts note in Phase 1). Prepend the `SKILL_DIR=` assignment to each call in the same Bash command, since shell state does not persist from Phase 1.
+The Phase 3 blocks below each set `SKILL_DIR` inline as well (the loaded `ce-optimize` skill directory; see the Bundled scripts note in Phase 1) — shell state does not persist from Phase 1, so each block carries its own assignment.
 
 **Worktree backend:**
 1. Create experiment worktree:
    ```bash
+   SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
    WORKTREE_PATH=$(bash "$SKILL_DIR/scripts/experiment-worktree.sh" create "<spec_name>" <exp_index> "optimize/<spec_name>" <shared_files...>)  # creates optimize-exp/<spec_name>/exp-<NNN>
    ```
 2. Apply port parameterization if configured (set env vars for the measurement script)
@@ -483,6 +487,7 @@ For each completed experiment, **immediately**:
 
 1. **Run measurement** in the experiment's worktree:
    ```bash
+   SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
    bash "$SKILL_DIR/scripts/measure.sh" "<measurement.command>" <timeout_seconds> "<worktree_path>/<measurement.working_directory or .>" <env_vars...>
    ```
    - If stability mode is `repeat`, run the measurement harness `repeat_count` times in that working directory and aggregate the results exactly as in Phase 1 before evaluating gates or ranking the experiment.

--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -251,6 +251,13 @@ mkdir -p .context/compound-engineering/ce-optimize/<spec-name>/
 
 **This phase is a HARD GATE. The user must approve baseline and parallel readiness before Phase 2.**
 
+**Bundled scripts.** Phases 1 and 3 call helper scripts that ship in this skill's `scripts/` directory (`measure.sh`, `parallel-probe.sh`, `experiment-worktree.sh`). The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. `SKILL_DIR` is the directory you loaded this `ce-optimize` SKILL.md from; shell state does not persist between Bash tool calls, so **prepend the assignment to every script call below, in the same command**:
+
+```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+bash "$SKILL_DIR/scripts/<name>"
+```
+
 ### 1.1 Clean-Tree Gate
 
 Verify no uncommitted changes to files within `scope.mutable` or `scope.immutable`:
@@ -269,7 +276,7 @@ Filter the output against the scope paths. If any in-scope files have uncommitte
 **If user provides a measurement harness** (the `measurement.command` already exists):
 1. Run it once via the measurement script:
    ```bash
-   bash scripts/measure.sh "<measurement.command>" <timeout_seconds> "<measurement.working_directory or .>"
+   bash "$SKILL_DIR/scripts/measure.sh" "<measurement.command>" <timeout_seconds> "<measurement.working_directory or .>"
    ```
 2. Validate the JSON output:
    - Contains keys for all degenerate gate metric names
@@ -312,7 +319,7 @@ If primary type is `judge`, also run the judge evaluation on baseline output to 
 
 Run the parallelism probe script:
 ```bash
-bash scripts/parallel-probe.sh "<project_directory>" "<measurement.command>" "<measurement.working_directory>" <shared_files...>
+bash "$SKILL_DIR/scripts/parallel-probe.sh" "<project_directory>" "<measurement.command>" "<measurement.working_directory>" <shared_files...>
 ```
 
 Read the JSON output. Present any blockers to the user with suggested mitigations. Treat the probe as intentionally narrow: it should inspect the measurement command, the measurement working directory, and explicitly declared shared files, not the entire repository.
@@ -321,7 +328,7 @@ Read the JSON output. Present any blockers to the user with suggested mitigation
 
 Count existing worktrees:
 ```bash
-bash scripts/experiment-worktree.sh count
+bash "$SKILL_DIR/scripts/experiment-worktree.sh" count
 ```
 
 If count + `execution.max_concurrent` would exceed 12:
@@ -437,10 +444,12 @@ If the backlog is non-empty but no runnable hypotheses remain because everything
 
 For each hypothesis in the batch, dispatch according to `execution.mode`. In `serial` mode, run exactly one experiment to completion before selecting the next hypothesis. In `parallel` mode, dispatch the full batch concurrently.
 
+The bundled-script calls below use `$SKILL_DIR` (the loaded `ce-optimize` skill directory; see the Bundled scripts note in Phase 1). Prepend the `SKILL_DIR=` assignment to each call in the same Bash command, since shell state does not persist from Phase 1.
+
 **Worktree backend:**
 1. Create experiment worktree:
    ```bash
-   WORKTREE_PATH=$(bash scripts/experiment-worktree.sh create "<spec_name>" <exp_index> "optimize/<spec_name>" <shared_files...>)  # creates optimize-exp/<spec_name>/exp-<NNN>
+   WORKTREE_PATH=$(bash "$SKILL_DIR/scripts/experiment-worktree.sh" create "<spec_name>" <exp_index> "optimize/<spec_name>" <shared_files...>)  # creates optimize-exp/<spec_name>/exp-<NNN>
    ```
 2. Apply port parameterization if configured (set env vars for the measurement script)
 3. Fill the experiment prompt template (`references/experiment-prompt-template.md`) with:
@@ -474,7 +483,7 @@ For each completed experiment, **immediately**:
 
 1. **Run measurement** in the experiment's worktree:
    ```bash
-   bash scripts/measure.sh "<measurement.command>" <timeout_seconds> "<worktree_path>/<measurement.working_directory or .>" <env_vars...>
+   bash "$SKILL_DIR/scripts/measure.sh" "<measurement.command>" <timeout_seconds> "<worktree_path>/<measurement.working_directory or .>" <env_vars...>
    ```
    - If stability mode is `repeat`, run the measurement harness `repeat_count` times in that working directory and aggregate the results exactly as in Phase 1 before evaluating gates or ranking the experiment.
    - Use the aggregated metrics as the experiment's score; if variance exceeds `noise_threshold`, record that in learnings so the operator knows the result is noisy.

--- a/skills/ce-polish/SKILL.md
+++ b/skills/ce-polish/SKILL.md
@@ -17,13 +17,20 @@ Start the dev server, open the feature in a browser, and iterate. You use the fe
 
 ## Phase 1: Start the dev server
 
+The scripts below ship in this skill's `scripts/` directory. The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. `SKILL_DIR` is the directory you loaded this `ce-polish` SKILL.md from; shell state does not persist between Bash tool calls, so **prepend the assignment to every script call below, in the same command**:
+
+```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+bash "$SKILL_DIR/scripts/<name>"
+```
+
 ### 1.1 Check for `.claude/launch.json`
 
-Run `bash scripts/read-launch-json.sh`. If it finds a configuration, use it — the user already told us how to start the project.
+Run `bash "$SKILL_DIR/scripts/read-launch-json.sh"`. If it finds a configuration, use it — the user already told us how to start the project.
 
 ### 1.2 Auto-detect (when no launch.json)
 
-Run `bash scripts/detect-project-type.sh` to identify the framework.
+Run `bash "$SKILL_DIR/scripts/detect-project-type.sh"` to identify the framework.
 
 Route by type to the matching recipe reference for start command and port defaults:
 
@@ -39,9 +46,9 @@ Route by type to the matching recipe reference for start command and port defaul
 | `procfile` | `references/dev-server-procfile.md` |
 | `unknown` | Ask the user how to start the project |
 
-For framework types that need a package manager, run `bash scripts/resolve-package-manager.sh` and substitute the result into the start command.
+For framework types that need a package manager, run `bash "$SKILL_DIR/scripts/resolve-package-manager.sh"` and substitute the result into the start command.
 
-Resolve the port with `bash scripts/resolve-port.sh --type <type>`.
+Resolve the port with `bash "$SKILL_DIR/scripts/resolve-port.sh" --type <type>`.
 
 ### 1.3 Start the server
 
@@ -82,7 +89,7 @@ Reference files (loaded on demand):
 - `references/dev-server-sveltekit.md` — SvelteKit dev-server defaults
 - `references/dev-server-procfile.md` — Procfile-based dev-server defaults
 
-Scripts (invoked via `bash scripts/<name>`):
+Scripts (invoked via `bash "$SKILL_DIR/scripts/<name>"` — see Phase 1 for `SKILL_DIR`):
 - `scripts/read-launch-json.sh` — launch.json reader
 - `scripts/detect-project-type.sh` — project-type classifier
 - `scripts/resolve-package-manager.sh` — lockfile-based package-manager resolver

--- a/skills/ce-polish/SKILL.md
+++ b/skills/ce-polish/SKILL.md
@@ -17,20 +17,25 @@ Start the dev server, open the feature in a browser, and iterate. You use the fe
 
 ## Phase 1: Start the dev server
 
-The scripts below ship in this skill's `scripts/` directory. The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. `SKILL_DIR` is the directory you loaded this `ce-polish` SKILL.md from; shell state does not persist between Bash tool calls, so **prepend the assignment to every script call below, in the same command**:
-
-```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
-bash "$SKILL_DIR/scripts/<name>"
-```
+The scripts below ship in this skill's `scripts/` directory. The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. Every runnable block below sets `SKILL_DIR` inline (shell state does not persist between Bash tool calls, so each command must carry it); replace the `<absolute path …>` placeholder with the directory you loaded this `ce-polish` SKILL.md from before running.
 
 ### 1.1 Check for `.claude/launch.json`
 
-Run `bash "$SKILL_DIR/scripts/read-launch-json.sh"`. If it finds a configuration, use it — the user already told us how to start the project.
+```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+bash "$SKILL_DIR/scripts/read-launch-json.sh"
+```
+
+If it finds a configuration, use it — the user already told us how to start the project.
 
 ### 1.2 Auto-detect (when no launch.json)
 
-Run `bash "$SKILL_DIR/scripts/detect-project-type.sh"` to identify the framework.
+Identify the framework:
+
+```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+bash "$SKILL_DIR/scripts/detect-project-type.sh"
+```
 
 Route by type to the matching recipe reference for start command and port defaults:
 
@@ -46,9 +51,19 @@ Route by type to the matching recipe reference for start command and port defaul
 | `procfile` | `references/dev-server-procfile.md` |
 | `unknown` | Ask the user how to start the project |
 
-For framework types that need a package manager, run `bash "$SKILL_DIR/scripts/resolve-package-manager.sh"` and substitute the result into the start command.
+For framework types that need a package manager, run the resolver and substitute the result into the start command:
 
-Resolve the port with `bash "$SKILL_DIR/scripts/resolve-port.sh" --type <type>`.
+```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+bash "$SKILL_DIR/scripts/resolve-package-manager.sh"
+```
+
+Resolve the port:
+
+```bash
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+bash "$SKILL_DIR/scripts/resolve-port.sh" --type <type>
+```
 
 ### 1.3 Start the server
 

--- a/skills/ce-riffrec-feedback-analysis/SKILL.md
+++ b/skills/ce-riffrec-feedback-analysis/SKILL.md
@@ -25,10 +25,11 @@ When the input is ambiguous (e.g., a zip arrived without context), inspect the r
 
 ## Analyzer entrypoint
 
-All non-setup paths share the same analyzer:
+All non-setup paths share the same analyzer, which ships in this skill's `scripts/` directory. The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve. Invoke it by the skill's own absolute path: set `SKILL_DIR` to the directory you loaded this `ce-riffrec-feedback-analysis` SKILL.md from, in the same command (shell state does not persist between Bash calls):
 
 ```bash
-python scripts/analyze_riffrec_zip.py /path/to/input
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+python "$SKILL_DIR/scripts/analyze_riffrec_zip.py" /path/to/input
 ```
 
 Accepted inputs: a Riffrec `.zip`, an `.mp4` / `.mov` / `.webm` video, an `.m4a` / `.mp3` / `.wav` audio file, or a meeting-notes `.md`. Use `--output-dir <dir>` to control where artifacts land. In repos with `docs/brainstorms/`, the default is `docs/brainstorms/riffrec-feedback/`. The quick path overrides the output dir to a temp location so nothing pollutes the repo.

--- a/skills/ce-riffrec-feedback-analysis/references/extensive-analysis.md
+++ b/skills/ce-riffrec-feedback-analysis/references/extensive-analysis.md
@@ -4,10 +4,11 @@ Use this path when the input is a longer recording (over ~60 seconds), contains 
 
 ## Workflow
 
-1. Run the analyzer:
+1. Run the analyzer (`SKILL_DIR` is the directory containing the `ce-riffrec-feedback-analysis` SKILL.md; set it in the same command — shell state does not persist between Bash calls):
 
    ```bash
-   python scripts/analyze_riffrec_zip.py /path/to/input
+   SKILL_DIR="<absolute path of the directory containing the ce-riffrec-feedback-analysis SKILL.md>"
+   python "$SKILL_DIR/scripts/analyze_riffrec_zip.py" /path/to/input
    ```
 
    Use `--output-dir <dir>` when the artifact should live somewhere specific. In a repo with `docs/brainstorms/`, the default output goes under `docs/brainstorms/riffrec-feedback/`.

--- a/skills/ce-riffrec-feedback-analysis/references/quick-bug-report.md
+++ b/skills/ce-riffrec-feedback-analysis/references/quick-bug-report.md
@@ -4,10 +4,11 @@ Use this path when the input is a short recording (under ~60 seconds), the user 
 
 ## Workflow
 
-1. Run the analyzer to a temp directory so nothing pollutes the repo:
+1. Run the analyzer to a temp directory so nothing pollutes the repo (`SKILL_DIR` is the directory containing the `ce-riffrec-feedback-analysis` SKILL.md; set it in the same command — shell state does not persist between Bash calls):
 
    ```bash
-   python scripts/analyze_riffrec_zip.py /path/to/input --output-dir "$(mktemp -d -t riffrec-quick-XXXXXX)"
+   SKILL_DIR="<absolute path of the directory containing the ce-riffrec-feedback-analysis SKILL.md>"
+   python "$SKILL_DIR/scripts/analyze_riffrec_zip.py" /path/to/input --output-dir "$(mktemp -d -t riffrec-quick-XXXXXX)"
    ```
 
    Capture the printed output directory; later steps read from it.


### PR DESCRIPTION
## Summary

Three skills invoke bundled scripts through **executed shell commands** — `ce-polish` and `ce-optimize` via `bash scripts/<name>`, `ce-riffrec-feedback-analysis` via `python scripts/analyze_riffrec_zip.py`. Under the repo's path-resolution model these are **tier-3** references (a command the agent runs through the Bash tool), where the shell's working directory is the user's **project**, not the skill directory, on Claude Code, Codex, and Cursor alike.

This migrates those executed-shell calls to the model-filled **`SKILL_DIR` anchor** (`SKILL_DIR="<abs path of the loaded SKILL.md dir>"; bash "$SKILL_DIR/scripts/<name>"`), which makes resolution **deterministic** by baking the skill-dir path into the command. Companion to #1010.

## Details

Bare relative paths in executed blocks are **not broken** — a capable agent resolves them against the skill dir it loaded (the agentskills.io spec's *"the agent resolves these paths automatically"*), and that is the dominant ecosystem pattern (e.g. superpowers ships bare `scripts/start-server.sh` with no anchor). The anchor is the repo's **conservative house default for tier 3 (executed shell)**: it removes the one residual failure mode — a fenced block copied verbatim into a Bash call, which resolves against the project root and misses — at the cost of some verbosity. It is **not** a claim that relative "cannot work."

The three tiers (see AGENTS.md "Platform-Specific Variables in Skills"): **(1)** read-time `references/*.md` → relative, no anchor; **(2)** prose pointers the agent acts on → relative + "from this skill's directory"; **(3)** executed shell → `SKILL_DIR` anchor. Everything this PR changes is tier 3.

## Changes

- `ce-polish` — 4 inline `bash scripts/…` invocations across Phase 1 (plus the Scripts inventory line, kept consistent with the executed form; it is a tier-2 mention left aligned with the blocks above for readability).
- `ce-optimize` — 5 executed `bash scripts/…` calls across Phase 1 and Phase 3.
- `ce-riffrec-feedback-analysis` — the `python scripts/…` analyzer block in `SKILL.md` and both workflow references.
- Each block sets `SKILL_DIR` inline because shell state does not persist between separate Bash-tool calls.

`ce-brainstorm` already used the tier-2 "resolve relative to this loaded skill directory" form and is unchanged.

## Validation

`bun test`: 1612 pass / 0 fail. `release:validate`: in sync (27 skills). Ran `/ce-simplify-code` — it caught a draft regression where the `SKILL_DIR=` assignment sat in a standalone code block that would not survive across separate Bash calls.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
