### PR TITLE
fix(skills): migrate ${CLAUDE_SKILL_DIR} script guards to the portable SKILL_DIR anchor

### DIFF
--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -12,10 +12,13 @@ gh pr view --json number -q .number
 Then fetch all feedback using the GraphQL script at [scripts/get-pr-comments](../scripts/get-pr-comments):
 
 ```bash
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/get-pr-comments" ]; then
-  SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"
-else
-  echo "ce-resolve-pr-feedback bundled scripts are unavailable in this harness; use the fallback gh commands below." >&2
+# SKILL_DIR = the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from.
+# The Bash tool's CWD is the user's project, not the skill dir, and shell state does not
+# persist between Bash calls — set SKILL_DIR in each block below that runs a bundled script.
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SCRIPT_DIR="$SKILL_DIR/scripts"
+if [ ! -f "$SCRIPT_DIR/get-pr-comments" ]; then
+  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use the fallback gh commands below." >&2
   exit 1
 fi
 
@@ -170,10 +173,10 @@ For `needs-human` verdicts, post the reply but do NOT resolve the thread. Leave 
 
 0. **Verify the thread ID** before replying. GitHub Enterprise can return inconsistent node IDs for the same thread depending on the query path. Always confirm the ID from `get-pr-comments` resolves to the correct thread using [scripts/get-thread-for-comment](../scripts/get-thread-for-comment) with the comment's numeric URL ID:
 ```bash
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/get-thread-for-comment" ]; then
-  SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"
-else
-  echo "ce-resolve-pr-feedback bundled scripts are unavailable in this harness; use gh api to inspect the review thread." >&2
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SCRIPT_DIR="$SKILL_DIR/scripts"
+if [ ! -f "$SCRIPT_DIR/get-thread-for-comment" ]; then
+  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use gh api to inspect the review thread." >&2
   exit 1
 fi
 
@@ -185,10 +188,10 @@ The returned `id` is the authoritative thread ID to use for reply and resolve. I
 
 1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread):
 ```bash
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/reply-to-pr-thread" ]; then
-  SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"
-else
-  echo "ce-resolve-pr-feedback bundled scripts are unavailable in this harness; post the reply with gh api or gh pr comment as appropriate." >&2
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SCRIPT_DIR="$SKILL_DIR/scripts"
+if [ ! -f "$SCRIPT_DIR/reply-to-pr-thread" ]; then
+  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; post the reply with gh api or gh pr comment as appropriate." >&2
   exit 1
 fi
 
@@ -198,10 +201,10 @@ Check that the returned comment URL contains the correct `OWNER/REPO` and PR num
 
 2. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread):
 ```bash
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/resolve-pr-thread" ]; then
-  SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"
-else
-  echo "ce-resolve-pr-feedback bundled scripts are unavailable in this harness; resolve the thread with gh api if supported." >&2
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SCRIPT_DIR="$SKILL_DIR/scripts"
+if [ ! -f "$SCRIPT_DIR/resolve-pr-thread" ]; then
+  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; resolve the thread with gh api if supported." >&2
   exit 1
 fi
 
@@ -223,10 +226,10 @@ Include enough quoted context in the reply so the reader can follow which commen
 Re-fetch feedback to confirm resolution:
 
 ```bash
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/get-pr-comments" ]; then
-  SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"
-else
-  echo "ce-resolve-pr-feedback bundled scripts are unavailable in this harness; use the fallback gh commands from Step 1." >&2
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SCRIPT_DIR="$SKILL_DIR/scripts"
+if [ ! -f "$SCRIPT_DIR/get-pr-comments" ]; then
+  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use the fallback gh commands from Step 1." >&2
   exit 1
 fi
 

--- a/skills/ce-resolve-pr-feedback/references/targeted-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/targeted-mode.md
@@ -17,10 +17,13 @@ gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID \
 
 **Step 2** -- Map comment to its thread ID. Use [scripts/get-thread-for-comment](../scripts/get-thread-for-comment):
 ```bash
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/get-thread-for-comment" ]; then
-  SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"
-else
-  echo "ce-resolve-pr-feedback bundled scripts are unavailable in this harness; use Full Mode's fallback gh commands to inspect the PR comments." >&2
+# SKILL_DIR = the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from
+# (the Bash tool's CWD is the user's project, not the skill dir; shell state does not
+#  persist between Bash calls, so always set it before calling a bundled script).
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SCRIPT_DIR="$SKILL_DIR/scripts"
+if [ ! -f "$SCRIPT_DIR/get-thread-for-comment" ]; then
+  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use Full Mode's fallback gh commands to inspect the PR comments." >&2
   exit 1
 fi
 

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -28,13 +28,14 @@ Before running the script, display:
 Compound Engineering -- checking your environment...
 ```
 
-Run the bundled check script when the skill directory can be resolved:
+Run the bundled check script. Set `SKILL_DIR` to the absolute directory you loaded this `ce-setup` SKILL.md from — the Bash tool's CWD is the user's project, not the skill dir, so a bare `scripts/` path will not resolve:
 
 ```bash
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/check-health" ]; then
-  bash "${CLAUDE_SKILL_DIR}/scripts/check-health" --version VERSION
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+if [ -f "$SKILL_DIR/scripts/check-health" ]; then
+  bash "$SKILL_DIR/scripts/check-health" --version VERSION
 else
