### PR TITLE
fix(tests): bump expected skill count to 29 after ce-sweep landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The first pass tightens recent branch changes before review. The targeted pass i
 
 After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
 
-The `compound-engineering` plugin currently ships 28 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+The `compound-engineering` plugin currently ships 29 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
 
 ### Full Skill Inventory
 

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -147,7 +147,7 @@ describe("release metadata", () => {
 
     expect(counts).toEqual({
       agents: 0,
-      skills: 28,
+      skills: 29,
       mcpServers: 0,
     })
   })


### PR DESCRIPTION
## Summary
- CI on main is failing: `tests/release-metadata.test.ts` asserts 28 skills but the repo now ships 29.
- ce-explain (#1058) and ce-sweep (#1056) each added a skill and each bumped the expected count from 27 to 28; when both merged, main ended at 29 skills with the assertion stuck at 28 (failure visible in run 28680491968).
- Bumps the assertion to 29 and updates the README inventory sentence ("ships 28 skills" -> 29) to match.

## Test plan
- [x] `bun test` — 1816 pass, 0 fail
- [x] `bun run release:validate` — reports metadata in sync at 29 skills