### PR TITLE
fix(ce-test-browser): keep pipeline runs from blocking on prompts

### DIFF
--- a/docs/skills/ce-test-browser.md
+++ b/docs/skills/ce-test-browser.md
@@ -86,7 +86,7 @@ Pipeline mode exists for LFG and other automated runners where multiple agents m
 The preferred port comes from a priority list:
 
 1. Explicit argument (`--port 5000`)
-2. Project instructions (`AGENTS.md`, `CLAUDE.md`)
+2. In-context project instructions (the dev-server port already in the agent's active instructions — not by grepping instruction files, where prose mentions are false-positive-prone)
 3. `package.json` (dev/start scripts)
 4. Environment files (`.env`, `.env.local`, `.env.development`)
 5. Default `3000`

--- a/skills/ce-test-browser/SKILL.md
+++ b/skills/ce-test-browser/SKILL.md
@@ -8,60 +8,31 @@ argument-hint: "[PR number, branch name, 'current', or --port PORT]"
 
 Run end-to-end browser tests on pages affected by a PR or branch changes using the `agent-browser` CLI.
 
-## Use `agent-browser` Only For Browser Automation
+## Modes
 
-This workflow uses the `agent-browser` CLI exclusively. Do not use any alternative browser automation system, browser MCP integration, or built-in browser-control tool. If the platform offers multiple ways to control a browser, always choose `agent-browser`.
+- **Manual (default):** the user controls the dev server. Follow the steps below as written, including the headed/headless question.
+- **Pipeline (`mode:pipeline`):** invoked by LFG or another automated runner. The run is unattended — never block on a question. Read `references/pipeline-orchestration.md` from this skill's directory and follow it; it overrides the free-port scan (step 4), dev-server startup (step 5), and the headed/headless question (step 6). It still uses the preferred port that step 4 computes.
 
-Use `agent-browser` for: opening pages, clicking elements, filling forms, taking screenshots, and scraping rendered content.
+## Use `agent-browser` Only
 
-Platform-specific hints:
-- In Claude Code, do not use Chrome MCP tools (`mcp__claude-in-chrome__*`).
-- In Codex, do not substitute unrelated browsing tools.
+Use the `agent-browser` CLI for every browser action in this skill — opening pages, clicking, filling forms, snapshots, screenshots. Do not substitute a browser MCP integration, a built-in browser-control tool, Playwright, or Puppeteer. If the host offers several ways to drive a browser, choose `agent-browser`.
 
-## Prerequisites
-
-- Local development server running (e.g., `bin/dev`, `rails server`, `npm run dev`)
-- `agent-browser` CLI installed (see Setup below)
-- Git repository with changes to test
-
-## Setup
-
-Check whether `agent-browser` is installed:
-
-```bash
-command -v agent-browser >/dev/null 2>&1 && echo "Installed" || echo "NOT INSTALLED"
-```
-
-If not installed, inform the user: "`agent-browser` is not installed. Run `/ce-setup` for the current install command, then install agent-browser and retry." Then stop — this skill cannot function without agent-browser.
+- Claude Code: do not use Chrome MCP tools (`mcp__claude-in-chrome__*`).
+- Codex: do not substitute unrelated browsing tools.
 
 ## Workflow
 
-### 1. Verify Installation
-
-Before starting, verify `agent-browser` is available:
+### 1. Verify `agent-browser` Is Installed
 
 ```bash
 command -v agent-browser >/dev/null 2>&1 && echo "Ready" || echo "NOT INSTALLED"
 ```
 
-If not installed, inform the user: "`agent-browser` is not installed. Run `/ce-setup` for the current install command, then install agent-browser and retry." Then stop.
+If not installed, tell the user: "`agent-browser` is not installed. Run `/ce-setup` for the current install command, then install agent-browser and retry." Then stop — this skill cannot function without it.
 
-### 2. Ask Browser Mode
+This also requires a git repository with changes to test.
 
-**Pipeline mode (`mode:pipeline`):** Skip this step entirely. Default to headless — no question, no blocking. Proceed directly to step 3.
-
-**Manual mode:** Ask the user whether to run headed or headless using the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question:
-
-```
-Do you want to watch the browser tests run?
-
-1. Headed (watch) - Opens visible browser window so you can see tests run
-2. Headless (faster) - Runs in background, faster but invisible
-```
-
-Store the choice and use the `--headed` flag when the user selects option 1.
-
-### 3. Determine Test Scope
+### 2. Determine Test Scope
 
 **If PR number provided:**
 ```bash
@@ -78,9 +49,9 @@ git diff --name-only main...HEAD
 git diff --name-only main...[branch]
 ```
 
-### 4. Map Files to Routes
+### 3. Map Changed Files to Routes
 
-Map changed files to testable routes:
+Map each changed file to the route(s) that render it, then build the list of URLs to test. The table below is a starting point of common patterns, not an exhaustive rule set — apply judgment for the project's actual layout:
 
 | File Pattern | Route(s) |
 |-------------|----------|
@@ -94,28 +65,18 @@ Map changed files to testable routes:
 | `src/app/*` (Next.js) | Corresponding routes |
 | `src/components/*` | Pages using those components |
 
-Build a list of URLs to test based on the mapping.
-
-### 5. Detect and Claim a Free Port
-
-**Pipeline mode only (`mode:pipeline`):** When invoked from LFG or another automated pipeline, always find a port that is actually free — never assume 3000 is available, as multiple agents may be running in parallel on the same machine.
-
-**Manual mode (no `mode:pipeline`):** Use the preferred port as-is. Do not scan for alternatives — the user controls their own server.
+### 4. Determine the Dev Server Port
 
 Determine the preferred port using this priority:
 
-1. **Explicit argument** — if the user passed `--port 5000`, use that directly (skip free-port scan)
+1. **Explicit argument** — if the user passed `--port 5000`, use that directly.
 2. **In-context project instructions** — if your active project instructions already in context explicitly state the dev-server port, use it. Don't grep instruction files for a port: prose mentions (docs, examples, troubleshooting) are unreliable and false-positive-prone — config files and `.env` are the trustworthy sources.
-3. **package.json** — check dev/start scripts for `--port` flags
-4. **Environment files** — check `.env`, `.env.local`, `.env.development` for `PORT=`
-5. **Default** — fall back to `3000`
-
-**In pipeline mode**, verify the preferred port is free and scan upward if not. **In manual mode**, use the preferred port directly.
+3. **package.json** — check dev/start scripts for `--port` flags.
+4. **Environment files** — check `.env`, `.env.local`, `.env.development` for `PORT=`.
+5. **Default** — fall back to `3000`.
 
 ```bash
-# Step 1: Determine preferred port.
-# If your in-context project instructions state the dev-server port, set PORT
-# here first (e.g. EXPLICIT_PORT). Do not grep instruction files for a port.
+# If your in-context project instructions state the dev-server port, set EXPLICIT_PORT first.
 PORT="${EXPLICIT_PORT:-}"
 if [ -z "$PORT" ]; then
   PORT=$(grep -Eo '\-\-port[= ]+[0-9]{4,5}' package.json 2>/dev/null | grep -Eo '[0-9]{4,5}' | head -1)
@@ -124,63 +85,46 @@ if [ -z "$PORT" ]; then
   PORT=$(grep -h '^PORT=' .env .env.local .env.development 2>/dev/null | tail -1 | cut -d= -f2)
 fi
 PORT="${PORT:-3000}"
-
-# Step 2 (pipeline mode only): scan for a free port
-if [ "${PIPELINE_MODE}" = "1" ]; then
-  find_free_port() {
-    local p=$1
-    while lsof -i ":$p" -sTCP:LISTEN -t >/dev/null 2>&1; do
-      p=$((p + 1))
-    done
-    echo $p
-  }
-  PORT=$(find_free_port "$PORT")
-fi
-echo "Using dev server port: $PORT"
+echo "Preferred dev server port: $PORT"
 ```
 
-Set `PIPELINE_MODE=1` in your shell when the argument `mode:pipeline` is present.
+Manual mode uses this preferred port as-is — the user controls their own server, so do not scan for alternatives. In pipeline mode, `references/pipeline-orchestration.md` scans upward from `$PORT` to a genuinely free port.
 
-### 6. Start Dev Server if Not Running, Then Verify
+### 5. Verify the Dev Server Is Running
 
-**Pipeline mode only:** If no server is already listening on `$PORT`, start one automatically in the background. In manual mode, inform the user and stop.
+Confirm the server is up before asking the headed/headless question — a manual run with no server stops here, so asking first would waste the question.
 
 ```bash
 if lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
-  echo "Server already running on port ${PORT}"
+  echo "Server running on port ${PORT}"
 else
-  if [ "${PIPELINE_MODE}" = "1" ]; then
-    # Auto-start in pipeline — pick the right command for this project
-    echo "Starting dev server on port ${PORT}..."
-    if [ -f "bin/dev" ]; then
-      PORT=${PORT} bin/dev > /tmp/dev-server-${PORT}.log 2>&1 &
-    elif [ -f "bin/rails" ]; then
-      bin/rails server -p ${PORT} > /tmp/dev-server-${PORT}.log 2>&1 &
-    elif [ -f "package.json" ]; then
-      PORT=${PORT} npm run dev > /tmp/dev-server-${PORT}.log 2>&1 &
-    fi
-    # Wait up to 30 seconds for server to become ready
-    for i in $(seq 1 30); do
-      lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1 && break
-      sleep 1
-    done
-    if ! lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
-      echo "Server did not start in 30s. Last output:"
-      tail -20 /tmp/dev-server-${PORT}.log 2>/dev/null
-      exit 1
-    fi
-  else
-    # Manual mode — ask the user to start the server
-    echo "Server not running on port ${PORT}"
-    echo ""
-    echo "Please start your development server:"
-    echo "  Rails: bin/dev  or  rails server -p ${PORT}"
-    echo "  Node/Next.js: npm run dev"
-    echo "  Custom port: run this skill again with --port <your-port>"
-    exit 0
-  fi
+  echo "Server not running on port ${PORT}"
+  echo "Start your dev server, then re-run:"
+  echo "  Rails: bin/dev  or  rails server -p ${PORT}"
+  echo "  Node/Next.js: npm run dev"
+  echo "  Custom port: run this skill again with --port <your-port>"
+  exit 0
 fi
+```
 
+In pipeline mode, do not stop here — `references/pipeline-orchestration.md` auto-starts the server in the background instead.
+
+### 6. Choose Headed or Headless
+
+Manual mode only — in pipeline mode, skip this step (see Modes; it defaults to headless).
+
+Ask the user whether to run headed or headless using the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question:
+
+```
+Do you want to watch the browser tests run?
+
+1. Headed (watch) - Opens visible browser window so you can see tests run
+2. Headless (faster) - Runs in background, faster but invisible
+```
+
+Store the choice and use the `--headed` flag when the user selects option 1. Then confirm the server serves the root before iterating (add `--headed` if the user chose headed):
+
+```bash
 agent-browser open http://localhost:${PORT}
 agent-browser snapshot -i
 ```
@@ -222,7 +166,7 @@ agent-browser screenshot --full page-name-full.png
 
 ### 8. Human Verification (When Required)
 
-Pause for human input when testing touches flows that require external interaction:
+Pause for human input when testing touches flows that require external interaction. **Pipeline mode:** do not pause — log each such flow as Skip with the reason and continue.
 
 | Flow Type | What to Ask |
 |-----------|-------------|
@@ -248,7 +192,7 @@ Did it work correctly?
 
 ### 9. Handle Failures
 
-When a test fails:
+When a test fails (**pipeline mode:** do not ask how to proceed — capture the error screenshot and repro steps, log the failure, and continue):
 
 1. **Document the failure:**
    - Screenshot the error state: `agent-browser screenshot error.png`

--- a/skills/ce-test-browser/SKILL.md
+++ b/skills/ce-test-browser/SKILL.md
@@ -15,7 +15,7 @@ Run end-to-end browser tests on pages affected by a PR or branch changes using t
 
 ## Use `agent-browser` Only
 
-Use the `agent-browser` CLI for every browser action in this skill — opening pages, clicking, filling forms, snapshots, screenshots. Do not substitute a browser MCP integration, a built-in browser-control tool, Playwright, or Puppeteer. If the host offers several ways to drive a browser, choose `agent-browser`.
+Use the `agent-browser` CLI for every browser action in this skill — opening pages, clicking, filling forms, snapshots, screenshots — and use it exclusively. Do not use any other browser-automation tool, including a browser MCP integration, a built-in browser-control tool, Playwright, or Puppeteer. If the host offers several ways to drive a browser, always choose `agent-browser`.
 
 - Claude Code: do not use Chrome MCP tools (`mcp__claude-in-chrome__*`).
 - Codex: do not substitute unrelated browsing tools.

--- a/skills/ce-test-browser/SKILL.md
+++ b/skills/ce-test-browser/SKILL.md
@@ -88,7 +88,7 @@ PORT="${PORT:-3000}"
 echo "Preferred dev server port: $PORT"
 ```
 
-Manual mode uses this preferred port as-is — the user controls their own server, so do not scan for alternatives. In pipeline mode, `references/pipeline-orchestration.md` scans upward from `$PORT` to a genuinely free port.
+Manual mode uses this preferred port as-is — the user controls their own server, so do not scan for alternatives. In pipeline mode, `references/pipeline-orchestration.md` takes the preferred port value printed here and scans upward to a genuinely free port.
 
 ### 5. Verify the Dev Server Is Running
 

--- a/skills/ce-test-browser/references/pipeline-orchestration.md
+++ b/skills/ce-test-browser/references/pipeline-orchestration.md
@@ -1,0 +1,53 @@
+# Pipeline-Mode Server Orchestration
+
+Read and follow this file only when invoked with `mode:pipeline` (LFG or another automated runner). It overrides three things in the main workflow: the headed/headless question, free-port selection, and dev-server startup. In pipeline mode you run unattended — never block on a question.
+
+## 1. No headed/headless question
+
+Default to headless. Do not ask. Skip the "Choose Headed or Headless" step entirely and never pass `--headed`.
+
+## 2. Claim a genuinely free port
+
+Multiple agents may run on the same machine, so never assume the preferred port is free. Start from the preferred port computed by the port-determination step (`$PORT`) and scan upward to the first free port:
+
+```bash
+find_free_port() {
+  local p=$1
+  while lsof -i ":$p" -sTCP:LISTEN -t >/dev/null 2>&1; do
+    p=$((p + 1))
+  done
+  echo "$p"
+}
+PORT=$(find_free_port "$PORT")
+echo "Using dev server port: $PORT"
+```
+
+## 3. Auto-start the dev server if nothing is listening
+
+In manual mode the skill stops and asks the user to start the server. In pipeline mode, start it in the background instead, picking the command that matches the project, then wait up to 30s for it to listen:
+
+```bash
+if lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
+  echo "Server already running on port ${PORT}"
+else
+  echo "Starting dev server on port ${PORT}..."
+  if [ -f "bin/dev" ]; then
+    PORT=${PORT} bin/dev > /tmp/dev-server-${PORT}.log 2>&1 &
+  elif [ -f "bin/rails" ]; then
+    bin/rails server -p ${PORT} > /tmp/dev-server-${PORT}.log 2>&1 &
+  elif [ -f "package.json" ]; then
+    PORT=${PORT} npm run dev > /tmp/dev-server-${PORT}.log 2>&1 &
+  fi
+  for i in $(seq 1 30); do
+    lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1 && break
+    sleep 1
+  done
+  if ! lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "Server did not start in 30s. Last output:"
+    tail -20 /tmp/dev-server-${PORT}.log 2>/dev/null
+    exit 1
+  fi
+fi
+```
+
+Once a server is confirmed listening on `$PORT`, return to the main workflow at the "Test Each Affected Page" step (open `http://localhost:${PORT}`, snapshot, then test each route).

--- a/skills/ce-test-browser/references/pipeline-orchestration.md
+++ b/skills/ce-test-browser/references/pipeline-orchestration.md
@@ -46,4 +46,4 @@ if ! lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
 fi
 ```
 
-Once the server is confirmed listening on `$PORT`, return to the main workflow at the "Test Each Affected Page" step (open `http://localhost:${PORT}`, snapshot, then test each route).
+The scan may land on a different port than the preferred one, and `$PORT` does not survive into later Bash calls. Note the number this block echoes ("Using dev server port: N") and substitute that literal port into every subsequent `agent-browser` command — do not rely on `${PORT}` carrying over into the main workflow's snippets. Then return to the "Test Each Affected Page" step (open `http://localhost:<N>`, snapshot, then test each route).

--- a/skills/ce-test-browser/references/pipeline-orchestration.md
+++ b/skills/ce-test-browser/references/pipeline-orchestration.md
@@ -6,11 +6,16 @@ Read and follow this file only when invoked with `mode:pipeline` (LFG or another
 
 Default to headless. Do not ask. Skip the "Choose Headed or Headless" step entirely and never pass `--headed`.
 
-## 2. Claim a genuinely free port
+## 2. Claim a free port and start the server
 
-Multiple agents may run on the same machine, so never assume the preferred port is free. Start from the preferred port computed by the port-determination step (`$PORT`) and scan upward to the first free port:
+Multiple agents may run on the same machine, so never assume the preferred port is free: scan upward to the first free port, then start the server there in the background.
+
+Run the whole thing as **one** command. Shell variables do not survive between separate Bash calls, so the free-port scan and the startup must share a single block, and that block must seed `PORT` itself — the `$PORT` computed in step 4 is gone by the time this runs. Set `PORT` on the first line to the preferred port step 4 printed ("Preferred dev server port: N"); it defaults to `3000` only if step 4 found nothing.
 
 ```bash
+PORT=3000   # replace 3000 with the preferred port from step 4
+
+# scan upward to the first free port
 find_free_port() {
   local p=$1
   while lsof -i ":$p" -sTCP:LISTEN -t >/dev/null 2>&1; do
@@ -20,34 +25,25 @@ find_free_port() {
 }
 PORT=$(find_free_port "$PORT")
 echo "Using dev server port: $PORT"
-```
 
-## 3. Auto-start the dev server if nothing is listening
-
-In manual mode the skill stops and asks the user to start the server. In pipeline mode, start it in the background instead, picking the command that matches the project, then wait up to 30s for it to listen:
-
-```bash
-if lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
-  echo "Server already running on port ${PORT}"
-else
-  echo "Starting dev server on port ${PORT}..."
-  if [ -f "bin/dev" ]; then
-    PORT=${PORT} bin/dev > /tmp/dev-server-${PORT}.log 2>&1 &
-  elif [ -f "bin/rails" ]; then
-    bin/rails server -p ${PORT} > /tmp/dev-server-${PORT}.log 2>&1 &
-  elif [ -f "package.json" ]; then
-    PORT=${PORT} npm run dev > /tmp/dev-server-${PORT}.log 2>&1 &
-  fi
-  for i in $(seq 1 30); do
-    lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1 && break
-    sleep 1
-  done
-  if ! lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
-    echo "Server did not start in 30s. Last output:"
-    tail -20 /tmp/dev-server-${PORT}.log 2>/dev/null
-    exit 1
-  fi
+# start in the background (the scan guarantees this port is free), then wait up to 30s
+echo "Starting dev server on port ${PORT}..."
+if [ -f "bin/dev" ]; then
+  PORT=${PORT} bin/dev > /tmp/dev-server-${PORT}.log 2>&1 &
+elif [ -f "bin/rails" ]; then
+  bin/rails server -p ${PORT} > /tmp/dev-server-${PORT}.log 2>&1 &
+elif [ -f "package.json" ]; then
+  PORT=${PORT} npm run dev > /tmp/dev-server-${PORT}.log 2>&1 &
+fi
+for i in $(seq 1 30); do
+  lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1 && break
+  sleep 1
+done
+if ! lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
+  echo "Server did not start in 30s. Last output:"
+  tail -20 /tmp/dev-server-${PORT}.log 2>/dev/null
+  exit 1
 fi
 ```
 
-Once a server is confirmed listening on `$PORT`, return to the main workflow at the "Test Each Affected Page" step (open `http://localhost:${PORT}`, snapshot, then test each route).
+Once the server is confirmed listening on `$PORT`, return to the main workflow at the "Test Each Affected Page" step (open `http://localhost:${PORT}`, snapshot, then test each route).


### PR DESCRIPTION
## Summary

Pipeline-mode (`mode:pipeline`) browser-test runs are meant to be unattended, but two steps could still hang an automated runner waiting for input the run will never receive. This tightens `ce-test-browser` from an evaluation: unattended runs stay unattended, the manual path is leaner, and a prompt that fired too early is gone.

## What changed

- **Pipeline runs no longer block.** The human-verification and failure-handling steps now skip their prompts in `mode:pipeline` — log the external flow as Skip / log the failure and continue — instead of posing a blocking question an automated runner can't answer.
- **Install check runs once.** The old `Setup` section and Step 1 were duplicate `command -v agent-browser` checks; an agent ran the gate twice. Now a single gate.
- **Pipeline orchestration is single-sourced.** The pipeline-only free-port scan and background server auto-start moved to `references/pipeline-orchestration.md`, which loads only on `mode:pipeline`. The manual default path is now fully inline and no longer steps over pipeline-only branches.
- **No wasted prompt.** The headed/headless question now fires only after the dev server is confirmed running, so a manual run with no server stops first instead of asking a question it then discards.

## Validation

Verified with old-vs-new dry-run evals — fresh agents reading isolated copies of the old and new skill, reporting their plan and every file opened without executing. Using an unfakeable proxy (the free-port-scan / auto-start logic now exists *only* in the reference), the runs confirmed: pipeline mode opens the reference and routes correctly; the manual path opens `SKILL.md` only; the duplicate install check is gone (old-baseline agents ran it twice); the step-8/9 pipeline guards fire (the agent cited them by step); and the reordered manual run no longer asks headed/headless when the server is down.

No live browser run was exercised — the skill drives a real dev server via `agent-browser`, which the eval harness can't reproduce. The change is to skill behavior contract, validated at the routing/contract level.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
