### PR TITLE
fix(skills): make pre-resolution commands shell-portable so skills load under PowerShell

### DIFF
--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -59,9 +59,9 @@ Do not proceed until you have a feature description from the user.
 Determine `OUTPUT_FORMAT` before any other phase fires. Output mode is **exclusive** — the requirements-only unified plan is written as either markdown (`.md`) OR HTML (`.html`), never both. Precedence: in-prompt request > user-stated preference > config > default (`md`), with a hard pipeline-mode override.
 
 **Read config.** The repo root is pre-resolved at skill load:
-!`git rev-parse --show-toplevel 2>/dev/null || true`
+!`git rev-parse --show-toplevel`
 
-If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty, shows an error, or still shows a backtick command string (a harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
 
 Resolution steps:
 

--- a/skills/ce-commit-push-pr/SKILL.md
+++ b/skills/ce-commit-push-pr/SKILL.md
@@ -33,13 +33,13 @@ argument-hint: "[PR ref] [mode:pipeline] [archive:on|off]"
 !`git log --oneline -10`
 
 **Remote default branch:**
-!`git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo 'DEFAULT_BRANCH_UNRESOLVED'`
+!`git rev-parse --abbrev-ref origin/HEAD`
 
 **Existing PR check:**
-!`gh pr view --json url,title,body,state 2>/dev/null || echo 'NO_OPEN_PR'`
+!`gh pr view --json url,title,body,state`
 
 **Repo root (pre-resolved):**
-!`git rev-parse --show-toplevel 2>/dev/null || true`
+!`git rev-parse --show-toplevel`
 
 ### Context fallback
 
@@ -51,7 +51,7 @@ printf '=== STATUS ===\n'; git status; printf '\n=== DIFF ===\n'; git diff HEAD;
 
 ## Step 1: Resolve branch and PR state
 
-The remote default branch returns something like `origin/main`; strip the `origin/` prefix. If it returned `DEFAULT_BRANCH_UNRESOLVED` or bare `HEAD`, try `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`. If both fail, fall back to `main`.
+The remote default branch returns something like `origin/main`; strip the `origin/` prefix. If it returned `DEFAULT_BRANCH_UNRESOLVED`, an error, or bare `HEAD`, try `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`. If both fail, fall back to `main`. An error from the existing-PR check means no open PR was found (or `gh` is unavailable) — treat it as `NO_OPEN_PR`.
 
 Branch routing:
 

--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -26,7 +26,7 @@ Create a single, well-crafted git commit from the current working tree changes.
 !`git log --oneline -10`
 
 **Remote default branch:**
-!`git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo '__DEFAULT_BRANCH_UNRESOLVED__'`
+!`git rev-parse --abbrev-ref origin/HEAD`
 
 ### Context fallback
 
@@ -46,7 +46,7 @@ printf '=== STATUS ===\n'; git status; printf '\n=== DIFF ===\n'; git diff HEAD;
 
 Use the context above (git status, working tree diff, current branch, recent commits, remote default branch). All data needed for this step is already available -- do not re-run those commands.
 
-The remote default branch value returns something like `origin/main`. Strip the `origin/` prefix to get the branch name. If it returned `__DEFAULT_BRANCH_UNRESOLVED__` or a bare `HEAD`, try:
+The remote default branch value returns something like `origin/main`. Strip the `origin/` prefix to get the branch name. If it returned `__DEFAULT_BRANCH_UNRESOLVED__`, an error, or a bare `HEAD`, try:
 
 ```bash
 gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -42,13 +42,13 @@ Headless mode is intended for automations and skill-to-skill invocation where no
 
 ## Pre-resolved context
 
-**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD 2>/dev/null || true`
+**Git branch (pre-resolved):** !`git rev-parse --abbrev-ref HEAD`
 
-If the line above resolved to a plain branch name (like `feat/my-branch`), use it in Phase 1 session-history filtering so the orchestrator does not waste a turn deriving it. If it still contains a backtick command string or is empty, derive the branch at runtime.
+If the line above resolved to a plain branch name (like `feat/my-branch`), use it in Phase 1 session-history filtering so the orchestrator does not waste a turn deriving it. If it still contains a backtick command string, shows an error, or is empty, derive the branch at runtime.
 
-**Repo root (pre-resolved):** !`git rev-parse --show-toplevel 2>/dev/null || pwd`
+**Repo root (pre-resolved):** !`git rev-parse --show-toplevel`
 
-If the line above resolved to an absolute path, use it as the session-history repo filter in Phase 1. If it still contains a backtick command string or is empty, derive the repo root at runtime with `git rev-parse --show-toplevel 2>/dev/null || pwd`.
+If the line above resolved to an absolute path, use it as the session-history repo filter in Phase 1. If it still contains a backtick command string, shows an error, or is empty, derive the repo root at runtime with the shell tool (`git rev-parse --show-toplevel`, falling back to the working directory outside a git repo).
 
 ## Support Files
 

--- a/skills/ce-ideate/SKILL.md
+++ b/skills/ce-ideate/SKILL.md
@@ -68,9 +68,9 @@ Determine `OUTPUT_FORMAT` for the ideation artifact this run might persist. Outp
 Unlike `ce-plan` and `ce-brainstorm` (which default to `md`), ce-ideate defaults to **`html`** — ideation artifacts are read mainly by humans weighing candidate directions, and a rich self-contained HTML file (with illustrative diagrams for the top candidates) makes the ideas easier to approach.
 
 **Read config.** The repo root is pre-resolved at skill load:
-!`git rev-parse --show-toplevel 2>/dev/null || true`
+!`git rev-parse --show-toplevel`
 
-If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty, shows an error, or still shows a backtick command string (a harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
 
 Resolution steps:
 

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -72,9 +72,9 @@ A plan is ready when an implementer can start confidently without needing the pl
 Determine `OUTPUT_FORMAT` before any other phase fires. Output mode is **exclusive** — the plan is written as either markdown (`.md`) OR HTML (`.html`), never both. Precedence: in-prompt request > user-stated preference > config > default (`md`), with a hard pipeline-mode override.
 
 **Read config.** The repo root is pre-resolved at skill load:
-!`git rev-parse --show-toplevel 2>/dev/null || true`
+!`git rev-parse --show-toplevel`
 
-If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty, shows an error, or still shows a backtick command string (a harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool. If the root cannot be resolved (not a git repo) or the file does not exist, fall through to the defaults below.
 
 Resolution steps:
 

--- a/skills/ce-product-pulse/SKILL.md
+++ b/skills/ce-product-pulse/SKILL.md
@@ -53,9 +53,9 @@ Apply a **15-minute trailing buffer** to the window's upper bound. Many analytic
 ### Phase 0: Route by Config State
 
 **Read config.** The repo root is pre-resolved at skill load:
-!`git rev-parse --show-toplevel 2>/dev/null || true`
+!`git rev-parse --show-toplevel`
 
-If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a non-Claude harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the root cannot be resolved or the file does not exist, treat this as a first run. Otherwise extract values for the `pulse_*` keys listed under "Config keys" below.
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty, shows an error, or still shows a backtick command string (a harness that did not run the pre-resolution), resolve `<repo-root>` at runtime by running `git rev-parse --show-toplevel` with the shell tool. Then read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool (e.g., Read in Claude Code, read_file in Codex). If the root cannot be resolved or the file does not exist, treat this as a first run. Otherwise extract values for the `pulse_*` keys listed under "Config keys" below.
 
 **Config keys:**
 - `pulse_product_name` -- string, used in report titles. Required for routing: if unset, skill is unconfigured.

--- a/skills/ce-sweep/SKILL.md
+++ b/skills/ce-sweep/SKILL.md
@@ -40,9 +40,9 @@ Parse a `mode:headless` token from anywhere in the arguments, strip it, and trea
 ### Phase 0: Route by Config State
 
 **Resolve the repo root.** Pre-resolved at skill load:
-!`git rev-parse --show-toplevel 2>/dev/null || true`
+!`git rev-parse --show-toplevel`
 
-If the line above is an absolute path, use it as `<repo-root>`. If it is empty or still shows a backtick command string (a harness that did not pre-resolve), run `git rev-parse --show-toplevel` with the shell tool. Read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool.
+If the line above is an absolute path, use it as `<repo-root>`. If it is empty, shows an error, or still shows a backtick command string (a harness that did not pre-resolve), run `git rev-parse --show-toplevel` with the shell tool. Read `<repo-root>/.compound-engineering/config.local.yaml` with the native file-read tool.
 
 **Route:**
 - Config file missing, or it has no `feedback_sources` key -> first run -> Phase 1.

--- a/tests/skill-shell-safety.test.ts
+++ b/tests/skill-shell-safety.test.ts
@@ -4,10 +4,12 @@ import { describe, expect, test } from "bun:test"
 
 /**
  * Skill `!` backtick pre-resolution commands run through Claude Code's shell
- * permission checker at skill-load time. The checker rejects several patterns
- * outright, failing the skill before its body ever runs. AGENTS.md guidance
- * for the `!` pre-resolution exception allows `&&`, `||`, `2>/dev/null`, and
- * fallback sentinels — but several specific shapes are not on that allowlist.
+ * permission checker at skill-load time, and then through the USER'S shell —
+ * which is PowerShell on some Windows installs, not bash. The permission
+ * checker rejects several patterns outright (failing the skill before its
+ * body ever runs), and bash-only syntax fails outright under PowerShell, so
+ * pre-resolution commands must stay in the portable subset: a single bare
+ * command with no redirects, no `||`/`&&` chaining, no `$(...)`, no pipes.
  *
  * Past incidents:
  *   - PR #699 introduced a `case "$common" in /*) ... ;; *) ... ;; esac` block
@@ -28,8 +30,18 @@ import { describe, expect, test } from "bun:test"
  *   - ce-compound and ce-sessions used `git rev-parse --abbrev-ref HEAD 2>/dev/null`
  *     with no fallback. Outside a git repo, `git rev-parse` exits 128;
  *     `2>/dev/null` suppresses stderr but the non-zero exit propagates and
- *     Claude Code reports "Shell command failed for pattern" (issue #730). Fix:
- *     pair `2>/dev/null` with `|| true` or `|| echo '__SENTINEL__'`.
+ *     Claude Code (at the time) reported "Shell command failed for pattern"
+ *     (issue #730). The fix then was to pair `2>/dev/null` with `|| true` or
+ *     `|| echo '__SENTINEL__'`.
+ *   - Those `2>/dev/null || true` guards themselves broke Windows users whose
+ *     harness executes `!` pre-resolution through PowerShell (issue #1066):
+ *     PowerShell resolves `/dev/null` as a literal file path (`D:\dev\null`)
+ *     and has no `true` command, so the guarded line fails at skill load even
+ *     inside a git repo. Current Claude Code substitutes error text for a
+ *     failing pre-resolution instead of aborting the skill, so the portable
+ *     shape is a BARE single command plus adjacent "if this line is empty or
+ *     shows an error, derive at runtime" prose. This supersedes the #730
+ *     guard pattern above.
  */
 
 const PLUGIN_SKILLS_GLOB = ["skills"]
@@ -173,21 +185,20 @@ function hasSemicolonSeparator(cmd: string): boolean {
 }
 
 /**
- * Returns true when the command's *trailing* top-level statement suppresses
- * stderr with `2>/dev/null` but has no `||` fallback. The trailing statement
- * determines the command's overall exit code (after `;` or `&&` chains). When
- * that exit code is non-zero, Claude Code reports "Shell command failed for
- * pattern" and aborts skill load before its body runs (issue #730). Established
- * defensive pattern: pair `2>/dev/null` with `|| true` or `|| echo '__SENTINEL__'`.
- *
- * `2>/dev/null` inside an earlier `;`-chained statement is fine if the trailing
- * statement (e.g., a final `echo`) succeeds — that case is not flagged.
+ * Returns true when the command uses bash-only shell syntax that PowerShell
+ * cannot execute: any redirect (`>`, `<`, including `2>/dev/null`) or an
+ * `||` / `&&` chain outside quotes. `!` pre-resolution runs through the
+ * user's shell, which is PowerShell on some Windows installs — PowerShell 5.1
+ * cannot parse `||`/`&&` at all, PowerShell 7 resolves `/dev/null` to a
+ * literal file path (`D:\dev\null`), and neither has a `true` command, so any
+ * of these shapes fails skill load for those users even inside a git repo
+ * (issue #1066). Pre-resolution commands must be a single bare command; the
+ * adjacent prose owns the fallback ("if this line is empty or shows an
+ * error, derive at runtime").
  */
-function hasUnguardedErrorSuppression(cmd: string): boolean {
-  let depth = 0
+function hasBashOnlyShellSyntax(cmd: string): boolean {
   let inSingleQuote = false
   let inDoubleQuote = false
-  let lastSeparatorEnd = 0
 
   for (let i = 0; i < cmd.length; i++) {
     const c = cmd[i]
@@ -197,18 +208,12 @@ function hasUnguardedErrorSuppression(cmd: string): boolean {
     if (!inSingleQuote && c === '"') { inDoubleQuote = !inDoubleQuote; continue }
     if (inSingleQuote || inDoubleQuote) continue
 
-    if (c === '$' && next === '(') { depth++; i++; continue }
-    if (c === '(') { depth++; continue }
-    if (c === ')') { depth--; continue }
-
-    if (depth === 0) {
-      if (c === ';') { lastSeparatorEnd = i + 1; continue }
-      if (c === '&' && next === '&') { lastSeparatorEnd = i + 2; i++; continue }
-      if (c === '|' && next === '|') { lastSeparatorEnd = i + 2; i++; continue }
-    }
+    if (c === '>' || c === '<') return true
+    if (c === '&' && next === '&') return true
+    if (c === '|' && next === '|') return true
   }
 
-  return cmd.slice(lastSeparatorEnd).includes("2>/dev/null")
+  return false
 }
 
 /**
@@ -339,45 +344,38 @@ describe("hasSemicolonSeparator", () => {
   })
 })
 
-describe("hasUnguardedErrorSuppression", () => {
-  test("flags single-statement `2>/dev/null` with no fallback", () => {
-    expect(hasUnguardedErrorSuppression("git rev-parse --abbrev-ref HEAD 2>/dev/null")).toBe(true)
+describe("hasBashOnlyShellSyntax", () => {
+  test("flags `2>/dev/null` stderr redirects", () => {
+    expect(hasBashOnlyShellSyntax("git rev-parse --abbrev-ref HEAD 2>/dev/null")).toBe(true)
   })
 
-  test("flags `command -v <name> 2>/dev/null` with no fallback", () => {
-    expect(hasUnguardedErrorSuppression("command -v codex 2>/dev/null")).toBe(true)
+  test("flags the former `2>/dev/null || true` guard pattern (issue #1066)", () => {
+    expect(hasBashOnlyShellSyntax("git rev-parse --abbrev-ref HEAD 2>/dev/null || true")).toBe(true)
   })
 
-  test("does not flag `2>/dev/null || true`", () => {
-    expect(hasUnguardedErrorSuppression("git rev-parse --abbrev-ref HEAD 2>/dev/null || true")).toBe(false)
+  test("flags bare `||` fallback chains", () => {
+    expect(hasBashOnlyShellSyntax("git rev-parse --show-toplevel || pwd")).toBe(true)
   })
 
-  test("does not flag `2>/dev/null || echo '__SENTINEL__'`", () => {
-    expect(hasUnguardedErrorSuppression("git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo '__DEFAULT_BRANCH_UNRESOLVED__'")).toBe(false)
+  test("flags `&&` chains", () => {
+    expect(hasBashOnlyShellSyntax("cd /tmp && git status")).toBe(true)
   })
 
-  test("does not flag commands without `2>/dev/null`", () => {
-    expect(hasUnguardedErrorSuppression("git status")).toBe(false)
+  test("flags output redirects", () => {
+    expect(hasBashOnlyShellSyntax("git status > /tmp/status.txt")).toBe(true)
   })
 
-  test("does not flag `2>/dev/null` inside a guarded subshell", () => {
-    expect(hasUnguardedErrorSuppression("(top=$(git rev-parse --show-toplevel 2>/dev/null); cat \"$top/file\") || echo '__NO_CONFIG__'")).toBe(false)
+  test("does not flag a bare single command", () => {
+    expect(hasBashOnlyShellSyntax("git rev-parse --abbrev-ref HEAD")).toBe(false)
   })
 
-  test("does not flag `2>/dev/null` in non-trailing statement followed by always-succeeding tail", () => {
-    expect(hasUnguardedErrorSuppression('common=$(git rev-parse --git-common-dir 2>/dev/null); repo="${common%/.git}"; echo "${repo##*/}"')).toBe(false)
+  test("does not flag a bare command with flags and arguments", () => {
+    expect(hasBashOnlyShellSyntax("gh pr view --json url,title,body,state")).toBe(false)
   })
 
-  test("flags `2>/dev/null` on the trailing statement of a `;` chain", () => {
-    expect(hasUnguardedErrorSuppression("setup; cmd 2>/dev/null")).toBe(true)
-  })
-
-  test("flags `2>/dev/null` on the trailing statement of an `&&` chain", () => {
-    expect(hasUnguardedErrorSuppression("setup && cmd 2>/dev/null")).toBe(true)
-  })
-
-  test("flags `2>/dev/null` on the trailing statement of an `||` chain (a `||` belonging to an earlier statement does not protect a later unguarded one)", () => {
-    expect(hasUnguardedErrorSuppression("probe || git rev-parse --abbrev-ref HEAD 2>/dev/null")).toBe(true)
+  test("does not flag operator characters inside quoted strings", () => {
+    expect(hasBashOnlyShellSyntax("echo 'a || b > c'")).toBe(false)
+    expect(hasBashOnlyShellSyntax('echo "a && b < c"')).toBe(false)
   })
 })
 
@@ -507,16 +505,16 @@ describe("skill `!` pre-resolution commands avoid Claude Code denylist", () => {
       ).toEqual([])
     })
 
-    test(`${rel} pre-resolution commands that suppress stderr with \`2>/dev/null\` also include a \`||\` fallback (issue #730)`, () => {
+    test(`${rel} pre-resolution commands contain no bash-only syntax — redirects or \`||\`/\`&&\` chains (issue #1066)`, () => {
       const offenders = preResolutionCommands.filter(({ command }) =>
-        hasUnguardedErrorSuppression(command),
+        hasBashOnlyShellSyntax(command),
       )
       const formatted = offenders
         .map(({ lineNumber, command }) => `  line ${lineNumber}: ${command}`)
         .join("\n")
       expect(
         offenders,
-        `\`2>/dev/null\` only suppresses stderr — the non-zero exit code still propagates. Outside the success path (e.g., \`git rev-parse\` outside a git repo), Claude Code reports "Shell command failed for pattern" and aborts skill load. Pair \`2>/dev/null\` with \`|| true\` (when an empty result is fine) or \`|| echo '__SENTINEL__'\` (when the agent should distinguish "did not resolve" from "resolved to empty").\nOffending commands:\n${formatted}`,
+        `\`!\` pre-resolution runs through the user's shell, which is PowerShell on some Windows installs. PowerShell 5.1 cannot parse \`||\`/\`&&\`, and PowerShell resolves \`/dev/null\` to a literal file path, so redirects or chaining fail skill load for those users even inside a git repo (issue #1066). Keep each pre-resolution command a single bare command, and state the fallback in the adjacent prose ("if this line is empty or shows an error, derive the value at runtime").\nOffending commands:\n${formatted}`,
       ).toEqual([])
     })
 


### PR DESCRIPTION
Fixes #1066

## Summary

The `!` backtick pre-resolution lines in eight skills use bash-only syntax (`2>/dev/null || true`, `|| echo 'SENTINEL'`, `|| pwd`). The harness executes these through the user's shell at skill load, and on Windows installs where that shell is PowerShell every one of these lines fails, even inside a git repo, so the skill breaks at load (#1066). This PR reduces each guarded line to a bare single command and moves the failure handling into the adjacent prose, which already told the agent what to do when a line does not resolve.

## Current behavior

From #1066, invoking `/ce-compound` on Windows with a PowerShell-shelled harness:

```
/ce-compound
  Error: Shell command failed for pattern "!git rev-parse --abbrev-ref HEAD 2>/dev/null || true":
  Out-File: Could not find a part of the path 'D:\dev\null'.
  true: The term 'true' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

Two independent failures: PowerShell resolves `/dev/null` as a literal file path (`D:\dev\null`), and `true` is not a command on Windows. PowerShell 5.1 additionally cannot parse `||` at all. So the guarded shape fails for these users on the happy path (inside a git repo), not just in the edge case the guard was written for.

## Root cause

The `2>/dev/null || true` guards were added for issue #730, when a failing pre-resolution aborted skill load on POSIX shells. The guard itself is bash-only syntax, so it trades a POSIX edge-case failure (outside a git repo) for a hard failure on every PowerShell-shelled Windows install.

## Fix

- Reduce all ten guarded pre-resolution lines (ce-brainstorm, ce-commit, ce-commit-push-pr, ce-compound, ce-ideate, ce-plan, ce-product-pulse, ce-sweep) to bare single commands, e.g. `` !`git rev-parse --show-toplevel` ``. A bare command parses and runs in bash, PowerShell 5.1, and PowerShell 7.
- Extend the adjacent fallback prose from "if empty or still a backtick string" to also cover "shows an error", so the agent derives the value at runtime in every non-resolving case (outside a git repo, `gh` missing, `origin/HEAD` unset, PowerShell error text).
- Update `tests/skill-shell-safety.test.ts`: replace the superseded "pair `2>/dev/null` with `|| true`" checker, whose failure message now instructs contributors to write the exact shape that breaks PowerShell, with a checker that rejects redirects and `||`/`&&` chains in pre-resolution commands outright. The policy header documents the incident and the succession from the #730 guidance.

The bare shape is not new to this repo. ce-commit and ce-commit-push-pr already ship bare pre-resolution lines (`` !`git status` ``, `` !`git diff HEAD` ``, `` !`git branch --show-current` ``, `` !`git log --oneline -10` ``) that fail outside a git repo the same way a bare `git rev-parse` does, and no #730-style reports have come in against them. Guarded and bare currently coexist across the skills; this PR converges on the shape that runs in every shell.

## Verification

- Probed current harness behavior empirically with a scratch skill carrying both a guarded and a bare line (Claude Code on Windows):
  - In a git repo, `` !`git rev-parse --abbrev-ref HEAD` `` resolves to the branch name.
  - Outside a git repo, the failing bare line substitutes to an error string and the skill body still runs. A failing pre-resolution no longer aborts skill load on current Claude Code, which is the failure mode the #730-era guard was defending against; the updated fallback prose handles the error text.
- Red then green: with one skill temporarily restored to the guarded form, the new shell-safety check fails naming the exact file and line; on this branch the suite passes (93 tests, 0 fail).
- Full `bun test` baseline diff against main on this machine: zero new failures.
- One honest gap: this machine's Claude Code routes `!` lines through git-bash, so the PowerShell execution path itself was not reproduced locally. The PowerShell claim rests on the reporter's error output in #1066 plus PowerShell semantics, each verifiable independently.

## Scope notes

- The runtime "Context fallback" compound commands in ce-commit and ce-commit-push-pr (the `printf` chains with `2>/dev/null`) are deliberately unchanged: agents run those adaptively through a shell tool at runtime and can translate per platform, unlike load-time pre-resolution, which the user cannot avoid.
- The bare shape re-exposes the #730 failure mode only on harness versions that still abort on a failing pre-resolution, and only outside a git repo. That is the same exposure the existing bare lines noted above have carried without reports.
