### PR TITLE
fix(ce-commit-push-pr): preserve related work references

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The `compound-engineering` plugin currently ships 27 skills and 0 standalone age
 | [`/ce-riffrec-feedback-analysis`](docs/skills/ce-riffrec-feedback-analysis.md) | Convert Riffrec recordings or notes into structured feedback |
 | [`/ce-resolve-pr-feedback`](docs/skills/ce-resolve-pr-feedback.md) | Resolve PR review feedback |
 | [`/ce-commit`](docs/skills/ce-commit.md) | Create a git commit with a clear message |
-| [`/ce-commit-push-pr`](docs/skills/ce-commit-push-pr.md) | Commit, push, and open a PR |
+| [`/ce-commit-push-pr`](docs/skills/ce-commit-push-pr.md) | Commit, push, and open a PR with related work references preserved |
 | [`/ce-worktree`](docs/skills/ce-worktree.md) | Ensure work happens in an isolated git worktree |
 | [`/ce-promote`](docs/skills/ce-promote.md) | Draft user-facing announcement copy |
 | [`/ce-test-browser`](docs/skills/ce-test-browser.md) | Run browser tests on PR-affected pages |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -82,7 +82,7 @@ Invoked when a specific need arises — not part of any chain.
 | Skill | Description |
 |-------|-------------|
 | [`/ce-commit`](./ce-commit.md) | Create a single, well-crafted git commit — convention-aware, sensitive-file-safe, file-level logical splitting |
-| [`/ce-commit-push-pr`](./ce-commit-push-pr.md) | Go from working changes to an open PR with adaptive descriptions — three modes (full workflow / description update / description-only generation) |
+| [`/ce-commit-push-pr`](./ce-commit-push-pr.md) | Go from working changes to an open PR with adaptive descriptions, related-reference handling, and three modes (full workflow / description update / description-only generation) |
 | [`/ce-worktree`](./ce-worktree.md) | Ensure work happens in an isolated git worktree — detect existing isolation, prefer the harness's native worktree tool, fall back to plain git |
 
 ---

--- a/docs/skills/ce-commit-push-pr.md
+++ b/docs/skills/ce-commit-push-pr.md
@@ -4,7 +4,7 @@
 
 `ce-commit-push-pr` is the **shipping** skill. Three modes — full workflow, description update on existing PR, description-only generation — handle the common shapes of "I want to ship" without forcing you through unnecessary steps. PR descriptions adapt to the change's complexity (not cookie-cutter templates) and cover the **full PR commit range**, not just the working-tree diff at invocation time.
 
-The skill is opinionated about a few specific things that have burned past contributors: it never `git add -A`, it splits naturally distinct concerns into separate commits when present, and it writes PR bodies via temp files (never via stdin pipes, which can silently produce empty PR bodies while `gh` still exits 0).
+The skill is opinionated about a few specific things that have burned past contributors: it never `git add -A`, it splits naturally distinct concerns into separate commits when present, preserves related work references with correct close-vs-link intent, and writes PR bodies via temp files (never via stdin pipes, which can silently produce empty PR bodies while `gh` still exits 0).
 
 The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /ce-plan → /ce-work`. `ce-commit-push-pr` is `/ce-work`'s Phase 4 handoff target — it produces the PR with summary, testing notes, evidence (when behavior is observable), and the operational validation section. It's also commonly invoked directly when you've already written the code and want to ship.
 
@@ -28,6 +28,7 @@ Going from "code written" to "PR open" is supposed to be a one-step move, but it
 - **Cookie-cutter PR descriptions** that don't scale with complexity — a one-line bug fix and a 2,000-line refactor get the same Summary / Test Plan / Notes shape
 - **`git add -A`** sweeps in unintended files (`.env`, build artifacts, generated files)
 - **Description covers only the working-tree diff** at invocation time, missing the commits already pushed
+- **Related work gets dropped or closed accidentally** — issue, incident, performance, and logging references need the right tracker syntax, not best-effort memory
 - **Empty PR bodies via stdin pipes** — `--body-file -`, heredoc-to-stdin, or `--body "$(cat ...)"` can silently produce an empty PR body while `gh` still exits 0 and returns a URL
 - **Convention detection done wrong** — falling back to a default convention even when the repo has its own clearly-established style
 - **Branch state surprises** — committing on the default branch, creating commits on a detached HEAD, pushing to a stale base
@@ -43,6 +44,7 @@ Going from "code written" to "PR open" is supposed to be a one-step move, but it
 - **Body-file safety** — every PR description is written to a temp file and passed via `--body-file <path>`, never via stdin
 - **Convention detection** — repo conventions in context > recent commit history > conventional-commits default
 - **Full PR commit-range resolution** — descriptions cover all commits in the PR, not just the working-tree diff
+- **Related-reference preflight** — identifies work-item references and uses closing magic words only when the PR truly resolves the item
 
 ---
 
@@ -96,7 +98,11 @@ For commit messages and PR titles: repo conventions in context win first; recent
 
 When the change has observable behavior (UI rendering, CLI output, API behavior with a runnable example, generated artifacts), the skill either incorporates user-supplied evidence (URL, markdown embed, or artifact path) or summarizes the manual validation that was performed. CE no longer owns a separate demo-capture skill; use the current harness's browser/screenshot/recording flow when you want a visual artifact, then provide the result to the PR flow. Categorical no-evidence cases (docs-only, markdown-only, changelog-only, CI/config-only, test-only, or pure internal refactors) skip evidence handling.
 
-### 8. Existing-PR confirmation before rewrite
+### 8. Related-reference preflight
+
+Before composing the body, the skill scans the prompt, caller handoff, branch name, full commit messages, existing PR body, PR template, plan/debug notes, and visible URLs or IDs for related work. It classifies each candidate as closing, non-closing, or uncertain. Common cases are explicit: GitHub Issues use syntax like `Fixes #123` or `Fixes owner/repo#123` only when targeting the default branch and truly resolving the issue; Linear uses closing words like `Fixes ENG-123` and non-closing words like `Related to ENG-123` in the PR description, not a PR comment. Other trackers use documented project/tracker syntax when known; otherwise the skill links neutrally instead of inventing a close action.
+
+### 9. Existing-PR confirmation before rewrite
 
 When the skill runs on a branch with an open PR and you want the description rewritten, it previews — first two sentences of the new Summary plus the total body line count — and asks for confirmation before applying. The first two sentences carry most of the reviewer's attention. If declined, you can pass focus text back for a regenerate without applying anything.
 
