### PR TITLE
docs(readme): link skill documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The point is not ceremony. The point is leverage. A good brainstorm makes the pl
 
 **Learn more**
 
+- [Skill documentation catalog](docs/skills/README.md)
 - [Compound engineering: how Every codes with agents](https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents)
 - [The story behind compounding engineering](https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it)
 
@@ -30,12 +31,12 @@ The core loop is six steps: **brainstorm** the requirements, **plan** the implem
 
 | Skill | Purpose |
 |-------|---------|
-| `/ce-brainstorm` | Interactive Q&A to think through a feature or problem and write a requirements-only unified plan before planning |
-| `/ce-plan` | Enrich feature ideas or requirements-only plans into implementation-ready plans |
-| `/ce-work` | Execute implementation-ready plans with worktrees and task tracking |
-| `/ce-simplify-code` | Refine the freshly written code for clarity and reuse before review |
-| `/ce-code-review` | Multi-agent review against the plan before merging |
-| `/ce-compound` | Capture the learning into `docs/solutions/` so the next loop starts smarter |
+| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Interactive Q&A to think through a feature or problem and write a requirements-only unified plan before planning |
+| [`/ce-plan`](docs/skills/ce-plan.md) | Enrich feature ideas or requirements-only plans into implementation-ready plans |
+| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation-ready plans with worktrees and task tracking |
+| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Refine the freshly written code for clarity and reuse before review |
+| [`/ce-code-review`](docs/skills/ce-code-review.md) | Multi-agent review against the plan before merging |
+| [`/ce-compound`](docs/skills/ce-compound.md) | Capture the learning into `docs/solutions/` so the next loop starts smarter |
 
 Each cycle compounds: `/ce-compound` writes learnings that the next `/ce-brainstorm` and `/ce-plan` read as grounding -- brainstorms sharpen plans, plans inform future plans, reviews catch more issues, patterns get documented. That return arrow is the whole point.
 
@@ -45,10 +46,10 @@ These sit around the loop or get reached for on demand -- not every cycle needs 
 
 | Skill | When to reach for it |
 |-------|---------|
