### PR TITLE
fix(ce-compound,ce-compound-refresh): validate doc claims at write time

### DIFF
--- a/docs/skills/ce-compound-refresh.md
+++ b/docs/skills/ce-compound-refresh.md
@@ -62,7 +62,7 @@ Phase 1.75 evaluates the document set as a whole: overlap detection across five 
 
 ### 4. Replace via subagent — context isolation
 
-When a learning's core guidance is now misleading, the orchestrator dispatches a subagent to write the replacement (one at a time, sequentially — replacements may need to read significant code, and parallelism risks context exhaustion). The subagent receives the old learning, the investigation evidence, the target path, and the contract files (schema, category mapping, template) — and writes a clean successor without polluting the orchestrator's context.
+When a learning's core guidance is now misleading, the orchestrator dispatches a subagent to write the replacement (one at a time, sequentially — replacements may need to read significant code, and parallelism risks context exhaustion). The subagent receives the old learning, the investigation evidence, the target path, and the contract files (schema, category mapping, template) — and writes a clean successor without polluting the orchestrator's context. The successor (and any consolidated canonical doc) then goes through the mechanical claims check (`scripts/validate-doc-claims.py`): cited paths, commit SHAs, relative links, and drafting scaffold are verified against the tree, with flags adjudicated rather than auto-failed.
 
 ### 5. Stale-marking when evidence is insufficient
 

--- a/docs/skills/ce-compound.md
+++ b/docs/skills/ce-compound.md
@@ -74,19 +74,25 @@ Every run checks whether the project's instruction file (`AGENTS.md` or `CLAUDE.
 
 The proposed addition matches the existing file's tone and density — a single-line entry in an existing directory listing when one fits, a small headed section only when nothing else does.
 
-### 5. Selective refresh trigger
+### 5. Grounding validation — claims are verified against the tree before they compound
+
+A solution doc is only as valuable as its claims are true, and drafting from conversation evidence invites three failure shapes: code-behavior claims written from a session-level summary instead of the source, "fixed in X" claims about merges the current checkout can't see, and drafting scaffold ("Learning 3") leaking into the written doc.
+
+Phase 2.45 closes this in two layers. A deterministic script (`scripts/validate-doc-claims.py`) checks cited repo paths, commit SHAs (classified by reachability from HEAD vs the upstream default branch, so a stale checkout is distinguished from a fabricated citation), relative links, and dangling scaffold — its flags are adjudicated, not auto-failed, because a doc may legitimately cite a path deleted by the very fix it documents. Then a read-only validator subagent (Full and headless modes) verifies code-behavior claims by quoting the defining source line, merge-state claims against remote truth (`gh` primary, local git fallback), and internal completeness of countable assertions. The same discipline applies at draft time: the Solution Extractor must read the defining line before asserting behavior, and cite PR numbers over rebase-fragile SHAs.
+
+### 6. Selective refresh trigger
 
 After capturing the new learning, `ce-compound` checks whether it should invoke `/ce-compound-refresh` on a narrow scope hint. It does NOT default to running refresh — only when the new learning suggests a specific older doc may now be stale (contradicted, superseded, or in a domain that just got refactored).
 
-### 6. Specialized post-review
+### 7. Specialized post-review
 
 Based on the problem type, optional skill-local prompt assets review the documentation: `performance-oracle` for performance issues, `security-sentinel` for security, and `data-integrity-guardian` for database-oriented issues. Code-heavy docs may also get a read-only simplification review of the drafted examples and explanatory claims; this does not invoke `ce-simplify-code` and does not mutate product code.
 
-### 7. Session history integration (opt-in)
+### 8. Session history integration (opt-in)
 
 Full mode optionally dispatches a skill-local session-history prompt to search prior sessions across harnesses for related context — what was tried before, what didn't work, key decisions. Findings are folded into "What Didn't Work" (bug track) or "Context" (knowledge track). Off by default because of token cost; the user explicitly opts in.
 
-### 8. Auto-invoke triggers
+### 9. Auto-invoke triggers
 
 Phrases like "that worked", "it's fixed", "working now", "problem solved" auto-invoke the skill so capture happens at the moment context is freshest. The user can override with `/ce-compound [context]` to capture immediately.
 
@@ -100,7 +106,7 @@ You've just spent 45 minutes debugging an N+1 query in the brief-generation flow
 
 Three subagents dispatch in parallel: Context Analyzer reads conversation history, classifies as `performance_issue` (bug track), proposes the filename and category. Solution Extractor structures the fix with before/after code. Related Docs Finder greps `docs/solutions/` for related issues, reports moderate overlap with an older doc on a different N+1 case.
 
-The orchestrator assembles the doc, validates frontmatter via the YAML safety script, and writes `docs/solutions/performance-issues/n-plus-one-brief-generation.md`. The discoverability check finds `AGENTS.md` doesn't mention `docs/solutions/`, proposes a one-line addition to the existing directory listing, and applies it after you confirm.
+The orchestrator assembles the doc, validates frontmatter via the YAML safety script, and writes `docs/solutions/performance-issues/n-plus-one-brief-generation.md`. Grounding validation then runs: the mechanical script confirms every cited path and SHA resolves, and the validator subagent quotes the defining source line behind the doc's claim about the ORM's default batching behavior. The discoverability check finds `AGENTS.md` doesn't mention `docs/solutions/`, proposes a one-line addition to the existing directory listing, and applies it after you confirm.
 
 Phase 3 dispatches the local `performance-oracle` prompt and, because the doc includes code examples, performs a read-only simplification check on the drafted examples and approach. Phase 2.5 surfaces a refresh recommendation: the older N+1 doc may benefit from consolidation review. The skill suggests `/ce-compound-refresh n-plus-one` as a narrow scope hint and ends.
 
@@ -161,7 +167,7 @@ docs/solutions/[category]/[filename].md
 
 Categories are auto-detected. Bug-track examples: `build-errors/`, `test-failures/`, `runtime-errors/`, `performance-issues/`, `database-issues/`, `security-issues/`, `ui-bugs/`, `integration-issues/`, `logic-errors/`. Knowledge-track examples: `architecture-patterns/`, `design-patterns/`, `tooling-decisions/`, `conventions/`, `workflow-issues/`, `developer-experience/`, `documentation-gaps/`, `best-practices/`.
 
-The doc carries YAML frontmatter (`module`, `tags`, `problem_type`, etc.) for searchability. Validation runs through `scripts/validate-frontmatter.py` to catch silent corruption (malformed `---` delimiters, unquoted `:` in scalar values).
+The doc carries YAML frontmatter (`module`, `tags`, `problem_type`, etc.) for searchability. Validation runs through `scripts/validate-frontmatter.py` to catch silent corruption (malformed `---` delimiters, unquoted `:` in scalar values), and `scripts/validate-doc-claims.py` checks the body's cited paths, SHAs, links, and drafting scaffold against the tree.
 
 The skill may also produce a small edit to `AGENTS.md`/`CLAUDE.md` if the discoverability check finds the knowledge store isn't surfaced.
 

--- a/skills/ce-compound-refresh/SKILL.md
+++ b/skills/ce-compound-refresh/SKILL.md
@@ -491,7 +491,7 @@ For each candidate, execute the flow that matches its classification from Phase 
 - **Keep** — no file edit by default; summarize why the learning remains trustworthy.
 - **Update** — in-place edits when the solution is still substantively correct (path renames, link refreshes, module renames).
 - **Consolidate** — merge overlapping docs into a canonical doc, delete subsumed docs, update cross-references. The orchestrator handles consolidation directly.
-- **Replace** — write a successor learning via subagent (passing the documentation contract files), validate frontmatter, then delete the old. When evidence is insufficient, mark stale instead.
+- **Replace** — write a successor learning via subagent (passing the documentation contract files), validate frontmatter and cited claims, then delete the old. When evidence is insufficient, mark stale instead.
 - **Delete** — final inbound-link check, then remove. Reclassify if late-discovered substantive citations surface.
 
 Only one flow runs per candidate; the reference contains the per-action criteria, examples, and step-by-step instructions.