@@ -139,7 +145,7 @@ Skip `ce-commit-push-pr` when:
 `ce-commit-push-pr` is the standard shipping handoff for several skills:
 
 - **`/ce-work` Phase 4** — passes plan summary, key decisions, testing notes, evidence context, operational validation, and any accepted Known Residuals
-- **`/ce-debug` Phase 4** (skill-owned branch) — defaults to commit-and-PR without prompting after a successful fix; includes auto-close syntax for the issue tracker (e.g., `Fixes #N` for GitHub, `Closes ABC-123` for Linear)
+- **`/ce-debug` Phase 4** (skill-owned branch) — defaults to commit-and-PR without prompting after a successful fix; includes closing syntax only when the PR resolves the issue, and non-closing related syntax for partial, investigative, or uncertain links
 - **`/ce-compound`** — after a learning doc is written, can commit + push to update an open PR with the new commit
 
 ---

--- a/skills/ce-commit-push-pr/SKILL.md
+++ b/skills/ce-commit-push-pr/SKILL.md
@@ -33,12 +33,12 @@ description: Commit, push, and open a PR. Use when asked to ship/open a PR, or f
 !`git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo 'DEFAULT_BRANCH_UNRESOLVED'`
 
 **Existing PR check:**
-!`gh pr view --json url,title,state 2>/dev/null || echo 'NO_OPEN_PR'`
+!`gh pr view --json url,title,body,state 2>/dev/null || echo 'NO_OPEN_PR'`
 
 ### Context fallback
 
 ```bash
-printf '=== STATUS ===\n'; git status; printf '\n=== DIFF ===\n'; git diff HEAD; printf '\n=== BRANCH ===\n'; git branch --show-current; printf '\n=== LOG ===\n'; git log --oneline -10; printf '\n=== DEFAULT_BRANCH ===\n'; git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo 'DEFAULT_BRANCH_UNRESOLVED'; printf '\n=== PR_CHECK ===\n'; gh pr view --json url,title,state 2>/dev/null || echo 'NO_OPEN_PR'
+printf '=== STATUS ===\n'; git status; printf '\n=== DIFF ===\n'; git diff HEAD; printf '\n=== BRANCH ===\n'; git branch --show-current; printf '\n=== LOG ===\n'; git log --oneline -10; printf '\n=== DEFAULT_BRANCH ===\n'; git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo 'DEFAULT_BRANCH_UNRESOLVED'; printf '\n=== PR_CHECK ===\n'; gh pr view --json url,title,body,state 2>/dev/null || echo 'NO_OPEN_PR'
 ```
 
 ---
@@ -54,7 +54,7 @@ Branch routing:
 - **On default branch with no work** — report no feature branch work and stop.
 - **Feature branch** — continue.
 
