### PR TITLE
refactor(converters): remove dead code in opencode permission builder

### DIFF
--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -478,17 +478,6 @@ function applyPermissions(
     }
   }
 
-  if (mode !== "broad") {
-    for (const [tool, toolPatterns] of Object.entries(patterns)) {
-      if (!toolPatterns || toolPatterns.size === 0) continue
-      const patternPermission: Record<string, "allow" | "deny"> = { "*": "deny" }
-      for (const pattern of toolPatterns) {
-        patternPermission[pattern] = "allow"
-      }
-      ;(permission)[tool] = patternPermission
-    }
-  }
-
   if (enabled.has("write") || enabled.has("edit")) {
     if (typeof permission.edit === "string") permission.edit = "allow"
     if (typeof permission.write === "string") permission.write = "allow"
@@ -506,10 +495,6 @@ function applyPermissions(
   }
 
   config.permission = permission
-}
-
-function normalizeTool(raw: string): string | null {
-  return parseToolSpec(raw).tool
 }
 
 function parseToolSpec(raw: string): { tool: string | null; pattern?: string } {


### PR DESCRIPTION
Removes two pieces of dead code in `src/converters/claude-to-opencode.ts`, with no behavior change:

- **Duplicate pattern loop in `applyPermissions`.** A second `if (mode !== "broad")` loop over `Object.entries(patterns)` rebuilt and overwrote pattern permissions identically to the `sourceTools` loop above it. Every `patterns` key comes from `TOOL_MAP`, whose values are all within `sourceTools`, so the first loop already emits the same `{ "*": "deny", ...patterns }` object for each — the second just overwrote with a byte-identical object.
- **Unused `normalizeTool`.** Defined but never referenced anywhere in `src/`, `tests/`, or `scripts/`.

### Scope change from the original PR

The original PR also included a tilde-expansion fix in `src/utils/resolve-home.ts`. That exact fix landed independently on `main` in #1055 (with an explanatory comment), so it has been dropped here to resolve the merge conflict; only the dead-code removal remains.

### Test plan
- [x] `bun test` — 1893 pass
- [x] `bun run release:validate` — in sync