-| `/ce-ideate` | *Before the loop*, when you don't yet know what to build -- generates and critically ranks grounded ideas, then routes the strongest one into `/ce-brainstorm` |
-| `/ce-strategy` | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
-| `/ce-product-pulse` | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
-| `/ce-debug` | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace the causal chain to root cause, then fix |
+| [`/ce-ideate`](docs/skills/ce-ideate.md) | *Before the loop*, when you don't yet know what to build -- generates and critically ranks grounded ideas, then routes the strongest one into `/ce-brainstorm` |
+| [`/ce-strategy`](docs/skills/ce-strategy.md) | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
+| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
+| [`/ce-debug`](docs/skills/ce-debug.md) | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace the causal chain to root cause, then fix |
 
 For the full catalog and how each skill chains together, see [docs/skills](docs/skills/README.md). The complete inventory is [below](#full-skill-inventory).
 
@@ -105,39 +106,39 @@ The first pass tightens recent branch changes before review. The targeted pass i
 
 After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
 
-The `compound-engineering` plugin currently ships 26 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+The `compound-engineering` plugin currently ships 27 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
 
 ### Full Skill Inventory
 
 | Skill | Purpose |
 |-------|---------|
-| `/ce-strategy` | Create or maintain `STRATEGY.md` |
-| `/ce-ideate` | Generate and critically evaluate grounded ideas |
-| `/ce-pov` | Form a decisive, project-grounded verdict on an external input |
-| `/ce-brainstorm` | Explore requirements and write a right-sized requirements doc |
-| `/ce-plan` | Create structured implementation plans |
-| `/ce-work` | Execute implementation plans systematically |
-| `/ce-code-review` | Review code with skill-local reviewer personas |
-| `/ce-doc-review` | Review requirements and plan documents |
-| `/ce-debug` | Reproduce failures, trace root cause, and fix bugs |
-| `/ce-compound` | Document solved problems to compound team knowledge |
-| `/ce-compound-refresh` | Refresh stale or drifting learnings |
-| `/ce-optimize` | Run iterative optimization loops |
-| `/ce-product-pulse` | Generate time-windowed product pulse reports |
-| `/ce-riffrec-feedback-analysis` | Convert Riffrec recordings or notes into structured feedback |
-| `/ce-resolve-pr-feedback` | Resolve PR review feedback |
-| `/ce-commit` | Create a git commit with a clear message |
-| `/ce-commit-push-pr` | Commit, push, and open a PR |
-| `/ce-worktree` | Ensure work happens in an isolated git worktree |
-| `/ce-promote` | Draft user-facing announcement copy |
-| `/ce-test-browser` | Run browser tests on PR-affected pages |
-| `/ce-test-xcode` | Build and test iOS apps on simulator |
-| `/ce-setup` | Diagnose optional tool capabilities and project config |
-| `/ce-simplify-code` | Simplify recent code changes |
-| `/ce-polish` | Start a dev server and iterate on UX polish |
-| `/ce-proof` | Create, edit, and share Proof documents |
-| `/ce-dogfood` | Hands-off diff-scoped browser QA of the active branch, with autonomous fixes |
-| `/lfg` | Full autonomous engineering workflow |
+| [`/ce-strategy`](docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` |
+| [`/ce-ideate`](docs/skills/ce-ideate.md) | Generate and critically evaluate grounded ideas |
+| [`/ce-pov`](docs/skills/ce-pov.md) | Form a decisive, project-grounded verdict on an external input |
+| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Explore requirements and write a right-sized requirements doc |
+| [`/ce-plan`](docs/skills/ce-plan.md) | Create structured implementation plans |
+| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation plans systematically |
+| [`/ce-code-review`](docs/skills/ce-code-review.md) | Review code with skill-local reviewer personas |
+| [`/ce-doc-review`](docs/skills/ce-doc-review.md) | Review requirements and plan documents |
+| [`/ce-debug`](docs/skills/ce-debug.md) | Reproduce failures, trace root cause, and fix bugs |
+| [`/ce-compound`](docs/skills/ce-compound.md) | Document solved problems to compound team knowledge |
+| [`/ce-compound-refresh`](docs/skills/ce-compound-refresh.md) | Refresh stale or drifting learnings |
+| [`/ce-optimize`](docs/skills/ce-optimize.md) | Run iterative optimization loops |
+| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | Generate time-windowed product pulse reports |
+| [`/ce-riffrec-feedback-analysis`](docs/skills/ce-riffrec-feedback-analysis.md) | Convert Riffrec recordings or notes into structured feedback |
+| [`/ce-resolve-pr-feedback`](docs/skills/ce-resolve-pr-feedback.md) | Resolve PR review feedback |
+| [`/ce-commit`](docs/skills/ce-commit.md) | Create a git commit with a clear message |
+| [`/ce-commit-push-pr`](docs/skills/ce-commit-push-pr.md) | Commit, push, and open a PR |
+| [`/ce-worktree`](docs/skills/ce-worktree.md) | Ensure work happens in an isolated git worktree |
+| [`/ce-promote`](docs/skills/ce-promote.md) | Draft user-facing announcement copy |
+| [`/ce-test-browser`](docs/skills/ce-test-browser.md) | Run browser tests on PR-affected pages |
+| [`/ce-test-xcode`](docs/skills/ce-test-xcode.md) | Build and test iOS apps on simulator |
+| [`/ce-setup`](docs/skills/ce-setup.md) | Diagnose optional tool capabilities and project config |
+| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Simplify recent code changes |
+| [`/ce-polish`](docs/skills/ce-polish.md) | Start a dev server and iterate on UX polish |
+| [`/ce-proof`](docs/skills/ce-proof.md) | Create, edit, and share Proof documents |
+| [`/ce-dogfood`](docs/skills/ce-dogfood.md) | Hands-off diff-scoped browser QA of the active branch, with autonomous fixes |
+| [`/lfg`](docs/skills/lfg.md) | Full autonomous engineering workflow |
 
 ---
 
@@ -440,7 +441,7 @@ No. Bun is only needed for repo development tasks and converter maintenance.
 
 ### Where do I see all available skills?
 
-The skill inventory is in this README. Each skill's authoritative runtime spec lives in `skills/<skill>/SKILL.md`.
+The skill inventory is in this README, and the deeper skill catalog is in [`docs/skills/README.md`](docs/skills/README.md). Each skill's authoritative runtime spec lives in `skills/<skill>/SKILL.md`.
 
 ### Where is release history?
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -87,6 +87,14 @@ Invoked when a specific need arises — not part of any chain.
 
 ---
 
+## Autonomous Pipeline
+
+| Skill | Description |
+|-------|-------------|
+| [`/lfg`](./lfg.md) | Run the full hands-off engineering pipeline from planning through a green PR — plan, work, simplify, review, fix, browser-test, ship, and watch CI |
+
+---
+
 ## Frontend Design
 
 | Skill | Description |
@@ -118,4 +126,4 @@ Invoked when a specific need arises — not part of any chain.
 
 ## See also
 
-For the complete catalog of skills (including those without dedicated docs here), see [`README.md`](../../README.md). Each skill's authoritative runtime spec is in `skills/<skill>/SKILL.md`.
+For the top-level install and usage guide, see [`README.md`](../../README.md). Each skill's authoritative runtime spec is in `skills/<skill>/SKILL.md`.

--- a/docs/skills/lfg.md
+++ b/docs/skills/lfg.md
@@ -1,0 +1,102 @@
+# `lfg`
+
+> Run the full hands-off engineering pipeline from planning through a green PR.
+
+`lfg` is the **autonomous pipeline** skill. It chains the main Compound Engineering workflow into one long-running run: plan the work, implement it, simplify the result, review it, apply eligible review fixes, run browser tests, commit, push, open a PR, then watch CI and repair failures within a bounded loop.
+
+Use it when you want the full agentic shipping path and are comfortable with the agent taking the work from a feature description to an open PR. It is best after `/ce-brainstorm`, because the pipeline can then plan against real requirements instead of a one-line prompt.
+
+---
+
+## TL;DR
+
+| Question | Answer |
+|----------|--------|
+| What does it do? | Runs the full CE software pipeline from planning through PR and CI watch |
+| When to use it | Software tasks that are ready for autonomous implementation |
+| What it produces | Code changes, commits, usually a PR, and durable residual notes when something cannot be fully resolved |
+| What's next | Review the PR, merge when ready, and run `/ce-compound` if there is reusable learning to capture |
+| Distinguishing | Hard ordering gates, return-to-caller execution, review-fix persistence, browser test pass, bounded CI autofix loop |
+
+---
+
+## The Problem
+
+The normal CE workflow is deliberately staged: plan, work, simplify, review, ship. That is useful when you want to inspect each step, but too much handoff when the task is well-bounded and you want the agent to carry the whole thing.
+
+Without an explicit pipeline, autonomous runs tend to skip planning, treat review as optional, forget to persist residual findings, or stop at "PR opened" while CI is still red.
+
+## The Solution
+
+`lfg` makes the sequence explicit and gated:
+
+- `/ce-plan` must produce an implementation-ready code plan before work starts
+- `/ce-work` runs in return-to-caller mode so the pipeline regains control after implementation
+- `/ce-simplify-code` runs before review unless the change is docs-only or trivial
+- `/ce-code-review` reports findings, then `lfg` applies eligible fixes and commits them
+- Residual review findings are made durable in the PR body or a fallback tracked file
+- `/ce-test-browser` runs in pipeline mode
+- `/ce-commit-push-pr` ships remaining changes when a remote exists
+- CI is watched for up to three repair iterations on an open PR
+
+The pipeline also has a local-only path: if the repository has no git remote, it commits locally and skips push, PR creation, and CI watch instead of retrying impossible network steps.
+
+---
+
+## When to Reach For It
+
+Reach for `lfg` when:
+
+- You have a software task that can be taken through plan, implementation, review, and PR
+- You want hands-off progress while preserving CE's quality gates
+- The task is already shaped by `/ce-brainstorm` or is clear enough for `/ce-plan` to turn into an implementation-ready plan
+- You want CI failures handled automatically within a bounded loop
+
+Skip `lfg` when:
+
+- The work is non-software or answer-seeking
+- You need interactive product shaping before implementation -> `/ce-brainstorm`
+- You want to inspect and approve each stage manually -> run `/ce-plan`, `/ce-work`, `/ce-code-review`, and `/ce-commit-push-pr` yourself
+- The repo has unusual shipping requirements that need hand-driven git or release work
+
+---
+
+## Use as Part of the Workflow
+
+```text
+/ce-brainstorm describe the feature
+/lfg
+```
+
+Starting with `/ce-brainstorm` gives the pipeline better requirements. `lfg` then invokes `/ce-plan` itself and stops if the resulting plan is not an implementation-ready code plan.
+
+You can also invoke it directly:
+
+```text
+/lfg add account-level notification mute settings
+```
+
+Direct invocation is useful for clear software tasks, but it gives the planner less product context.
+
+---
+
+## Reference
+
+| Argument | Effect |
+|----------|--------|
+| _(empty)_ | Plans from current context, then runs the pipeline if the plan is eligible |
+| `<feature description>` | Passes the description to `/ce-plan`, then runs the pipeline |
+
+Output: code changes, commits, and usually a PR. If there is no configured git remote, output is local commits only. If CI remains red after the bounded repair loop, unresolved failures are recorded durably before the run ends.
+
+---
+
+## See Also
+
+- [`ce-brainstorm`](./ce-brainstorm.md) — strongest upstream source of requirements
+- [`ce-plan`](./ce-plan.md) — first required pipeline step
+- [`ce-work`](./ce-work.md) — implementation engine called in return-to-caller mode
+- [`ce-simplify-code`](./ce-simplify-code.md) — pre-review simplification step
+- [`ce-code-review`](./ce-code-review.md) — review gate
+- [`ce-test-browser`](./ce-test-browser.md) — browser validation step
+- [`ce-commit-push-pr`](./ce-commit-push-pr.md) — shipping handoff when a remote exists


### PR DESCRIPTION
## Summary

Skill documentation is now easier to find from the repo README. The top-level docs point to the skill catalog, and the README skill tables link each skill name to its dedicated documentation page.

The skill catalog no longer has a `/lfg` exception: it includes an autonomous pipeline section and a dedicated `/lfg` page, so the README inventory has a complete set of working documentation targets. The visible skill count now matches the 27 shipped skill definitions.

## Testing

- Verified all local Markdown links in the touched docs resolve.
- Confirmed the repo has 27 `SKILL.md` files and `docs/skills` has the catalog plus 27 dedicated skill pages.
- Not run: `bun test` (docs-only change).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