-Note the existing PR URL from the PR check if `state: OPEN`. Step 5 uses it to route between new-PR and existing-PR application.
+Note the existing PR URL and body from the PR check if `state: OPEN`. Step 5 uses the URL to route between new-PR and existing-PR application. Step 4 uses the existing body as preservation context when rewriting.
 
 ## Step 2: Determine conventions
 
@@ -85,7 +85,7 @@ If the working tree is clean and all commits are already pushed, this step is a 
 
 ## Step 4: Compose the PR title and body
 
-**You MUST read `references/pr-description-writing.md`** in full — the core principle at the top governs every step. The only input it needs from this skill is the PR ref, if one was identified by mode dispatch (description-only with a pasted URL, or description update).
+**You MUST read `references/pr-description-writing.md`** in full — the core principle at the top governs every step. The only input it needs from this skill is the PR ref, if one was identified by mode dispatch (description-only with a pasted URL, description update, or confirmed existing-PR rewrite in full workflow). If Step 1 found an existing PR, pass its URL to Step 4 when rewriting so PR mode fetches the existing body and can preserve `Related:` / `Fixes` references already present there.
 
 **Evidence decision** before composition. CE no longer owns a dedicated capture workflow; modern harnesses provide their own browser, screenshot, terminal recording, and artifact capture tools. Treat evidence as user-supplied context or as validation prose, not as a separate skill dispatch.
 

