### PR TITLE
fix(ce-commit-push-pr): auto-branch detached PR flows

### DIFF
--- a/docs/skills/ce-commit-push-pr.md
+++ b/docs/skills/ce-commit-push-pr.md
@@ -75,8 +75,8 @@ When changes touch naturally distinct concerns (e.g., backend models + frontend 
 
 Every weird branch state has an explicit branch in the decision tree:
 
-- Detached HEAD → ask whether to create a feature branch
-- On default branch with unpushed commits → ask whether to create a feature branch
+- Detached HEAD → automatically create a feature branch from current `HEAD`
+- On default branch with work to do → automatically create a feature branch, asking only when unpushed local commits create a real carry-forward decision
 - On default branch, all pushed, no PR → "no feature branch work" and stop
 - Feature branch, no upstream → push and continue
 - Feature branch, all pushed, no open PR → skip commit/push, generate description, open PR

--- a/docs/solutions/skill-design/git-workflow-skills-need-explicit-state-machines.md
+++ b/docs/solutions/skill-design/git-workflow-skills-need-explicit-state-machines.md
@@ -73,7 +73,7 @@ git checkout -b <branch-name>
 git branch --show-current
 ```
 
-The second `git branch --show-current` is not redundant. It converts "the skill thinks it created branch X" into "Git says the current branch is X."
+In `ce-commit-push-pr`, create that branch automatically: the user invoked a commit/push/PR workflow, and later push/PR steps require a branch-backed ref. The second `git branch --show-current` is not redundant. It converts "the skill thinks it created branch X" into "Git says the current branch is X."
 
 Apply the same pattern before default-branch safety checks:
 
@@ -121,9 +121,9 @@ This keeps PR detection tied to the current branch context instead of a bare bra
 
 If the current branch is `main`, `master`, or the resolved default branch, and the workflow is about to push or create a PR:
 
-- ask whether to create a feature branch first
-- if the user agrees, create the branch and re-read the branch name
-- if the user declines in `ce-commit-push-pr`, stop rather than trying to open a PR from the default branch
+- create a feature branch first and re-read the branch name
+- ask only when unpushed local commits create a real carry-forward decision, such as preserving them on the feature branch vs starting from the fresh remote base
+- if the safe branch transition cannot be completed in `ce-commit-push-pr`, stop rather than trying to open a PR from the default branch
 
 This prevents "push default branch, then attempt impossible PR flow" behavior.
 

--- a/skills/ce-commit-push-pr/SKILL.md
+++ b/skills/ce-commit-push-pr/SKILL.md
@@ -49,7 +49,7 @@ The remote default branch returns something like `origin/main`; strip the `origi
 
 Branch routing:
 
-- **Detached HEAD** — explain a branch is required and ask whether to create a feature branch. If yes, derive a name from the change content. If no, stop.
+- **Detached HEAD** — automatically create a feature branch from the current `HEAD` before continuing. Derive the branch name from the change content, run `git checkout -b <branch-name>`, re-read `git branch --show-current`, and use that result for the rest of the workflow. Do not ask whether to create the branch — invoking the full commit/push/PR workflow is already confirmation that the work should become branch-backed. If the derived branch name already exists, choose a non-conflicting suffix or ask only if the conflict cannot be resolved safely.
 - **On default branch with work to do** (uncommitted, unpushed, or no upstream) — automatically create a feature branch (pushing the default directly is not supported). Derive a name from the change content and continue at Step 3, which handles branch creation safely. Do not ask whether to branch — committing on the default is not an option here.
 - **On default branch with no work** — report no feature branch work and stop.
 - **Feature branch** — continue.


### PR DESCRIPTION
## Summary

Detached `HEAD` PR flows no longer stop to ask whether to create the branch that the workflow already requires. The skill now creates a feature branch from current `HEAD`, re-reads the branch Git reports, and continues with commit/push/PR using that verified branch state.

Prompts remain reserved for real branch-state choices, such as whether to carry unpushed default-branch commits forward or start from the fresh remote base. The public skill docs and state-machine note now describe the same behavior as the runtime instructions.

## Validation

- `bun run release:validate`
- `git diff --check`
- `bun test tests/frontmatter.test.ts tests/skill-conventions.test.ts`
- Attempted `skill-creator`'s `quick_validate.py`; both available Python environments lacked `PyYAML`, so the repo's frontmatter and skill-convention tests covered the practical equivalent.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
