### PR TITLE
docs(readme): list ce-pov in the Additional skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These sit around the loop or get reached for on demand -- not every cycle needs 
 | `/ce-strategy` | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
 | `/ce-product-pulse` | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
 | `/ce-debug` | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace the causal chain to root cause, then fix |
+| `/ce-pov` | *On demand, before you commit* -- a decisive, project-grounded verdict on whether to adopt, switch to, or revisit an external technology, library, pattern, or platform; works cold or mid-session, and proposes the next step (`/ce-plan`, `/ce-brainstorm`, or a spike) from the verdict |
 
 For the full catalog and how each skill chains together, see [docs/skills](docs/skills/README.md). The complete inventory is [below](#full-skill-inventory).
 


### PR DESCRIPTION
`/ce-pov` shipped in #1020 and is in the **Full Skill Inventory**, but it was never added to the curated **Additional skills** section (which features `/ce-ideate`, `/ce-strategy`, `/ce-product-pulse`, `/ce-debug`). It earns a place there as an on-demand decision skill — a decisive, project-grounded verdict on whether to adopt/switch to an external option, cold or mid-session, that routes into `/ce-plan` or `/ce-brainstorm` from the verdict.

Docs-only; the docs/skills catalog already lists it.