-  echo "Bundled health script is unavailable on this platform; run the inline checks from ce-setup instead."
+  echo "Bundled health script not found at $SKILL_DIR/scripts/check-health; run the inline checks from ce-setup instead."
 fi
 ```
 

--- a/tests/skills/ce-resolve-pr-feedback-script-dir.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-script-dir.test.ts
@@ -23,8 +23,12 @@ describe("ce-resolve-pr-feedback script directory handling", () => {
 
     expect(scriptDirBlocks.length).toBeGreaterThan(0)
     for (const block of scriptDirBlocks) {
-      expect(block).toContain('if [ -n "${CLAUDE_SKILL_DIR}" ]')
-      expect(block).toContain('SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"')
+      // Each block must self-resolve the skill dir locally (shell state does not persist
+      // between Bash calls), via the portable model-filled SKILL_DIR anchor — not the
+      // Claude-only ${CLAUDE_SKILL_DIR} substitution.
+      expect(block).toContain('SKILL_DIR="')
+      expect(block).toContain('SCRIPT_DIR="$SKILL_DIR/scripts"')
+      expect(block).not.toContain("CLAUDE_SKILL_DIR")
     }
   })
 })


### PR DESCRIPTION
## Summary

`ce-resolve-pr-feedback` and `ce-setup` gated their **executed** bundled-script calls on **`${CLAUDE_SKILL_DIR}`** — a Claude-Code-only SKILL.md *content* substitution that is empty on Codex, Cursor, and Gemini. Off-Claude the guard's `then` branch silently never fired (a genuine silent skip), so the skill quietly degraded to doing by hand the work the bundled script would have done. These are **tier-3** references (commands run through the Bash tool).

This migrates them to the portable model-filled **`SKILL_DIR` anchor**, which depends on no host-specific variable and resolves identically across Claude Code, Codex, and Cursor. Companion to #1009.

## Why the anchor (over `${CLAUDE_SKILL_DIR}` and over bare relative)

- **vs `${CLAUDE_SKILL_DIR}`:** it's a Claude-only footgun for a plugin that ships to many harnesses (including as a *native* Codex plugin) — off-Claude it silently no-ops. This is the real defect being fixed.
- **vs bare relative:** bare relative would work via agent resolution (the ecosystem norm) but isn't deterministic for executed shell. The `SKILL_DIR` anchor is the repo's tier-3 house default: deterministic, portable, and it removes the verbatim-copy failure mode.

Three-tier model (AGENTS.md "Platform-Specific Variables in Skills"): read-time refs → relative, no anchor; prose pointers → relative + "from this skill's directory"; **executed shell → `SKILL_DIR` anchor.** Everything this PR touches is executed shell.

## Changes

Representative transform:

```diff
-if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/get-pr-comments" ]; then
-  SCRIPT_DIR="${CLAUDE_SKILL_DIR}/scripts"
-else
-  echo "...unavailable in this harness; use the fallback gh commands below." >&2
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SCRIPT_DIR="$SKILL_DIR/scripts"
+if [ ! -f "$SCRIPT_DIR/get-pr-comments" ]; then
+  echo "...not found under $SCRIPT_DIR; use the fallback gh commands below." >&2
   exit 1
 fi
```

- `ce-resolve-pr-feedback` — 5 blocks in `full-mode.md`, 1 in `targeted-mode.md`. Each sets `SKILL_DIR` inline (shell state does not persist between Bash calls). The `-n "${CLAUDE_SKILL_DIR}"` guard is dropped because the model-filled `SKILL_DIR` is never an unset env var. **Fallbacks preserved:** it still errors and exits to its `gh` fallback when a script is absent.
- `ce-setup` — the `check-health` invocation in `SKILL.md`; the inline-checks fallback is preserved.
- Updated `ce-resolve-pr-feedback-script-dir.test.ts` to assert the new anchor (each `$SCRIPT_DIR` block self-resolves via `SKILL_DIR`, no `CLAUDE_SKILL_DIR`).

## Deferred (intentionally not in this PR)

`ce-compound` / `ce-compound-refresh`'s `validate-frontmatter.py` still uses `${CLAUDE_SKILL_DIR}`. It is the *named canonical example* of that pattern in `AGENTS.md` and carries a permission-pin auto-approval tradeoff (a dynamic absolute path won't match a `Bash(bash *…sh)` allow-rule). Best migrated after the `AGENTS.md` three-tier guidance settles.

## Validation

`bun test`: 1612 pass / 0 fail. `release:validate`: in sync (27 skills). Ran `/ce-simplify-code` — reviewers confirmed the control-flow inversion is behavior-preserving and all tailored fallback messages are intact; applied two cleanups (a "each block below" wording bug where only one block exists, and no-op `# see Step 1` trailing comments).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
