### PR TITLE
fix(ce-plan): require post-review handoff

### DIFF
--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -14,6 +14,14 @@ argument-hint: "[optional: feature description, requirements doc path, plan path
 
 This workflow produces a durable implementation plan. It does **not** implement code, run tests, or learn from execution-time results. If the answer depends on changing code and seeing what happens, that belongs in `ce-work`, not here.
 
+## Mandatory Completion Contract
+
+Every normal interactive `ce-plan` branch that produces a plan artifact or checkpoint is incomplete until its owning handoff question is presented. For software implementation-plan runs that continue past Phase 0.1b, that boundary is Phase 5.4's post-generation handoff menu. Non-software plan-seeking and approach-altitude branches use the terminal handoff in the reference workflow they route to; do not force those branches through Phase 5.4 after they have been told to skip subsequent phases. Answer-seeking is the exception: it may end after delivering the answer unless the universal-planning reference says to offer save/share.
+
+For software implementation-plan runs, writing the plan file, running the confidence check, and running or skipping `ce-doc-review` are intermediate milestones, not completion. This remains true when the user's prompt says only "create a plan", "write the doc", "run `ce-doc-review`", or similar. The only exception is pipeline mode (LFG or any `disable-model-invocation` context), where the caller owns the next step after the plan file, confidence check, and headless document review are complete.
+
+Before any response that could end a software implementation-plan run, verify that the plan path is known, the headless review state or documented skip state is summarized, and the user has been asked: "Plan ready at `<absolute path to plan>`. What would you like to do next?" If the menu fits the platform's blocking-question tool, ask it there; otherwise render the numbered handoff options in chat and wait. If the user selects an action, execute the Phase 5.4 routing for that selection before treating the skill as complete.
+
 ## Interaction Method
 
 When asking the user a question, use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
@@ -779,6 +787,18 @@ After document review and final checks, print a one-line summary of the headless
 
 If the user types free-form prompts targeting the findings (e.g., "review", "walk through", "deep review"), route as if they picked `Decide on the review's open items` — fire the skill rather than looping back to the menu. For other free-text revisions, accept the input and loop back to this menu after applying the revision.
 
+**Final pre-response checklist:** Before sending any response that could end `ce-plan`, verify:
+- Plan file exists on disk
+- Confidence check ran or was intentionally skipped by the interactive re-deepen no-accepted-findings path
+- `ce-doc-review` ran in headless mode, or the documented HTML format gate / interactive re-deepen no-accepted-findings path skipped it
+- Headless review state or documented skip state was summarized above the menu
+- Phase 5.4 menu was presented for software implementation-plan runs, even if the user only asked to create the plan or run doc review
+- If the user selected an action, the selected routing was executed
+
 **Completion check:** This skill is not complete until the post-generation menu above has been presented, the user has selected an action, and the inline routing for that selection has been executed. Presenting the menu and stopping at the user's selection is not completion — fire the routed action.