--- a/skills/ce-compound-refresh/references/per-action-flows.md
+++ b/skills/ce-compound-refresh/references/per-action-flows.md
@@ -40,6 +40,8 @@ The orchestrator handles consolidation directly (no subagent needed — the docs
 
 If a doc cluster has 3+ overlapping docs, process pairwise: consolidate the two most overlapping docs first, then evaluate whether the merged result should be consolidated with the next doc.
 
+After the merge, run the mechanical claims check on the canonical doc (step 4 of the Replace flow below) — merged content brings its citations with it, and consolidation is where cross-references most often dangle.
+
 **Structural edits beyond merge:** Consolidate also covers the reverse case. If one doc has grown unwieldy and covers multiple distinct problems that would benefit from separate retrieval, it is valid to recommend splitting it. Only do this when the sub-topics are genuinely independent and a maintainer might search for one without needing the other.
 
 ## Replace Flow
@@ -79,7 +81,15 @@ Do not let replacement subagents invent frontmatter fields, enum values, or sect
      Nested values, array items, and already-quoted values are out of scope here (array-item quoting is handled by the schema/YAML-safety step above). Then note in the completion output that the bundled script validator was unavailable on this platform and the checks were applied manually.
 
    The validator does not enforce schema rules and does not flag YAML reserved-indicator characters (those produce loud parser errors downstream rather than silent corruption — out of scope). Uses Python 3 stdlib only (no PyYAML or other deps).
-4. After the subagent completes, the orchestrator deletes the old learning file. The new learning's frontmatter may include `supersedes: [old learning filename]` for traceability, but this is optional — the git history and commit message provide the same information.
+4. **Run the mechanical claims check on the successor doc.** The bundled `scripts/validate-doc-claims.py` flags cited repo paths missing from the tree, commit SHAs that do not resolve or are unreachable, relative doc links that do not resolve, and dangling drafting scaffold ("Learning 3", unresolved `{{...}}` tokens):
+
+   ```bash
+   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+   python3 "$SKILL_DIR/scripts/validate-doc-claims.py" <new-learning-path>
+   ```
+
+   Exit 1 flags are **adjudication input, not failures** — a successor doc describing removed code legitimately cites paths that no longer exist. Resolve each flag by fixing the citation, annotating it as historical, or confirming it intentional; always fix scaffold flags. If the script is not resolvable on this platform, scan the body for those same patterns manually and say so in the report.
+5. After the subagent completes, the orchestrator deletes the old learning file. The new learning's frontmatter may include `supersedes: [old learning filename]` for traceability, but this is optional — the git history and commit message provide the same information.
 
 **When evidence is insufficient:**
 

--- a/skills/ce-compound-refresh/scripts/validate-doc-claims.py
+++ b/skills/ce-compound-refresh/scripts/validate-doc-claims.py
@@ -14,11 +14,12 @@ validate-frontmatter.py (parser-safety) — this script checks the body's
 citations against the repository:
 
     1. Cited repo-relative paths (backticked, containing at least one '/')
-       exist in the working tree; misses tracked at HEAD or the upstream
-       default branch still count as real paths and are classified
-       (deleted/uncommitted vs stale checkout). Tokens missing everywhere
-       are flagged only when path-shaped; slash-delimited identifiers
-       (branch names, git refs, provider/model IDs) are skipped.
+       exist in the working tree; tokens containing '../' resolve from the
+       doc's directory (those escaping the repo are skipped). Misses tracked
+       at HEAD or the upstream default branch still count as real paths and
+       are classified (deleted/uncommitted vs stale checkout). Tokens
+       missing everywhere are flagged only when path-shaped; slash-delimited
+       identifiers (branch names, git refs, provider/model IDs) are skipped.
     2. Cited commit SHAs (7-40 hex chars with at least one digit and one
        a-f letter) resolve to commits, classified by reachability from
        HEAD and the upstream default branch.
@@ -200,16 +201,28 @@ def main(argv: list[str]) -> int:
     base = repo_root if in_git else os.getcwd()
     for raw in BACKTICK_RE.findall(body):
         token = normalize_path(raw)
-        if not is_path_candidate(token) or token in seen_paths:
+        if not is_path_candidate(token):
             continue
-        seen_paths.add(token)
-        if os.path.exists(os.path.join(base, token)):
+        check = token
+        if token.startswith("../") or "/../" in token:
+            # A `../` citation is doc-relative (matching how markdown links
+            # resolve), so map it to a repo-root path before checking.
+            if not in_git:
+                continue
+            resolved = os.path.realpath(os.path.join(doc_dir, token))
+            check = os.path.relpath(resolved, os.path.realpath(base))
+            if check.startswith(".."):
+                continue  # escapes the repo — not checkable as a repo path
+        if check in seen_paths:
+            continue
+        seen_paths.add(check)
+        if os.path.exists(os.path.join(base, check)):
             checked_paths += 1
             continue
-        tracked_head = head_has_path(token)
-        tracked_upstream = upstream_has_path(token)
+        tracked_head = head_has_path(check)
+        tracked_upstream = upstream_has_path(check)
         if not (tracked_head or tracked_upstream) and not is_path_shaped(
-            token, base
+            check, base
         ):
             continue  # branch name / provider ID, not a path citation
         checked_paths += 1

--- a/skills/ce-compound-refresh/scripts/validate-doc-claims.py
+++ b/skills/ce-compound-refresh/scripts/validate-doc-claims.py
@@ -14,9 +14,11 @@ validate-frontmatter.py (parser-safety) — this script checks the body's
 citations against the repository:
 
     1. Cited repo-relative paths (backticked, containing at least one '/')
-       exist in the working tree; misses are classified against the
-       upstream default branch to distinguish a stale checkout from a
-       fabricated path.
+       exist in the working tree; misses tracked at HEAD or the upstream
+       default branch still count as real paths and are classified
+       (deleted/uncommitted vs stale checkout). Tokens missing everywhere
+       are flagged only when path-shaped; slash-delimited identifiers
+       (branch names, git refs, provider/model IDs) are skipped.
     2. Cited commit SHAs (7-40 hex chars with at least one digit and one
        a-f letter) resolve to commits, classified by reachability from
        HEAD and the upstream default branch.
@@ -91,11 +93,24 @@ def is_path_candidate(token: str) -> bool:
         return False
     if "://" in token or token.startswith(("http", "#", "/", "~")):
         return False
+    if token.startswith(("origin/", "upstream/", "refs/")):
+        return False  # git refs, not repo paths
     if PLACEHOLDER_CHARS & set(token):
         return False
     if any(sub in token for sub in PLACEHOLDER_SUBSTRINGS):
         return False
     return True
+
+
+def is_path_shaped(token: str, base: str) -> bool:
+    """Distinguish a path citation from a slash-delimited identifier
+    (branch name, provider/model ID) among tokens found nowhere in git."""
+    segments = token.split("/")
+    if re.search(r"\.[A-Za-z0-9]{1,8}$", segments[-1]):
+        return True
+    if token.endswith("/"):
+        return True
+    return os.path.isdir(os.path.join(base, segments[0]))
 
 
 def normalize_path(token: str) -> str:
@@ -173,20 +188,39 @@ def main(argv: list[str]) -> int:
         code, _ = git(["cat-file", "-e", f"{upstream}:{path}"], repo_root)
         return code == 0
 
+    def head_has_path(path: str) -> bool:
+        if not in_git:
+            return False
+        code, _ = git(["cat-file", "-e", f"HEAD:{path}"], repo_root)
+        return code == 0
+
     # --- 1. Cited repo paths ----------------------------------------------
     checked_paths = 0
     seen_paths: set[str] = set()
+    base = repo_root if in_git else os.getcwd()
     for raw in BACKTICK_RE.findall(body):
         token = normalize_path(raw)
         if not is_path_candidate(token) or token in seen_paths:
             continue
         seen_paths.add(token)
-        checked_paths += 1
-        base = repo_root if in_git else os.getcwd()
         if os.path.exists(os.path.join(base, token)):
+            checked_paths += 1
             continue
+        tracked_head = head_has_path(token)
+        tracked_upstream = upstream_has_path(token)
+        if not (tracked_head or tracked_upstream) and not is_path_shaped(
+            token, base
+        ):
+            continue  # branch name / provider ID, not a path citation
+        checked_paths += 1
         loc = loc_suffix(raw)
-        if upstream_has_path(token):
+        if tracked_head:
+            flags.append(
+                f"FLAG path `{token}`{loc} — tracked at HEAD but missing from "
+                "the working tree: deleted or uncommitted removal? Annotate as "
+                "historical (e.g. removed by this fix) or restore it."
+            )
+        elif tracked_upstream:
             flags.append(
                 f"FLAG path `{token}`{loc} — not in working tree but exists at "
                 f"{upstream}: stale checkout? Annotate or verify against upstream."

--- a/skills/ce-compound-refresh/scripts/validate-doc-claims.py
+++ b/skills/ce-compound-refresh/scripts/validate-doc-claims.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Validate cited claims in a solution doc against the git tree.
+
+Usage:
+    python3 validate-doc-claims.py <doc-path>
+
+Exit codes:
+    0 — nothing flagged
+    1 — one or more flags need adjudication (report on stdout)
+    2 — usage error (bad arguments, missing file)
+
+Scope: mechanical grounding checks on a written doc's *body*. Complements
+validate-frontmatter.py (parser-safety) — this script checks the body's
+citations against the repository:
+
+    1. Cited repo-relative paths (backticked, containing at least one '/')
+       exist in the working tree; misses are classified against the
+       upstream default branch to distinguish a stale checkout from a
+       fabricated path.
+    2. Cited commit SHAs (7-40 hex chars with at least one digit and one
+       a-f letter) resolve to commits, classified by reachability from
+       HEAD and the upstream default branch.
+    3. Relative markdown link targets resolve from the doc's location.
+    4. Dangling drafting scaffold: "Learning(s) N" numbering and
+       unresolved {{...}} placeholder tokens.
+
+Flags are adjudication input, NOT hard failures — a doc may legitimately
+cite a path deleted by the very fix it documents. The calling agent
+decides per flag: fix, annotate as historical, or confirm intentional.
+Only the summary exit code distinguishes "clean" from "needs a look".
+
+The script never touches the network (no fetch); classification uses
+whatever refs exist locally. Run a best-effort `git fetch --quiet` first
+when freshness matters. Pure stdlib (no third-party deps).
+"""
+import os
+import re
+import subprocess
+import sys
+
+# Tokens containing these are placeholders/examples, not real citations.
+PLACEHOLDER_CHARS = set("<>{}*$")
+PLACEHOLDER_SUBSTRINGS = ("path/to", "...", "…")
+
+SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+BACKTICK_RE = re.compile(r"`([^`\n]+)`")
+MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+SCAFFOLD_RES = (
+    re.compile(r"\bLearnings?\s+#?\d"),
+    re.compile(r"\{\{[^}\n]*\}\}"),
+)
+
+
+def usage_fail(msg: str) -> "NoReturn":
+    sys.stderr.write(f"validate-doc-claims: {msg}\n")
+    sys.exit(2)
+
+
+def git(args: list[str], cwd: str) -> tuple[int, str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode, result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        return 1, ""
+
+
+def split_body(text: str) -> tuple[str, int]:
+    """Return (body, 1-indexed line number the body starts on).
+
+    Skips YAML frontmatter when present so frontmatter fields are not
+    scanned as body citations.
+    """
+    lines = text.split("\n")
+    if lines and lines[0].rstrip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].rstrip() == "---":
+                return "\n".join(lines[i + 1 :]), i + 2
+    return text, 1
+
+
+def is_path_candidate(token: str) -> bool:
+    if any(ch.isspace() for ch in token):
+        return False
+    if "/" not in token:
+        return False
+    if "://" in token or token.startswith(("http", "#", "/", "~")):
+        return False
+    if PLACEHOLDER_CHARS & set(token):
+        return False
+    if any(sub in token for sub in PLACEHOLDER_SUBSTRINGS):
+        return False
+    return True
+
+
+def normalize_path(token: str) -> str:
+    token = token.strip().rstrip(".,;")
+    token = re.sub(r":\d+(-\d+)?$", "", token)  # strip `:line` / `:a-b` refs
+    if token.startswith("./"):
+        token = token[2:]
+    return token
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        usage_fail(f"usage: {os.path.basename(argv[0])} <doc-path>")
+
+    doc_path = argv[1]
+    if not os.path.isfile(doc_path):
+        usage_fail(f"file not found: {doc_path}")
+
+    with open(doc_path) as f:
+        text = f.read()
+
+    doc_dir = os.path.dirname(os.path.abspath(doc_path))
+    body, body_start = split_body(text)
+    body_lines = body.split("\n")
+
+    def loc_suffix(needle: str) -> str:
+        for i, line in enumerate(body_lines):
+            if needle in line:
+                return f" (line {body_start + i})"
+        return ""
+
+    infos: list[str] = []
+    flags: list[str] = []
+
+    # --- Repo context -----------------------------------------------------
+    code, repo_root = git(["rev-parse", "--show-toplevel"], doc_dir)
+    in_git = code == 0 and bool(repo_root)
+    upstream: str | None = None
+    if in_git:
+        code, ref = git(["rev-parse", "--abbrev-ref", "origin/HEAD"], repo_root)
+        if code == 0 and ref:
+            upstream = ref
+        else:
+            for candidate in ("origin/main", "origin/master"):
+                code, _ = git(
+                    ["rev-parse", "--verify", "--quiet", candidate], repo_root
+                )
+                if code == 0:
+                    upstream = candidate
+                    break
+        if upstream:
+            code, behind = git(
+                ["rev-list", "--count", f"HEAD..{upstream}"], repo_root
+            )
+            if code == 0 and behind.isdigit() and int(behind) > 0:
+                infos.append(
+                    f"INFO: worktree is {behind} commits behind {upstream} — "
+                    "verify merge-state claims against remote truth (gh pr view), "
+                    "not this checkout"
+                )
+        else:
+            infos.append(
+                "INFO: no upstream default branch found — "
+                "path/SHA classification limited to HEAD"
+            )
+    else:
+        infos.append(
+            "INFO: not a git repository — path and SHA classification skipped "
+            "(scaffold and link checks still apply)"
+        )
+
+    def upstream_has_path(path: str) -> bool:
+        if not (in_git and upstream):
+            return False
+        code, _ = git(["cat-file", "-e", f"{upstream}:{path}"], repo_root)
+        return code == 0
+
+    # --- 1. Cited repo paths ----------------------------------------------
+    checked_paths = 0
+    seen_paths: set[str] = set()
+    for raw in BACKTICK_RE.findall(body):
+        token = normalize_path(raw)
+        if not is_path_candidate(token) or token in seen_paths:
+            continue
+        seen_paths.add(token)
+        checked_paths += 1
+        base = repo_root if in_git else os.getcwd()
+        if os.path.exists(os.path.join(base, token)):
+            continue
+        loc = loc_suffix(raw)
+        if upstream_has_path(token):
+            flags.append(
+                f"FLAG path `{token}`{loc} — not in working tree but exists at "
+                f"{upstream}: stale checkout? Annotate or verify against upstream."
+            )
+        else:
+            where = (
+                f"working tree or {upstream}" if upstream else "working tree"
+            )
+            flags.append(
+                f"FLAG path `{token}`{loc} — not found in {where}. Fix the "
+                "citation, or annotate it as historical (e.g. removed by this fix)."
+            )
+
+    # --- 2. Cited commit SHAs ----------------------------------------------
+    checked_shas = 0
+    seen_shas: set[str] = set()
+    if in_git:
+        for m in SHA_RE.finditer(body):
+            sha = m.group(0)
+            if sha in seen_shas:
+                continue
+            if not (any(c.isdigit() for c in sha) and any(c in "abcdef" for c in sha)):
+                continue  # dates and decimal ids are not SHAs
+            seen_shas.add(sha)
+            checked_shas += 1
+            loc = loc_suffix(sha)
+            code, _ = git(["cat-file", "-e", f"{sha}^{{commit}}"], repo_root)
+            if code != 0:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — does not resolve to a commit in this "
+                    "repository. Replace with the PR number, or drop it."
+                )
+                continue
+            in_head = (
+                git(["merge-base", "--is-ancestor", sha, "HEAD"], repo_root)[0] == 0
+            )
+            in_up = (
+                upstream is not None
+                and git(["merge-base", "--is-ancestor", sha, upstream], repo_root)[0]
+                == 0
+            )
+            if in_head and (in_up or upstream is None):
+                continue
+            if in_head and not in_up:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — reachable from HEAD but not {upstream}: "
+                    "local-only commit whose SHA may be rewritten on merge "
+                    "(rebase/squash). Prefer citing the PR number."
+                )
+            elif in_up:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — not reachable from HEAD but reachable "
+                    f"from {upstream}: this checkout predates the merge. Add a "
+                    "temporal qualifier or verify the claim via gh."
+                )
+            else:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — exists but unreachable from HEAD"
+                    + (f" or {upstream}" if upstream else "")
+                    + ": likely a rebased-away commit. Prefer citing the PR number."
+                )
+
+    # --- 3. Relative markdown links -----------------------------------------
+    checked_links = 0
+    seen_links: set[str] = set()
+    for target in MD_LINK_RE.findall(body):
+        if re.match(r"^[a-z][a-z0-9+.-]*:", target, re.IGNORECASE):
+            continue  # URL scheme
+        if target.startswith("#"):
+            continue  # intra-doc anchor
+        bare = target.split("#", 1)[0]
+        if not bare or bare in seen_links:
+            continue
+        seen_links.add(bare)
+        checked_links += 1
+        if not os.path.exists(os.path.normpath(os.path.join(doc_dir, bare))):
+            loc = loc_suffix(target)
+            flags.append(
+                f"FLAG link ({target}){loc} — relative target does not resolve "
+                "from the doc's location. Fix the path."
+            )
+
+    # --- 4. Dangling drafting scaffold ---------------------------------------
+    for i, line_text in enumerate(body_lines):
+        for pattern in SCAFFOLD_RES:
+            m = pattern.search(line_text)
+            if m:
+                flags.append(
+                    f'FLAG scaffold "{m.group(0)}" (line {body_start + i}) — '
+                    "drafting-context reference leaked into the doc. Rewrite it "
+                    "as a real path or link."
+                )
+
+    # --- Report ---------------------------------------------------------------
+    for info in infos:
+        print(info)
+    for flag in flags:
+        print(flag)
+    print(
+        f"checked {checked_paths} paths, {checked_shas} SHAs, "
+        f"{checked_links} links; {len(flags)} flags"
+    )
+    if flags:
+        return 1
+    print(f"OK: {doc_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -23,6 +23,8 @@ Captures problem solutions while context is fresh, creating structured documenta
 /ce-compound mode:headless [context]    # Non-interactive run with context hint
 ```
 
+**One learning per run.** The workflow's grounding, overlap detection, and cross-referencing all assume a single solved problem. When a session produced multiple distinct learnings, run the skill once per learning, sequentially — each run grounds fresh against the tree. Do not batch several learnings through one run and stitch cross-references between the drafts afterward; drafting-context numbering ("Learning 3") leaking into written docs is the failure this rule prevents.
+
 ## CONCEPTS.md bootstrap requests
 
 If invoked specifically to create or bootstrap `CONCEPTS.md` from scratch rather than to document a solved problem, do not run the normal phases — `ce-compound` populates `CONCEPTS.md` only as a side effect of documenting a real learning (it seeds the *learning's area*, not the whole repo; see Phase 2.4). Repo-wide concept-map creation is `ce-compound-refresh`'s job. Redirect a standalone bootstrap request to `ce-compound-refresh` (which asks whether to build the concept map or run a refresh cycle), then exit.
@@ -56,9 +58,11 @@ These files are the durable contract for the workflow. Read them on-demand at th
 - `references/yaml-schema.md` — category mapping from problem_type to directory (read when classifying)
 - `references/concepts-vocabulary.md` — CONCEPTS.md format and inclusion rules (read in Phase 2.4 when domain terms surface)
 - `references/agents/session-historian.md` — skill-local synthesis prompt for optional session-history compounding context (read only when the user opts into session history)
+- `references/grounding-validation.md` — grounding-validation protocol: flag adjudication rules and the semantic validator prompt (read in Phase 2.45)
 - `assets/resolution-template.md` — section structure for new docs (read when assembling)
 - `scripts/session-history/` — session discovery and extraction scripts copied into this skill so session-history support does not depend on the deleted `ce-sessions` public skill
 - `scripts/validate-frontmatter.py` — frontmatter parser-safety validator (run in Phase 2 step 8 through the existence guard documented there; resolves only on Claude Code via `${CLAUDE_SKILL_DIR}`, with a manual-checklist fallback elsewhere)
+- `scripts/validate-doc-claims.py` — mechanical claims validator: cited paths, commit SHAs, relative links, dangling drafting scaffold (run in Phase 2.45 via the `SKILL_DIR` anchor)
 
 When spawning subagents, pass the relevant file contents into the task prompt so they have the contract without needing cross-skill paths.
 
@@ -188,6 +192,8 @@ Pass `{run_id}` (the resolved `$RUN_ID` value) into every Phase 1 subagent promp
    - Adapts output structure based on the problem_type track
    - **Writes the full doc-body prose** (all track-appropriate sections below) to `solution.md` and returns only the artifact path. This is the subagent most prone to the issue #956 summary-collapse, so its prose must land on disk rather than only in the inline return.
    - Incorporates auto memory excerpts (if provided by the orchestrator) as supplementary evidence -- conversation history and the verified fix take priority; if memory notes contradict the conversation, note the contradiction as cautionary context
+   - **Grounds code-behavior claims in source, not conversation memory.** Before asserting how code behaves (enum values, status semantics, limits, defaults), Read the defining line at the current tree and cite `file:line` alongside the claim. A claim that cannot be verified against the tree is softened or attributed ("per this session's conclusion…"), never stated as fact
+   - **Writes merge-state claims for time.** Cite PR numbers rather than bare commit SHAs — SHAs are rewritten by rebase/squash merges and may not exist on other checkouts. A "fixed in X" claim requires the fix to be reachable from the current tree; otherwise phrase it as pending ("fix opened in #1608, unmerged as of this writing")
 
    **Bug track output sections:**
 
@@ -359,6 +365,8 @@ When creating a new doc, preserve the section order from `assets/resolution-temp
 
 Then, applying those criteria, scan the new doc **and** the surrounding conversation for qualifying domain terms. If `CONCEPTS.md` exists at repo root, add missing qualifying terms and refine existing entries when new precision surfaced. If it does not exist and at least one qualifying term surfaced, create it.
 
+**Verify behavior assertions against source before writing them.** When an entry asserts how code behaves (states, transitions, limits, semantics), Read the defining source at the current tree first — an entry drafted from a session-level summary is exactly how wrong semantics enter the glossary. Phase 2.45 re-checks these entries, but the cheap fix is to not write the error.
+
 **Seed the learning's area at creation — don't write a lone term.** When `CONCEPTS.md` does not yet exist, alongside the surfaced term also seed the core domain nouns of the area this learning touched, following the **Seed goal** and **Scope of a seed** rules in `references/concepts-vocabulary.md`. The seed is scoped to the learning's area (the modules and domain the fix touched) and defines only terms investigated here — it does not reach for repo-wide nouns. This anchors the surfaced term so it does not dangle against undefined siblings. A repo-wide concept map is `ce-compound-refresh`'s bootstrap path, not this one.
 
 **At creation, hold the qualifying bar conservatively for borderline terms.** A borderline term, or a class/table/file name dressed up as an entity, defers to a later run — clear core nouns are seeded, borderline ones wait. The conservatism is about quality, not count; updates to an existing file follow the normal criteria.
@@ -372,6 +380,21 @@ Then, applying those criteria, scan the new doc **and** the surrounding conversa
 If no terms qualified after applying the reference's criteria, record that outcome explicitly in the success output (e.g., "Vocabulary capture: scanned, no qualifying terms"). Do not silently skip — the visible scan-and-no-result record is the audit signal that the reference was consulted.
 
 **Apply edits silently in every mode — no user prompt in interactive, lightweight, or headless.** Vocabulary capture is a side effect of compounding, not a decision the user makes per run. Lightweight mode reaches this through its own single-pass step (see Lightweight Mode), and runs an **update-only** version — it refines an existing `CONCEPTS.md` but defers creation/seeding to a Full run.
+
+### Phase 2.45: Grounding Validation
+
+The doc (and any `CONCEPTS.md` entries from Phase 2.4) is about to become permanent, trusted knowledge. Validate its claims against the tree before it compounds. **Read `references/grounding-validation.md` now** — it holds the adjudication rules and the validator prompt; the steps below are only the trigger.
+
+1. **Mechanical claims check (every mode, including headless).** Optionally run `git fetch --quiet` first (best-effort — skip silently offline; the network is never a correctness dependency). Then run the bundled validator against the written doc:
+
+   ```bash
+   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+   python3 "$SKILL_DIR/scripts/validate-doc-claims.py" <doc-path>
+   ```
+
+   Exit 0 means nothing flagged. Exit 1 means flags to **adjudicate, not auto-fix** — each flagged path, SHA, link, or scaffold pattern is fixed, annotated as historical, or confirmed intentional per the reference's adjudication table. A doc may legitimately cite a path deleted by the very fix it documents; a flag is a question, not a failure. If the script cannot be resolved on this platform, apply the reference's manual checklist and say so in the output — never silently skip.
+
+2. **Semantic grounding validator (Full and headless; lightweight skips it).** Dispatch one read-only generic subagent built from the prompt template in the reference, covering the written doc plus any `CONCEPTS.md` entries added or edited this run. It verifies code-behavior claims by quoting the defining source line, merge-state claims against remote truth (`gh` primary, git reachability fallback), and internal completeness of countable assertions. Apply its verdicts per the reference (fix contradicted claims from the quoted evidence; soften or drop unverifiable ones; mark offline merge-state checks as degraded), then re-run the mechanical check if the body changed.
 
 ### Phase 2.5: Selective Refresh Check
 
@@ -496,14 +519,15 @@ Headless mode forces Full and does not enter Lightweight — automations get the
 
 The orchestrator (main conversation) performs ALL of the following in one sequential pass:
 
-1. **Extract from conversation**: Identify the problem and solution from conversation history. Also scan the "user's auto-memory" block injected into your system prompt, if present (Claude Code only) -- use any relevant notes as supplementary context alongside conversation history. Tag any memory-sourced content incorporated into the final doc with "(auto memory [claude])"
+1. **Extract from conversation**: Identify the problem and solution from conversation history. Also scan the "user's auto-memory" block injected into your system prompt, if present (Claude Code only) -- use any relevant notes as supplementary context alongside conversation history. Tag any memory-sourced content incorporated into the final doc with "(auto memory [claude])". Before asserting how code behaves (enum values, status semantics, limits, defaults), Read the defining line at the current tree — soften or attribute any claim you cannot verify. Cite PR numbers over bare commit SHAs, and phrase unmerged fixes as pending
 2. **Classify**: Read `references/schema.yaml` and `references/yaml-schema.md`, then determine track (bug vs knowledge), category, and filename
 3. **Write minimal doc**: Create `docs/solutions/[category]/[filename].md` using the appropriate track template from `assets/resolution-template.md`, with:
    - YAML frontmatter with track-appropriate fields, applying the YAML-safety quoting rule for array items (see `references/yaml-schema.md` > YAML Safety Rules)
    - Bug track: Problem, root cause, solution with key code snippets, one prevention tip
    - Knowledge track: Context, guidance with key examples, one applicability note
 4. **Vocabulary capture (update-only)**: if `CONCEPTS.md` exists at repo root, read `references/concepts-vocabulary.md`, then scan the new doc and the conversation for qualifying terms and add/refine entries silently (same criteria as Phase 2.4). Do **not** bootstrap or seed in lightweight mode — if `CONCEPTS.md` does not exist, defer creation to a Full run, which owns seeding. Record the outcome in the output (e.g., "Vocabulary: 1 entry refined" or "scanned, no qualifying terms"). If you refined `CONCEPTS.md` and a quick read of `AGENTS.md`/`CLAUDE.md` shows it isn't surfaced there, add the discoverability tip to the output below — lightweight **tips**, it does not edit instruction files (a Full run owns that edit).
-5. **Skip specialized agent reviews** (Phase 3) to conserve context
+5. **Mechanical claims check**: run `scripts/validate-doc-claims.py` against the written doc exactly as in Phase 2.45 step 1 (same `SKILL_DIR` anchor, same adjudicate-not-auto-fix rule — read `references/grounding-validation.md` for the adjudication table when it flags anything). Lightweight skips only the semantic validator subagent, not this deterministic check.
+6. **Skip specialized agent reviews** (Phase 3) and the semantic grounding validator (Phase 2.45 step 2) to conserve context
 
 **Lightweight output:**
 ```
@@ -521,8 +545,8 @@ Tip: Your AGENTS.md/CLAUDE.md doesn't surface CONCEPTS.md —
 a one-line mention helps agents find the shared vocabulary.
 
 Note: This was created in lightweight mode. For richer documentation
-(cross-references, detailed prevention strategies, specialized reviews),
-re-run /ce-compound in a fresh session.
+(cross-references, detailed prevention strategies, specialized reviews,
+semantic grounding validation), re-run /ce-compound in a fresh session.
 ```
 
 **No subagents are launched. No parallel tasks. The solution doc is the one deliverable** (Phase 2.4's update-only vocabulary capture may also refine an existing `CONCEPTS.md`).
@@ -592,6 +616,8 @@ Knowledge track:
 | Research and assembly run in parallel | Research completes → then assembly runs |
 | Multiple files created during workflow | One solution doc written or updated: `docs/solutions/[category]/[filename].md` (plus optional maintenance writes: a `CONCEPTS.md` create/update from Phase 2.4 and a small instruction-file edit for discoverability) |
 | Creating a new doc when an existing doc covers the same problem | Check overlap assessment; update the existing doc when overlap is high |
+| Asserting code behavior or merge-state from conversation memory | Read the defining source line before asserting; cite PR numbers over SHAs; soften unverifiable claims (Phase 1 extractor rules, re-checked in Phase 2.45) |
+| Batching several learnings through one run and stitching cross-references between drafts | One learning per run; run the skill sequentially for each additional learning |
 
 ## Success Output
 
@@ -606,6 +632,7 @@ File: docs/solutions/<category>/<filename>.md  (created | updated)
 Track: <bug | knowledge>
 Category: <category>
 Overlap: <none | low | moderate — see <path> | high — existing doc updated>
+Grounding: <clean | N flags adjudicated (X fixed, Y annotated, Z confirmed) | N claims softened or corrected | degraded — merge-state claims unverified offline>
 Instruction-file edit: <none needed | applied to <path> | gap noted, not applied>
 CONCEPTS.md: <scanned, no qualifying terms | created with N entries (M seeded from the learning's area) | updated — N added, N refined>
 Refresh recommendation: <none | scope hint for /ce-compound-refresh>
@@ -636,6 +663,10 @@ Subagent Results:
   ✓ Solution Extractor: 3 code fixes, prevention strategies
   ✓ Related Docs Finder: 2 related issues
   ✓ Session History: 3 prior sessions on same branch, 2 failed approaches surfaced
+
+Grounding Validation:
+  ✓ Mechanical check: 14 paths, 2 SHAs, 3 links checked — 1 flag annotated as historical
+  ✓ Semantic validator: 9 claims verified, 1 merge-state claim softened to pending
 
 Specialized Agent Reviews (Auto-Triggered):
   ✓ performance-oracle: Validated query optimization approach

--- a/skills/ce-compound/references/grounding-validation.md
+++ b/skills/ce-compound/references/grounding-validation.md
@@ -1,0 +1,84 @@
+# Grounding Validation (Phase 2.45)
+
+Read this when Phase 2.45 runs. The doc just written becomes permanent, trusted knowledge — future agents will act on its claims without re-verifying them. This phase checks the claims against reality before they compound: a deterministic mechanical pass (bundled script) plus a semantic pass (one read-only validator subagent). Neither pass is a hard gate — every flag is adjudicated, because solution docs legitimately cite deleted paths and pre-fix states.
+
+## Which tree is the ground truth
+
+Two claim categories verify against different trees:
+
+- **Code-behavior claims** (enum values, status semantics, limits, defaults) verify against the **local working tree** — they describe what this session's work produced and verified here.
+- **Merge-state claims** ("fixed in #1608", "landed", "shipped") verify against **remote truth** — the checkout may predate a merge, so `gh pr view` (or the tracker equivalent) is primary and local git reachability is only the fallback. The script's `INFO: worktree is N commits behind …` line tells you how much to distrust the local tree for this category.
+
+Before running the script, optionally run `git fetch --quiet` (best-effort — skip silently on failure or offline; the network is never a correctness dependency). When remote state cannot be checked at all, keep the claim, add an as-of qualifier ("as of this writing"), and record degraded verification in the run report.
+
+## Step 1: Adjudicate the mechanical flags
+
+The script reports flags; you decide each one. Three resolutions — **fix**, **annotate**, or **confirm intentional** — never an automatic rewrite and never an automatic pass:
+
+| Flag | Likely meaning | Resolution |
+|------|----------------|------------|
+| path not found anywhere | Typo, or drafted from memory | Fix the citation or remove the claim |
+| path missing here, exists at upstream | Stale checkout | Verify the claim against upstream; annotate if the doc implies the file is present locally |
+| path deliberately gone (doc says removed/renamed) | Historical citation | Confirm the surrounding prose marks it as historical ("removed by this fix", "pre-fix state"); add that marker if absent |
+| SHA does not resolve | Fabricated or from another repo | Replace with the PR number, or drop |
+| SHA reachable from HEAD only | Local-only commit; SHA will change on rebase/squash merge | Replace with the PR number |
+| SHA reachable from upstream only | Checkout predates the merge | Keep, with a temporal qualifier; verify the landed claim via `gh` |
+| SHA exists but unreachable | Rebased-away commit | Replace with the PR number |
+| scaffold ("Learning 3", `{{…}}`) | Drafting-context leak | Always fix — rewrite as a real path or link |
+| relative link unresolved | Wrong target | Fix the path |
+
+If the script cannot be resolved on this platform, apply its checks manually at the same scope — scan the body for cited paths that don't exist, hex SHAs, `Learning(s) N` / `{{…}}` scaffold, and broken relative links — and note in the run output that the check was manual. Do not silently skip.
+
+After any body edit from this step or Step 2, re-run the script until it reports clean or every remaining flag is confirmed intentional.
+
+## Step 2: Semantic validator subagent (Full and headless; skipped in lightweight)
+
+Dispatch **one generic read-only subagent** covering the written solution doc plus any `CONCEPTS.md` entries added or edited this run (Phase 2.4's entries are claims too — a glossary entry written from a session-level summary is exactly how wrong semantics enter the vocabulary). Use the same mid-tier model class as other reviewer subagents when the platform exposes one. Build its prompt from this template:
+
+```
+You are a grounding validator for documentation about to enter a permanent
+knowledge store. You are read-only: never edit files. Inspect with Read,
+Grep, Glob, git (non-mutating), and gh when available.
+
+Inputs: the doc content below, the CONCEPTS.md entries below (if any), and
+this staleness context: <INFO line from the mechanical script, or "none">.
+
+Check every factual claim in three categories:
+
+1. CODE-BEHAVIOR CLAIMS — assertions about how code behaves: enum values,
+   status semantics, limits, defaults, ordering, state transitions. For
+   each, locate the defining source in the current tree and quote the
+   defining line(s) with file:line. Verdict: verified (with quote),
+   contradicted (with the quote showing otherwise), or unverifiable
+   (defining source not found).
+
+2. MERGE-STATE CLAIMS — assertions that a change landed ("fixed in",
+   "merged", "shipped in", "resolved by #N"). Primary check: gh pr view
+   <n> --json state,mergedAt,baseRefName (remote truth). Fallback: git
+   reachability from the upstream default branch. Verdict: verified,
+   contradicted (e.g. PR open, not merged), or unverifiable (offline / no
+   gh) — mark unverifiable as "degraded", do not guess.
+
+3. INTERNAL COMPLETENESS — countable assertions ("six PRs", "three root
+   causes", "all N consumers"). Count the substantiating items in the doc
+   itself. Verdict: complete, or short (found M of N).
+
+Ignore session narrative ("we first tried X") — that describes the
+conversation, not the tree. Ignore style.
+
+Return a structured list, one entry per claim checked:
+  claim (verbatim) | category | verdict | evidence (quote + file:line, or
+  command output) | suggested edit (only for non-verified claims)
+```
+
+**Orchestrator handling of verdicts:**
+
+- **contradicted** → fix the doc using the quoted evidence (the quote, not the conversation, is authoritative)
+- **unverifiable** (behavior) → soften or attribute: "per this session's conclusion…" — or drop the claim
+- **unverifiable/degraded** (merge-state) → keep with an as-of qualifier; record degraded verification in the report
+- **short** (completeness) → complete the enumeration or restate the count to match what the doc substantiates
+- **verified** → no change
+
+## Reporting
+
+Summarize the phase in one line of the run output (headless report's `Grounding:` line; interactive success output): flags adjudicated (fixed / annotated / confirmed), claims checked, claims softened or corrected, and `degraded — merge-state claims unverified offline` when applicable.

--- a/skills/ce-compound/scripts/validate-doc-claims.py
+++ b/skills/ce-compound/scripts/validate-doc-claims.py
@@ -14,11 +14,12 @@ validate-frontmatter.py (parser-safety) — this script checks the body's
 citations against the repository:
 
     1. Cited repo-relative paths (backticked, containing at least one '/')
-       exist in the working tree; misses tracked at HEAD or the upstream
-       default branch still count as real paths and are classified
-       (deleted/uncommitted vs stale checkout). Tokens missing everywhere
-       are flagged only when path-shaped; slash-delimited identifiers
-       (branch names, git refs, provider/model IDs) are skipped.
+       exist in the working tree; tokens containing '../' resolve from the
+       doc's directory (those escaping the repo are skipped). Misses tracked
+       at HEAD or the upstream default branch still count as real paths and
+       are classified (deleted/uncommitted vs stale checkout). Tokens
+       missing everywhere are flagged only when path-shaped; slash-delimited
+       identifiers (branch names, git refs, provider/model IDs) are skipped.
     2. Cited commit SHAs (7-40 hex chars with at least one digit and one
        a-f letter) resolve to commits, classified by reachability from
        HEAD and the upstream default branch.
@@ -200,16 +201,28 @@ def main(argv: list[str]) -> int:
     base = repo_root if in_git else os.getcwd()
     for raw in BACKTICK_RE.findall(body):
         token = normalize_path(raw)
-        if not is_path_candidate(token) or token in seen_paths:
+        if not is_path_candidate(token):
             continue
-        seen_paths.add(token)
-        if os.path.exists(os.path.join(base, token)):
+        check = token
+        if token.startswith("../") or "/../" in token:
+            # A `../` citation is doc-relative (matching how markdown links
+            # resolve), so map it to a repo-root path before checking.
+            if not in_git:
+                continue
+            resolved = os.path.realpath(os.path.join(doc_dir, token))
+            check = os.path.relpath(resolved, os.path.realpath(base))
+            if check.startswith(".."):
+                continue  # escapes the repo — not checkable as a repo path
+        if check in seen_paths:
+            continue
+        seen_paths.add(check)
+        if os.path.exists(os.path.join(base, check)):
             checked_paths += 1
             continue
-        tracked_head = head_has_path(token)
-        tracked_upstream = upstream_has_path(token)
+        tracked_head = head_has_path(check)
+        tracked_upstream = upstream_has_path(check)
         if not (tracked_head or tracked_upstream) and not is_path_shaped(
-            token, base
+            check, base
         ):
             continue  # branch name / provider ID, not a path citation
         checked_paths += 1

--- a/skills/ce-compound/scripts/validate-doc-claims.py
+++ b/skills/ce-compound/scripts/validate-doc-claims.py
@@ -14,9 +14,11 @@ validate-frontmatter.py (parser-safety) — this script checks the body's
 citations against the repository:
 
     1. Cited repo-relative paths (backticked, containing at least one '/')
-       exist in the working tree; misses are classified against the
-       upstream default branch to distinguish a stale checkout from a
-       fabricated path.
+       exist in the working tree; misses tracked at HEAD or the upstream
+       default branch still count as real paths and are classified
+       (deleted/uncommitted vs stale checkout). Tokens missing everywhere
+       are flagged only when path-shaped; slash-delimited identifiers
+       (branch names, git refs, provider/model IDs) are skipped.
     2. Cited commit SHAs (7-40 hex chars with at least one digit and one
        a-f letter) resolve to commits, classified by reachability from
        HEAD and the upstream default branch.
@@ -91,11 +93,24 @@ def is_path_candidate(token: str) -> bool:
         return False
     if "://" in token or token.startswith(("http", "#", "/", "~")):
         return False
+    if token.startswith(("origin/", "upstream/", "refs/")):
+        return False  # git refs, not repo paths
     if PLACEHOLDER_CHARS & set(token):
         return False
     if any(sub in token for sub in PLACEHOLDER_SUBSTRINGS):
         return False
     return True
+
+
+def is_path_shaped(token: str, base: str) -> bool:
+    """Distinguish a path citation from a slash-delimited identifier
+    (branch name, provider/model ID) among tokens found nowhere in git."""
+    segments = token.split("/")
+    if re.search(r"\.[A-Za-z0-9]{1,8}$", segments[-1]):
+        return True
+    if token.endswith("/"):
+        return True
+    return os.path.isdir(os.path.join(base, segments[0]))
 
 
 def normalize_path(token: str) -> str:
@@ -173,20 +188,39 @@ def main(argv: list[str]) -> int:
         code, _ = git(["cat-file", "-e", f"{upstream}:{path}"], repo_root)
         return code == 0
 
+    def head_has_path(path: str) -> bool:
+        if not in_git:
+            return False
+        code, _ = git(["cat-file", "-e", f"HEAD:{path}"], repo_root)
+        return code == 0
+
     # --- 1. Cited repo paths ----------------------------------------------
     checked_paths = 0
     seen_paths: set[str] = set()
+    base = repo_root if in_git else os.getcwd()
     for raw in BACKTICK_RE.findall(body):
         token = normalize_path(raw)
         if not is_path_candidate(token) or token in seen_paths:
             continue
         seen_paths.add(token)
-        checked_paths += 1
-        base = repo_root if in_git else os.getcwd()
         if os.path.exists(os.path.join(base, token)):
+            checked_paths += 1
             continue
+        tracked_head = head_has_path(token)
+        tracked_upstream = upstream_has_path(token)
+        if not (tracked_head or tracked_upstream) and not is_path_shaped(
+            token, base
+        ):
+            continue  # branch name / provider ID, not a path citation
+        checked_paths += 1
         loc = loc_suffix(raw)
-        if upstream_has_path(token):
+        if tracked_head:
+            flags.append(
+                f"FLAG path `{token}`{loc} — tracked at HEAD but missing from "
+                "the working tree: deleted or uncommitted removal? Annotate as "
+                "historical (e.g. removed by this fix) or restore it."
+            )
+        elif tracked_upstream:
             flags.append(
                 f"FLAG path `{token}`{loc} — not in working tree but exists at "
                 f"{upstream}: stale checkout? Annotate or verify against upstream."

--- a/skills/ce-compound/scripts/validate-doc-claims.py
+++ b/skills/ce-compound/scripts/validate-doc-claims.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Validate cited claims in a solution doc against the git tree.
+
+Usage:
+    python3 validate-doc-claims.py <doc-path>
+
+Exit codes:
+    0 — nothing flagged
+    1 — one or more flags need adjudication (report on stdout)
+    2 — usage error (bad arguments, missing file)
+
+Scope: mechanical grounding checks on a written doc's *body*. Complements
+validate-frontmatter.py (parser-safety) — this script checks the body's
+citations against the repository:
+
+    1. Cited repo-relative paths (backticked, containing at least one '/')
+       exist in the working tree; misses are classified against the
+       upstream default branch to distinguish a stale checkout from a
+       fabricated path.
+    2. Cited commit SHAs (7-40 hex chars with at least one digit and one
+       a-f letter) resolve to commits, classified by reachability from
+       HEAD and the upstream default branch.
+    3. Relative markdown link targets resolve from the doc's location.
+    4. Dangling drafting scaffold: "Learning(s) N" numbering and
+       unresolved {{...}} placeholder tokens.
+
+Flags are adjudication input, NOT hard failures — a doc may legitimately
+cite a path deleted by the very fix it documents. The calling agent
+decides per flag: fix, annotate as historical, or confirm intentional.
+Only the summary exit code distinguishes "clean" from "needs a look".
+
+The script never touches the network (no fetch); classification uses
+whatever refs exist locally. Run a best-effort `git fetch --quiet` first
+when freshness matters. Pure stdlib (no third-party deps).
+"""
+import os
+import re
+import subprocess
+import sys
+
+# Tokens containing these are placeholders/examples, not real citations.
+PLACEHOLDER_CHARS = set("<>{}*$")
+PLACEHOLDER_SUBSTRINGS = ("path/to", "...", "…")
+
+SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
+BACKTICK_RE = re.compile(r"`([^`\n]+)`")
+MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+SCAFFOLD_RES = (
+    re.compile(r"\bLearnings?\s+#?\d"),
+    re.compile(r"\{\{[^}\n]*\}\}"),
+)
+
+
+def usage_fail(msg: str) -> "NoReturn":
+    sys.stderr.write(f"validate-doc-claims: {msg}\n")
+    sys.exit(2)
+
+
+def git(args: list[str], cwd: str) -> tuple[int, str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode, result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        return 1, ""
+
+
+def split_body(text: str) -> tuple[str, int]:
+    """Return (body, 1-indexed line number the body starts on).
+
+    Skips YAML frontmatter when present so frontmatter fields are not
+    scanned as body citations.
+    """
+    lines = text.split("\n")
+    if lines and lines[0].rstrip() == "---":
+        for i in range(1, len(lines)):
+            if lines[i].rstrip() == "---":
+                return "\n".join(lines[i + 1 :]), i + 2
+    return text, 1
+
+
+def is_path_candidate(token: str) -> bool:
+    if any(ch.isspace() for ch in token):
+        return False
+    if "/" not in token:
+        return False
+    if "://" in token or token.startswith(("http", "#", "/", "~")):
+        return False
+    if PLACEHOLDER_CHARS & set(token):
+        return False
+    if any(sub in token for sub in PLACEHOLDER_SUBSTRINGS):
+        return False
+    return True
+
+
+def normalize_path(token: str) -> str:
+    token = token.strip().rstrip(".,;")
+    token = re.sub(r":\d+(-\d+)?$", "", token)  # strip `:line` / `:a-b` refs
+    if token.startswith("./"):
+        token = token[2:]
+    return token
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        usage_fail(f"usage: {os.path.basename(argv[0])} <doc-path>")
+
+    doc_path = argv[1]
+    if not os.path.isfile(doc_path):
+        usage_fail(f"file not found: {doc_path}")
+
+    with open(doc_path) as f:
+        text = f.read()
+
+    doc_dir = os.path.dirname(os.path.abspath(doc_path))
+    body, body_start = split_body(text)
+    body_lines = body.split("\n")
+
+    def loc_suffix(needle: str) -> str:
+        for i, line in enumerate(body_lines):
+            if needle in line:
+                return f" (line {body_start + i})"
+        return ""
+
+    infos: list[str] = []
+    flags: list[str] = []
+
+    # --- Repo context -----------------------------------------------------
+    code, repo_root = git(["rev-parse", "--show-toplevel"], doc_dir)
+    in_git = code == 0 and bool(repo_root)
+    upstream: str | None = None
+    if in_git:
+        code, ref = git(["rev-parse", "--abbrev-ref", "origin/HEAD"], repo_root)
+        if code == 0 and ref:
+            upstream = ref
+        else:
+            for candidate in ("origin/main", "origin/master"):
+                code, _ = git(
+                    ["rev-parse", "--verify", "--quiet", candidate], repo_root
+                )
+                if code == 0:
+                    upstream = candidate
+                    break
+        if upstream:
+            code, behind = git(
+                ["rev-list", "--count", f"HEAD..{upstream}"], repo_root
+            )
+            if code == 0 and behind.isdigit() and int(behind) > 0:
+                infos.append(
+                    f"INFO: worktree is {behind} commits behind {upstream} — "
+                    "verify merge-state claims against remote truth (gh pr view), "
+                    "not this checkout"
+                )
+        else:
+            infos.append(
+                "INFO: no upstream default branch found — "
+                "path/SHA classification limited to HEAD"
+            )
+    else:
+        infos.append(
+            "INFO: not a git repository — path and SHA classification skipped "
+            "(scaffold and link checks still apply)"
+        )
+
+    def upstream_has_path(path: str) -> bool:
+        if not (in_git and upstream):
+            return False
+        code, _ = git(["cat-file", "-e", f"{upstream}:{path}"], repo_root)
+        return code == 0
+
+    # --- 1. Cited repo paths ----------------------------------------------
+    checked_paths = 0
+    seen_paths: set[str] = set()
+    for raw in BACKTICK_RE.findall(body):
+        token = normalize_path(raw)
+        if not is_path_candidate(token) or token in seen_paths:
+            continue
+        seen_paths.add(token)
+        checked_paths += 1
+        base = repo_root if in_git else os.getcwd()
+        if os.path.exists(os.path.join(base, token)):
+            continue
+        loc = loc_suffix(raw)
+        if upstream_has_path(token):
+            flags.append(
+                f"FLAG path `{token}`{loc} — not in working tree but exists at "
+                f"{upstream}: stale checkout? Annotate or verify against upstream."
+            )
+        else:
+            where = (
+                f"working tree or {upstream}" if upstream else "working tree"
+            )
+            flags.append(
+                f"FLAG path `{token}`{loc} — not found in {where}. Fix the "
+                "citation, or annotate it as historical (e.g. removed by this fix)."
+            )
+
+    # --- 2. Cited commit SHAs ----------------------------------------------
+    checked_shas = 0
+    seen_shas: set[str] = set()
+    if in_git:
+        for m in SHA_RE.finditer(body):
+            sha = m.group(0)
+            if sha in seen_shas:
+                continue
+            if not (any(c.isdigit() for c in sha) and any(c in "abcdef" for c in sha)):
+                continue  # dates and decimal ids are not SHAs
+            seen_shas.add(sha)
+            checked_shas += 1
+            loc = loc_suffix(sha)
+            code, _ = git(["cat-file", "-e", f"{sha}^{{commit}}"], repo_root)
+            if code != 0:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — does not resolve to a commit in this "
+                    "repository. Replace with the PR number, or drop it."
+                )
+                continue
+            in_head = (
+                git(["merge-base", "--is-ancestor", sha, "HEAD"], repo_root)[0] == 0
+            )
+            in_up = (
+                upstream is not None
+                and git(["merge-base", "--is-ancestor", sha, upstream], repo_root)[0]
+                == 0
+            )
+            if in_head and (in_up or upstream is None):
+                continue
+            if in_head and not in_up:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — reachable from HEAD but not {upstream}: "
+                    "local-only commit whose SHA may be rewritten on merge "
+                    "(rebase/squash). Prefer citing the PR number."
+                )
+            elif in_up:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — not reachable from HEAD but reachable "
+                    f"from {upstream}: this checkout predates the merge. Add a "
+                    "temporal qualifier or verify the claim via gh."
+                )
+            else:
+                flags.append(
+                    f"FLAG sha {sha}{loc} — exists but unreachable from HEAD"
+                    + (f" or {upstream}" if upstream else "")
+                    + ": likely a rebased-away commit. Prefer citing the PR number."
+                )
+
+    # --- 3. Relative markdown links -----------------------------------------
+    checked_links = 0
+    seen_links: set[str] = set()
+    for target in MD_LINK_RE.findall(body):
+        if re.match(r"^[a-z][a-z0-9+.-]*:", target, re.IGNORECASE):
+            continue  # URL scheme
+        if target.startswith("#"):
+            continue  # intra-doc anchor
+        bare = target.split("#", 1)[0]
+        if not bare or bare in seen_links:
+            continue
+        seen_links.add(bare)
+        checked_links += 1
+        if not os.path.exists(os.path.normpath(os.path.join(doc_dir, bare))):
+            loc = loc_suffix(target)
+            flags.append(
+                f"FLAG link ({target}){loc} — relative target does not resolve "
+                "from the doc's location. Fix the path."
+            )
+
+    # --- 4. Dangling drafting scaffold ---------------------------------------
+    for i, line_text in enumerate(body_lines):
+        for pattern in SCAFFOLD_RES:
+            m = pattern.search(line_text)
+            if m:
+                flags.append(
+                    f'FLAG scaffold "{m.group(0)}" (line {body_start + i}) — '
+                    "drafting-context reference leaked into the doc. Rewrite it "
+                    "as a real path or link."
+                )
+
+    # --- Report ---------------------------------------------------------------
+    for info in infos:
+        print(info)
+    for flag in flags:
+        print(flag)
+    print(
+        f"checked {checked_paths} paths, {checked_shas} SHAs, "
+        f"{checked_links} links; {len(flags)} flags"
+    )
+    if flags:
+        return 1
+    print(f"OK: {doc_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -64,7 +64,14 @@ beforeAll(() => {
   sh(repo, "git", ["config", "user.name", "Test"])
   mkdirSync(path.join(repo, "src"), { recursive: true })
   mkdirSync(path.join(repo, "docs/solutions/workflow"), { recursive: true })
+  mkdirSync(path.join(repo, "docs/solutions/best-practices"), {
+    recursive: true,
+  })
   writeFileSync(path.join(repo, "src/real-file.ts"), "export const x = 1\n")
+  writeFileSync(
+    path.join(repo, "docs/solutions/best-practices/linked-target.md"),
+    "# linked target\n",
+  )
   writeFileSync(
     path.join(repo, "docs/solutions/workflow/existing-doc.md"),
     "# existing\n",
@@ -230,6 +237,38 @@ describe("validate-doc-claims script", () => {
         expect(result.code).toBe(1)
         expect(result.stdout).toContain("FLAG scaffold")
         expect(result.stdout).toContain("{{DOC:3}}")
+      })
+
+      test("resolves a `../` code-formatted link label from the doc's location", () => {
+        const docPath = writeRepoDoc(
+          "See [`../best-practices/linked-target.md`]" +
+            "(../best-practices/linked-target.md) for the pattern.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).not.toContain("FLAG")
+      })
+
+      test("flags a `../` cited path whose doc-relative target is missing", () => {
+        const docPath = writeRepoDoc(
+          "See `../best-practices/does-not-exist.md` for background.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain(
+          "FLAG path `../best-practices/does-not-exist.md`",
+        )
+        expect(result.stdout).toContain("not found")
+      })
+
+      test("skips a `../` token that escapes the repository", () => {
+        // Four levels up from docs/solutions/workflow lands outside the repo.
+        const docPath = writeRepoDoc(
+          "The temp copy was `../../../../outside-repo.md` during the run.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).not.toContain("FLAG")
       })
 
       test("flags a relative markdown link that does not resolve", () => {

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -145,6 +145,26 @@ describe("validate-doc-claims script", () => {
         expect(result.stdout).toContain("exists at origin/main")
       })
 
+      test("skips slash-delimited identifiers that are not path-shaped", () => {
+        const docPath = writeRepoDoc(
+          "Branched as `feat/foo` off `origin/main`, drafted by " +
+            "`anthropic/claude-sonnet-4-6`.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).not.toContain("FLAG")
+      })
+
+      test("flags a missing extension-less token under a real repo directory", () => {
+        const docPath = writeRepoDoc(
+          "The helper is `src/nonexistent-helper` in the tree.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG path `src/nonexistent-helper`")
+        expect(result.stdout).toContain("not found")
+      })
+
       test("ignores placeholder and URL-like tokens", () => {
         const docPath = writeRepoDoc(
           "Use `path/to/your-file.ts`, `docs/<category>/file.md`, and " +

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -1,0 +1,269 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+const SKILL_DIRS = [
+  path.join(__dirname, "../skills/ce-compound"),
+  path.join(__dirname, "../skills/ce-compound-refresh"),
+] as const
+
+function scriptPath(skillDir: string): string {
+  return path.join(skillDir, "scripts/validate-doc-claims.py")
+}
+
+function runValidator(
+  skillDir: string,
+  docPath: string,
+): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync("python3", [scriptPath(skillDir), docPath], {
+    encoding: "utf8",
+  })
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  }
+}
+
+function sh(cwd: string, cmd: string, args: string[]): string {
+  const result = spawnSync(cmd, args, { cwd, encoding: "utf8" })
+  if (result.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed in ${cwd}: ${result.stderr}`,
+    )
+  }
+  return (result.stdout ?? "").trim()
+}
+
+const FRONTMATTER = `---
+title: "Sample doc"
+date: 2026-07-07
+module: ce-compound
+problem_type: best_practice
+component: tooling
+severity: low
+---
+`
+
+// Scratch git repo shared by all repo-dependent tests. Layout:
+//   src/real-file.ts committed and reachable from both HEAD and the
+//   simulated origin/main; sharedSha = that commit; localOnlySha = a later
+//   commit reachable from HEAD only; upstreamOnlySha = a commit only the
+//   simulated origin/main can reach.
+let repo: string
+let sharedSha: string
+let localOnlySha: string
+let upstreamOnlySha: string
+
+beforeAll(() => {
+  repo = mkdtempSync(path.join(tmpdir(), "doc-claims-repo-"))
+  sh(repo, "git", ["init", "-b", "main"])
+  sh(repo, "git", ["config", "user.email", "test@example.com"])
+  sh(repo, "git", ["config", "user.name", "Test"])
+  mkdirSync(path.join(repo, "src"), { recursive: true })
+  mkdirSync(path.join(repo, "docs/solutions/workflow"), { recursive: true })
+  writeFileSync(path.join(repo, "src/real-file.ts"), "export const x = 1\n")
+  writeFileSync(
+    path.join(repo, "docs/solutions/workflow/existing-doc.md"),
+    "# existing\n",
+  )
+  sh(repo, "git", ["add", "-A"])
+  sh(repo, "git", ["commit", "-m", "base"])
+  sharedSha = sh(repo, "git", ["rev-parse", "HEAD"])
+
+  // upstream-only commit: branch from base, commit, point origin/main at it
+  sh(repo, "git", ["checkout", "-b", "upstream-work"])
+  writeFileSync(path.join(repo, "src/upstream-only.ts"), "export const u = 1\n")
+  sh(repo, "git", ["add", "-A"])
+  sh(repo, "git", ["commit", "-m", "upstream only"])
+  upstreamOnlySha = sh(repo, "git", ["rev-parse", "HEAD"])
+  sh(repo, "git", ["update-ref", "refs/remotes/origin/main", upstreamOnlySha])
+  sh(repo, "git", ["checkout", "main"])
+
+  // local-only commit: on main, after origin/main was pinned
+  writeFileSync(path.join(repo, "src/local-only.ts"), "export const l = 1\n")
+  sh(repo, "git", ["add", "-A"])
+  sh(repo, "git", ["commit", "-m", "local only"])
+  localOnlySha = sh(repo, "git", ["rev-parse", "HEAD"])
+})
+
+let docCounter = 0
+function writeRepoDoc(body: string): string {
+  const filePath = path.join(
+    repo,
+    `docs/solutions/workflow/doc-${docCounter++}.md`,
+  )
+  writeFileSync(filePath, FRONTMATTER + "\n" + body, "utf8")
+  return filePath
+}
+
+function writeBareDoc(body: string): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "doc-claims-bare-"))
+  const filePath = path.join(dir, "doc.md")
+  writeFileSync(filePath, FRONTMATTER + "\n" + body, "utf8")
+  return filePath
+}
+
+describe("validate-doc-claims script", () => {
+  // Run every test against both skill copies — they must behave
+  // identically since AGENTS.md requires duplication, not sharing.
+  for (const skillDir of SKILL_DIRS) {
+    const skillName = path.basename(skillDir)
+
+    describe(`in ${skillName}`, () => {
+      test("passes a clean doc citing an existing path and a shared SHA", () => {
+        const docPath = writeRepoDoc(
+          "The fix lives in `src/real-file.ts` and landed in commit " +
+            `${sharedSha.slice(0, 12)}.\n` +
+            "See [the existing doc](existing-doc.md) for background.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).toContain("OK:")
+        expect(result.stdout).not.toContain("FLAG")
+      })
+
+      test("flags a cited path that exists nowhere", () => {
+        const docPath = writeRepoDoc(
+          "The handler is `src/does-not-exist.ts` in the tree.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG path `src/does-not-exist.ts`")
+        expect(result.stdout).toContain("not found")
+      })
+
+      test("classifies a path that only exists upstream as stale-checkout", () => {
+        const docPath = writeRepoDoc(
+          "See `src/upstream-only.ts` for the new helper.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG path `src/upstream-only.ts`")
+        expect(result.stdout).toContain("exists at origin/main")
+      })
+
+      test("ignores placeholder and URL-like tokens", () => {
+        const docPath = writeRepoDoc(
+          "Use `path/to/your-file.ts`, `docs/<category>/file.md`, and " +
+            "`https://example.com/a/b` as needed.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+      })
+
+      test("flags a fabricated SHA", () => {
+        const docPath = writeRepoDoc(
+          "Fixed in commit 0123456789abcdef0123.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG sha 0123456789abcdef0123")
+        expect(result.stdout).toContain("does not resolve")
+      })
+
+      test("flags a HEAD-only SHA as rewritable on merge", () => {
+        const docPath = writeRepoDoc(
+          `Landed in ${localOnlySha.slice(0, 12)} on this branch.\n`,
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain(`FLAG sha ${localOnlySha.slice(0, 12)}`)
+        expect(result.stdout).toContain("local-only commit")
+      })
+
+      test("flags an upstream-only SHA as predating-the-merge (the stale-branch bug)", () => {
+        const docPath = writeRepoDoc(
+          `Fixed by ${upstreamOnlySha.slice(0, 12)} which merged upstream.\n`,
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain(
+          `FLAG sha ${upstreamOnlySha.slice(0, 12)}`,
+        )
+        expect(result.stdout).toContain("predates the merge")
+      })
+
+      test("does not treat dates or decimal ids as SHAs", () => {
+        const docPath = writeRepoDoc(
+          "On 20260707 we bumped build 123456789 without incident.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+      })
+
+      test("flags dangling learning-number scaffold", () => {
+        const docPath = writeRepoDoc(
+          "This complements Learnings 3, 4, 5 from the same batch.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG scaffold")
+        expect(result.stdout).toContain("Learnings 3")
+      })
+
+      test("flags unresolved placeholder tokens", () => {
+        const docPath = writeRepoDoc("Cross-reference: {{DOC:3}}.\n")
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG scaffold")
+        expect(result.stdout).toContain("{{DOC:3}}")
+      })
+
+      test("flags a relative markdown link that does not resolve", () => {
+        const docPath = writeRepoDoc(
+          "See [the missing doc](../missing/nope.md) for details.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG link (../missing/nope.md)")
+      })
+
+      test("reports staleness INFO when HEAD is behind the upstream ref", () => {
+        // HEAD (main) does not contain upstream-only work, so rev-list
+        // HEAD..origin/main is non-zero in the scratch repo.
+        const docPath = writeRepoDoc("Nothing cited here.\n")
+        const result = runValidator(skillDir, docPath)
+        expect(result.stdout).toContain("INFO: worktree is")
+        expect(result.stdout).toContain("behind origin/main")
+      })
+
+      test("still checks scaffold and links outside a git repository", () => {
+        const docPath = writeBareDoc(
+          "This continues Learning 2 — see [gone](./gone.md).\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("not a git repository")
+        expect(result.stdout).toContain("FLAG scaffold")
+        expect(result.stdout).toContain("FLAG link (./gone.md)")
+      })
+
+      test("exits 2 (usage error) on missing file", () => {
+        const result = runValidator(
+          skillDir,
+          "/tmp/this-file-does-not-exist-claims.md",
+        )
+        expect(result.code).toBe(2)
+        expect(result.stderr).toContain("file not found")
+      })
+
+      test("exits 2 (usage error) on missing argument", () => {
+        const result = spawnSync("python3", [scriptPath(skillDir)], {
+          encoding: "utf8",
+        })
+        expect(result.status).toBe(2)
+        expect(result.stderr).toContain("usage")
+      })
+    })
+  }
+
+  test("script content is identical across skill copies (per AGENTS.md duplication rule)", () => {
+    const [a, b] = SKILL_DIRS
+    const aContent = readFileSync(scriptPath(a), "utf8")
+    const bContent = readFileSync(scriptPath(b), "utf8")
+    expect(aContent).toBe(bContent)
+  })
+})


### PR DESCRIPTION
## Summary

`ce-compound` wrote `docs/solutions/` entries from conversation evidence alone — nothing verified a claim against the actual tree before it became permanent, trusted knowledge. Four observed failure shapes motivated this: enum semantics written from a session-level summary instead of the defining source, "fixed in X" claims whose commits didn't exist on the branch being committed to, a doc asserting "six PRs" while substantiating three, and batch-drafting scaffold ("Learnings 3, 4, 5") shipping as prose. Docs now pass grounding validation before they compound.

## How it works

- **Draft-time rules (all modes):** the Solution Extractor and lightweight mode must Read the defining source line before asserting code behavior (citing `file:line`), cite PR numbers over rebase-fragile SHAs, and phrase unmerged fixes as pending. Phase 2.4 applies the same read-before-assert rule to `CONCEPTS.md` entries.
- **Phase 2.45 mechanical check (all modes):** a new bundled `validate-doc-claims.py` checks cited repo paths, commit SHAs, relative links, and dangling scaffold. SHAs and missing paths are classified by reachability from HEAD vs the upstream default branch, so a stale checkout is distinguishable from a fabricated citation, and a staleness banner reports how far the worktree is behind.
- **Phase 2.45 semantic validator (Full and headless; lightweight documents the skip):** one read-only subagent quotes the defining source line behind each code-behavior claim, checks merge-state claims against remote truth (`gh` primary, git reachability fallback, explicit degraded note offline), and verifies countable assertions against the doc's own content.
- **One learning per run** is now an explicit contract, closing the batch-drafting path that produced the scaffold leak.
- **ce-compound-refresh** runs the same mechanical check on Replace successors and consolidated canonical docs (byte-duplicated script per the no-cross-skill-sharing rule).

Two design decisions worth review attention: flags are **adjudication input, never hard failures** — a solution doc legitimately cites paths deleted by the very fix it documents, so each flag resolves to fixed / annotated-historical / confirmed-intentional; and ground truth is **per claim category** — behavior claims verify against the local tree (they describe this session's work), merge-state claims verify against remote truth (the checkout may predate the merge). The network is never a correctness dependency: offline runs degrade visibly instead of blocking.

## Validation

- `bun test`: 1848 pass, including 31 new tests for the script across both skill copies (stale-branch SHA classification, local-only SHAs, upstream-only paths, scaffold, links, non-git fallback) plus a byte-parity guard mirroring the existing `validate-frontmatter` pattern. `bun run release:validate` in sync.
- skill-creator behavioral evals (fixture repo with planted traps; three scenarios, new skill vs pre-change baseline): **17/17 vs 11/17 assertions.** The new skill corrected a planted wrong-enum claim against source with `file:line` cites, rephrased an unmerged fix to pending, adjudicated the deleted-path flag as historical, ran the semantic validator in headless and correctly skipped it in lightweight, and handled a batched three-learnings request as three sequential self-contained runs with no scaffold leakage. The baseline failed every mechanism assertion (no script, no validator pass, no Grounding report line); one scenario (single-learning contract) was non-discriminating because the old one-deliverable rule already resisted batching.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
