### PR TITLE
fix(ce-doc-review): fail fast when document paths are not on disk

### DIFF
--- a/skills/ce-doc-review/SKILL.md
+++ b/skills/ce-doc-review/SKILL.md
@@ -43,10 +43,10 @@ If `mode:headless` is not present, the skill runs in its default interactive mod
 
 **If no document is specified (headless mode):** Output "Review failed: headless mode requires a document path. Re-invoke with: Skill(\"ce-doc-review\", \"mode:headless <path>\")" without dispatching agents.
 
-**Missing-document gate — verify before any dispatch.** Persona reviewers read documents from the filesystem, and several run without Bash, so they cannot read git refs — a path that exists only on a branch that is not checked out wastes the entire persona team discovering they cannot proceed (issue #925). Before Phase 2, confirm every resolved document path exists on disk in the working tree. If any is missing, do not dispatch any personas:
+**Missing-document gate — verify before any dispatch.** Persona reviewers read documents from the filesystem, and several run without Bash, so they cannot read git refs — a path that exists only on a branch that is not checked out wastes the entire persona team discovering they cannot proceed (issue #925). Before Phase 2, confirm every resolved document path is readable on disk (the Read above succeeded). Location does not matter: an absolute path outside the checkout (e.g. `/tmp/plan.md`) or a doc in another checkout reviews fine. If any path is not readable, do not dispatch any personas:
 
-- **Interactive mode:** stop and name the missing path(s): "Document(s) not found in the working tree: <paths>. If they exist on another branch, check it out (or use a worktree) and re-invoke; otherwise correct the path(s)."
-- **Headless mode:** output "Review failed: document(s) not found in the working tree: <paths>. Check out the branch containing them (or pass on-disk paths) and re-invoke." and return without dispatching agents.
+- **Interactive mode:** stop and name the missing path(s): "Document(s) not found on disk: <paths>. If they only exist on another branch, check it out (or use a worktree) and re-invoke; otherwise correct the path(s)."
+- **Headless mode:** output "Review failed: document(s) not found on disk: <paths>. Check out the branch containing them (or pass paths to files on disk) and re-invoke." and return without dispatching agents.
 
 ### Classify Document Type
 

--- a/skills/ce-doc-review/SKILL.md
+++ b/skills/ce-doc-review/SKILL.md
@@ -37,11 +37,16 @@ If `mode:headless` is not present, the skill runs in its default interactive mod
 
 ## Phase 1: Get and Analyze Document
 
-**If a document path is provided:** Read it, then proceed.
+**If a document path is provided:** Read it, then proceed. If the Read fails or the file is not on disk, apply the missing-document gate below instead of continuing.
 
 **If no document is specified (interactive mode):** Ask which document to review, or find the most recent in `docs/brainstorms/` or `docs/plans/` using a file-search/glob tool (e.g., Glob in Claude Code).
 
 **If no document is specified (headless mode):** Output "Review failed: headless mode requires a document path. Re-invoke with: Skill(\"ce-doc-review\", \"mode:headless <path>\")" without dispatching agents.
+
+**Missing-document gate — verify before any dispatch.** Persona reviewers read documents from the filesystem, and several run without Bash, so they cannot read git refs — a path that exists only on a branch that is not checked out wastes the entire persona team discovering they cannot proceed (issue #925). Before Phase 2, confirm every resolved document path exists on disk in the working tree. If any is missing, do not dispatch any personas:
+
+- **Interactive mode:** stop and name the missing path(s): "Document(s) not found in the working tree: <paths>. If they exist on another branch, check it out (or use a worktree) and re-invoke; otherwise correct the path(s)."
+- **Headless mode:** output "Review failed: document(s) not found in the working tree: <paths>. Check out the branch containing them (or pass on-disk paths) and re-invoke." and return without dispatching agents.
 
 ### Classify Document Type
 


### PR DESCRIPTION
Fixes #925

## Summary

ce-doc-review Phase 1 said "Read it, then proceed" and nothing verified that the document paths exist on disk before Phase 2 dispatches the persona team. When the docs live only on a branch that is not checked out, the whole team dispatches against files it cannot read. This adds a missing-document gate to Phase 1.

## Current behavior

From #925: pointing ce-doc-review at 7 solution docs that lived on an unchecked-out feature branch dispatched the full persona team. The no-Bash personas (e.g. the coherence reviewer) spent their run discovering "The docs do not exist in the current working tree" and returned empty; Bash-capable personas made 7-13 tool calls and returned idle final messages. The same doc set reviewed fine once it was on disk, so the personas behave correctly given their tools; the failure is that Stage 1 dispatched them at all.

## Fix

Two changes in the SKILL.md Phase 1 contract:

- The "If a document path is provided" step now routes Read failures to the gate instead of proceeding.
- A new "Missing-document gate" block: before Phase 2, confirm every resolved path is readable on disk; if any is not, do not dispatch any personas. The gate is about filesystem readability, not checkout membership: an absolute path outside the checkout (e.g. `/tmp/plan.md`) or a doc in another checkout reviews fine. Interactive mode stops and names the missing paths, suggesting checking out the branch (or a worktree) or correcting the paths. Headless mode returns a structured "Review failed: document(s) not found on disk: ..." message, mirroring the shape of the existing headless no-path failure.

## Verification

- `bun test tests/pipeline-review-contract.test.ts tests/review-skill-contract.test.ts`: no new failures (the one failing test on this machine also fails on clean main).
- `bun test tests/skill-conventions.test.ts tests/skill-shell-safety.test.ts`: 296 tests, 0 fail.
- Full `bun test` baseline diff against main on this machine: zero new failures.

## Scope notes

Prose-only change to the skill contract; no converter or CLI surface touched. The gate reuses the fail-fast message pattern Phase 1 already established for headless invocations without a path.