+
+Incorrect final response: "Created the plan and ran doc review."
+
+Correct terminal handoff: "Created the plan and ran doc review. Plan ready at `<absolute path to plan>`. What would you like to do next?" followed by the numbered handoff options or the platform's blocking question.
 
 **Pipeline mode exception:** In LFG or any `disable-model-invocation` context, skip the interactive menu and return control to the caller after the plan file is written, confidence check has run, and `ce-doc-review` has run in headless mode (per `references/plan-handoff.md`). Pipeline mode forces `OUTPUT_FORMAT=md` at Phase 0.0, so the 5.3.8 format gate never selects the HTML skip path in pipeline runs.

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -792,7 +792,7 @@ If the user types free-form prompts targeting the findings (e.g., "review", "wal
 - Confidence check ran or was intentionally skipped by the interactive re-deepen no-accepted-findings path
 - `ce-doc-review` ran in headless mode, or the documented HTML format gate / interactive re-deepen no-accepted-findings path skipped it
 - Headless review state or documented skip state was summarized above the menu
-- Phase 5.4 menu was presented for software implementation-plan runs, even if the user only asked to create the plan or run doc review
+- Phase 5.4 menu was presented for software implementation-plan runs, even if the user only asked to create the plan or run doc review, unless pipeline mode returned control to the caller
 - If the user selected an action, the selected routing was executed
 
 **Completion check:** This skill is not complete until the post-generation menu above has been presented, the user has selected an action, and the inline routing for that selection has been executed. Presenting the menu and stopping at the user's selection is not completion — fire the routed action.

--- a/tests/skills/ce-plan-handoff-routing.test.ts
+++ b/tests/skills/ce-plan-handoff-routing.test.ts
@@ -233,7 +233,7 @@ describe("ce-plan post-generation menu routing", () => {
     for (const expected of [
       "Plan file exists on disk",
       "Headless review state or documented skip state was summarized above the menu",
-      "Phase 5.4 menu was presented for software implementation-plan runs",
+      "Phase 5.4 menu was presented for software implementation-plan runs, even if the user only asked to create the plan or run doc review, unless pipeline mode returned control to the caller",
       "If the user selected an action, the selected routing was executed",
       'Incorrect final response: "Created the plan and ran doc review."',
       'Correct terminal handoff: "Created the plan and ran doc review. Plan ready at `<absolute path to plan>`. What would you like to do next?"',

--- a/tests/skills/ce-plan-handoff-routing.test.ts
+++ b/tests/skills/ce-plan-handoff-routing.test.ts
@@ -164,6 +164,87 @@ describe("ce-plan post-generation menu routing", () => {
     }
   })
 
+  test("completion contract is visible before the workflow and guarded at the end", () => {
+    const contractStart = SKILL_BODY.indexOf("## Mandatory Completion Contract")
+    const interactionStart = SKILL_BODY.indexOf("## Interaction Method")
+    expect(
+      contractStart,
+      "ce-plan SKILL.md must keep the Mandatory Completion Contract near the top so agents see the handoff boundary before entering the workflow.",
+    ).toBeGreaterThan(-1)
+    expect(
+      interactionStart,
+      "ce-plan SKILL.md no longer contains the Interaction Method heading — update this test anchor if the top section was restructured.",
+    ).toBeGreaterThan(-1)
+    expect(
+      contractStart,
+      "Mandatory Completion Contract must appear before Interaction Method, not only after Phase 5.4, so 'create the plan and stop' does not look like completion.",
+    ).toBeLessThan(interactionStart)
+
+    const topContract = SKILL_BODY.slice(contractStart, interactionStart)
+    expect(
+      /Every normal interactive `ce-plan` branch that produces a plan artifact or checkpoint is incomplete until its owning handoff question is presented/i.test(topContract),
+      "Top completion contract must state that artifact/checkpoint branches are incomplete until their owning handoff question is presented.",
+    ).toBe(true)
+    expect(
+      /software implementation-plan runs[\s\S]{0,120}Phase 5\.4[\s\S]{0,120}handoff menu/i.test(topContract),
+      "Top completion contract must state that software implementation-plan runs are incomplete until the Phase 5.4 handoff menu is presented.",
+    ).toBe(true)
+    expect(
+      /Non-software plan-seeking and approach-altitude branches[\s\S]{0,160}do not force those branches through Phase 5\.4/i.test(topContract),
+      "Top completion contract must preserve branch-owned handoffs for non-software plan-seeking and approach-altitude branches.",
+    ).toBe(true)
+    expect(
+      /Answer-seeking is the exception:[\s\S]{0,140}may end after delivering the answer unless[\s\S]{0,100}offer save\/share/i.test(topContract),
+      "Top completion contract must allow answer-seeking to end after the answer unless universal-planning says to offer save/share.",
+    ).toBe(true)
+    expect(
+      /intermediate milestones, not completion/i.test(topContract),
+      "Top completion contract must say writing/reviewing the plan are intermediate milestones, not completion.",
+    ).toBe(true)
+    expect(
+      /only ["“]create a plan["”][\s\S]{0,160}run [`']?ce-doc-review[`']?/i.test(topContract),
+      "Top completion contract must make 'user only asked to create a plan / run ce-doc-review' non-exempt.",
+    ).toBe(true)
+    expect(
+      /Plan ready at `<absolute path to plan>`\. What would you like to do next\?/i.test(topContract),
+      "Top completion contract must include the literal Phase 5.4 handoff question.",
+    ).toBe(true)
+    expect(
+      /headless review state or documented skip state is summarized/i.test(topContract),
+      "Top completion contract must allow documented skip-state summaries, not only headless review summaries.",
+    ).toBe(true)
+
+    const checklistStart = SKILL_BODY.indexOf("**Final pre-response checklist:**")
+    const completionStart = SKILL_BODY.indexOf("**Completion check:**")
+    expect(
+      checklistStart,
+      "ce-plan SKILL.md must include a final pre-response checklist before the completion check.",
+    ).toBeGreaterThan(-1)
+    expect(
+      completionStart,
+      "ce-plan SKILL.md must keep the existing Completion check anchor.",
+    ).toBeGreaterThan(-1)
+    expect(
+      checklistStart,
+      "Final pre-response checklist should appear immediately before the terminal completion check.",
+    ).toBeLessThan(completionStart)
+
+    const finalGuard = SKILL_BODY.slice(checklistStart, SKILL_BODY.indexOf("**Pipeline mode exception:**"))
+    for (const expected of [
+      "Plan file exists on disk",
+      "Headless review state or documented skip state was summarized above the menu",
+      "Phase 5.4 menu was presented for software implementation-plan runs",
+      "If the user selected an action, the selected routing was executed",
+      'Incorrect final response: "Created the plan and ran doc review."',
+      'Correct terminal handoff: "Created the plan and ran doc review. Plan ready at `<absolute path to plan>`. What would you like to do next?"',
+    ]) {
+      expect(
+        finalGuard.includes(expected),
+        `Final completion guard is missing expected text: ${expected}`,
+      ).toBe(true)
+    }
+  })
+
   test("inline-routing regex rejects empty-action bullets even when followed by another bullet", () => {
     // Regression guard for Codex P2 finding on PR #715: the previous
     // `\s*(?:...)\s*` shape allowed newline consumption, so a bullet with no


### PR DESCRIPTION
## Summary

`ce-plan` now treats plan creation and headless document review as intermediate milestones, so software implementation-plan runs still finish by asking which handoff to take. The completion contract is scoped to artifact/checkpoint branches, preserving universal planning, approach-altitude, and answer-seeking behavior instead of forcing every branch through the software Phase 5.4 menu.

The regression guard now checks the original post-review shortcut, the `only create the plan` pressure case, documented review-skip states, and the branch exceptions that should not render the software handoff.

## Validation

- `bun test tests/skills/ce-plan-handoff-routing.test.ts`
- `bun run release:validate`
- `bun test`
- Dry-run fresh-agent transcript evals for: original post-review handoff failure, `only create` pressure, universal planning, approach-altitude, interactive re-deepen with all findings rejected, HTML review skip, and pure answer-seeking. The answer-seeking eval exposed an over-broad contract in the first draft; this PR includes the narrowed contract and regression assertion.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
