### PR TITLE
fix: align skill count with 29 skills on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The first pass tightens recent branch changes before review. The targeted pass i
 
 After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
 
-The `compound-engineering` plugin currently ships 28 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+The `compound-engineering` plugin currently ships 29 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
 
 ### Full Skill Inventory
 

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -147,7 +147,7 @@ describe("release metadata", () => {
 
     expect(counts).toEqual({
       agents: 0,
-      skills: 28,
+      skills: 29,
       mcpServers: 0,
     })
   })


### PR DESCRIPTION
The ce-sweep (#1056) and ce-explain (#1058) PRs each bumped the skill-count line 27->28 identically, so git merged both without a conflict and each branch was green in isolation. After both landed, main has 29 skills on disk with assertions of 28, which is failing the `test` check on release PR #1059.

Bumps `tests/release-metadata.test.ts` and the README count sentence to 29. `bun test` and `bun run release:validate` green locally at 29.

Unblocks #1059 (v3.18.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)