--- a/skills/ce-commit-push-pr/references/pr-description-writing.md
+++ b/skills/ce-commit-push-pr/references/pr-description-writing.md
@@ -36,6 +36,7 @@ For current-branch mode, resolve `<base>` in priority order: caller-supplied (`b
 git fetch --no-tags <base-remote> <base>
 git fetch --no-tags <base-remote> <head>   # PR mode only: <head> is headRefOid and may not be local
 git log  --oneline "<base-remote>/<base>..<head>"
+git log  --format=fuller "<base-remote>/<base>..<head>"   # full commit messages for related-reference discovery
 git diff           "<base-remote>/<base>...<head>"
 ```
 
@@ -81,9 +82,41 @@ For small + non-trivial bugfixes, the 3-5 sentence target still needs a user-vis
 
 ---
 
+## Step B1: Resolve related work references
+
+Before writing the body, make an explicit related-reference pass. Gather candidate work-item references from the user prompt, caller handoff, branch name, full commit messages, existing PR body, PR template, plan/debug notes, and visible URLs or IDs already in context. Preserve existing related references when rewriting a PR unless the user asks to remove them.
+
+Classify each candidate as:
+
+- **closing reference** — the PR fully resolves the item and the tracker's closing syntax is known.
+- **non-closing reference** — the PR is related, partial, investigative, follow-up, validation-only, or the tracker semantics are unknown.
+- **uncertain** — the change clearly came from a tracked bug, incident, performance investigation, alert, or log trace, but the exact ID/link or close-vs-link intent is missing. Ask the user for the reference or intent; in non-interactive flows, use a non-closing reference or omit rather than pretending to close it.
+
+Do not invent a closing keyword. Magic words are workflow actions, not decoration. If the candidate is ambiguous, put a neutral related reference in the related-reference sentence/block or omit it; do not scatter the ID through the summary.
+
+Do not put a non-closing reference next to close/fix/resolve/address/report wording in prose. For partial or related work, write the behavioral scope in one sentence and put the tracker ID separately. Use the table's non-closing reference labels exactly; do not substitute synonyms like `Refs`, `References`, or `Toward` unless the project's documented tracker convention requires one of those labels. For a non-closing reference, the tracker ID appears only in that related-reference sentence or block, never in the summary/opening/body prose. This avoids both accidental automation and reviewer confusion.
+
+- Bad: "closing one corruption path from #123"
+- Bad: "partial fix for #123"
+- Bad: "This addresses the retry-related corruption path reported in #123."
+- Good: "This covers the duplicate-row retry path; concurrent cancellation remains follow-up work."
+- Good: "Related: #123"
+
+Common syntax examples:
+
+| Tracker | Closing reference | Non-closing reference | Notes |
+|---|---|---|---|
+| GitHub Issues | `Fixes #123`; cross-repo: `Fixes owner/repo#123` | `Related: #123`; cross-repo: `Related: owner/repo#123` | Closing keywords are `close(s/d)`, `fix(es/ed)`, and `resolve(s/d)`. Use closing syntax only when the PR targets the default branch and truly resolves the issue; otherwise use a non-closing reference. Repeat the keyword for multiple closing issues. |
+| Linear | `Fixes ENG-123` | `Related to ENG-123` | Linear supports closing and non-closing magic words. Put magic words in the PR description, not a PR comment. Multiple issues can follow one magic word when they share the same intent, e.g. `Fixes ENG-123, DES-5 and ENG-256`. |
+| Other trackers | Use the project's documented closing keyword only when known. | Prefer a full URL or tracker ID under `Related`. | Some trackers parse commit messages, PR descriptions, or both. Follow project docs or tracker integration docs when present; otherwise never guess a closing action. |
+
+Closing references can live in the opening paragraph when the body is tiny. Non-closing references always get their own sentence or `## Related` block before validation/evidence. For one item that truly closes, a single line like `Fixes ENG-123.` can be enough; for mixed items, separate closing and non-closing bullets.
+
+---
+
 ## Step C: Assemble the body
 
-In order: opening → body sections that earn their keep → test plan if non-obvious → evidence block if one exists → Compound Engineering badge after a `---` rule.
+In order: opening → body sections that earn their keep → related references when they need their own block → test plan if non-obvious → evidence block if one exists → Compound Engineering badge after a `---` rule.
 
 The opening goes under `## Summary` if the body uses any `##` headings; bare paragraph otherwise. No orphaned opening paragraphs above the first heading.
 

--- a/tests/commit-push-pr-contract.test.ts
+++ b/tests/commit-push-pr-contract.test.ts
@@ -7,6 +7,16 @@ async function readRepoFile(relativePath: string): Promise<string> {
 }
 
 describe("ce-commit-push-pr contract", () => {
+  test("existing PR rewrites carry the old body into composition", async () => {
+    const content = await readRepoFile("skills/ce-commit-push-pr/SKILL.md")
+
+    expect(content).toContain("gh pr view --json url,title,body,state")
+    expect(content).toContain("Note the existing PR URL and body from the PR check")
+    expect(content).toContain("If Step 1 found an existing PR, pass its URL to Step 4")
+    expect(content).toContain("existing body")
+    expect(content).toMatch(/preserve.+Related.+Fixes/is)
+  })
+
   test("requires related work references to use tracker-specific closing semantics", async () => {
     const content = await readRepoFile(
       "skills/ce-commit-push-pr/references/pr-description-writing.md",

--- a/tests/commit-push-pr-contract.test.ts
+++ b/tests/commit-push-pr-contract.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return readFile(path.join(process.cwd(), relativePath), "utf8")
+}
+
+describe("ce-commit-push-pr contract", () => {
+  test("requires related work references to use tracker-specific closing semantics", async () => {
+    const content = await readRepoFile(
+      "skills/ce-commit-push-pr/references/pr-description-writing.md",
+    )
+
+    expect(content).toContain("## Step B1: Resolve related work references")
+    expect(content).toContain("closing reference")
+    expect(content).toContain("non-closing reference")
+    expect(content).toContain("Do not invent a closing keyword")
+    expect(content).toMatch(/git log\s+--format=fuller/)
+    expect(content).toContain("full commit messages")
+    expect(content).toContain("Do not put a non-closing reference next to close/fix/resolve/address/report wording")
+    expect(content).toContain("Use the table's non-closing reference labels exactly")
+    expect(content).toContain("Non-closing references always get their own sentence or `## Related` block")
+    expect(content).toContain("For a non-closing reference, the tracker ID appears only in that related-reference sentence or block, never in the summary/opening/body prose")
+    expect(content).toContain('Bad: "closing one corruption path from #123"')
+    expect(content).toContain('Bad: "This addresses the retry-related corruption path reported in #123."')
+    expect(content).toContain('Good: "This covers the duplicate-row retry path; concurrent cancellation remains follow-up work."')
+
+    expect(content).toContain("GitHub Issues")
+    expect(content).toContain("Fixes #123")
+    expect(content).toContain("Fixes owner/repo#123")
+    expect(content).toMatch(/target.+default branch/i)
+
+    expect(content).toContain("Linear")
+    expect(content).toContain("Fixes ENG-123")
+    expect(content).toContain("Related to ENG-123")
+    expect(content).toMatch(/PR description.+not.+comment/i)
+  })
+})


### PR DESCRIPTION
## Summary

`ce-commit-push-pr` now makes an explicit related-reference pass before drafting PR bodies, so work-item IDs from prompts, branch names, commit bodies, existing PRs, templates, and handoffs are preserved with the right close-vs-link intent.

The PR-description guidance now gives concrete GitHub Issues and Linear examples for closing and non-closing syntax, while leaving other trackers to documented project conventions instead of guessed magic words.

Partial work gets an extra guard: tracker IDs stay in a Related sentence or block rather than summary prose that could imply accidental closure.

## Validation

- `bun test tests/commit-push-pr-contract.test.ts`
- `bun test` (1698 pass, 0 fail)
- `bun run release:validate`
- Forward evals: closing Linear reference used `Fixes ENG-123`; existing PR rewrite preserved `Related to ENG-123`; partial GitHub issue kept `#123` only under `## Related` as `Related: #123`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
