### PR TITLE
feat(antigravity): enable one-command agy plugin install from GitHub

### DIFF
--- a/.agy/INSTALL.md
+++ b/.agy/INSTALL.md
@@ -1,0 +1,78 @@
+# Installing Compound Engineering for Antigravity CLI (`agy`)
+
+Antigravity installs CE as a native plugin bundle. The repository root is the plugin package: `plugin.json` plus the `skills/` directory. The committed `.agy/` subdirectory is a compatibility entry point for local checkouts that prefer an explicit bundle path.
+
+## One-command install (recommended)
+
+With [Antigravity CLI](https://antigravity.google) installed:
+
+```bash
+agy plugin install https://github.com/EveryInc/compound-engineering-plugin
+```
+
+Verify:
+
+```bash
+agy plugin list
+agy plugin validate https://github.com/EveryInc/compound-engineering-plugin
+```
+
+No clone step is required. `agy` stages the plugin under `~/.gemini/antigravity-cli/plugins/compound-engineering/`.
+
+## Local checkout install
+
+Clone first when you need a specific branch, tag, or unpublished changes:
+
+```bash
+git clone https://github.com/EveryInc/compound-engineering-plugin
+agy plugin install ./compound-engineering-plugin
+```
+
+Or install the bundled `.agy/` entry point (equivalent manifest via symlink):
+
+```bash
+agy plugin install ./compound-engineering-plugin/.agy
+```
+
+## Pin a release
+
+Install from a release tag:
+
+```bash
+git clone --branch compound-engineering-vX.Y.Z --depth 1 \
+  https://github.com/EveryInc/compound-engineering-plugin.git
+agy plugin install ./compound-engineering-plugin
+```
+
+Replace `X.Y.Z` with a tag from the [releases page](https://github.com/EveryInc/compound-engineering-plugin/releases).
+
+## Local development
+
+From your working copy:
+
+```bash
+agy plugin install "$PWD"
+agy plugin validate "$PWD"
+```
+
+Edit skills under `skills/` and restart `agy` or start a new session to pick up prose changes.
+
+## Context files
+
+`agy` reads `GEMINI.md` and `AGENTS.md` as workspace context. Run `agy` from a project that includes those files, or from this checkout when developing CE itself.
+
+## Uninstall
+
+```bash
+agy plugin uninstall compound-engineering
+```
+
+## Legacy Gemini CLI import
+
+If you previously installed CE under Gemini CLI:
+
+```bash
+agy plugin import gemini
+```
+
+Prefer the native install commands above for new setups.

--- a/.agy/plugin.json
+++ b/.agy/plugin.json
@@ -1,4 +1,1 @@
-{
-  "name": "compound-engineering",
-  "version": "3.16.0"
-}
+../plugin.json

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -76,7 +76,7 @@
         },
         {
           "type": "json",
-          "path": ".agy/plugin.json",
+          "path": "plugin.json",
           "jsonpath": "$.version"
         }
       ]

--- a/README.md
+++ b/README.md
@@ -307,14 +307,24 @@ pi install npm:pi-ask-user
 
 ### Antigravity CLI (`agy`)
 
