### PR TITLE
fix(cli): expand "~/" home shorthand on Windows

### DIFF
--- a/src/utils/resolve-home.ts
+++ b/src/utils/resolve-home.ts
@@ -3,7 +3,11 @@ import path from "path"
 
 export function expandHome(value: string): string {
   if (value === "~") return os.homedir()
-  if (value.startsWith(`~${path.sep}`)) {
+  // Accept the portable "~/" shorthand on every OS in addition to the native
+  // separator. On Windows `path.sep` is "\\", so a bare `~${path.sep}` check
+  // left "~/x" (the spelling users and config files commonly write) unexpanded
+  // and the CLI then treated a literal "~" as a real directory.
+  if (value.startsWith("~/") || value.startsWith(`~${path.sep}`)) {
     return path.join(os.homedir(), value.slice(2))
   }
   return value

--- a/tests/resolve-home.test.ts
+++ b/tests/resolve-home.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import path from "path"
+import { expandHome } from "../src/utils/resolve-home"
+
+describe("expandHome", () => {
+  test("expands a bare tilde to the home directory", () => {
+    expect(expandHome("~")).toBe(os.homedir())
+  })
+
+  // "~/x" is the portable home shorthand users and config files write on
+  // every OS. It must expand regardless of the platform separator. Pre-fix,
+  // expandHome only matched `~${path.sep}`, so on Windows (path.sep === "\\")
+  // "~/x" was returned literally and the CLI treated a bogus "~" as a real
+  // directory. This invariant holds on POSIX and Windows alike with the fix;
+  // without it, it fails on Windows.
+  test("expands the forward-slash home shorthand on every platform", () => {
+    expect(expandHome("~/.codex")).toBe(path.join(os.homedir(), ".codex"))
+    expect(expandHome("~/sub/dir")).toBe(path.join(os.homedir(), "sub", "dir"))
+  })
+
+  test("expands the native path-separator form", () => {
+    expect(expandHome(`~${path.sep}config`)).toBe(path.join(os.homedir(), "config"))
+  })
+
+  test("leaves ~name, relative, and absolute values untouched", () => {
+    expect(expandHome("~foo")).toBe("~foo")
+    expect(expandHome("relative/path")).toBe("relative/path")
+    const abs = path.join(os.homedir(), "abs")
+    expect(expandHome(abs)).toBe(abs)
+  })
+})


### PR DESCRIPTION
## Problem

On Windows, the `~/` home shorthand is not expanded, so the CLI treats a literal `~` as a real path segment.

`expandHome()` in `src/utils/resolve-home.ts` only matched `` `~${path.sep}` ``. On Windows `path.sep` is `\`, so that check is `~\`. The portable `~/` spelling, the one users and config files write across platforms, falls through unmatched and is returned verbatim.

Because `expandHome` backs `resolveTargetHome` / `resolveCodexHome`, the unexpanded value reaches `convert`, `install`, and `cleanup` through `--output`, `--codex-home`, `--pi-home`, `CODEX_HOME`, and `OPENCODE_CONFIG_DIR`. The result is a bogus `~` directory created in the working tree instead of a path under the user's home.

This is Linux/macOS-invisible: there `path.sep` is `/`, so `~/` already matches. CI runs on `ubuntu-latest` only, which is why it was not caught.

## Root cause / evidence

Reproduced with the real function on Windows (`path.sep === "\\"`, `os.homedir() === C:\Users\lukej`):

```
expandHome("~")         -> "C:\Users\lukej"          (ok)
expandHome("~/.codex")  -> "~/.codex"                (BUG: unexpanded)
expandHome("~\.codex")  -> "C:\Users\lukej\.codex"   (native separator already worked)
```

## Fix

Match `~/` in addition to the native separator:

```ts
if (value.startsWith("~/") || value.startsWith(`~${path.sep}`)) {
  return path.join(os.homedir(), value.slice(2))
}
```

Surgical by design: POSIX behaviour is unchanged. On POSIX `~\foo` still passes through untouched (backslash is a legal filename character there); only Windows `~/x` handling changes.

## Tests

Adds `tests/resolve-home.test.ts`:

- `~/.codex` and `~/sub/dir` expand to a home-joined path on every platform (the regression guard: red on Windows before this change, green after).
- the native-separator form and bare `~` still expand.
- `~foo`, relative, and absolute paths pass through unchanged.

Verification on Windows:

- The forward-slash test fails on the pre-fix code (`Expected "C:\Users\lukej\.codex"`, `Received "~/.codex"`) and passes after the fix (4/4).
- Full-suite baseline diff (clean `main` vs this branch, per-test timings stripped): 168 pre-existing Windows failures on both sides, **zero added, zero removed**. The new suite adds four passing tests.

## Related

Same cross-platform path class as prior Windows fixes in this area: #398 (sanitize colons in skill/agent names for Windows), #226 (Windows NTFS colons), and issues #366 / #48 / #49 (colon-in-path ENOENT on Windows). Windows is a supported target with a history of exactly these Unix-invisible path bugs.
