### PR TITLE
fix(ce-compound): detect Claude sessions with long metadata preambles in extract-skeleton

### DIFF
--- a/skills/ce-compound/scripts/session-history/extract-skeleton.py
+++ b/skills/ce-compound/scripts/session-history/extract-skeleton.py
@@ -523,7 +523,12 @@ for line in sys.stdin:
     buffer.append(line)
     stats["lines"] += 1
 
-    if not detected and len(buffer) <= 10:
+    # Scan until a decisive record appears (short-circuits once detected).
+    # Claude Code sessions front-load 10+ non-message metadata records
+    # (last-prompt, custom-title, attachments, ...), so capping detection to
+    # the first N lines silently misroutes them to the codex handler and
+    # produces an empty skeleton with parse_errors: 0 (issue #923).
+    if not detected:
         try:
             obj = json.loads(line)
             if obj.get("type") == "session" and "cwd" in obj:

--- a/tests/session-history-scripts.test.ts
+++ b/tests/session-history-scripts.test.ts
@@ -851,6 +851,42 @@ describe("extract-skeleton", () => {
     expect(stdout).toContain("auth.ts")
   })
 
+  test("detects Claude sessions whose metadata preamble exceeds ten records", async () => {
+    // Issue #923: current Claude Code session files front-load more than ten
+    // non-message metadata records (last-prompt, custom-title, attachments,
+    // ...) before the first user/assistant record. Detection must keep
+    // scanning until a decisive record appears — a scan capped at the first
+    // ten lines misroutes these sessions to the codex handler and returns an
+    // empty skeleton with parse_errors: 0.
+    const preamble = [
+      "last-prompt",
+      "custom-title",
+      "agent-name",
+      "mode",
+      "permission-mode",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+      "attachment",
+    ]
+      .map((t) => JSON.stringify({ type: t, value: "x" }))
+      .join("\n")
+    const fixture = await Bun.file(
+      path.join(FIXTURES_DIR, "claude-session.jsonl")
+    ).text()
+    const { stdout, exitCode } = await runScript(
+      "extract-skeleton.py",
+      [],
+      preamble + "\n" + fixture
+    )
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain("[user] fix the auth bug")
+    expect(stdout).toContain("[assistant] I'll investigate the auth module.")
+  })
+
   test("strips local-command-stdout from Claude output", async () => {
     const fixture = await Bun.file(
       path.join(FIXTURES_DIR, "claude-session.jsonl")


### PR DESCRIPTION
Fixes #923

## Summary

`extract-skeleton.py` caps platform auto-detection at the first 10 lines. Current Claude Code session files front-load more than 10 metadata records before the first user/assistant message, so detection never fires, the file falls through to the codex handler, and the script returns an empty skeleton with `parse_errors: 0`. It reads as "no relevant prior sessions" rather than a bug, which disables session-history synthesis silently.

The issue was filed against ce-sessions; the script now lives at `skills/ce-compound/scripts/session-history/extract-skeleton.py` and the cap is still present there. A prior PR (#958) predated that move and was closed; this PR applies the fix at the script's current location.

## Current behavior

Piping a session with a 12-record metadata preamble (the record types observed in #923: last-prompt, custom-title, agent-name, mode, permission-mode, attachments) followed by the repo's own `claude-session.jsonl` fixture through the script:

```
{"_meta": true, "lines": 22, "parse_errors": 0, "user": 0, "assistant": 0, "tool": 0, "summary": 0}
```

22 lines read, zero errors reported, nothing extracted.

## Fix

Drop the cap: `if not detected and len(buffer) <= 10:` becomes `if not detected:`, so detection scans until the first decisive record. The guard already short-circuits once a platform is detected, so files that detect early are processed identically. The same piped input after the fix:

```
[2026-04-05T10:00:00] [user] fix the auth bug
---
[2026-04-05T10:00:05] [assistant] I'll investigate the auth module.
```

## Verification

- New regression test in `tests/session-history-scripts.test.ts`: prepends the 12-record metadata preamble to the existing Claude fixture and asserts user and assistant messages are still extracted. Fails on main, passes with the fix.
- All four platform fixtures (claude, codex, cursor, pi) still detect and extract identically after the change, verified by piping each through the script directly.
- One environment note: this machine has no `python3` launcher, so the script tests were verified by piping through `python` directly; the bun-side tests exercise the same path on CI.
- Full `bun test` baseline diff against main on this machine: zero new failures.

## Scope notes

The issue's optional hardening (fail loudly when detection falls through to the default handler) is left out to keep this the minimal detection fix. Happy to follow up on it separately.