-Google has replaced the consumer Gemini CLI with [Antigravity CLI](https://antigravity.google) (`agy`), which still runs on Gemini models. Unlike Gemini CLI, `agy` installs plugins from a **local checkout** (not a repository URL), so clone this repository and install the bundled `.agy` plugin directory:
+Google has replaced the consumer Gemini CLI with [Antigravity CLI](https://antigravity.google) (`agy`), which still runs on Gemini models. Install Compound Engineering directly from GitHub — no clone step required:
+
+```bash
+agy plugin install https://github.com/EveryInc/compound-engineering-plugin
+```
+
+Verify with `agy plugin list`. The repository root is the plugin package (`plugin.json` plus `skills/`).
+
+For a local checkout or pinned release:
 
 ```bash
 git clone https://github.com/EveryInc/compound-engineering-plugin
-agy plugin install ./compound-engineering-plugin/.agy
+agy plugin install ./compound-engineering-plugin
 ```
 
-`agy` also loads `GEMINI.md` workspace context from the checkout.
+The bundled `.agy/` directory remains a compatibility entry point (`agy plugin install ./compound-engineering-plugin/.agy`). `agy` also loads `GEMINI.md` workspace context from the checkout.
+
+See [`.agy/INSTALL.md`](.agy/INSTALL.md) for pinning, local development, uninstall, and legacy Gemini import.
 
 ### Existing Installs
 
@@ -423,10 +433,17 @@ pi -e "$PWD"
 **Antigravity CLI (`agy`)**
 
 ```bash
+agy plugin install "$PWD"
+agy plugin validate "$PWD"
+```
+
+Or install the bundled `.agy/` entry point:
+
+```bash
 agy plugin install "$PWD/.agy"
 ```
 
-`agy` installs the bundled `.agy` plugin directory from your checkout and loads `GEMINI.md` workspace context.
+See [`.agy/INSTALL.md`](.agy/INSTALL.md) for remote install and pinning examples.
 
 ## Limitations
 

--- a/docs/solutions/integrations/native-plugin-install-strategy.md
+++ b/docs/solutions/integrations/native-plugin-install-strategy.md
@@ -48,7 +48,7 @@ The install strategy follows from that: prefer each harness's native plugin/pack
 | Kimi Code CLI | Native plugin install from this repository using `.kimi-plugin/plugin.json` | No | Kimi can install directly from the GitHub repo and can browse the committed `.kimi-plugin/marketplace.json` custom catalog. |
 | OpenCode | Git-backed OpenCode plugin entry in `opencode.json` | No | `.opencode/plugins/compound-engineering.js` registers the CE skills directory directly. |
 | Pi | Git-backed Pi package install from this repository | No | Root `package.json` exposes `.pi/extensions/compound-engineering.ts` and the CE skills directory. `pi-ask-user` is a recommended companion for richer prompts. |
-| Antigravity CLI | Native Antigravity plugin from the committed `.agy/` bundle | No | Clone the repo, then `agy plugin install ./compound-engineering-plugin/.agy`. The `.agy/` bundle holds `plugin.json` plus a `skills -> ../skills` symlink. `agy` still reads `GEMINI.md` as workspace context. |
+| Antigravity CLI | Native plugin install from root `plugin.json` + `skills/`, or bundled `.agy/` entry point | No | `agy plugin install https://github.com/EveryInc/compound-engineering-plugin` for one-command remote install. `.agy/plugin.json` symlinks to the root manifest; `.agy/skills` symlinks to `skills/`. |
 
 Kiro is no longer a documented CE install target. Historical converter and cleanup code may remain for regression coverage or old artifact handling, but user-facing install docs should not advertise Kiro.
 
@@ -110,14 +110,24 @@ pi -e /path/to/compound-engineering-plugin
 
 ## Antigravity CLI
 
-Antigravity installs plugins from a **local directory** — there is no install-from-URL. The committed `.agy/` bundle holds `plugin.json` plus a `skills -> ../skills` symlink, letting `agy` resolve all skills through the symlink without duplicating them:
+Antigravity installs plugins from a local directory or a remote Git URL when the source root contains `plugin.json` and `skills/`. CE publishes both at the repository root.
+
+Recommended one-command install:
+
+```bash
+agy plugin install https://github.com/EveryInc/compound-engineering-plugin
+```
+
+Local checkout:
 
 ```bash
 git clone https://github.com/EveryInc/compound-engineering-plugin
-agy plugin install ./compound-engineering-plugin/.agy
+agy plugin install ./compound-engineering-plugin
 ```
 
-`agy` still reads `GEMINI.md` as workspace context (retained despite the Gemini CLI converter target being removed). For local development, point `agy` at the `.agy/` subdirectory of the checkout so it finds `plugin.json`, the `skills` symlink, and `GEMINI.md` together.
+The committed `.agy/` bundle remains for explicit local installs (`agy plugin install ./compound-engineering-plugin/.agy`). Its `plugin.json` symlinks to the root manifest and `skills` symlinks to `../skills`.
+
+`agy` still reads `GEMINI.md` as workspace context. See `.agy/INSTALL.md` for pinning, validation, and uninstall.
 
 ## Kimi Code CLI
 

--- a/docs/specs/antigravity.md
+++ b/docs/specs/antigravity.md
@@ -19,20 +19,35 @@ All facts below were verified by building a fixture plugin and running `agy plug
 
 ## Install model (user-facing)
 
-`agy` installs a plugin from a **local directory**, not a repository URL:
+`agy` installs a plugin from a **local directory** or a **remote Git repository URL** when the source contains a root `plugin.json`:
+
+```bash
+agy plugin install https://github.com/EveryInc/compound-engineering-plugin
+```
+
+Local checkout (repository root or bundled `.agy/` entry point):
 
 ```bash
 git clone https://github.com/EveryInc/compound-engineering-plugin
 agy plugin install ./compound-engineering-plugin
+agy plugin install ./compound-engineering-plugin/.agy   # equivalent via symlinked manifest
 ```
 
 - `agy plugin install <target>` requires `<target>` to be a directory containing a `plugin.json` at
-  its root (`agy plugin validate .` fails with "missing plugin.json" otherwise).
-- There is no install-from-URL. `agy plugin install <plugin>@<marketplace>` exists for marketplaces.
+  its root (`agy plugin validate .` fails with "missing plugin.json" otherwise), or a remote Git URL
+  whose root contains `plugin.json`.
+- `agy plugin install <plugin>@<marketplace>` exists for marketplaces; Antigravity does not yet
+  ship a curated marketplace catalog equivalent to Kimi's `.kimi-plugin/marketplace.json`.
 - `agy plugin import [gemini|claude]` imports an existing Gemini-CLI / Claude install; on this machine
   `agy plugin list` showed `compound-engineering` already imported with `source: gemini-cli`.
 - Other subcommands: `list`, `uninstall <name>`, `enable <name>`, `disable <name>`, `validate [path]`,
   `link <mp> <target>`.
+
+Compound Engineering publishes root `plugin.json` plus `skills/` so remote Git install works without
+a clone step. The committed `.agy/` bundle holds a symlinked manifest (`plugin.json -> ../plugin.json`)
+and `skills -> ../skills` for explicit local `.agy` installs.
+
+See `.agy/INSTALL.md` for pinning, validation, and uninstall.
 
 Installed/imported plugins are tracked in an internal registry surfaced by `agy plugin list --json`
 (not a readable `plugins/` directory tree). Each entry records `name`, `source`
@@ -124,4 +139,6 @@ Builtin skills ship under `~/.gemini/antigravity-cli/builtin/skills/`.
 - Whether `agy plugin install` supports a monorepo subdirectory or only a root `plugin.json`.
 - Whether a generated root `plugin.json` (vs `.claude-plugin/plugin.json`) is the right emission
   target, and how it coexists with the existing Claude/Codex manifests at the repo root.
-- Marketplace (`<plugin>@<marketplace>`, `agy plugin link`) distribution, if we want it later.
+  **Resolved for CE:** root `plugin.json` is the Antigravity manifest; `.agy/plugin.json` symlinks to it.
+- Marketplace (`<plugin>@<marketplace>`, `agy plugin link`) distribution — deferred until Antigravity
+  documents a stable catalog schema (unlike Kimi's `.kimi-plugin/marketplace.json`).

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://antigravity.google/schemas/v1/plugin.json",
+  "name": "compound-engineering",
+  "version": "3.16.0",
+  "description": "Brainstorm, plan, debug, review, and compound learnings with AI agents"
+}

--- a/src/release/components.ts
+++ b/src/release/components.ts
@@ -19,6 +19,7 @@ const FILE_COMPONENT_MAP: Array<{ component: ReleaseComponent; prefixes: string[
     component: "compound-engineering",
     prefixes: [
       "skills/",
+      "plugin.json",
       ".claude-plugin/plugin.json",
       ".cursor-plugin/plugin.json",
       ".codex-plugin/",
@@ -182,7 +183,7 @@ export function bumpVersion(version: string, bump: BumpLevel | null): string | n
 export async function loadCurrentVersions(cwd = process.cwd()): Promise<VersionSources> {
   const root = await readJson<RootPackageJson>(`${cwd}/package.json`)
   const ce = await readJson<PluginManifest>(`${cwd}/.claude-plugin/plugin.json`)
-  const antigravity = await readJson<PluginManifest>(`${cwd}/.agy/plugin.json`)
+  const antigravity = await readJson<PluginManifest>(`${cwd}/plugin.json`)
   const kimi = await readJson<PluginManifest>(`${cwd}/.kimi-plugin/plugin.json`)
   const marketplace = await readJson<MarketplaceManifest>(`${cwd}/.claude-plugin/marketplace.json`)
   const cursorMarketplace = await readJson<MarketplaceManifest>(`${cwd}/.cursor-plugin/marketplace.json`)
@@ -192,7 +193,7 @@ export async function loadCurrentVersions(cwd = process.cwd()): Promise<VersionS
   }
 
   if (root.version !== antigravity.version) {
-    throw new Error(`package.json version ${root.version} does not match .agy/plugin.json version ${antigravity.version}`)
+    throw new Error(`package.json version ${root.version} does not match plugin.json version ${antigravity.version}`)
   }
 
   if (root.version !== kimi.version) {

--- a/src/release/metadata.ts
+++ b/src/release/metadata.ts
@@ -218,7 +218,7 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
   const compoundPackagePath = path.join(root, "package.json")
   const compoundClaudePath = path.join(root, ".claude-plugin", "plugin.json")
   const compoundCursorPath = path.join(root, ".cursor-plugin", "plugin.json")
-  const compoundAntigravityPath = path.join(root, ".agy", "plugin.json")
+  const compoundAntigravityPath = path.join(root, "plugin.json")
   const compoundKimiPath = path.join(root, ".kimi-plugin", "plugin.json")
   const marketplaceClaudePath = path.join(root, ".claude-plugin", "marketplace.json")
   const marketplaceCursorPath = path.join(root, ".cursor-plugin", "marketplace.json")
@@ -272,7 +272,7 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
     })
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      errors.push(`${compoundAntigravityPath} is missing but ${compoundClaudePath} exists. Antigravity bundle parity required.`)
+      errors.push(`${compoundAntigravityPath} is missing but ${compoundClaudePath} exists. Antigravity plugin.json parity required.`)
       updates.push({ path: compoundAntigravityPath, changed: false })
     } else {
       throw err

--- a/tests/release-components.test.ts
+++ b/tests/release-components.test.ts
@@ -46,6 +46,14 @@ describe("release component detection", () => {
     expect(components.get("compound-engineering")).toEqual([])
   })
 
+  test("maps Antigravity root plugin.json to root plugin component", () => {
+    const components = detectComponentsFromFiles(["plugin.json", ".agy/INSTALL.md"])
+
+    expect(components.get("compound-engineering")).toEqual(["plugin.json", ".agy/INSTALL.md"])
+    expect(components.get("marketplace")).toEqual([])
+    expect(components.get("cursor-marketplace")).toEqual([])
+  })
+
   test("maps Kimi plugin manifest to root plugin component but leaves marketplace static", () => {
     const components = detectComponentsFromFiles([
       ".kimi-plugin/plugin.json",

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -78,11 +78,11 @@ async function makeFixtureRoot(): Promise<string> {
       2,
     ),
   )
-  await mkdir(path.join(root, ".agy"), { recursive: true })
   await writeFile(
-    path.join(root, ".agy", "plugin.json"),
-    JSON.stringify({ version: "2.42.0" }, null, 2),
+    path.join(root, "plugin.json"),
+    JSON.stringify({ name: "compound-engineering", version: "2.42.0" }, null, 2),
   )
+  await mkdir(path.join(root, ".agy"), { recursive: true })
   await writeFile(
     path.join(root, ".agents", "plugins", "marketplace.json"),
     JSON.stringify(
@@ -233,15 +233,15 @@ describe("release metadata", () => {
     expect(afterContents.version).toBe("2.41.0")
   })
 
-  test("reports Antigravity bundle version drift without auto-correcting", async () => {
+  test("reports Antigravity plugin.json version drift without auto-correcting", async () => {
     const root = await makeFixtureRoot()
     await writeFile(
-      path.join(root, ".agy", "plugin.json"),
-      JSON.stringify({ version: "2.41.0" }, null, 2),
+      path.join(root, "plugin.json"),
+      JSON.stringify({ name: "compound-engineering", version: "2.41.0" }, null, 2),
     )
 
     const result = await syncReleaseMetadata({ root, write: true })
-    const antigravityPath = path.join(root, ".agy", "plugin.json")
+    const antigravityPath = path.join(root, "plugin.json")
     const antigravityUpdate = result.updates.find((u) => u.path === antigravityPath)
 
     expect(antigravityUpdate).toBeDefined()
@@ -251,13 +251,13 @@ describe("release metadata", () => {
     expect(afterContents.version).toBe("2.41.0")
   })
 
-  test("reports missing Antigravity bundle manifest as a structural error", async () => {
+  test("reports missing Antigravity plugin.json as a structural error", async () => {
     const root = await makeFixtureRoot()
-    await Bun.$`rm ${path.join(root, ".agy", "plugin.json")}`.quiet()
+    await Bun.$`rm ${path.join(root, "plugin.json")}`.quiet()
 
     const result = await syncReleaseMetadata({ root, write: false })
 
-    expect(result.errors.some((err) => err.includes(".agy/plugin.json is missing"))).toBe(true)
+    expect(result.errors.some((err) => err.includes("plugin.json is missing"))).toBe(true)
   })
 
   test("rewrites Codex plugin.json description on write when drifted from Claude", async () => {

--- a/tests/release-preview.test.ts
+++ b/tests/release-preview.test.ts
@@ -44,7 +44,7 @@ describe("release preview", () => {
     expect(preview.components).toHaveLength(0)
   })
 
-  test("rejects Gemini extension version drift from the root plugin version", async () => {
+  test("rejects Antigravity plugin.json version drift from the root plugin version", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "release-preview-"))
     await mkdir(path.join(root, ".claude-plugin"), { recursive: true })
     await mkdir(path.join(root, ".cursor-plugin"), { recursive: true })
@@ -53,8 +53,7 @@ describe("release preview", () => {
     await writeFile(path.join(root, ".claude-plugin", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
     await mkdir(path.join(root, ".kimi-plugin"), { recursive: true })
     await writeFile(path.join(root, ".kimi-plugin", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
-    await mkdir(path.join(root, ".agy"), { recursive: true })
-    await writeFile(path.join(root, ".agy", "plugin.json"), JSON.stringify({ version: "3.13.0" }))
+    await writeFile(path.join(root, "plugin.json"), JSON.stringify({ version: "3.13.0" }))
     await writeFile(
       path.join(root, ".claude-plugin", "marketplace.json"),
       JSON.stringify({ metadata: { version: "3.13.1" } }),
@@ -64,7 +63,7 @@ describe("release preview", () => {
       JSON.stringify({ metadata: { version: "3.13.1" } }),
     )
 
-    await expect(loadCurrentVersions(root)).rejects.toThrow(".agy/plugin.json version 3.13.0")
+    await expect(loadCurrentVersions(root)).rejects.toThrow("plugin.json version 3.13.0")
     await Bun.$`rm -rf ${root}`.quiet()
   })
 
@@ -73,12 +72,11 @@ describe("release preview", () => {
     await mkdir(path.join(root, ".claude-plugin"), { recursive: true })
     await mkdir(path.join(root, ".cursor-plugin"), { recursive: true })
     await mkdir(path.join(root, ".kimi-plugin"), { recursive: true })
-    await mkdir(path.join(root, ".agy"), { recursive: true })
 
     await writeFile(path.join(root, "package.json"), JSON.stringify({ version: "3.13.1" }))
     await writeFile(path.join(root, ".claude-plugin", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
     await writeFile(path.join(root, ".kimi-plugin", "plugin.json"), JSON.stringify({ version: "3.13.0" }))
-    await writeFile(path.join(root, ".agy", "plugin.json"), JSON.stringify({ version: "3.13.1" }))
+    await writeFile(path.join(root, "plugin.json"), JSON.stringify({ version: "3.13.1" }))
     await writeFile(
       path.join(root, ".claude-plugin", "marketplace.json"),
       JSON.stringify({ metadata: { version: "3.13.1" } }),


### PR DESCRIPTION
## Summary

- Add root `plugin.json` so `agy plugin install https://github.com/EveryInc/compound-engineering-plugin` works without cloning first
- Symlink `.agy/plugin.json` -> `../plugin.json` so the bundled `.agy/` entry point stays compatible
- Add `.agy/INSTALL.md` with remote install, pinning, local dev, uninstall, and legacy Gemini import
- Update README, `docs/specs/antigravity.md`, and native-plugin install strategy docs
- Point release-please and release validation at root `plugin.json`

## Why

Antigravity accepts remote Git installs when the repo root contains `plugin.json` plus `skills/`. CE already ships `skills/` at the root; only the manifest lived under `.agy/`, forcing a clone + manual path. This matches the Kimi/OpenCode polish goal: one-command install from GitHub.

## Test plan

- [x] `bun run release:validate` passes
- [x] `bun test` — 1684 pass, 0 fail
- [x] `.agy/plugin.json` symlink resolves to root manifest
- [x] Release metadata tests updated for root `plugin.json` path