### PR TITLE
fix(ce-code-review): call codex via `command` to bypass shell wrappers

### DIFF
--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -119,7 +119,9 @@ run_codex() {
   # = true), so the streamed reasoning keeps PEERLOG growing and gives the idle watchdog a
   # liveness signal -- otherwise a long, quiet reasoning phase on a big diff could be
   # misread as a stall and reaped.
-  codex exec - -C "$REPO_ROOT" -s read-only -o "$OUT" \
+  # `command codex` bypasses any interactive shell function/alias a user has wrapped
+  # around codex, so we hit the real binary.
+  command codex exec - -C "$REPO_ROOT" -s read-only -o "$OUT" \
     -c 'model_reasoning_effort="high"' -c 'hide_agent_reasoning=false' < "$PROMPT_FILE" > "$PEERLOG" 2>&1 &
   local pid=$!
   [ "$prev" = 0 ] && set +m   # group is already assigned; restoring silences job-control noise


### PR DESCRIPTION
The cross-model adversarial review invoked `codex` bare, so a user's interactive shell function or alias around `codex` could shadow the real binary — silently breaking or mutating the read-only peer review instead of running it. Prefixing the invocation with `command` forces the actual codex binary, the same hardening steipete's `codex-first` skill applies. The peer's other path (`claude`) already runs unwrapped, so only the codex call site changed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
