### PR TITLE
feat(ce-explain): add personal learning explainer skill with check-in loop

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -52,6 +52,12 @@ A documented solution to a past problem — a bug fix, a convention, or a workfl
 ### Pattern doc
 Guidance generalized from several Learnings into a broader rule. Higher-leverage than any single incident-level Learning, and higher-risk when stale, because future work treats it as broadly applicable.
 
+### Explainer
+A dense, visual teaching artifact written for the developer personally — explaining a concept, a change, an idea, or a window of their own recent work — so the human keeps learning when agents do the writing. The complement of a Learning: a Learning teaches the repo's future work; an explainer teaches the human.
+
+### Check-in
+The active-recall step that can follow an explainer in the same session: the developer predicts or answers first and the explanation confirms or corrects — predict-then-reveal for changes, checked exercises for concepts. Skippable when the material does not warrant retention work.
+
 ## Skill orchestration
 
 ### Model tier

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ These sit around the loop or get reached for on demand -- not every cycle needs 
 | [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
 | [`/ce-debug`](docs/skills/ce-debug.md) | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace root cause, fix, then polish/review before PR handoff when warranted |
 | [`/ce-pov`](docs/skills/ce-pov.md) | *On demand, before you commit* -- a decisive, project-grounded verdict on whether to adopt, switch to, or revisit an external technology, library, pattern, or platform; works cold or mid-session, and proposes the next step (`/ce-plan`, `/ce-brainstorm`, or a spike) from the verdict |
+| [`/ce-explain`](docs/skills/ce-explain.md) | *On demand, to keep learning* -- turns a concept, a diff, an idea, or "what did I do this week?" into a dense, visual explainer written for you personally, with an optional check-in (predict-then-reveal for diffs, corrected exercises) that makes it stick |
 
 For the full catalog and how each skill chains together, see [docs/skills](docs/skills/README.md). The complete inventory is [below](#full-skill-inventory).
 
@@ -107,7 +108,7 @@ The first pass tightens recent branch changes before review. The targeted pass i
 
 After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
 
-The `compound-engineering` plugin currently ships 27 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+The `compound-engineering` plugin currently ships 28 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
 
 ### Full Skill Inventory
 
@@ -116,6 +117,7 @@ The `compound-engineering` plugin currently ships 27 skills and 0 standalone age
 | [`/ce-strategy`](docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` |
 | [`/ce-ideate`](docs/skills/ce-ideate.md) | Generate and critically evaluate grounded ideas |
 | [`/ce-pov`](docs/skills/ce-pov.md) | Form a decisive, project-grounded verdict on an external input |
+| [`/ce-explain`](docs/skills/ce-explain.md) | Explain a concept, diff, idea, or window of your own work as a personal learning artifact |
 | [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Explore requirements and write a right-sized requirements doc |
 | [`/ce-plan`](docs/skills/ce-plan.md) | Create structured implementation plans |
 | [`/ce-work`](docs/skills/ce-work.md) | Execute implementation plans systematically |

--- a/docs/plans/2026-07-02-002-feat-ce-explain-skill-plan.md
+++ b/docs/plans/2026-07-02-002-feat-ce-explain-skill-plan.md
@@ -268,10 +268,10 @@ The tree is a scope declaration; per-unit Files lists are authoritative.
 - **Requirements:** R12.
 - **Dependencies:** U1 (final description text).
 - **Files:** `README.md`, `docs/skills/README.md`, `docs/skills/ce-explain.md`, `tests/release-metadata.test.ts`.
-- **Approach:** README inventory row linking `docs/skills/ce-explain.md`; bump the "ships 28 skills" sentence to 29; judgment call — also add to the curated "Additional skills" table (it fits the on-demand anchor shape alongside `/ce-pov`). Catalog row under **On-Demand** in `docs/skills/README.md`. Docs page follows `docs/skills/ce-pov.md`'s heading shape (TL;DR, Problem, Solution, Novel mechanics, Quick example, When to reach for it, Reference, See Also). Bump `skills: 28` → `29` at `tests/release-metadata.test.ts:150` (the count is derived from disk; the assertion is the only hand edit). No manifest edits — skills auto-discover. No legacy-cleanup entries (additions don't need them).
+- **Approach:** README inventory row linking `docs/skills/ce-explain.md`; bump the "ships 27 skills" sentence to 28; judgment call — also add to the curated "Additional skills" table (it fits the on-demand anchor shape alongside `/ce-pov`). Catalog row under **On-Demand** in `docs/skills/README.md`. Docs page follows `docs/skills/ce-pov.md`'s heading shape (TL;DR, Problem, Solution, Novel mechanics, Quick example, When to reach for it, Reference, See Also). Bump `skills: 27` → `28` at `tests/release-metadata.test.ts:150` (the count is derived from disk; the assertion is the only hand edit; the unmerged ce-sweep branch bumps the same lines, so whichever merges second resolves the trivial conflict to 29). No manifest edits — skills auto-discover. No legacy-cleanup entries (additions don't need them).
 - **Patterns to follow:** `docs/skills/ce-pov.md`; row formats at `README.md:118` and the On-Demand rows in `docs/skills/README.md`.
 - **Test scenarios:**
-  - `bun test` release-metadata suite green at 29.
+  - `bun test` release-metadata suite green at 28.
   - `bun run release:validate` passes.
 - **Verification:** Both commands green; README count sentence, inventory row, catalog row, and docs page all present and consistent.
 
@@ -307,7 +307,7 @@ Behavioral changes to skill prose are never validated by re-invoking the skill i
 - All six units complete; `bun test` and `bun run release:validate` green.
 - The six U6 evals pass, or carry documented downgrade decisions (the ce-polish handoff is the known candidate).
 - The leak test (R13) passes structurally: prediction turn ends before any interpretive content in the transcript.
-- Registration surfaces are mutually consistent: README count sentence says 29, inventory row, On-Demand catalog row, and `docs/skills/ce-explain.md` all exist and agree with the SKILL.md description.
+- Registration surfaces are mutually consistent: README count sentence says 28, inventory row, On-Demand catalog row, and `docs/skills/ce-explain.md` all exist and agree with the SKILL.md description.
 - The skill description is within the 100–300 character budget.
 - No abandoned experiments or dead reference files remain in the diff.
 

--- a/docs/plans/2026-07-02-002-feat-ce-explain-skill-plan.md
+++ b/docs/plans/2026-07-02-002-feat-ce-explain-skill-plan.md
@@ -1,0 +1,324 @@
+---
+title: ce-explain Skill - Plan
+type: feat
+date: 2026-07-02
+topic: ce-explain-skill
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# ce-explain Skill - Plan
+
+## Goal Capsule
+
+- **Objective:** Ship a new `ce-explain` skill that turns a concept, diff, idea, or window of the user's own work into a dense, visual, personal learning artifact, with an optional in-session check-in that makes the material stick.
+- **Product authority:** The Product Contract below. Product behavior, scope boundaries, and success signals were resolved in brainstorm dialogue; planning amendments are recorded in the Planning Contract's preservation note.
+- **Execution profile:** Skill-prose work — markdown authoring under `skills/ce-explain/` plus registration touchpoints. Behavioral validation runs through `skill-creator` evals, not `bun test` alone.
+- **Stop conditions:** Surface rather than guess if an eval shows the ce-polish handoff cannot receive seed observations (downgrade decision), or if any amendment below turns out to contradict a product decision rather than fill a gap.
+- **Open blockers:** None. Remaining open questions are deferred to implementation and non-blocking.
+
+---
+
+## Product Contract
+
+### Summary
+
+A new `ce-explain` skill: point it at a concept (repo-grounded or external), a diff, an idea, or a window of recent work, and it produces a dense, visual explainer written for the user personally.
+When the material warrants retention, the session continues with a check-in — predict-then-reveal for diffs, exercises answered in chat and corrected.
+At the end, the skill asks where to publish the artifact, offering only destinations it detects.
+
+### Problem Frame
+
+Agent-driven development removed the learning that writing code by hand used to provide.
+The user ships work through agents, rarely reads the code, and no longer accumulates the understanding that typing it themselves once forced.
+The cost shows up twice: comprehension debt on their own projects — the concern in Geoffrey Litt's thread on why understanding agent-written code still matters — and recall gaps when a meeting requires speaking to what happened recently.
+Existing plugin skills capture knowledge for the repo (`ce-compound`) or judge options (`ce-pov`); none teaches the human.
+
+### Key Decisions
+
+- **A lesson, not just a doc.** The chosen shape is an explainer plus an active check-in loop, over both a read-only artifact (reading alone doesn't stick) and a full learning library (deferred until real use shows the artifacts get re-read).
+- **Always written for the user.** One voice: dense and technical, no audience adaptation. Meeting prep preps the user; it never produces the deck.
+- **HTML-first, markdown fallback.** Show-n-tell — sketches, diagrams, annotated snippets — degrades badly in plain markdown, so HTML is the default and reuses the plugin's generic self-contained artifact invariants.
+- **Check-in lives in the session; the artifact stays display-only.** The doing happens in chat where the skill can correct answers; the artifact carries no interactive widgets.
+- **Idea mode treats the idea as a fixed given.** It explains the idea's implications, mechanics, and trade-offs for the user's understanding — it never scopes the idea (`ce-brainstorm`'s job) or generates and ranks alternatives (`ce-ideate`'s job).
+- **Catalog-only integration.** No inbound menu edits in other skills for v1. The inspiration wiring runs outbound only: ce-explain's closing routes surfaced opportunities by type — new-capability ideas to `ce-ideate`, UI/UX polish to `ce-polish`, code-clarity findings to `ce-simplify-code`.
+- **Destination is asked, not fixed.** The end-of-run ask offers only detected destinations; detection is by capability, never by assuming a specific CLI or tool exists. Bare `/ce-explain` with no input asks one blocking question: what to explain.
+
+### Requirements
+
+**Intake and modes**
+
+- R1. One skill accepts four input shapes: a concept, a diff or change, an idea, and a window of recent work ("what happened / what did I do").
+- R2. Concepts may be fully external with no repo footprint (e.g., interview prep on a language topic); repo grounding applies when the topic touches the repo and is skipped when it does not. When external research is unavailable, the skill may explain from model knowledge but must label that content as unverified in the artifact.
+- R3. Work-recap mode draws from git activity and project docs (plans, brainstorms, solutions) over the requested window.
+
+**Explainer artifact**
+
+- R4. The explainer is dense and personal — written for the user, with no audience adaptation.
+- R5. Show-n-tell by default: diagrams, sketches, annotated code snippets — whichever fits the material, chosen per topic.
+- R6. HTML is the default output format, following the plugin's generic self-contained artifact invariants (single file, inline CSS/SVG, metadata visible as text); markdown is available as a fallback.
+- R7. When the explanation surfaces improvement opportunities, the closing routes them by type: new-capability ideas seed `ce-ideate`, UI/UX polish opportunities seed `ce-polish`, code-clarity findings seed `ce-simplify-code`.
+
+**Check-in (active learning)**
+
+- R8. When the material warrants retention, the session continues after the artifact with a check-in: for diffs, predict-then-reveal (the user states what they think the change does before the explanation confirms or corrects); for concepts, ideas, and non-routine recaps, exercises answered in chat that the skill checks and corrects.
+- R9. The check-in is skippable: the skill judges when material doesn't need one (e.g., a routine recap), and the user can always decline.
+- R10. The artifact stays display-only — no embedded quizzes, forms, or widgets.
+- R13. In diff mode with the check-in accepted, no interpretive content — explanation, annotation, diagram, or surfaced opportunity — is shown before the user's prediction turn ends; only the raw change reference may be shown pre-prediction. When no blocking-question tool exists, the skill stops and waits for a chat reply; it never prints the reveal in the same message as the prediction prompt.
+
+**Publish and destination**
+
+- R11. At the end of a run the skill asks where to put the artifact, offering only detected destinations: an artifact-publishing surface when the harness exposes one, a local file (always offered), and external destinations detected by capability (e.g., Proof, Thinkroom).
+- R12. Ships as a standard plugin skill: registered in the README inventory, the docs/skills catalog and page, and the release-metadata skill count.
+- R14. When no interaction is possible at the destination ask, the skill degrades to the local artifact it already wrote and reports that path — it never hangs and never discards the artifact.
+
+### Key Flows
+
+```mermaid
+flowchart TB
+  A[ce-explain input] --> B{Classify: explicit token wins, else infer; resolvable change wins ties}
+  B -->|diff, check-in accepted| P[Show raw change only, take prediction, end turn]
+  P --> R[Reveal explainer, name prediction gaps]
+  B -->|diff, check-in declined| E[Explainer artifact to run dir]
+  B -->|concept or idea| G{Repo footprint?}
+  B -->|recap window| W[Gather git and docs evidence]
+  G -->|yes| GR[Ground in repo]
+  G -->|no| GX[External research, or model memory labeled unverified]
+  GR --> E
+  GX --> E
+  W --> E
+  R --> Q{Exercises warranted?}
+  E --> Q
+  Q -->|yes| X[Exercises answered in chat and corrected]
+  Q -->|no| D[Destination ask over detected options]
+  X --> D
+  D --> F[Copy from run dir to chosen destination, or report the run path]
+```
+
+- F1. **Concept or idea lesson.**
+  - **Trigger:** `/ce-explain <topic or idea>` where the input classifies as a concept or idea.
+  - **Steps:** Ground in the repo when the topic touches it, otherwise research externally (labeling model-memory fallback per R2); produce the explainer into the run directory; offer the check-in when the material warrants; check exercise answers in chat and fill the gaps they expose; ask the destination.
+  - **Outcome:** The user can restate the concept or the idea's implications and knows what their answers got wrong.
+  - **Covers:** R1, R2, R5, R8, R9, R11.
+- F2. **Diff comprehension with predict-then-reveal.**
+  - **Trigger:** `/ce-explain` with a resolvable change reference.
+  - **Steps:** Gather evidence from git and project docs; offer the check-in; when accepted, show only the raw change, take the user's prediction, and end the turn (R13); then produce the reveal explainer naming the gaps between prediction and reality; ask the destination.
+  - **Outcome:** The user can say what changed and why without opening the code.
+  - **Covers:** R1, R3, R8, R13, R11.
+- F3. **Work recap.**
+  - **Trigger:** `/ce-explain` with a recap request or `since:` window.
+  - **Steps:** Gather git and docs evidence over the window; produce the recap explainer; skip the check-in for routine recaps (AE1), offer recall exercises for dense windows; ask the destination.
+  - **Outcome:** The user can speak to what happened without opening the repo.
+  - **Covers:** R1, R3, R8, R9, R11.
+
+### Acceptance Examples
+
+- AE1. **Covers R9.** Given a routine work-recap before a meeting, when the skill judges no retention work is needed, then it produces the explainer and goes straight to the destination ask without offering a check-in.
+- AE2. **Covers R8, R13.** Given a diff input with the check-in accepted, when the user's prediction of the change's purpose is wrong, then the reveal names the gap between the prediction and what the change actually does — and no interpretive content appeared before the prediction turn ended.
+- AE3. **Covers R2.** Given an external topic with no footprint in the current repo, when the skill grounds the explainer, then it uses external knowledge without forcing repo grounding into the output.
+- AE4. **Covers R11, R14.** Given a harness with no artifact surface and no detected external destinations, when the run ends, then the skill offers only a local file save and reports the written path.
+- AE5. **Covers Key Decisions (idea mode).** Given an idea as input, when the explainer is produced, then it explains implications and trade-offs of the idea as given — it does not restate the idea as options, rank alternatives, or open a scoping dialogue.
+- AE6. **Covers R3.** Given a recap window with no git activity and no doc changes, when evidence gathering returns empty, then the skill says so, offers to widen the window, and writes no artifact.
+- AE7. **Covers R11, R14.** Given the user declines every offered destination, when the run ends, then the skill reports the run-directory path where the artifact already exists and confirms nothing else was written.
+
+### Success Criteria
+
+- The user reports understanding work they didn't hand-write — learning comparable to the old write-it-yourself days.
+- A meeting-prep recap is absorbable in minutes and lets the user speak to what happened without opening the repo.
+- Artifact form visibly adapts to material: a diff lesson, a concept lesson, and a recap read differently.
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- A durable indexed learning library or journal with cross-links between explainers. The stable run-directory layout (KTD4) is the hook it will build on.
+- Spaced repetition, retention tracking, or any stored progress state.
+- Inbound suggestions from other skills' wrap-up menus (lfg/ce-work, ce-compound, ce-code-review) — revisit after real usage shows where the skill gets reached for.
+- A `mode:agent` headless mode mirroring `ce-code-review`'s contract (skip check-in and destination ask, return `{status, artifact_path, summary}` JSON). Reserved, not implemented — activate when a real pipeline caller appears (a scheduled morning-recap loop is the obvious candidate).
+- Session transcripts as recap-mode evidence. Git + docs is the portable v1 evidence base; transcripts are harness-specific.
+
+**Outside this feature's identity**
+
+- Audience-facing output: decks, presentations, or docs written for others.
+- Interactive artifacts with embedded quizzes or widgets.
+- Repo knowledge capture — that remains `ce-compound`'s job; ce-explain teaches the human, not the repo.
+- A headless check-in. The check-in exists to exercise the human; automating the answers deletes the product.
+
+### Dependencies and Assumptions
+
+- Reuses the plugin's generic HTML artifact invariants (single self-contained file, inline CSS/SVG, visible metadata): `skills/ce-brainstorm/references/html-rendering.md` is the source to trim from, not to copy whole — its plan-navigation structure does not apply.
+- Reusable intake and grounding patterns exist: `ce-code-review`'s token-table intake, the shared repo-profile cache consumer pattern guarded by `tests/repo-profile-cache-parity.test.ts`, and `ce-setup`'s probe-and-degrade capability detection.
+- Assumption: success is qualitative and self-reported; v1 carries no metrics or instrumentation.
+- Assumption: external destinations vary by machine; absence of a destination is a normal state, not an error. Thinkroom has no prior integration in this plugin — detection is a capability probe, and its absence hides the option silently.
+- Assumption (planning): the recap window defaults to the last 7 days of the current repo when unspecified; the implementer may tune the default from eval feedback.
+- Assumption (planning): `ce-polish` is user-invoked only (`disable-model-invocation: true`) and has no observation intake (its argument is a PR/branch), so the R7 polish handoff presents observations in chat for a user-run `/ce-polish`, relying on in-session context to carry them. U6's eval verifies the carryover; if observations demonstrably don't influence ce-polish, downgrade that half of R7 to a mention rather than editing ce-polish.
+
+---
+
+## Planning Contract
+
+**Product Contract preservation:** changed — Key Flows mermaid corrected (the original showed the artifact rendering before the prediction, contradicting F2 and spoiling predict-then-reveal); R7 gained `ce-simplify-code` and type-based routing; R8 extended to name the exercise mechanic for ideas and non-routine recaps; R13, R14, AE5–AE7 added; idea mode pinned in Key Decisions. All are gap-fills from planning research aligned with the brainstormed intent — no scope reversals. The four "Deferred to Planning" questions from the requirements-only artifact are resolved into KTDs below and removed.
+
+### Key Technical Decisions
+
+- KTD1. **Structural template is `ce-pov`, not the multi-phase dialogue skills.** ce-explain shares its shape: single-shot artifact, optional deeper loop, tier-gated closing. Mirror the topical `references/` layout (`intake.md`, `check-in.md`, rendering references, `references/agents/*.md`) and ce-pov's inline three-tier model note with degradation rule.
+- KTD2. **Intake is a token table with inference fallback, parsed harness-neutrally.** Explicit tokens (`diff:<ref-or-range>`, `since:<window|date|ref>`, `output:<md|html>`) beat inference; free text classifies as concept/idea/recap by shape; an input matching both a concept and a resolvable change resolves to diff mode. Phrase parsing as "reason over the user's prompt" — never rely on `$ARGUMENTS` substitution in body prose (Claude-only; see the arguments-token learning). Conflicting tokens error; unknown tokens pass through as topic text.
+- KTD3. **Predict-then-reveal is enforced by turn structure.** The prediction is elicited with the platform's blocking-question tool (with the standard numbered-chat stop-and-wait fallback) and the turn ends; the explainer is composed only after the prediction lands. This makes R13 structural rather than behavioral discipline.
+- KTD4. **The artifact is written to a stable run directory before the destination ask.** `/tmp/compound-engineering/ce-explain/<run-id>/` (the repo's documented cross-invocation scratch convention). The destination ask copies out of the run dir; declining everything leaves the artifact there, reported (AE7). The run dir plus the artifact's visible metadata (topic, date, input shape) is the hook the deferred library layers onto without rework.
+- KTD5. **Destination detection probes the agent's own toolset, with a local-file floor.** An artifact-publishing tool present in the current session's tools enables the artifact-surface option; Proof is offered for markdown output unconditionally and degrades gracefully on failure (the ce-proof pattern); Thinkroom is offered only when a Thinkroom skill/CLI capability is detectable. Never shell-only binary checks as proof of absence; never a closed list. Per-option routing for the destination menu is **inlined in SKILL.md** (post-menu-routing learning); only elaborate per-destination sub-flows live in `references/destinations.md`. The artifact-surface sub-flow re-emits the explainer as body-only markup — no doctype/html/head/body of its own, all styles inline, no external font links — because artifact surfaces wrap published content in their own document skeleton and enforce a CSP that blocks external hosts; the run-dir file remains the complete standalone document for the local-file and open-in-browser paths.
+- KTD6. **ce-explain becomes a full repo-profile cache consumer.** Byte-identical copies of the three cache assets, registered in `CONSUMER_SKILLS` in `tests/repo-profile-cache-parity.test.ts`. The cached profile grounds repo-touching modes only; external topics skip grounding entirely; the cache is never a correctness dependency.
+- KTD7. **New trimmed rendering references, not copies of the plan-shaped ones.** `references/explainer-html.md` keeps only the generic invariants (single self-contained file, inline CSS/SVG, no hidden machine-readable metadata copy, ASCII identifiers/anchors, ~70ch prose measure, visible metadata header) plus explainer-specific guidance (show-n-tell selection per material, conditional visual-aids discipline). `references/explainer-markdown.md` is the fallback equivalent. Rendering references load at compose time, not at skill start.
+- KTD8. **Executed scripts use the model-filled `SKILL_DIR` anchor.** Any bundled script (cache helper, optional recap evidence script) is invoked with `SKILL_DIR` set inline in the same Bash call. Never `${CLAUDE_SKILL_DIR}`.
+- KTD9. **Recap evidence gathering is dispatchable and script-assisted.** A `references/agents/work-recap-scout.md` persona (extraction tier) gathers git + docs evidence over the window; the unit may add a small bundled script for `git log`/diff summarization if token cost warrants (script-first learning: 60–75% savings elsewhere). Behavior, not mechanism, is the contract.
+- KTD10. **Blocking-question protocol is self-contained.** SKILL.md carries its own copy of the platform question-tool protocol (AskUserQuestion / request_user_input / ask_question / ask_user, numbered-chat fallback, never silently skip) — skills cannot reference other skills' copies.
+
+### High-Level Technical Design
+
+The corrected run shape is the mermaid in Key Flows. Structurally, SKILL.md orchestrates four phases — classify, ground, produce/check-in, publish — with conditional substance extracted: `intake.md` (token table + classification + tiebreak), `check-in.md` (prediction elicitation, exercise design, correction shape), the two rendering references (compose-time), `destinations.md` (per-destination sub-flows behind the inlined routing), and `references/agents/` personas for grounding scouts. The repo-profile cache assets are the standard byte-duplicated trio.
+
+### Output Structure
+
+```text
+skills/ce-explain/
+  SKILL.md
+  references/
+    intake.md
+    check-in.md
+    explainer-html.md
+    explainer-markdown.md
+    destinations.md
+    repo-profile-cache.md          (byte-copy, shared cache asset)
+    agents/
+      repo-profiler.md             (byte-copy, shared cache asset)
+      work-recap-scout.md
+  scripts/
+    repo-profile-cache.py          (byte-copy, shared cache asset)
+docs/skills/ce-explain.md
+tests/skills/ce-explain-routing.test.ts
+```
+
+The tree is a scope declaration; per-unit Files lists are authoritative.
+
+---
+
+## Implementation Units
+
+### U1. Skill core: SKILL.md orchestration
+
+- **Goal:** The complete `skills/ce-explain/SKILL.md` — frontmatter, intake, mode routing, check-in gating, run-dir write, and the inlined destination/handoff routing.
+- **Requirements:** R1, R2 (routing half), R4, R7, R8, R9, R13, R14; Key Decisions (idea mode, bare invocation).
+- **Dependencies:** None.
+- **Files:** `skills/ce-explain/SKILL.md`, `skills/ce-explain/references/intake.md`, `skills/ce-explain/references/check-in.md`.
+- **Approach:** Frontmatter `name: ce-explain`, description in the 100–300 char budget stating the four input shapes and the learning purpose (disambiguate from `ce-pov` verdicts and `ce-compound` repo learnings), `argument-hint`. Inline at top: intake classification trigger routing to `references/intake.md`; the blocking-question protocol copy (KTD10); the model-tier note (ce-pov style). Mode phases follow the Key Flows mermaid, with R13's turn-end enforcement written into the diff path (KTD3). Run-dir write precedes the destination ask (KTD4). Destination menu options and their per-option actions inline (KTD5). Outbound handoffs split by invocability: `ce-ideate` and `ce-simplify-code` use platform-explicit skill-invocation language ("invoke the `ce-ideate` skill via the platform's skill-invocation primitive... do not merely tell the user"); `ce-polish` is user-invoked only (`disable-model-invocation: true`, pinned in `EXPECTED_USER_INVOKED_SKILLS` in `tests/skill-conventions.test.ts`), so its route presents the surfaced polish observations in chat and tells the user to run `/ce-polish`, relying on in-session context to carry them. Bare invocation asks one blocking question. Empty-recap path per AE6.
+- **Patterns to follow:** `skills/ce-pov/SKILL.md` (layout, tiering, tier-gated close); `skills/ce-code-review/SKILL.md` intake table and conflict rules; `skills/ce-brainstorm/references/handoff.md` "Open in browser" one-liner for the local-display option; `docs/solutions/skill-design/post-menu-routing-belongs-inline.md`; `docs/solutions/skill-design/arguments-token-is-claude-only-in-skill-bodies.md`.
+- **Test scenarios:**
+  - Covers AE2. Diff input, check-in accepted: prediction prompt shows only the raw change reference; the turn ends before any interpretive content; the reveal names the prediction gap.
+  - Diff input, check-in declined: explainer produced directly, no prediction prompt.
+  - Covers AE5. Idea input: explainer explains implications of the idea as given; no options, no ranking, no scoping dialogue.
+  - Ambiguous input naming a repo topic with a resolvable recent change: resolves to diff mode.
+  - Bare invocation: exactly one blocking question asking what to explain; no default artifact.
+  - Covers AE6. Empty recap window: reports no activity, offers widening, writes nothing.
+  - Covers AE7 + R14. All destinations declined / no interaction possible: run-dir path reported; nothing else written.
+  - `output:md` token: markdown artifact via the fallback reference.
+- **Verification:** skill-creator eval transcripts show each scenario's required turn structure; `bun test` unaffected.
+
+### U2. Rendering references
+
+- **Goal:** The explainer's HTML and markdown rendering contracts, trimmed to explainer shape.
+- **Requirements:** R5, R6, R10; visible-metadata half of KTD4.
+- **Dependencies:** U1 (loads them at compose time).
+- **Files:** `skills/ce-explain/references/explainer-html.md`, `skills/ce-explain/references/explainer-markdown.md`.
+- **Approach:** Start from `skills/ce-brainstorm/references/html-rendering.md`'s generic hard invariants; drop every plan-artifact structure (nav region, R/U-ID anchors, contract sections). Add explainer-specific rules: visible metadata header (topic, date, input shape — machine-greppable, no hidden copy), show-n-tell selection guidance keyed to material shape (diagram for structure, annotated snippet for code, timeline for recaps), the conditional visual-aids discipline (`docs/solutions/best-practices/conditional-visual-aids-in-generated-documents.md`), ~70ch measure, display-only constraint (R10). Markdown reference mirrors content rules with mermaid/code-fence equivalents.
+- **Patterns to follow:** Generic invariants at `skills/ce-brainstorm/references/html-rendering.md:19-68`.
+- **Test scenarios:** Test expectation: none — reference prose consumed by U6's evals (artifact conformance is asserted there: single file, no hidden metadata, visible header present).
+- **Verification:** U6 eval artifacts conform; no companion asset files emitted.
+
+### U3. Grounding: repo-profile cache consumership and recap scout
+
+- **Goal:** Repo-grounded modes resolve the shared profile through the cache; recap mode has its evidence gatherer.
+- **Requirements:** R2 (grounding half), R3.
+- **Dependencies:** U1.
+- **Files:** `skills/ce-explain/references/repo-profile-cache.md`, `skills/ce-explain/scripts/repo-profile-cache.py`, `skills/ce-explain/references/agents/repo-profiler.md` (all three byte-copied from a current consumer), `skills/ce-explain/references/agents/work-recap-scout.md`, `tests/repo-profile-cache-parity.test.ts` (add `ce-explain` to `CONSUMER_SKILLS`).
+- **Approach:** Standard consumer wiring per the cache protocol (get → HIT/MISS/NO-CACHE; cache never correctness-dependency; external topics skip entirely). `work-recap-scout.md` is an extraction-tier persona: gather commits, merged PRs, and doc changes over the window with `file:line`/sha pointers, return an evidence summary; unprefixed filename (internal prompt asset). Optionally add a bundled evidence script later if eval shows token pressure (KTD9) — not required for done.
+- **Patterns to follow:** `skills/ce-pov/` consumer wiring (commit `8443410a`); AGENTS.md "Shared Repo-Grounding Profile Cache" section; `docs/solutions/skill-design/cross-skill-shared-cache-primitive.md`.
+- **Test scenarios:**
+  - Parity test green with `ce-explain` registered (byte-identical assets).
+  - Covers AE3. External topic: no cache call, no repo grounding in output.
+  - Recap run on this repo: evidence cites real commits/docs from the window.
+- **Verification:** `bun test tests/repo-profile-cache-parity.test.ts` passes; eval shows cache HIT path used on second repo-grounded run at the same commit.
+
+### U4. Destination detection and routing test
+
+- **Goal:** The destination ask offers exactly what the environment supports, and the inlined routing is regression-guarded.
+- **Requirements:** R11, R14.
+- **Dependencies:** U1.
+- **Files:** `skills/ce-explain/references/destinations.md`, `tests/skills/ce-explain-routing.test.ts`.
+- **Approach:** `destinations.md` carries per-destination sub-flows only (Proof publish shape from `ce-proof`; Thinkroom send via its skill/CLI when detected; artifact-surface publish as body-only re-emission per KTD5; local copy-out with the browser-open one-liner); the menu itself and one-action-per-option routing stay inline in SKILL.md (KTD5). Detection language describes capabilities, not tools; absence hides an option silently; local file always present. The test asserts the inline routing lines exist in SKILL.md (mirror `tests/skills/ce-plan-handoff-routing.test.ts`), so a future refactor can't silently extract them.
+- **Patterns to follow:** `ce-setup` probe-and-degrade idiom; `ce-brainstorm` Slack-routing conditional notes; `skills/ce-proof/SKILL.md` publish flow.
+- **Test scenarios:**
+  - Routing test: SKILL.md contains the inline action language for each destination option; skill-invocation language for the ce-ideate and ce-simplify-code handoffs; and the chat-presentation-plus-user-run-`/ce-polish` language for the polish handoff (never skill-invocation for ce-polish — it is user-invoked only).
+  - Covers AE4. Eval: bare environment (no artifact tool, no external destinations) → local-only offer, path reported.
+- **Verification:** `bun test tests/skills/ce-explain-routing.test.ts` passes.
+
+### U5. Registration and docs
+
+- **Goal:** ce-explain is discoverable everywhere the plugin catalogs skills.
+- **Requirements:** R12.
+- **Dependencies:** U1 (final description text).
+- **Files:** `README.md`, `docs/skills/README.md`, `docs/skills/ce-explain.md`, `tests/release-metadata.test.ts`.
+- **Approach:** README inventory row linking `docs/skills/ce-explain.md`; bump the "ships 28 skills" sentence to 29; judgment call — also add to the curated "Additional skills" table (it fits the on-demand anchor shape alongside `/ce-pov`). Catalog row under **On-Demand** in `docs/skills/README.md`. Docs page follows `docs/skills/ce-pov.md`'s heading shape (TL;DR, Problem, Solution, Novel mechanics, Quick example, When to reach for it, Reference, See Also). Bump `skills: 28` → `29` at `tests/release-metadata.test.ts:150` (the count is derived from disk; the assertion is the only hand edit). No manifest edits — skills auto-discover. No legacy-cleanup entries (additions don't need them).
+- **Patterns to follow:** `docs/skills/ce-pov.md`; row formats at `README.md:118` and the On-Demand rows in `docs/skills/README.md`.
+- **Test scenarios:**
+  - `bun test` release-metadata suite green at 29.
+  - `bun run release:validate` passes.
+- **Verification:** Both commands green; README count sentence, inventory row, catalog row, and docs page all present and consistent.
+
+### U6. Behavioral evals
+
+- **Goal:** The behaviors that make or break the product are proven through skill-creator evals against the real skill content.
+- **Requirements:** R2, R7, R13, R14; AE1–AE7.
+- **Dependencies:** U1, U2, U3, U4.
+- **Files:** No repo files required beyond notes; eval transcripts are the evidence. If the ce-polish downgrade fires, edit `skills/ce-explain/SKILL.md` R7 routing accordingly.
+- **Approach:** Run the skill-creator eval workflow (the repo's mandated path — plugin skill content caches at session start, so typed-skill invocation in the authoring session tests stale content). Required evals: (1) leak test — diff mode check-in surfaces nothing interpretive before the prediction turn ends; (2) AE1 routine-recap skip; (3) AE3 external topic; (4) AE4 bare environment; (5) no-blocking-tool fallback stops and waits; (6) handoff seed — ce-ideate receives the surfaced observations via skill invocation; the polish route presents observations in chat with a user-run `/ce-polish` suggestion (pass condition: the observation summary is present in-session at the point the user would invoke it), and downgrade that R7 half to a mention if the carryover demonstrably fails.
+- **Patterns to follow:** AGENTS.md "Validating Agent and Skill Changes".
+- **Test scenarios:** The six evals above are the scenarios; each names its pass condition.
+- **Verification:** All evals pass or carry a documented downgrade decision; no eval relies on the cached-session invocation path.
+
+---
+
+## Verification Contract
+
+| Gate | Command / method | Applies to |
+|---|---|---|
+| Unit and metadata tests | `bun test` | U3, U4, U5 |
+| Cache parity | `bun test tests/repo-profile-cache-parity.test.ts` | U3 |
+| Routing regression | `bun test tests/skills/ce-explain-routing.test.ts` | U4 |
+| Release consistency | `bun run release:validate` | U5 |
+| Behavioral evals | skill-creator eval workflow (fresh-content dispatch) | U1, U2, U6 |
+
+Behavioral changes to skill prose are never validated by re-invoking the skill in the authoring session (cached content); use skill-creator dispatch.
+
+---
+
+## Definition of Done
+
+- All six units complete; `bun test` and `bun run release:validate` green.
+- The six U6 evals pass, or carry documented downgrade decisions (the ce-polish handoff is the known candidate).
+- The leak test (R13) passes structurally: prediction turn ends before any interpretive content in the transcript.
+- Registration surfaces are mutually consistent: README count sentence says 29, inventory row, On-Demand catalog row, and `docs/skills/ce-explain.md` all exist and agree with the SKILL.md description.
+- The skill description is within the 100–300 character budget.
+- No abandoned experiments or dead reference files remain in the diff.
+
+---
+
+## Sources
+
+- Geoffrey Litt on why understanding agent-written code still matters: https://x.com/geoffreylitt/status/2072522251300409556 — the framing this skill answers.
+- Structural template: `skills/ce-pov/SKILL.md` and its `references/` layout.
+- Generic HTML invariants to trim from: `skills/ce-brainstorm/references/html-rendering.md`.
+- Intake token pattern: `skills/ce-code-review/SKILL.md` (`base:<sha-or-ref>` table and conflict rules).
+- Capability detection idiom: `skills/ce-setup/SKILL.md`; Slack routing notes in `skills/ce-brainstorm/SKILL.md`.
+- Load-bearing learnings: `docs/solutions/skill-design/post-menu-routing-belongs-inline.md`, `docs/solutions/skill-design/arguments-token-is-claude-only-in-skill-bodies.md`, `docs/solutions/skill-design/bundled-script-path-resolution-across-harnesses.md`, `docs/solutions/skill-design/cross-skill-shared-cache-primitive.md`, `docs/solutions/skill-design/script-first-skill-architecture.md`, `docs/solutions/best-practices/conditional-visual-aids-in-generated-documents.md`.
+- Registration touchpoints: `README.md:110` (count sentence), `docs/skills/README.md` catalog, `tests/release-metadata.test.ts:150`.

--- a/docs/residual-review-findings/feat-ce-explain-skill.md
+++ b/docs/residual-review-findings/feat-ce-explain-skill.md
@@ -1,0 +1,7 @@
+# Residual Review Findings
+
+Source: ce-code-review run `20260702-211155-42168d78` on branch `feat/ce-explain-skill` (pre-PR; review verdict "Ready with fixes", 4 actionable findings, 3 applied in `fix(review)` commit).
+
+## Residual Review Findings
+
+- **P2** — `skills/ce-explain/SKILL.md:70` — Predict-then-reveal protocol duplicated with only substring guard — filed: https://github.com/EveryInc/compound-engineering-plugin/issues/1057 (resolution is keep-both-plus-parity-guard per AGENTS.md inline-the-trigger doctrine; the reviewer's trim-to-pointer fix was rejected by validation)

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -61,6 +61,7 @@ Invoked when a specific need arises — not part of any chain.
 | Skill | Description |
 |-------|-------------|
 | [`/ce-pov`](./ce-pov.md) | Form a decisive, project-grounded verdict on an external input (framework, library, CVE, pattern) — dual-grounding floors, cold or warm (mid-session) invocation, graded Adopt/Trial/Hold/Reject/Not-our-problem with a reasoned handoff |
+| [`/ce-explain`](./ce-explain.md) | Turn a concept, a diff, an idea, or a window of your own recent work into a dense, visual explainer written for you personally — optional check-in (predict-then-reveal for diffs, corrected exercises), capability-detected destination ask |
 | [`/ce-debug`](./ce-debug.md) | Find root causes systematically — causal chain gate, predictions, post-fix polish/review, PR handoff |
 | [`/ce-code-review`](./ce-code-review.md) | Structured code review with skill-local reviewer personas, confidence-gated findings, four modes |
 | [`/ce-doc-review`](./ce-doc-review.md) | Review requirements or plan documents using skill-local reviewer personas — coherence, feasibility, product-lens, design-lens, security-lens, scope-guardian, adversarial |

--- a/docs/skills/ce-explain.md
+++ b/docs/skills/ce-explain.md
@@ -1,0 +1,76 @@
+# `ce-explain`
+
+## TL;DR
+
+Point it at a concept, a diff, an idea, or a window of your own recent work, and get a dense, visual explainer written for you personally — with an optional check-in (predict what a diff does before the reveal; answer exercises that get corrected) that makes the material actually stick.
+
+## The Problem
+
+Agent-driven development removed the learning that writing code by hand used to provide. You ship work through agents, rarely read the code, and stop accumulating the understanding that typing it yourself once forced. The cost shows up twice: comprehension debt on your own projects, and recall gaps when a meeting needs you to speak to what happened last week. The plugin's other skills capture knowledge for the *repo* (`/ce-compound`) or judge options (`/ce-pov`); none of them teaches *you*.
+
+## The Solution
+
+One skill, four input shapes:
+
+- **Concept** — repo-grounded when the topic touches your repo, fully external when it doesn't (interview prep counts).
+- **Diff** — understand a change you didn't type, with predict-then-reveal: you say what you think it does *before* any explanation appears.
+- **Idea** — your idea, taken as a fixed given, explained for implications and trade-offs (never scoped or ranked — that's brainstorm/ideate territory).
+- **Work recap** — "what did I do this week?" answered from git activity and project docs, absorbable in minutes before a meeting.
+
+The explainer is HTML-first (markdown on request), show-n-tell by default — diagrams for structure, annotated snippets for code, timelines for recaps — and written to a stable temp location before the skill asks where you want it: an artifact surface, a local file, or a detected destination like Proof or Thinkroom. Destinations are offered only when actually available.
+
+## What Makes It Novel
+
+1. **Predict-then-reveal for diffs.** The turn *ends* after you're shown the raw change and asked for your prediction. No interpretive content leaks early — the reveal then names exactly what your prediction missed. That gap-naming is the teaching.
+2. **The check-in lives in the session, not the artifact.** The doc stays display-only; exercises are posed in chat where the skill can check and correct your answers.
+3. **Skippable by design.** Routine recaps skip the check-in; you can always decline. Some things don't need a learning loop.
+4. **Capability-detected destinations.** The destination ask offers only what your environment supports, with a local file as the always-present floor — and the artifact exists on disk before the ask, so declining everything loses nothing.
+5. **Honest external grounding.** External topics with no web access fall back to model knowledge — labeled as unverified in the artifact, never passed off as checked.
+
+## Quick Example
+
+```text
+/ce-explain diff:HEAD~3..HEAD
+/ce-explain ruby garbage compaction
+/ce-explain since:monday          # meeting prep
+/ce-explain my idea of caching explainers per repo
+```
+
+## When to Reach For It
+
+- An agent just landed a change you didn't fully follow and you want to *understand* it, not just review it.
+- You keep meeting a concept you've been nodding along to.
+- Interview or presentation prep where you need the material in your head, not in a doc.
+- Before standup or a meeting: "catch me up on what I did."
+
+## Use as Part of the Workflow
+
+`ce-explain` sits outside the core loop — invoke it whenever comprehension lags behind shipping. When an explanation surfaces things that could be better, its closing routes them onward: new-capability ideas seed `/ce-ideate`, code-clarity findings seed `/ce-simplify-code`, and UI/UX polish observations are handed to you to take into `/ce-polish`.
+
+## Use Standalone
+
+Fully standalone — it needs no plan, no brainstorm, and works in any repo (or no repo at all, for external topics).
+
+## Reference
+
+| Argument | Effect |
+|----------|--------|
+| free text | Classified as concept, idea, diff, or recap by shape |
+| `diff:<ref-or-range>` | Force diff mode on that change |
+| `since:<window\|date\|ref>` | Force recap mode over that window (default: last 7 days) |
+| `output:md` | Markdown artifact instead of HTML |
+| *(bare)* | Asks what to explain |
+
+## FAQ
+
+**Where does the artifact go?** It's written to `/tmp/compound-engineering/ce-explain/<run-id>/` before the destination ask; choosing a destination copies it out. That path is temporary — pick a destination if you want to keep it.
+
+**Is this ce-compound for humans?** Roughly — a Learning teaches the repo's future work; an explainer teaches you. They're complements, not substitutes.
+
+**Can it quiz me later / track what I've learned?** Not in v1 — no library, no spaced repetition, no progress state. The stable run-dir layout is the hook a future library can build on.
+
+## See Also
+
+- [`/ce-pov`](./ce-pov.md) — when you need a verdict on something external, not a lesson about it
+- [`/ce-compound`](./ce-compound.md) — when the knowledge belongs to the repo, not (only) your head
+- [`/ce-ideate`](./ce-ideate.md) — where surfaced improvement ideas land

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -58,7 +58,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 
 On `HIT`, load the profile JSON — stack, conventions, vocabulary — and take orientation from it. On `MISS`, dispatch a generic subagent with `references/agents/repo-profiler.md` to derive the profile, write its JSON to a file, then persist with `python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <file>` (re-set `SKILL_DIR` in that call — shell vars don't persist between Bash invocations). On `NO-CACHE` — or if the call errors — derive orientation inline and skip the `put`. The cache is an optimization, never a correctness dependency. The topic-specific evidence (the diff, the concept's call-sites, the window's commits) is always gathered fresh.
 
-- **Diff mode:** resolve the change (the `diff:` ref, or the most recent substantial change when the request points at one implicitly) and gather its evidence — the diff itself, the files it touches, any plan or solution doc that motivated it.
+- **Diff mode:** resolve the change (the `diff:` ref, or the most recent substantial change when the request points at one implicitly) and gather its evidence — the diff itself, the files it touches, any plan or solution doc that motivated it. Gather silently: nothing learned here is narrated to the user until Phase 3's ordering rule is satisfied.
 - **Recap mode:** dispatch a generic subagent seeded with `references/agents/work-recap-scout.md` (extraction tier), passing the resolved window, the repo root, and `$RUN_DIR`. It returns an evidence summary with commit shas and `file:line` pointers. **Empty window** (no git activity, no doc changes): say so, offer to widen the window, write no artifact, and end the run after the user responds.
 - **External concepts** (no footprint in this repo): skip repo grounding entirely — do not force repo context into the output. Research with whatever web tools are reachable. When none are, you may explain from model knowledge, but the artifact must label that content **Unverified — from model knowledge, not checked against current sources** in its metadata header.
 - **Idea mode:** the idea is a fixed given. Explain its implications, mechanics, and trade-offs for the user's understanding. Never scope it (`ce-brainstorm`'s job), never generate and rank alternatives (`ce-ideate`'s job).
@@ -79,7 +79,7 @@ For concepts, ideas, and dense recaps where the check-in was accepted: pose the 
 
 ### Phase 6: Destination ask and close
 
-Detect destinations by capability — probe the agent's own toolset and session context, never a closed list, and never treat a missing binary, env var, or unloaded MCP tool as proof a destination is unavailable when a connector could supply it. A local file is always available and always offered. Offer only what is detected; absence hides an option silently. Ask once with the blocking question tool. Per-option routing:
+Detect destinations by capability — probe the agent's own toolset and session context, never a closed list, and never treat a missing binary, env var, or unloaded MCP tool as proof a destination is unavailable when a connector could supply it. Local file and Leave it are ungated and always offered. Offer only what is detected; absence hides an option silently. Ask once with the blocking question tool. Per-option routing:
 
 - **Artifact surface** (offered when an artifact-publishing tool is present in the current session's tools) — publish per `references/destinations.md`: re-emit the explainer as body-only markup (no doctype/html/head/body, styles inline, no external font links); the surface wraps content in its own skeleton and blocks external hosts.
 - **Local file** — copy the artifact out of `$RUN_DIR` to the path the user names, then where the platform exposes a browser-opening primitive (`open` on macOS, `xdg-open` on Linux, `start` on Windows) offer to open it; otherwise print the absolute path.
@@ -87,12 +87,12 @@ Detect destinations by capability — probe the agent's own toolset and session 
 - **Send to Thinkroom** (offered only when a Thinkroom skill or CLI capability is detected) — send per `references/destinations.md`.
 - **Leave it** — report the `$RUN_DIR` path and state it is a temporary location that does not survive reboot; nothing else is written.
 
-**Non-interactive degradation:** when no interaction is possible at this ask (no blocking tool and no reply), do not hang and do not discard — the artifact is already at `$RUN_DIR`; report that path and end.
+**Non-interactive degradation:** when no interaction is possible at this ask (no blocking tool and no reply), do not hang and do not discard — the artifact is already at `$RUN_DIR`; report that path and end, skipping the improvement-observation handoffs below (they are offers, and an offer cannot fire without a user).
 
 **Improvement observations.** When composing the explainer surfaced things that could be better, route them by type after the destination ask — offer, don't auto-fire:
 
-- **New-capability ideas** — invoke the `ce-ideate` skill via the platform's skill-invocation primitive, passing the observations as seed context. Do not merely tell the user to run it.
-- **Code-clarity findings** — invoke the `ce-simplify-code` skill via the platform's skill-invocation primitive, passing the observations and the files they concern. Do not merely tell the user to run it.
+- **New-capability ideas** — offer first; on acceptance invoke the `ce-ideate` skill via the platform's skill-invocation primitive, passing the observations as seed context. Do not merely tell the user to run it.
+- **Code-clarity findings** — offer first; on acceptance invoke the `ce-simplify-code` skill via the platform's skill-invocation primitive, passing the observations and the files they concern. Do not merely tell the user to run it.
 - **UI/UX polish opportunities** — present the observations in chat and tell the user to run `/ce-polish` themselves; ce-polish is user-invoked only (`disable-model-invocation`), so never attempt to invoke it via the skill primitive — the in-session observations carry into their run.
 
 ## Boundaries

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -71,7 +71,7 @@ Judge whether the material warrants a check-in (a routine recap does not; a gnar
 
 ### Phase 4: Compose the explainer
 
-Read the rendering reference for the resolved format **now**, not earlier: `references/explainer-html.md` (default) or `references/explainer-markdown.md` (when intake resolved `output:md`). Compose per its contract — visible metadata header, show-n-tell form matched to the material, ~70ch measure, single self-contained file — and write the artifact into `$RUN_DIR` before anything else happens with it. Display it to the user (inline summary plus the file path; open locally per Phase 6 when chosen). The artifact exists at that stable path from this moment — a declined destination ask never loses it.
+Read the rendering reference for the resolved format **now**, not earlier: `references/explainer-html.md` (default) or `references/explainer-markdown.md` (when intake resolved `output:md`). Compose per its contract — visible metadata header, show-n-tell form matched to the material, ~70ch measure, single self-contained file — and write the artifact to `$RUN_DIR/explainer.html` (or `$RUN_DIR/explainer.md` when intake resolved `output:md`) before anything else happens with it. Display it to the user (inline summary plus the file path; open locally per Phase 6 when chosen). The artifact exists at that stable path from this moment — a declined destination ask never loses it.
 
 ### Phase 5: Exercises (when warranted)
 
@@ -79,7 +79,7 @@ For concepts, ideas, and dense recaps where the check-in was accepted: pose the 
 
 ### Phase 6: Destination ask and close
 
-Detect destinations by capability — probe the agent's own toolset and session context, never a closed list, and never treat a missing binary, env var, or unloaded MCP tool as proof a destination is unavailable when a connector could supply it. Local file and Leave it are ungated and always offered. Offer only what is detected; absence hides an option silently. Ask once with the blocking question tool. Per-option routing:
+Detect destinations by capability — probe the agent's own toolset and session context, never a closed list, and never treat a missing binary, env var, or unloaded MCP tool as proof a destination is unavailable when a connector could supply it. Local file and Leave it are ungated and always offered. Offer only what is detected; absence hides an option silently. Ask once with the blocking question tool — counting visible options against the platform's cap first (Claude Code's `AskUserQuestion` allows up to 4 explicit options; Codex's `request_user_input` only 2-3): when the visible set exceeds the cap, render a numbered list in chat with "Pick a number or describe what you want." and wait instead. Per-option routing:
 
 - **Artifact surface** (offered when an artifact-publishing tool is present in the current session's tools) — publish per `references/destinations.md`: re-emit the explainer as body-only markup (no doctype/html/head/body, styles inline, no external font links); the surface wraps content in its own skeleton and blocks external hosts.
 - **Local file** — copy the artifact out of `$RUN_DIR` to the path the user names, then where the platform exposes a browser-opening primitive (`open` on macOS, `xdg-open` on Linux, `start` on Windows) offer to open it; otherwise print the absolute path.

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ce-explain
+description: "Turn a concept, a diff, an idea, or a window of your own recent work into a dense, visual explainer written for you personally — with an optional check-in (predict-then-reveal for diffs, corrected exercises) that makes the material stick. For learning, not repo docs or verdicts."
+argument-hint: "[a concept, a diff ref, an idea, or 'what happened this week?'] — or invoke bare to be asked"
+---
+
+# Explain It To Me
+
+Teach the user one thing well: a concept, a change, an idea, or a window of their own recent work. Agent-driven development removed the learning that writing code by hand used to provide; this skill is the replacement — the human keeps learning while agents do the writing.
+
+<explain_request> #$ARGUMENTS </explain_request>
+
+*(If `$ARGUMENTS` above appears as a literal token rather than the user's words — it was not substituted on this host — use the user's actual request from the conversation as the input.)*
+
+**Note: The current year is 2026.** Use this when weighting external sources and dating artifacts.
+
+## Who the explainer is for
+
+The user personally — dense, technical, one voice, no audience adaptation. Meeting prep preps the user; it never produces the deck. The artifact is display-only: no embedded quizzes, forms, or widgets — the doing happens in the session, where answers can be checked.
+
+## Interaction Method
+
+When you must ask the user a question, use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to numbered options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. In the fallback, stop and wait for the user's reply. Never silently skip the question. Ask one question at a time.
+
+## Model Tiers
+
+Dispatch is tiered by task shape, never hardcoded to a model name:
+
+- **Extraction tier** — the work-recap scout and the repo-profiler: search-and-quote work. Use the platform's cheapest capable model when the harness exposes a known override; otherwise inherit.
+- **Ceiling tier** — the explainer composition, the check-in reasoning, and the corrections. These run in the main conversation on the orchestrator's model; nothing is dispatched for them.
+
+**Degradation rule.** When the platform's subagent primitive cannot select per-agent models, dispatch scouts on the inherited model and keep their read budgets. When the platform has no subagent primitive at all, run the scout work inline with the same budgets.
+
+## Execution Flow
+
+### Phase 1: Classify the input
+
+Read `references/intake.md` now and classify the request into one of the four input shapes — concept, diff, idea, or work-recap window. It owns the token table (`diff:`, `since:`, `output:`), the explicit-token-beats-inference rule, the concept-vs-diff tiebreak, and conflict handling. Do not improvise classification.
+
+**Bare invocation** (no input at all): ask one blocking question — "What should I explain?" — offering a shortcut option for a recap of recent work in this repo alongside free-text. Do not produce a default artifact unprompted.
+
+### Phase 2: Ground
+
+Match grounding to the input shape. Create the run directory first — every run gets one, before any artifact exists:
+
+```bash
+RUN_DIR="/tmp/compound-engineering/ce-explain/$(date +%Y%m%d)-$(openssl rand -hex 3)"
+mkdir -p "$RUN_DIR"
+echo "$RUN_DIR"
+```
+
+**Repo-touching inputs** (a concept with footprint in this repo, a diff, a recap): resolve the question-agnostic project profile from the shared cache instead of re-deriving it. Set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
+
+```bash
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
+```
+
+On `HIT`, load the profile JSON — stack, conventions, vocabulary — and take orientation from it. On `MISS`, dispatch a generic subagent with `references/agents/repo-profiler.md` to derive the profile, write its JSON to a file, then persist with `python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <file>` (re-set `SKILL_DIR` in that call — shell vars don't persist between Bash invocations). On `NO-CACHE` — or if the call errors — derive orientation inline and skip the `put`. The cache is an optimization, never a correctness dependency. The topic-specific evidence (the diff, the concept's call-sites, the window's commits) is always gathered fresh.
+
+- **Diff mode:** resolve the change (the `diff:` ref, or the most recent substantial change when the request points at one implicitly) and gather its evidence — the diff itself, the files it touches, any plan or solution doc that motivated it.
+- **Recap mode:** dispatch a generic subagent seeded with `references/agents/work-recap-scout.md` (extraction tier), passing the resolved window, the repo root, and `$RUN_DIR`. It returns an evidence summary with commit shas and `file:line` pointers. **Empty window** (no git activity, no doc changes): say so, offer to widen the window, write no artifact, and end the run after the user responds.
+- **External concepts** (no footprint in this repo): skip repo grounding entirely — do not force repo context into the output. Research with whatever web tools are reachable. When none are, you may explain from model knowledge, but the artifact must label that content **Unverified — from model knowledge, not checked against current sources** in its metadata header.
+- **Idea mode:** the idea is a fixed given. Explain its implications, mechanics, and trade-offs for the user's understanding. Never scope it (`ce-brainstorm`'s job), never generate and rank alternatives (`ce-ideate`'s job).
+
+### Phase 3: Check-in gate — before anything is revealed
+
+Judge whether the material warrants a check-in (a routine recap does not; a gnarly diff or a hard concept does), then offer it with the blocking question tool. The user can always decline, and declining is never re-litigated. Read `references/check-in.md` for the warrant test, the prediction protocol, and exercise design.
+
+**Diff mode with check-in accepted — hard ordering rule.** No interpretive content — explanation, annotation, diagram, or surfaced opportunity — may be shown before the user's prediction turn ends. Show only the raw change reference (the diff or its stat summary), ask for the prediction ("What do you think this change does, and why was it made?"), and **end the turn there**. When no blocking tool exists, ask in chat and stop — never print the reveal in the same message as the prediction prompt. Compose the explainer only after the prediction lands; the reveal names the gaps between the prediction and what the change actually does.
+
+### Phase 4: Compose the explainer
+
+Read the rendering reference for the resolved format **now**, not earlier: `references/explainer-html.md` (default) or `references/explainer-markdown.md` (when intake resolved `output:md`). Compose per its contract — visible metadata header, show-n-tell form matched to the material, ~70ch measure, single self-contained file — and write the artifact into `$RUN_DIR` before anything else happens with it. Display it to the user (inline summary plus the file path; open locally per Phase 6 when chosen). The artifact exists at that stable path from this moment — a declined destination ask never loses it.
+
+### Phase 5: Exercises (when warranted)
+
+For concepts, ideas, and dense recaps where the check-in was accepted: pose the exercises from `references/check-in.md` in chat, one at a time, using the blocking question tool where its option shape fits and free chat where the answer is narrative. Check each answer, correct it, and name the gap it exposed. Do not put exercises inside the artifact.
+
+### Phase 6: Destination ask and close
+
+Detect destinations by capability — probe the agent's own toolset and session context, never a closed list, and never treat a missing binary, env var, or unloaded MCP tool as proof a destination is unavailable when a connector could supply it. A local file is always available and always offered. Offer only what is detected; absence hides an option silently. Ask once with the blocking question tool. Per-option routing:
+
+- **Artifact surface** (offered when an artifact-publishing tool is present in the current session's tools) — publish per `references/destinations.md`: re-emit the explainer as body-only markup (no doctype/html/head/body, styles inline, no external font links); the surface wraps content in its own skeleton and blocks external hosts.
+- **Local file** — copy the artifact out of `$RUN_DIR` to the path the user names, then where the platform exposes a browser-opening primitive (`open` on macOS, `xdg-open` on Linux, `start` on Windows) offer to open it; otherwise print the absolute path.
+- **Publish to Proof** (markdown output only) — publish per `references/destinations.md` and surface the returned share URL; on failure retry once, then report and move on.
+- **Send to Thinkroom** (offered only when a Thinkroom skill or CLI capability is detected) — send per `references/destinations.md`.
+- **Leave it** — report the `$RUN_DIR` path and state it is a temporary location that does not survive reboot; nothing else is written.
+
+**Non-interactive degradation:** when no interaction is possible at this ask (no blocking tool and no reply), do not hang and do not discard — the artifact is already at `$RUN_DIR`; report that path and end.
+
+**Improvement observations.** When composing the explainer surfaced things that could be better, route them by type after the destination ask — offer, don't auto-fire:
+
+- **New-capability ideas** — invoke the `ce-ideate` skill via the platform's skill-invocation primitive, passing the observations as seed context. Do not merely tell the user to run it.
+- **Code-clarity findings** — invoke the `ce-simplify-code` skill via the platform's skill-invocation primitive, passing the observations and the files they concern. Do not merely tell the user to run it.
+- **UI/UX polish opportunities** — present the observations in chat and tell the user to run `/ce-polish` themselves; ce-polish is user-invoked only (`disable-model-invocation`), so never attempt to invoke it via the skill primitive — the in-session observations carry into their run.
+
+## Boundaries
+
+- **Not a verdict.** "Should we adopt X?" is `ce-pov`. ce-explain teaches what X is and how it works.
+- **Not repo memory.** Documenting a solved problem for future work is `ce-compound`. ce-explain teaches the human, not the repo.
+- **Not ideation or scoping.** An idea input is explained as given — implications and trade-offs — never expanded into options or a requirements dialogue.
+- **The check-in is never headless.** It exists to exercise the human; automating the answers deletes the product.

--- a/skills/ce-explain/references/agents/repo-profiler.md
+++ b/skills/ce-explain/references/agents/repo-profiler.md
@@ -1,0 +1,31 @@
+You are a repo-profiling scout. Your job is to derive the **question-agnostic project profile** for the repository at the current working directory — the stable orientation that every repo-grounding skill reuses. You are dispatched only on a cache miss; your output is written to the shared profile cache and reused across skills and sessions at this commit.
+
+Derive ONLY agnostic, question-independent facts. Do NOT do any work specific to the caller's current question (a candidate's call-sites, a feature's footprint, prior-decision matches for a topic, feature-specific patterns, git history of touched files). Anything question-specific is the caller's job and must stay out of this profile, or the cached artifact becomes wrong to reuse.
+
+Read efficiently — manifests, lockfiles, the license, the root instruction/doc files, and a top-level structure listing are enough. Do not read the whole tree.
+
+Produce the profile by inspecting:
+
+- **Stack & versions** — detected languages and major frameworks *with versions* (from manifests/lockfiles **and runtime version selectors** like `.nvmrc`/`.node-version`/`.python-version`/`.ruby-version`/`.tool-versions`/`mise.toml`, which pin versions outside the manifests), build/test tooling and commands.
+- **Dependency surface** — manifest + lockfile paths present, the top-level (direct) dependency list, the project license, and dependency licenses where readily available.
+- **Topology** — monorepo? the workspace/service map (name + primary language each), deployment model (monolith / multi-service / serverless), API styles (REST/gRPC/GraphQL/none), data stores and migration/ORM locations, and the module/internal-boundary layout.
+- **Conventions & instruction files** — paths and a short digest of the *root* `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`/`ARCHITECTURE.md`/`README.md`/`CONTRIBUTING.md`/`STRATEGY.md`, **and any project-wide Cursor rules** (`.cursor/rules/*.mdc` or a root `.cursorrules`): coding standards, testing conventions, review process, and (from `STRATEGY.md`) the target problem/approach/active tracks. These are project-wide conventions, so they belong in the cached profile (unlike *subdirectory-scoped* instruction files, which stay fresh per the exclusion below).
+- **Vocabulary** — from `CONCEPTS.md` if present, the canonical domain terms/processes/status concepts.
+
+Do NOT include the `docs/solutions/` file enumeration or subdirectory-scoped instruction files — those are re-globbed fresh by consumers, never cached.
+
+## Output
+
+Return ONLY a single JSON object (no prose, no code fence) with these top-level keys, each populated from what you found (use `null` or `[]` when a category is absent):
+
+```
+{
+  "stack": { "languages": [...], "frameworks": [...], "tooling": [...] },
+  "dependencies": { "manifests": [...], "lockfiles": [...], "top_level": [...], "project_license": "...", "dependency_licenses": [...] },
+  "topology": { "monorepo": true/false, "workspaces": [...], "deployment": "...", "api_styles": [...], "data_stores": [...], "module_layout": "..." },
+  "conventions": { "instruction_files": [...], "coding_standards": "...", "testing": "...", "review_process": "...", "strategy": "..." },
+  "vocabulary": { "concepts_present": true/false, "terms": [...] }
+}
+```
+
+Keep each field concise — enough for a downstream skill to orient without re-reading the repo. This JSON is the entire deliverable.

--- a/skills/ce-explain/references/agents/work-recap-scout.md
+++ b/skills/ce-explain/references/agents/work-recap-scout.md
@@ -1,0 +1,23 @@
+You are a work-recap scout. Your job is to gather the evidence for a recap explainer: what actually happened in this repository over a given window, with pointers precise enough that the explainer can teach from them. You extract and quote; you do not interpret, rank, or editorialize.
+
+Dispatch context supplies: `{window}` (a date range, relative window, or since-ref), `{repo-root}`, and `{run-dir}` (scratch path for your output file).
+
+## What to gather
+
+Work through these sources for the window, cheapest first:
+
+1. **Git activity** — `git log` over the window (subjects, shas, dates, authors), and for the substantial commits, a stat-level view of what they touched. Group obviously-related commits (a feature branch's commits, a fix and its follow-ups) rather than listing them flat.
+2. **Merged and open PRs** — only when a PR interface is reachable (a `gh` CLI that responds, a connector/MCP tool). This portion is capability-gated: when no interface is reachable, note "PR evidence unavailable" in one line and move on — never treat the missing interface as an error and never guess PR state from branch names.
+3. **Project docs** — plans, brainstorms, and solution docs added or modified in the window (`docs/plans/`, `docs/brainstorms/`, `docs/solutions/`, or wherever this repo keeps them). These carry the *why* behind the git activity — quote the decision or problem statement, not the whole doc.
+
+## Output
+
+Write an **evidence file** to `{run-dir}/recap-evidence.md`: at most 120 lines. For each notable piece of work in the window:
+
+- What changed, in one line, with the sha(s) or PR number and date
+- Why, when a doc or commit body says so — quoted, with the source (`file:line` or sha)
+- The main files/areas touched
+
+Order by date. Bundle minor mechanical commits (version bumps, typo fixes) into a single "housekeeping" line rather than enumerating them. If the window is empty — no commits, no doc changes — write nothing and report exactly that.
+
+Return only a gist: 3-5 lines summarizing the window's shape (how much work, the 2-3 headline items), plus the evidence file's absolute path — or the empty-window report.

--- a/skills/ce-explain/references/check-in.md
+++ b/skills/ce-explain/references/check-in.md
@@ -8,6 +8,8 @@ Offer a check-in when retention is the point: a hard or unfamiliar concept, a gn
 
 The user can always decline the offer, and a decline is final for the run — do not re-offer.
 
+In diff mode, word the offer without describing the change's content or purpose — an offer that summarizes the change pre-leaks the reveal.
+
 ## Predict-then-reveal (diff mode)
 
 The prediction must come before any interpretation reaches the user, or the mechanic is dead on arrival.

--- a/skills/ce-explain/references/check-in.md
+++ b/skills/ce-explain/references/check-in.md
@@ -1,0 +1,31 @@
+# Check-in
+
+The check-in is the active-recall step that makes the explainer stick: the user produces first, the explanation confirms or corrects. It runs in the session — never inside the artifact, never automated.
+
+## Warrant test — offer or skip
+
+Offer a check-in when retention is the point: a hard or unfamiliar concept, a gnarly or consequential diff, a dense recap window with decisions worth recalling later. Skip it (produce the explainer and move on) when comprehension is the point and retention is incidental: a routine recap before a meeting, a small mechanical diff, a topic the user signals they only need to skim. When skipping, do not announce a justification — just proceed.
+
+The user can always decline the offer, and a decline is final for the run — do not re-offer.
+
+## Predict-then-reveal (diff mode)
+
+The prediction must come before any interpretation reaches the user, or the mechanic is dead on arrival.
+
+1. Show only the raw change reference: the diff or its stat summary, with zero commentary.
+2. Ask for the prediction with the blocking question tool: what does this change do, and why was it made? Free-text is the primary answer path; options, if offered, must be genuinely competing readings, not one right answer plus padding.
+3. **End the turn.** In the no-blocking-tool fallback, ask in chat and stop. Never place any explanation in the same message as the prediction prompt.
+4. After the prediction lands, compose and present the reveal. Name the gaps explicitly: what the prediction got right, what it missed, what it got wrong and why the reality differs. The gap-naming is the teaching — a reveal that doesn't reference the prediction wastes the prediction.
+
+## Exercises (concepts, ideas, dense recaps)
+
+Two to four exercises, posed in chat one at a time after the artifact is presented. Design them to expose understanding, not recall of the artifact's phrasing:
+
+- **Apply:** a small scenario the concept decides ("given X, what happens / what would you choose?").
+- **Explain-back:** the user restates the core mechanism in their own words.
+- **Boundary:** a case where the concept does not apply, or where the naive reading fails.
+- **Recap recall (recap mode):** why a notable change in the window was made, or what its consequence was.
+
+Check each answer as it arrives: confirm what is right, correct what is wrong, and name the specific gap the answer exposed. One correction per exercise — do not lecture past the gap. If an answer exposes a misunderstanding the artifact should have prevented, say so plainly and fix the mental model before moving on.
+
+Stop after the planned exercises. Do not spiral into quiz mode; the run ends at the destination ask.

--- a/skills/ce-explain/references/destinations.md
+++ b/skills/ce-explain/references/destinations.md
@@ -18,7 +18,7 @@ The run-dir file remains the complete standalone document; the fragment is a re-
 ## Local file
 
 1. Ask nothing extra if the user already named a path; otherwise accept the path from their menu answer's free-text.
-2. Copy the artifact out of the run dir to that path (`cp "$RUN_DIR/explainer.html" <path>`), creating parent directories if needed.
+2. Copy the artifact out of the run dir to that path (`cp "$RUN_DIR/explainer.html" <path>` — or `explainer.md` for a markdown run), creating parent directories if needed.
 3. Where the platform exposes a browser-opening primitive (`open` on macOS, `xdg-open` on Linux, `start` on Windows), offer to open it; otherwise print the absolute path.
 
 ## Publish to Proof (markdown output only)

--- a/skills/ce-explain/references/destinations.md
+++ b/skills/ce-explain/references/destinations.md
@@ -1,0 +1,30 @@
+# Destination Sub-flows
+
+Per-destination mechanics for Phase 6. The menu itself and the one-line action per option live inline in SKILL.md — this file carries only the elaborate sub-flows. Detection is by capability: probe the current session's tools and context; a missing binary, env var, or unloaded MCP tool is not proof of absence when a connector could supply the capability. Local file is the always-present floor.
+
+## Artifact surface
+
+Offered when an artifact-publishing tool is present in the session's toolset.
+
+Artifact surfaces wrap published content in their own document skeleton (doctype, head, body) and enforce a CSP that blocks requests to external hosts. Publishing the run-dir file verbatim would nest a full HTML document inside theirs and break on any external reference. So:
+
+1. Re-emit the explainer as **body-only markup**: strip the doctype/`<html>`/`<head>`/`<body>` shell; keep the content elements.
+2. Keep all CSS inline (a `<style>` element at the top of the fragment is acceptable); no external font links, no external images — the explainer's no-external-request invariant already guarantees this.
+3. Keep the visible metadata header and composition footer in the fragment — they are part of the artifact.
+4. Publish, confirm the returned URL/reference to the user.
+
+The run-dir file remains the complete standalone document; the fragment is a re-emission, not a replacement.
+
+## Local file
+
+1. Ask nothing extra if the user already named a path; otherwise accept the path from their menu answer's free-text.
+2. Copy the artifact out of the run dir to that path (`cp "$RUN_DIR/explainer.html" <path>`), creating parent directories if needed.
+3. Where the platform exposes a browser-opening primitive (`open` on macOS, `xdg-open` on Linux, `start` on Windows), offer to open it; otherwise print the absolute path.
+
+## Publish to Proof (markdown output only)
+
+Proof ingests markdown, so this option renders only when the run resolved `output:md`. Invoke the `ce-proof` skill via the platform's skill-invocation primitive when it is installed, passing the artifact path, a title (`Explainer: <subject>`), and identity `ai:compound-engineering` / `Compound Engineering`; surface the returned share URL. When the skill is not installed but the Proof web API is reachable, POST the markdown per that API. On failure: retry once after a short wait, then report plainly that the upload didn't succeed and why, and fall back to the local-file path. One-way publish; the run-dir file stays canonical.
+
+## Send to Thinkroom
+
+Offered only when a Thinkroom capability is detected — a Thinkroom skill in the session's skill list, a reachable MCP tool, or a documented CLI that responds. Use whatever interface that capability exposes to create/share a document from the explainer content, following that interface's own contract for title and body format. Surface the returned document reference. When the send fails, report it and fall back to the local-file path. Never guess at a Thinkroom API shape when no capability is detectable — the option simply doesn't render.

--- a/skills/ce-explain/references/explainer-html.md
+++ b/skills/ce-explain/references/explainer-html.md
@@ -1,0 +1,36 @@
+# Explainer HTML Rendering
+
+How an explainer renders as HTML. Load at compose time (Phase 4), not earlier. The explainer is a personal teaching artifact — these rules keep it self-contained, readable, and honest about its own provenance. It is not a plan artifact: no navigation region, no R/U-ID anchors, no contract sections.
+
+## Hard invariants
+
+- **Single self-contained HTML5 file.** No companion `.css`, `.js`, or `.svg` files. CSS lives in `<style>`. SVG lives inline. Images are base64 data URIs or inline SVG. No external requests of any kind — explainers must read identically offline and inside CSP-restricted viewers, so unlike the plan-artifact convention there is **no webfont exception**: use a system font stack.
+- **All metadata appears as visible text — single source of truth.** A visible header block carries: title, date, input shape (concept / diff / idea / recap), the subject (topic, ref, or window), and — when Phase 2 fell back to model knowledge — the label `Unverified — from model knowledge, not checked against current sources`. No hidden machine-readable copy: no JSON script block, no `data-*` mirror, no `<meta>` duplication. This header is what a future library layer indexes, so keep the field names stable.
+- **Display-only.** No forms, no click handlers, no embedded quizzes, no "submit" affordances, no scripts. The check-in lives in the session.
+- **ASCII identifiers.** Class names and element IDs are ASCII-only.
+- **Composition signal.** A visible footer names the composition timestamp and the composing skill: `Composed 2026-07-02 by ce-explain`.
+
+## Show-n-tell: match the form to the material
+
+Show, then tell — every explainer leads with something to look at, chosen by what the material actually is. One visual per load-bearing concept; never decoration.
+
+| Material | Show |
+|----------|------|
+| Architecture, relationships, boundaries | Inline SVG diagram (boxes and labeled arrows; halo/contrast so labels stay legible) |
+| Code behavior, a diff's mechanics | Annotated snippet: the real lines, with margin notes explaining the *why* per hunk |
+| A process, lifecycle, or state change | Numbered flow or state strip |
+| A window of work (recap) | Timeline: date-ordered entries, each with what changed and why it mattered |
+| A comparison or trade-off | Two-column contrast, prose verdict underneath |
+
+Diagrams complement prose; they never replace it. A reader who skips every visual still gets the full explanation in text.
+
+## Reading ergonomics
+
+- Hold prose to ~70ch (`max-width` on text blocks); full-width only for diagrams and code.
+- Lead each section with the point, then the mechanism, then the caveat.
+- Dense is good; long is not. The explainer is one sitting's read — cut background that doesn't change understanding.
+- Code samples: real code from the grounding evidence where it exists, invented minimal examples only for external topics, always syntax-highlighted with inline `<style>` classes.
+
+## Post-compose audit
+
+Before presenting: no external URLs anywhere in the file; metadata header complete and visible; every visual has a prose equivalent; the file opens correctly standalone (`open <path>`).

--- a/skills/ce-explain/references/explainer-markdown.md
+++ b/skills/ce-explain/references/explainer-markdown.md
@@ -1,0 +1,30 @@
+# Explainer Markdown Rendering
+
+How an explainer renders as markdown — the fallback format when intake resolved `output:md`. Load at compose time (Phase 4), not earlier. Content rules match the HTML reference; only the presentation medium differs.
+
+## Hard invariants
+
+- **YAML frontmatter carries the metadata:** `title`, `date`, `input_shape` (concept / diff / idea / recap), `subject`, and `unverified: true` when Phase 2 fell back to model knowledge. Field names are stable — a future library layer indexes them.
+- **Pure markdown.** No HTML elements, no `<details>`, no inline styles.
+- **Display-only.** No exercise or quiz content in the artifact; the check-in lives in the session.
+- **Repo-relative paths** for any file reference; never absolute paths.
+
+## Show-n-tell in markdown
+
+Markdown's visual affordances are narrower than HTML's — compensate, don't skip:
+
+| Material | Show |
+|----------|------|
+| Architecture, relationships, boundaries | Fenced `mermaid` block (`flowchart TB`) |
+| Code behavior, a diff's mechanics | Fenced code block per hunk with a one-line *why* comment above each |
+| A process, lifecycle, or state change | `mermaid` state/sequence diagram or a numbered list |
+| A window of work (recap) | Date-ordered list, each entry: what changed and why it mattered |
+| A comparison or trade-off | Pipe-delimited table, prose verdict underneath |
+
+Never hand-draw box-drawing/ASCII diagrams — mermaid or prose. Diagrams complement prose; a reader who skips them still gets the full explanation in text.
+
+## Reading ergonomics
+
+- Lead each section with the point, then the mechanism, then the caveat.
+- Dense is good; long is not — one sitting's read.
+- Real code from the grounding evidence where it exists; language-tagged fences always.

--- a/skills/ce-explain/references/intake.md
+++ b/skills/ce-explain/references/intake.md
@@ -1,0 +1,31 @@
+# Intake
+
+Classify the request into exactly one input shape — concept, diff, idea, or work-recap window — before any grounding runs. Parse by reasoning over the user's prompt; do not depend on argument-token substitution mechanics, which vary by harness.
+
+## Flag tokens
+
+Literal-prefix tokens are consumed and stripped; everything else is the request text.
+
+| Token | Example | Effect |
+|-------|---------|--------|
+| `diff:<ref-or-range>` | `diff:abc1234`, `diff:main..HEAD`, `diff:PR#42` | Forces diff mode on that change |
+| `since:<window-or-ref>` | `since:monday`, `since:7d`, `since:v2.1.0` | Forces recap mode over that window |
+| `output:<md\|html>` | `output:md` | Overrides the artifact format (default `html`) |
+
+- An explicit token always beats inference.
+- `diff:` and `since:` together conflict — say so and ask which mode the user wants.
+- An unrecognized `<word>:<word>` token (including conventional-commit prefixes like `feat:` appearing inside a topic) is not a flag — it passes through verbatim as request text.
+- `output:` with an unknown value: drop the token, note `Ignored unknown output: value '<value>' — using html`, and continue.
+
+## Inference (no forcing token)
+
+Classify the remaining text by shape:
+
+- **Diff** — the request names a resolvable change: a sha, branch, PR, "the last commit", "what you just did", "this change".
+- **Recap** — the request asks what happened over time: "what did I do this week", "catch me up", "prep me for standup". Default window when unspecified: the last 7 days in the current repo.
+- **Idea** — the request presents a proposal or notion of the user's to be understood: "explain my idea of X", "what would Y imply". The idea is a fixed given (see SKILL.md Boundaries).
+- **Concept** — everything else: a topic, pattern, subsystem, or external subject to learn.
+
+**Tiebreak — concept vs diff:** when the request is plausibly both (a repo topic that also names an identifiable recent change, e.g. "explain the retry logic we just added"), a concretely resolvable change wins: diff mode, with the concept as framing context. A topic with no resolvable change is a concept.
+
+**Repo footprint check (concept mode):** a concept grounds in the repo only when it actually touches it. An external subject (a language feature, an interview topic, a paper) gets no repo grounding — do not force it.

--- a/skills/ce-explain/references/repo-profile-cache.md
+++ b/skills/ce-explain/references/repo-profile-cache.md
@@ -1,0 +1,63 @@
+# Shared Repo-Grounding Profile Cache
+
+Read this when a repo-grounding skill needs the question-agnostic **project profile** (stack, deps, conventions, structure). The profile is derived once and reused within a session and across sessions and skills at an unchanged commit — only the *question-specific* grounding for the current run is ever re-derived.
+
+This file is **byte-duplicated** into every consuming skill (the plugin has no cross-skill import mechanism). All copies must stay identical; `tests/repo-profile-cache-parity.test.ts` enforces it. The deterministic cache I/O lives in the co-located `scripts/repo-profile-cache.py`; the derivation-on-miss is done by the co-located `references/agents/repo-profiler.md` persona.
+
+## What is cached (the agnostic profile)
+
+A single JSON object, versioned by `profile_schema_version`:
+
+- **Stack & versions** — languages, major frameworks + versions, build/test tooling.
+- **Dependency surface** — manifest + lockfile paths, top-level dependencies, project license + dependency licenses.
+- **Topology** — monorepo/workspace map, deployment model, API styles, data stores, module layout.
+- **Conventions & instruction files** — paths + digests of the *root* `AGENTS.md`/`CLAUDE.md`/`GEMINI.md`/`ARCHITECTURE.md`/`README.md`/`CONTRIBUTING.md`/`STRATEGY.md`.
+- **Vocabulary** — `CONCEPTS.md` canonical terms.
+
+## What is NOT cached (always re-globbed fresh)
+
+Never read from the cache — recompute every run:
+
+- The `docs/solutions/` enumeration (a new learning, even uncommitted, must be visible — re-globbing it is ~free and the match reads files fresh anyway).
+- Subdirectory-scoped instruction files (area-scoped `CLAUDE.md`/`AGENTS.md`).
+- All question-specific grounding: a candidate's call-sites/footprint, prior-decision matches, feature patterns, git history of touched files, tracker/PR activity, external research.
+
+## Cache location & key
+
+```
+/tmp/compound-engineering/repo-profile/<root-sha>/<head-sha>.json
+```
+
+- `<root-sha>` = lexicographically-first `git rev-list --max-parents=0 HEAD` — the repo identity (stable, shared across worktrees and clones).
+- `<head-sha>` = `git rev-parse HEAD` — the working state.
+
+Two checkouts at the same commit share the same entry. Lookup is git metadata only; on a hit, only this one file is read.
+
+## Protocol — how a skill uses it
+
+Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
+
+```bash
+SKILL_DIR="<absolute path of this skill's directory>"
+python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
+```
+
+`get` prints exactly one of:
+
+- `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
+- `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
+  ```bash
+  SKILL_DIR="<absolute path of this skill's directory>"
+  python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
+  ```
+- `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).
+
+In all three cases, after the agnostic profile is in hand, run **this skill's question-specific grounding fresh** on top of it.
+
+## Freshness (delta-aware)
+
+A cached entry is a `HIT` only when, at the current `HEAD`, its `profile_schema_version` matches and **no profile-input path** is dirty or newly-added. Freshness is checked with `git status --porcelain --untracked-files=all`, so untracked (`??`) new inputs invalidate too. The profile-input set is a conservative **superset** of every file the schema derives from — dependency manifests + lockfiles (any depth), license, root instruction/doc files, `CONCEPTS.md`/`STRATEGY.md`, topology sources (`Dockerfile`, `.github/workflows/`, `.cursor/rules`). A dirty source file, `docs/plans/*`, or other non-input path does **not** invalidate. Completeness of this set is the cardinal-rule safety requirement: over-invalidating costs a re-derive; under-invalidating would serve a stale profile.
+
+## Degradation
+
+The cache is an optimization, never a correctness dependency. Outside a git repo, with no writable `/tmp`, or on an unreadable/malformed entry, the helper returns `NO-CACHE`/`MISS` (exit 0) and the skill derives fresh. It never blocks and never serves a profile it cannot prove fresh. And if the helper *invocation itself* fails — a non-zero exit, empty output, or an unresolved `SKILL_DIR` so the script isn't found — treat it exactly like `NO-CACHE`: derive the profile fresh this run and proceed. Never stall waiting on the cache.

--- a/skills/ce-explain/scripts/repo-profile-cache.py
+++ b/skills/ce-explain/scripts/repo-profile-cache.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Shared repo-grounding project-profile cache: deterministic get/put.
+
+This helper owns the *deterministic* cache I/O for the question-agnostic
+project profile that repo-grounding skills reuse. The non-deterministic
+derivation (reading manifests, summarizing conventions) is done by the
+`repo-profiler` persona only on a miss — never here.
+
+Usage:
+    python3 repo-profile-cache.py get
+    python3 repo-profile-cache.py put <profile-json-file>
+
+`get` prints exactly one of:
+    HIT\\n<profile-json>     a valid entry exists for the current repo state;
+                            the profile JSON follows on subsequent lines
+    MISS\\n<write-path>      git repo, no valid entry — caller derives the
+                            profile and calls `put <write-path-or-any-file>`
+    NO-CACHE                no git repo or no writable cache — caller derives
+                            the profile fresh and skips `put`
+
+`put <file>` reads the profile JSON from <file>, wraps it with a validity
+stamp, and writes it atomically to the computed cache path. Prints the path
+on success, `NO-CACHE` when the repo/cache is unavailable.
+
+Cache path:
+    /tmp/compound-engineering/repo-profile/<root-sha>/<head-sha>.json
+  root-sha = lexicographically-first `git rev-list --max-parents=0 HEAD`
+             (deterministic even for multi-root histories) — the repo identity,
+             shared across worktrees and clones.
+  head-sha = `git rev-parse HEAD` — the working state.
+
+Validity (HIT) requires ALL of:
+  - the cache file exists and parses as JSON,
+  - stored `head_sha` == current HEAD,
+  - stored `profile_schema_version` == PROFILE_SCHEMA_VERSION,
+  - no profile-input path is dirty or newly-added per `git status --porcelain`
+    (the schema-derived superset in `is_profile_input`, which also catches
+    untracked `??` files — a newly-added manifest or AGENTS.md must invalidate).
+
+Cardinal rule: this cache is an optimization, never a correctness dependency.
+Every failure mode (not a git repo, unreadable/malformed cache, no writable
+/tmp, git errors) degrades to NO-CACHE/MISS and exits 0 — it never raises and
+never serves a profile it cannot prove fresh.
+
+Pure stdlib. No third-party dependencies.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+# Bump when the profile schema changes so a newer reader never reuses an
+# entry written under an older (narrower) schema.
+PROFILE_SCHEMA_VERSION = "1"
+
+CACHE_ROOT = "/tmp/compound-engineering/repo-profile"
+
+# --- Profile-input set (the schema-derived superset, per the plan's R3) -------
+# Any change to one of these — including a NEW untracked file — must invalidate
+# the cached profile. Conservative by design: over-invalidating costs a
+# re-derive; under-invalidating serves a stale profile (a cardinal-rule break).
+
+# Dependency manifests + lockfiles. Matched by basename at ANY depth so a
+# monorepo workspace's manifest also invalidates. The profiler derives
+# stack/deps for ANY language, so this list must span ecosystems, not just JS —
+# an omitted manifest means a dirty dep bump at unchanged HEAD serves a stale
+# profile (a cardinal-rule break).
+_MANIFEST_LOCKFILE = {
+    # JavaScript / TypeScript / Deno
+    "package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
+    "pnpm-workspace.yaml", "bun.lock", "bun.lockb", "npm-shrinkwrap.json",
+    "deno.json", "deno.jsonc", "deno.lock",
+    # Monorepo / workspace orchestrators
+    "nx.json", "lerna.json", "turbo.json", "rush.json",
+    # Go (incl. workspaces)
+    "go.mod", "go.sum", "go.work", "go.work.sum",
+    # Rust
+    "Cargo.toml", "Cargo.lock",
+    # Ruby
+    "Gemfile", "Gemfile.lock", "gems.rb", "gems.locked",
+    # Python
+    "pyproject.toml", "poetry.lock", "Pipfile", "Pipfile.lock",
+    "requirements.txt", "setup.py", "setup.cfg",
+    "uv.lock", "pdm.lock", "environment.yml", "environment.yaml",
+    # PHP
+    "composer.json", "composer.lock",
+    # JVM (Maven / Gradle incl. version catalogs)
+    "pom.xml", "build.gradle", "build.gradle.kts", "settings.gradle",
+    "settings.gradle.kts", "libs.versions.toml", "build.sbt",
+    # Elixir / Dart
+    "mix.exs", "mix.lock", "pubspec.yaml", "pubspec.lock",
+    # Swift / iOS (a live target for this project)
+    "Package.swift", "Package.resolved", "Podfile", "Podfile.lock",
+    "Cartfile", "Cartfile.resolved",
+    # .NET
+    "packages.config", "Directory.Packages.props", "Directory.Build.props",
+    "paket.dependencies", "paket.lock",
+    # C / C++
+    "CMakeLists.txt", "conanfile.txt", "conanfile.py", "vcpkg.json",
+    # Haskell
+    "stack.yaml", "stack.yaml.lock", "cabal.project",
+}
+
+# Project-file extensions whose presence or version edit changes the stack
+# profile. Suffix-matched at any depth (e.g. Foo.csproj, App.sln).
+_PROJECT_FILE_SUFFIXES = (
+    ".csproj", ".fsproj", ".vbproj", ".sln", ".cabal", ".tf", ".tfvars",
+)
+
+_LICENSE = {"LICENSE", "LICENSE.md", "LICENSE.txt", "LICENCE", "COPYING"}
+
+# Topology / deployment sources. Basename match at any depth — these determine
+# the derived deployment model (monolith / multi-service / serverless).
+_TOPOLOGY = {
+    "Dockerfile", "Containerfile",
+    "docker-compose.yml", "docker-compose.yaml",
+    "vercel.json", "netlify.toml", "fly.toml", "render.yaml",
+    "serverless.yml", "serverless.yaml", "app.yaml", "Procfile",
+    # IaC descriptors that define the deployment topology.
+    "Pulumi.yaml", "Pulumi.yml", "Chart.yaml",
+    # CI descriptors outside .github/workflows/ (that prefix is handled below).
+    ".gitlab-ci.yml", "Jenkinsfile", "azure-pipelines.yml",
+}
+
+# Path prefixes whose contents shape the profile (conventions / CI / deploy).
+_INPUT_PREFIXES = (
+    ".cursor/", ".github/workflows/", ".circleci/",
+    "terraform/", "k8s/", "kubernetes/",
+)
+
+# Root-level instruction/doc files cached in the profile. Matched ONLY at the
+# repo root — subdirectory-scoped instruction files (e.g. nested CLAUDE.md /
+# AGENTS.md) are NOT cached; consumers re-glob those fresh, so a subdir change
+# must not invalidate the root profile.
+_ROOT_DOCS = {
+    "AGENTS.md", "CLAUDE.md", "GEMINI.md",
+    "CONCEPTS.md", "STRATEGY.md",
+    "ARCHITECTURE.md", "README.md", "CONTRIBUTING.md",
+    ".cursorrules",  # legacy root-level Cursor rules (the profiler reads it)
+}
+
+# Runtime / tool version selectors that pin a language or tool version OUTSIDE
+# the manifests (the profiler reads these for stack versions). Basename match.
+_VERSION_SELECTORS = {
+    ".nvmrc", ".node-version", ".python-version", ".ruby-version",
+    ".java-version", ".go-version", ".terraform-version",
+    ".tool-versions", "mise.toml", ".mise.toml", ".sdkmanrc",
+}
+
+
+def is_profile_input(path: str) -> bool:
+    """True when a changed path is one the cached profile derives from.
+
+    Deliberately a conservative superset: anything plausibly feeding the
+    stack/deps/topology/conventions profile invalidates. Over-matching costs a
+    re-derive; under-matching serves a stale profile (a cardinal-rule break).
+    """
+    base = os.path.basename(path)
+    if (
+        base in _MANIFEST_LOCKFILE
+        or base in _LICENSE
+        or base in _TOPOLOGY
+        or base in _VERSION_SELECTORS
+    ):
+        return True
+    if base.endswith(_PROJECT_FILE_SUFFIXES):
+        return True
+    if "/" not in path and base in _ROOT_DOCS:
+        return True
+    if path.startswith(_INPUT_PREFIXES):
+        return True
+    return False
+
+
+def git(*args: str) -> "str | None":
+    """Run a git command; return stripped stdout, or None on any failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=False
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def root_sha() -> "str | None":
+    out = git("rev-list", "--max-parents=0", "HEAD")
+    if not out:
+        return None
+    # Multi-root histories print several SHAs; pick a deterministic one.
+    return sorted(out.split("\n"))[0]
+
+
+def changed_paths() -> "list[str] | None":
+    """Paths from `git status --porcelain`, or None if it could not run.
+
+    Includes untracked (`??`) entries so a newly-added profile input is seen.
+    None signals "could not determine cleanliness" — the caller treats that
+    conservatively as a miss rather than serving an unverified profile.
+    """
+    # --untracked-files=all lists individual untracked files; without it git
+    # collapses a fully-untracked new directory to a single `?? dir/` entry,
+    # which would hide a newly-added manifest inside it.
+    #
+    # Call subprocess directly rather than via git(): porcelain's status
+    # columns include a significant LEADING space (e.g. " M path"), and
+    # git()'s .strip() would eat it and shift the path slice.
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=all"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    def clean(token: str) -> str:
+        token = token.strip()
+        # git quotes paths containing special characters.
+        if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+            token = token[1:-1]
+        return token
+
+    paths: list[str] = []
+    for line in result.stdout.split("\n"):
+        if not line.strip():
+            continue
+        rest = line[3:]
+        # Rename/copy entries are "old -> new"; BOTH endpoints changed. A
+        # profile input renamed *away* (e.g. `package.json -> pkg.json`) must
+        # still invalidate, so keep the source path, not just the destination.
+        if " -> " in rest:
+            for token in rest.split(" -> ", 1):
+                p = clean(token)
+                if p:
+                    paths.append(p)
+            continue
+        p = clean(rest)
+        if p:
+            paths.append(p)
+    return paths
+
+
+def cache_path(root: str, head: str) -> str:
+    return os.path.join(CACHE_ROOT, root, f"{head}.json")
+
+
+def resolve_keys() -> "tuple[str, str] | None":
+    """The (root-sha, head-sha) cache key, or None if not a usable git repo."""
+    root = root_sha()
+    head = git("rev-parse", "HEAD")
+    if not root or not head:
+        return None
+    return root, head
+
+
+_PROFILE_KEYS = ("stack", "dependencies", "topology", "conventions", "vocabulary")
+
+
+def is_valid_profile(profile: object) -> bool:
+    """A profile must be an object carrying every expected top-level key. This
+    rejects a profiler failure that still returned JSON — a wrapper/error object
+    or a partial result — which would otherwise be cached and served as a HIT,
+    leaving consumers to skip fresh derivation and read missing fields from a
+    broken object."""
+    return isinstance(profile, dict) and all(k in profile for k in _PROFILE_KEYS)
+
+
+def do_get() -> int:
+    keys = resolve_keys()
+    if keys is None:
+        print("NO-CACHE")
+        return 0
+    root, head = keys
+    path = cache_path(root, head)
+
+    def miss() -> int:
+        print("MISS")
+        print(path)
+        return 0
+
+    # A missing file raises FileNotFoundError (an OSError) and degrades to the
+    # same MISS, so no separate existence check is needed.
+    try:
+        with open(path) as f:
+            # /tmp is world-shared, so reject a cache file not owned by us: a
+            # co-tenant could plant an entry that passes the gates below and
+            # feed attacker-controlled text into the agent as the "profile"
+            # (indirect prompt injection). Skip where geteuid is unavailable
+            # (non-POSIX), where this shared-tmp threat does not apply.
+            geteuid = getattr(os, "geteuid", None)
+            if geteuid is not None and os.fstat(f.fileno()).st_uid != geteuid():
+                return miss()
+            doc = json.load(f)
+    except (OSError, ValueError):
+        return miss()
+
+    profile = doc.get("profile") if isinstance(doc, dict) else None
+    if (
+        not isinstance(doc, dict)
+        or doc.get("head_sha") != head
+        or doc.get("profile_schema_version") != PROFILE_SCHEMA_VERSION
+        or not is_valid_profile(profile)
+    ):
+        return miss()
+
+    changed = changed_paths()
+    # Could not determine cleanliness, or a profile input changed/was added.
+    if changed is None or any(is_profile_input(p) for p in changed):
+        return miss()
+
+    print("HIT")
+    print(json.dumps(profile))
+    return 0
+
+
+def do_put(profile_file: str) -> int:
+    keys = resolve_keys()
+    if keys is None:
+        print("NO-CACHE")
+        return 0
+    root, head = keys
+
+    try:
+        with open(profile_file) as f:
+            profile = json.load(f)
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"repo-profile-cache: cannot read profile: {exc}\n")
+        print("NO-CACHE")  # nothing persisted; keep the stdout contract
+        return 0  # degrade — never block the caller
+
+    # Shape guard: the profile must be an object carrying the expected top-level
+    # keys. A misbehaving profiler that returns garbage JSON (`{}`, `"oops"`,
+    # `[]`, `42`) or a partial/error object must not be cached and then served
+    # to every skill as the agnostic profile. Reject it (the caller already has
+    # its own derived profile for this run; the next run re-derives).
+    if not is_valid_profile(profile):
+        sys.stderr.write(
+            "repo-profile-cache: profile is not a valid profile object; not caching\n"
+        )
+        print("NO-CACHE")
+        return 0
+
+    # Do not cache a profile derived from a DIRTY tree: it reflects uncommitted
+    # edits to profile inputs, yet it would be stored under the clean HEAD key
+    # and served as a HIT after those edits are reverted (same HEAD, clean tree)
+    # — stale. Only persist a profile that matches the committed HEAD.
+    changed = changed_paths()
+    if changed is None or any(is_profile_input(p) for p in changed):
+        sys.stderr.write(
+            "repo-profile-cache: profile inputs are dirty; not caching\n"
+        )
+        print("NO-CACHE")
+        return 0
+
+    doc = {
+        "profile_schema_version": PROFILE_SCHEMA_VERSION,
+        "root_sha": root,
+        "head_sha": head,
+        "built_at": datetime.now(timezone.utc).isoformat(),
+        "profile": profile,
+    }
+
+    path = cache_path(root, head)
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # Atomic write: temp file in the same dir + os.replace (atomic on
+        # POSIX) so a concurrent reader never sees a torn JSON.
+        fd, tmp = tempfile.mkstemp(
+            dir=os.path.dirname(path), prefix=".tmp-", suffix=".json"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(doc, f)
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception as exc:  # never block the caller, whatever the failure
+        sys.stderr.write(f"repo-profile-cache: cannot write cache: {exc}\n")
+        print("NO-CACHE")
+        return 0
+
+    print(path)
+    return 0
+
+
+def usage() -> int:
+    sys.stderr.write(
+        "usage: repo-profile-cache.py get | put <profile-json-file>\n"
+    )
+    return 2
+
+
+def main(argv: "list[str]") -> int:
+    if len(argv) < 2:
+        return usage()
+    cmd = argv[1]
+    if cmd == "get":
+        return do_get()
+    if cmd == "put":
+        if len(argv) != 3:
+            return usage()
+        return do_put(argv[2])
+    return usage()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -147,7 +147,7 @@ describe("release metadata", () => {
 
     expect(counts).toEqual({
       agents: 0,
-      skills: 27,
+      skills: 28,
       mcpServers: 0,
     })
   })

--- a/tests/repo-profile-cache-parity.test.ts
+++ b/tests/repo-profile-cache-parity.test.ts
@@ -23,6 +23,7 @@ const CONSUMER_SKILLS = [
   "ce-code-review",
   "ce-compound",
   "ce-debug",
+  "ce-explain",
 ]
 
 describe("repo-profile-cache shared-asset parity", () => {

--- a/tests/skills/ce-explain-routing.test.ts
+++ b/tests/skills/ce-explain-routing.test.ts
@@ -37,9 +37,11 @@ describe("ce-explain destination and handoff routing", () => {
       // Bullet form: `- **<fragment>**` then a separator and at least one
       // non-newline character of action text on the SAME line ([ \t]*, not
       // \s*, so an empty-action bullet cannot match by spilling into the next
-      // bullet's leading `-`).
+      // bullet's leading `-`). The separator requires surrounding whitespace
+      // (` — ` / ` - `) so a mid-word hyphen in a qualifier like
+      // "(auto-generated)" cannot satisfy the action-separator match.
       const inlineRoutingPattern = new RegExp(
-        `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*[^\\n]*[—-][ \\t]*[^\\n]+`,
+        `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*[^\\n]*[ \\t][—-][ \\t]+[^\\n]+`,
         "m",
       )
       expect(

--- a/tests/skills/ce-explain-routing.test.ts
+++ b/tests/skills/ce-explain-routing.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const SKILL_PATH = path.join(process.cwd(), "skills/ce-explain/SKILL.md")
+const SKILL_BODY = readFileSync(SKILL_PATH, "utf8")
+
+// Regression guard mirroring tests/skills/ce-plan-handoff-routing.test.ts
+// (issue #714 class): SKILL.md content caches at session start while reference
+// files load on demand, so the bare per-option action for the Phase 6
+// destination ask and the outbound handoffs MUST live inline in SKILL.md —
+// not solely in references/destinations.md. Symptom when this regresses: the
+// agent renders the destination menu, the user picks an option, and the agent
+// stops in prose without firing the action.
+describe("ce-explain destination and handoff routing", () => {
+  const phaseStart = SKILL_BODY.indexOf("### Phase 6")
+
+  test("SKILL.md contains the Phase 6 destination-ask region", () => {
+    expect(
+      phaseStart,
+      "ce-explain SKILL.md no longer contains the '### Phase 6' heading — the test anchor needs updating, or the destination ask was removed.",
+    ).toBeGreaterThan(-1)
+  })
+
+  const phaseRegion = phaseStart > -1 ? SKILL_BODY.slice(phaseStart) : ""
+
+  test("inline routing exists for every destination option", () => {
+    const optionFragments: { name: string; fragment: string }[] = [
+      { name: "Artifact surface", fragment: "Artifact surface" },
+      { name: "Local file", fragment: "Local file" },
+      { name: "Publish to Proof", fragment: "Publish to Proof" },
+      { name: "Send to Thinkroom", fragment: "Send to Thinkroom" },
+      { name: "Leave it", fragment: "Leave it" },
+    ]
+    for (const { name, fragment } of optionFragments) {
+      const escaped = fragment.replace(/[.*+?^${}()|[\]\\`]/g, "\\$&")
+      // Bullet form: `- **<fragment>**` then a separator and at least one
+      // non-newline character of action text on the SAME line ([ \t]*, not
+      // \s*, so an empty-action bullet cannot match by spilling into the next
+      // bullet's leading `-`).
+      const inlineRoutingPattern = new RegExp(
+        `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*[^\\n]*[—-][ \\t]*[^\\n]+`,
+        "m",
+      )
+      expect(
+        inlineRoutingPattern.test(phaseRegion),
+        `ce-explain SKILL.md Phase 6 is missing inline routing for destination option "${name}". The bare per-option action MUST live in SKILL.md (not solely in references/destinations.md). See docs/solutions/skill-design/post-menu-routing-belongs-inline.md.`,
+      ).toBe(true)
+    }
+  })
+
+  test("ce-ideate and ce-simplify-code handoffs use the skill-invocation primitive", () => {
+    for (const target of ["ce-ideate", "ce-simplify-code"]) {
+      const bullet = phaseRegion.match(
+        new RegExp(`^- \\*\\*[^\\n]+\\*\\*[^\\n]*\`${target}\`[^\\n]+`, "m"),
+      )
+      expect(
+        bullet,
+        `ce-explain SKILL.md Phase 6 is missing the inline handoff bullet naming ${target}.`,
+      ).not.toBeNull()
+      expect(
+        /skill[\s-]?invocation|Skill tool|skill primitive/i.test(bullet![0]),
+        `ce-explain SKILL.md ${target} handoff must name the skill-invocation primitive so the agent fires the invocation rather than announcing a handoff in prose.`,
+      ).toBe(true)
+    }
+  })
+
+  test("ce-polish handoff is user-run, never skill-invoked", () => {
+    // ce-polish sets disable-model-invocation: true (pinned in
+    // EXPECTED_USER_INVOKED_SKILLS in tests/skill-conventions.test.ts), so the
+    // model cannot dispatch it via the Skill tool. The routing must present
+    // observations in chat and tell the user to run /ce-polish themselves.
+    const polishBullet = phaseRegion.match(/^- \*\*[^\n]*polish[^\n]*\*\*[^\n]+/im)
+    expect(
+      polishBullet,
+      "ce-explain SKILL.md Phase 6 is missing the inline UI/UX polish handoff bullet.",
+    ).not.toBeNull()
+    const line = polishBullet![0]
+    expect(
+      /tell the user to run\s+`\/ce-polish`|user-invoked only/i.test(line),
+      "ce-explain SKILL.md polish handoff must present observations in chat and route to a user-run /ce-polish.",
+    ).toBe(true)
+    expect(
+      /invoke the `ce-polish` skill/i.test(line),
+      "ce-explain SKILL.md polish handoff must NOT instruct invoking ce-polish via the skill primitive — it is user-invoked only (disable-model-invocation).",
+    ).toBe(false)
+  })
+
+  test("predict-then-reveal ordering rule is inline in SKILL.md", () => {
+    // R13: the leak-proof ordering is load-bearing and must not live only in
+    // references/check-in.md, which an agent might not load before acting.
+    expect(
+      /end the turn/i.test(SKILL_BODY) &&
+        /before the user's prediction turn ends/i.test(SKILL_BODY),
+      "ce-explain SKILL.md must carry the predict-then-reveal ordering rule inline (show raw change only, take the prediction, end the turn).",
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Adds `/ce-explain` — a personal learning skill: point it at a concept (repo-grounded or external), a diff, an idea, or a window of your own recent work, and it produces a dense, visual, HTML-first explainer written for you personally. When the material warrants retention, the session continues with a check-in: **predict-then-reveal** for diffs (you say what you think the change does before any explanation appears — the turn ends before the reveal), corrected exercises for concepts. The run ends with a capability-detected destination ask (artifact surface / local file / Proof / Thinkroom), with the artifact safely written to a stable run dir before the ask.

Implements `docs/plans/2026-07-02-002-feat-ce-explain-skill-plan.md` (brainstormed, planned, doc-reviewed, and code-reviewed via the full CE pipeline this session).

## What's in the diff

- `skills/ce-explain/` — SKILL.md + topical references (intake token table, check-in protocol, HTML/markdown rendering contracts, destination sub-flows, work-recap scout persona) following the ce-pov structural template
- Repo-profile cache consumership: byte-copied asset trio + `ce-explain` registered in the parity test
- `tests/skills/ce-explain-routing.test.ts` — regression guard for inline destination/handoff routing (post-menu-routing-belongs-inline learning); notably asserts ce-polish is NEVER skill-invoked (it is user-invoked only)
- Registration: README inventory + curated table rows, docs/skills catalog row + page, release-metadata count 27→28
- `CONCEPTS.md`: adds Explainer and Check-in vocabulary

## Verification

- `bun test`: 1742 pass / 0 fail; `bun run release:validate`: green at 28 skills
- Six behavioral evals (fresh-content subagent dispatch per AGENTS.md): all pass — leak test (no interpretive content before the prediction turn ends), routine-recap skip, external-topic grounding with Unverified labeling, bare-environment destination fallback, no-blocking-tool stop-and-wait, handoff routing
- Independent code review (6 personas + 2 validators): verdict "Ready with fixes" — 3 of 4 findings applied in `fix(review)`, plus an agent-native option-cap fix

## Residual Review Findings

- **P2** — `skills/ce-explain/SKILL.md:70` — Predict-then-reveal protocol duplicated with only substring guard — filed: https://github.com/EveryInc/compound-engineering-plugin/issues/1057 (resolution: keep both copies per AGENTS.md inline-the-trigger doctrine; add cross-file parity assertions)

## Merge-order note

The unmerged `feat/ce-sweep-skill` branch bumps the same skill-count lines (README sentence + `tests/release-metadata.test.ts`). Whichever PR merges second resolves the trivial conflict to 29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
