### PR TITLE
fix(ce-brainstorm,ce-plan): add blindspot pass for unfamiliar territory

### DIFF
--- a/docs/skills/ce-brainstorm.md
+++ b/docs/skills/ce-brainstorm.md
@@ -50,6 +50,7 @@ A typical "let's brainstorm" with an AI also has shape problems: it asks five qu
 - **One question per turn**, even when sub-questions feel related
 - **Right-sized ceremony** — Lightweight / Standard / Deep / Deep-product tiers
 - **Named gap lenses** force rigor on premises before generating approaches
+- **An opt-in blindspot pass** maps the decision surface of territory the user doesn't know before the interview proceeds on it
 - **A background grounding scout** gathers verbatim repo evidence on a cheap model while you answer the opening questions
 - **2-3 concrete approaches** with tradeoffs, then a stated recommendation
 - **Opt-in visual probes** for decisions that are faster to judge as rough sketches than prose
@@ -105,7 +106,11 @@ Building a software feature? Standard flow. Naming a product? Choosing a vacatio
 
 Requirements describe **what** behavior is expected from the user's perspective. They do not describe libraries, schemas, endpoints, file layouts, or code structure — unless the brainstorm is itself about a technical or architectural decision. This keeps planning's job clean: invent the **how**, not the **what**.
 
-### 10. Grounding and verification ride inside your think-time
+### 10. Blindspot pass for unfamiliar territory
+
+The interview machinery assumes you can evaluate what it asks — and that assumption fails exactly when you're scoping work in territory you don't know. When you flag unfamiliarity ("I know nothing about the auth modules", "I don't know what color grading is"), or consecutive answers show you *can't weigh the options* rather than merely haven't decided, `ce-brainstorm` offers a **blindspot pass** before questioning you further on that territory: a grounded map of 3-7 decisions and hazards you didn't know to ask about, each with why it matters for your topic, the realistic options, and a recommended default. You pick which to walk through; the rest take defaults recorded as explicit assumptions. It converts unknown unknowns into known unknowns, so the interview extracts choices instead of guesses. Works on both the software and non-software routes.
+
+### 11. Grounding and verification ride inside your think-time
 
 On Standard and Deep brainstorms, a cheap extraction-tier scout is dispatched in the background while you answer the first question. It writes a grounding dossier — verbatim quotes with `file:line` pointers — to scratch storage and hands back a short gist, so the dialogue stays lean while the evidence stays available on demand. Before the requirements-only unified plan is written, a fresh-context verifier (a mid-tier model that never saw the dialogue) checks the Product Contract's repo claims — absence claims, file references — against the codebase, running while you review the synthesis confirmation. Refuted claims are corrected before the plan lands; unverifiable ones become explicit assumptions. The dossier path is handed to `ce-plan` so planning starts from verified quotes instead of re-scanning. On platforms without per-agent model selection, both run on the inherited model with the same read budgets; with no subagent support at all, the skill falls back to inline scanning and verification.
 
@@ -132,6 +137,7 @@ Reach for `ce-brainstorm` when:
 - The scope is unclear ("add notifications" — what kind? for whom? when?)
 - You want a structured artifact you can hand to another contributor or to planning
 - A vague problem statement needs to become a real product decision
+- You have to scope work in territory you don't know — the blindspot pass maps the decision surface before questions begin
 - You're working on something non-software (named products, roadmap choices, decisions)
 
 Skip `ce-brainstorm` when:

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-brainstorm
-description: 'Explore vague or ambitious ideas into a right-sized requirements-only unified plan. Use when the user wants to brainstorm, think through scope, decide what to build, or needs collaborative product framing before planning. Not for executing already-specified work — direct implementation, debugging, or code review where no product scope is left to decide. Not for a decisive verdict on whether to adopt or switch to a specific external technology, library, or platform — brainstorming scopes what to build, not whether to commit to an outside option.'
+description: 'Explore vague or ambitious ideas into a right-sized requirements-only unified plan. Use when the user wants to brainstorm, think through scope, decide what to build, or needs collaborative product framing before planning. Also use when the user must scope work in territory they say they do not know ("I know nothing about X but need to...") or asks for a blindspot pass — mapping the decision surface before questions begin. Not for executing already-specified work — direct implementation, debugging, or code review where no product scope is left to decide. Not for a decisive verdict on whether to adopt or switch to a specific external technology, library, or platform — brainstorming scopes what to build, not whether to commit to an outside option.'
 argument-hint: "[feature idea or problem to explore] [output:html]"
 ---
 
@@ -142,6 +142,8 @@ Product-tier triggers additional Phase 1.2 questions and additional Product Cont
 
 **Visual probe tripwire.** If the feature is inherently visual or spatial — drawing/canvas tools, annotation behavior, visual editors, UI layout or navigation, interaction states, charts, diagrams, animation, maps, timelines, or spatial flows — read `references/visual-probes.md` now. Strong signals include freehand vs constrained drawing behavior, canvas annotation tools, layout comparisons, and state/flow placement. Loading the reference here is readiness only; it owns when the gate fires (state-based, at the first shape/behavior/state/layout/flow/diagram decision), the text-vs-visual offer, and helper invocation.
 
+**Unfamiliarity tripwire.** If the user signals they lack working knowledge of the domain or the territory the topic touches — "I know nothing about X", "never touched the auth modules", "I don't know what's possible / what I should be asking" — read `references/blindspot-pass.md` now. Loading here is readiness only; the reference owns when the offer fires (territory-scoped, before the first substantive question into the flagged territory), the map's shape, and how mapped decisions re-enter the dialogue.
+
 ### Phase 1: Understand the Idea
 
 #### 1.1 Existing Context Scan
@@ -188,6 +190,8 @@ Read `references/product-pressure-test.md` for the per-tier lens catalog (Lightw
 #### 1.3 Collaborative Dialogue
 
 Follow the Interaction Rules above. Use the platform's blocking question tool when available.
+
+**Blindspot gate — check it before probing flagged territory.** If the Phase 0.3 unfamiliarity tripwire fired, fire the blindspot offer from `references/blindspot-pass.md` before the first substantive question into the flagged territory (questions about the user's own problem, users, and evidence proceed normally — the gate is territory-scoped). The gate also arms mid-dialogue without a tripwire: when two consecutive answers show the user *cannot evaluate* the question's substance — not merely hasn't decided — read the reference and offer the pass then. Never silently switch into teaching; the offer is a blocking question.
 
 **Visual-probe gate — precondition, check it before raising the first shape decision.** If the Phase 0.3 tripwire fired, then before raising the first decision about shape, behavior, state, layout, flow, or a diagram — in any form, plain chat or a blocking tool — fire the text-vs-visual offer from `references/visual-probes.md`. The gate is state-based: offer unless this specific decision has already been through it; anchor the check to the decision you are about to raise, not a "pending gate" remembered since Phase 0.3. It **takes precedence over the default blocking-question path** (Interaction Rule 4): do not raise the shape decision as an `AskUserQuestion`/`request_user_input` menu until the user has declined visual. **An ASCII preview or text mockup inside the question's choices does not satisfy the offer** — that is the shortcut this gate exists to stop. Use the platform's blocking question tool for the text-vs-visual offer itself when available; the reference owns the offer wording, the cheapest-probe build, helper invocation, and the display-only feedback contract.
 

--- a/skills/ce-brainstorm/references/blindspot-pass.md
+++ b/skills/ce-brainstorm/references/blindspot-pass.md
@@ -1,0 +1,70 @@
+# Blindspot Pass
+
+The interview machinery in this skill assumes the user can evaluate what it asks. On territory the user doesn't know, that assumption fails: questions extract guesses, not requirements. The blindspot pass converts the user's unknown unknowns into known unknowns — it maps the decision surface of the flagged territory so the user chooses among options they can now evaluate, instead of generating answers from nothing.
+
+A blindspot pass is a decision map, not a tutorial. Test for every item: it must end in something the user will decide, delegate, or explicitly defer during this brainstorm. An item that feeds no decision is domain trivia — cut it.
+
+## Trigger
+
+Two signals arm the pass:
+
+- **Opening signal** — the user explicitly flags missing working knowledge of the domain or the territory the topic touches: "I know nothing about X", "never touched the auth modules", "I don't know what's possible here", "I don't know what I should be asking".
+- **Mid-dialogue signal** — two consecutive answers show the user *cannot evaluate* the question's substance: "I don't know", "whatever you think", "you decide" in response to questions that need domain judgment.
+
+**Can't-evaluate vs. hasn't-decided — the guard against over-firing.** A user who understands the options but hasn't picked one needs the normal interview, not a teaching pass. Offer only when the signal shows the user cannot weigh the options at all. Offering a blindspot pass to a domain expert who is merely undecided is the failure mode; when the signal is ambiguous, keep interviewing.
+
+## The gate
+
+The gate is **territory-scoped, not conversation-wide**. Questions about the user's own problem, users, evidence, and priorities proceed normally — the user is the authority on those. The gate fires only before the first substantive question *into the flagged territory* (the domain or system area the user cannot evaluate).
+
+Never silently switch into teaching. The offer is a blocking question (Interaction Rule 4), asked once per flagged territory. If the user declines, do not re-offer for that territory — fill gaps with recommended defaults recorded as explicit assumptions, per the normal rigor-probe discipline.
+
+**Non-interactive degradation:** in a pipeline or headless run where no user can answer, never fire the offer — treat flagged territory exactly like a declined offer (recommended defaults recorded as explicit assumptions) and continue.
+
+## Offer
+
+Use this wording, substituting the territory:
+
+> Part of this sits in territory you've flagged as unfamiliar (<territory>). I can map the decision surface first — the decisions you'll face there, the realistic options for each, and what I'd default to — so you're choosing rather than guessing. Or we keep going with questions and I fill gaps with defaults recorded as assumptions. Which do you prefer?
+
+Two options: **Map the territory first** / **Proceed with questions** (defaults become assumptions).
+
+## Building the map
+
+Ground it before writing it:
+
+- **In-repo territory** (a module, subsystem, or pattern in this codebase): use the Phase 1.1 grounding — the scout's dossier and targeted reads. If the scout has not returned yet, wait for it or read the relevant area directly; do not map in-repo territory from model knowledge alone.
+- **External domain** (a technology, practice, or field outside the repo): research with whatever web tools are reachable. When none are, model knowledge is allowed, but label each such item **Unverified — from model knowledge, not checked against current sources**.
+
+**The territory closes questions the user should never be asked.** Before an item goes on the map, check whether the codebase or sources already answer it — if so, it is not a decision: show the question and the found answer with its citation as settled ground, not as an option menu. The map holds only what genuinely needs the user's judgment. But a question closed off-screen isn't closed — territory-answered items are shown, never silently resolved.
+
+While grounding, hunt hazards specifically: things that bite silently (wrong-by-default data, filters that pass bad rows, escaping that corrupts output), unwritten conventions the code enforces that no doc states, and half-built or reverted prior attempts at the same job — the reason a prior attempt died is usually the landmine.
+
+The map is **3-7 items**, delivered in chat. Each item is a **decision** the user will face or a **hazard** that constrains one, in at most 4 lines — an item that runs longer has started teaching instead of framing the decision; cut it back:
+
+- what the decision or hazard is, in the user's vocabulary — when a term of art is unavoidable, define it and name what knowing it unlocks the user to decide
+- why it matters *for this topic* — tie it to something the user said, not to the domain in general; a hazard states what it changes about the task
+- decisions only: the realistic options (2-4), one clause each on the trade-off that matters here — list only options you would defend if the user picked them; a menu padded with options the map itself rules out is a strawman, not a choice. An option you ruled out belongs in why-it-matters as one clause ("subdomain isolation is closed — single-domain config"), never in the menu
+- decisions only: the recommended default, stated plainly
+
+A hazard is not a vote — it gets no option menu and no default. When a hazard forces a choice among genuinely viable mitigations, that choice is its own decision item and the hazard is its why-it-matters.
+
+The highest-stakes item earns first placement, not extra length — depth belongs in the walk-through after the user selects it, not in the map.
+
+Order items by how much the user's answer would change the product shape — architecture-changing decisions first, hazards and reversible choices last. Do not pad to 7; a territory with three real decisions gets three items.
+
+## Re-entering the dialogue
+
+After the map, ask **one** multi-select blocking question (a legitimate Rule 3 compatible set): *"Which of these do you want to walk through now? Anything unselected takes the recommended default, recorded as an explicit assumption."*
+
+Then:
+
+- **Selected decisions** — walk through one per turn as informed single-select menus. Post-pass, menus over mapped options are the right form even where Rule 5 would normally prefer open-ended: the options no longer steer, they recall what was just taught.
+- **Unselected decisions and hazards** — record the recommended default (or the hazard's constraint) as an explicit assumption, the same way rigor-probe uncertainty is recorded: in the Product Contract on the software route, in the synthesis on the universal route.
+- **"I want to actually learn this one"** — offer a handoff to the `ce-explain` skill for that item (offer, don't auto-fire); the brainstorm resumes when they return or continues with the default meanwhile.
+
+The pass never resolves decisions by itself and never replaces the dialogue. It runs once, converts blindspots into questions the user can answer, and the normal flow — rigor probes, approaches, synthesis — continues on informed ground.
+
+## Universal route
+
+The pass applies unchanged on the non-software route (an unfamiliar craft, market, or process — "I need to grade this video but don't know what color grading is"). Grounding is web research or labeled model knowledge; delegated defaults land as named assumptions in the wrap-up synthesis instead of a Product Contract.

--- a/skills/ce-brainstorm/references/universal-brainstorming.md
+++ b/skills/ce-brainstorm/references/universal-brainstorming.md
@@ -35,6 +35,8 @@ Drop the blocking tool only when (a) the answer is inherently narrative ("walk m
 
 **Ask what they're already thinking.** Before offering ideas, find out what the user has considered, tried, or rejected. This prevents fixation on AI-generated ideas and surfaces hidden constraints.
 
+**When the user doesn't know the domain** — if they flag missing working knowledge of the territory ("I need to grade this video but don't know what color grading is"), or two consecutive answers show they *cannot evaluate* a question's substance rather than merely haven't decided, read `references/blindspot-pass.md` and offer the pass before questioning them further on that territory. It applies on this route unchanged (see its "Universal route" section).
+
 **When the user represents a group** (couple, family, team) — surface whose preferences are in play and where they diverge. The brainstorm shifts from "help you decide" to "help you find alignment." Ask about each person's priorities, not just the speaker's.
 
 **Understand before generating.** Spend time on the problem before jumping to solutions. "What would success look like?" and "What have you already ruled out?" reveal more than "Here are 10 ideas."

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -206,6 +206,7 @@ If no relevant Product Contract source exists, planning may proceed from the use
 If no relevant requirements document exists, or the input needs more structure:
 - Assess whether the request is already clear enough for direct technical planning — if so, continue to Phase 0.5
 - If the ambiguity is mainly product framing, user behavior, or scope definition, recommend `ce-brainstorm` as a suggestion — but always offer to continue planning here as well
+- If the user signals they lack working knowledge of the problem domain itself, recommend `ce-brainstorm` — its blindspot pass maps the territory's decision surface before requirements are extracted — but honor their choice to continue here; Phase 2's unfamiliar-territory scaffolding then applies
 - If the user wants to continue here (or was already explicit about wanting a plan), run the planning bootstrap below
 
 The planning bootstrap should establish:
@@ -455,6 +456,8 @@ For each question, decide whether it should be:
 - **Deferred to implementation** - the answer depends on code changes, runtime behavior, or execution-time discovery
 
 Ask the user only when the answer materially affects architecture, scope, sequencing, or risk and cannot be responsibly inferred. Use the platform's blocking question tool when available (see Interaction Method).
+
+**Scaffold questions on unfamiliar territory.** When the user has signaled they lack working knowledge of the area a question lives in — an explicit "I don't know X", or earlier answers showing they *cannot evaluate* options rather than merely haven't decided — do not ask the question naked. Present it as a taught decision: the realistic options, one clause each on the trade-off that matters for this plan, and a recommended default. If the user still cannot evaluate, record the default as an explicit assumption in the plan instead of extracting a guess. In pipeline mode (LFG, any `disable-model-invocation` context) this scaffolding never presents anything — resolve to the recommended default and record it as an explicit assumption in the plan.
 
 **Do not** run tests, build the app, or probe runtime behavior in this phase. The goal is a strong plan, not partial execution.
 


### PR DESCRIPTION
## Summary

`ce-brainstorm` and `ce-plan` interview the user one question at a time — machinery that quietly assumes the user can evaluate what it asks. That assumption fails exactly when someone is scoping work in territory they don't know: "I don't know, whatever you think" gets recorded as if it were a product decision, and the decisions they never knew existed get silently defaulted during implementation, where discovering them is expensive. Inspired by [Thariq's field guide on finding your unknowns](https://x.com/trq212/status/2073100352921215386), both skills now convert unknown unknowns into known unknowns *before* extracting answers — so the interview collects informed choices, and everything else becomes a visible assumption instead of a disguised guess.

## What changed

**ce-brainstorm — opt-in blindspot pass** (new `references/blindspot-pass.md`, wired via an unfamiliarity tripwire and a territory-scoped gate):

- When the user flags missing working knowledge ("I know nothing about X but need to...") — or two consecutive answers show they *can't evaluate* a question rather than merely haven't decided — the skill offers to map the territory's decision surface before questioning further. Declining is never re-litigated.
- The map is 3-7 decisions and hazards, each with why it matters for this topic, the realistic options, and a recommended default. Hazards are constraints, not votes — no option menus, no strawman choices. Questions the codebase already answers are shown as settled ground with citations rather than asked.
- One multi-select re-entry: picked items get walked through as informed choices; everything delegated is recorded as an **explicit assumption** in the Product Contract. Works on the non-software route too.

**ce-plan — taught decisions on flagged territory:**

- Phase 2 questions into territory the user flagged as unknown are never asked naked — they arrive with options, one-clause trade-offs, and a recommended default. If the user still can't evaluate, the default is recorded as an explicit plan assumption instead of a fake resolution.
- The planning bootstrap routes domain-unfamiliar users toward the brainstorm's fuller pass.

**Headless / lfg compatibility:** in pipeline mode (`disable-model-invocation`) neither skill ever blocks — the offer suppresses, the scaffold goes inert, and defaults land as explicit assumptions in the artifact, so the human reviewing the eventual PR sees exactly which calls were made on their behalf.

## Validation

Behavioral changes to skill prose can't be tested by `bun test`, so this was validated with decision-point evals (fresh subagents executing the on-disk skill against staged conversations, graded independently against falsifiable rubrics, with the pre-change skill as baseline):

- **Over-ceremony guards** — expert-but-undecided, no-signal, and single-"I don't know" scenarios, with repetitions: zero false offers in every sample; no-signal behavior indistinguishable from the pre-change skill.
- **Correct firing** — explicit-unfamiliarity and two-consecutive-can't-evaluate scenarios fired the offer exactly per contract, where the baseline asked naked domain questions or dumped ungated lectures.
- **Map quality, iterated** — rubric-driven refinement over three rounds caught and fixed three real prose defects (hazards receiving option menus, strawman options, item sprawl); planted traps (a territory-answered fact, a reverted prior attempt whose revert reason is the landmine) verified the settled-ground and hazard rules land.
- **Headless degradation** — pipeline-mode runs of both skills presented no questions, chose grounded defaults, and recorded them as explicit assumptions.
- **Cross-model** — the matrix re-ran on Opus with identical scenarios, rubrics, and graders: identical behavioral fingerprint, zero divergence on any of the new machinery, and the residual imperfections (occasional long map item) appear at the same rate on both models — confirming a single, model-agnostic prose version with no model references needed.

Docs: `docs/skills/ce-brainstorm.md` gains the new mechanic and a when-to-reach-for-it entry. `bun run release:validate` passes.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
