### PR TITLE
fix(cli): bump sonnet and opus model aliases to latest generations

### DIFF
--- a/docs/plans/2026-07-08-001-fix-model-alias-map-latest-generations-plan.md
+++ b/docs/plans/2026-07-08-001-fix-model-alias-map-latest-generations-plan.md
@@ -1,0 +1,94 @@
+---
+title: "fix: Bump Claude family alias map to latest generations (Sonnet 5, Opus 4.8)"
+date: 2026-07-08
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+---
+
+# fix: Bump Claude family alias map to latest generations (Sonnet 5, Opus 4.8)
+
+## Summary
+
+The `CLAUDE_FAMILY_ALIASES` map in `src/utils/model.ts` is the single source of truth that resolves bare Claude aliases (`model: sonnet`) to pinned model IDs when converting plugins to multi-provider target platforms (OpenCode, Qwen, OpenClaw, etc.). Two of its three entries are stale now that Sonnet 5 and Opus 4.8 have shipped: `sonnet` still maps to the previous generation `claude-sonnet-4-6`, and `opus` is two generations behind at `claude-opus-4-6`. Bump both to the current generation. `haiku` stays at `claude-haiku-4-5` (still current). Update the docstring examples and the affected test assertions in lockstep.
+
+## Problem Frame
+
+- The map's own comment states: *"Update these when new model generations are released."* — it is designed to be bumped on each release and is now out of date.
+- A user who writes `model: sonnet` in a skill/agent and converts to a normalizing target (e.g. OpenCode) currently gets `anthropic/claude-sonnet-4-6` — the prior generation, not the latest Sonnet.
+- This is broken/stale behavior the map is meant to keep current, so it is a `fix:`, not a `feat:`.
+
+**Non-goals (explicitly out of scope):**
+- Pass-through fixture IDs like `claude-sonnet-4-20250514` in converter tests (`converter.test.ts`, `codex-converter.test.ts`, `droid-converter.test.ts`, `kiro-converter.test.ts`, `copilot-converter.test.ts`, `antigravity-converter.test.ts`, and the `sample-plugin` fixture) — these verify that an arbitrary *dated* ID forwards unchanged; they are not claims about the latest model and must not be touched.
+- Historical provenance in `docs/plans/*` (`completed_by: "Claude Opus 4.6"`) — historical record, do not rewrite.
+- The historical solution doc `docs/solutions/integrations/cross-platform-model-field-normalization.md` — its `claude-sonnet-4-6` examples document the mechanism at the time; cosmetic only, leave as-is.
+
+## Target values
+
+| Alias | Current | New | Reason |
+|-------|---------|-----|--------|
+| `haiku` | `claude-haiku-4-5` | `claude-haiku-4-5` | unchanged — still current |
+| `sonnet` | `claude-sonnet-4-6` | `claude-sonnet-5` | Sonnet 5 released |
+| `opus` | `claude-opus-4-6` | `claude-opus-4-8` | Opus 4.8 is the current Opus generation |
+
+Canonical short-form (no date suffix) matches the existing map convention and the current model IDs.
+
+## Requirements
+
+- R1: `resolveClaudeFamilyAlias("sonnet")` returns `claude-sonnet-5`; `resolveClaudeFamilyAlias("opus")` returns `claude-opus-4-8`; `haiku` unchanged.
+- R2: `normalizeModelWithProvider` composes the new values with the provider prefix (`anthropic/claude-sonnet-5`, `anthropic/claude-opus-4-8`).
+- R3: Docstring examples in `src/utils/model.ts` that use `claude-sonnet-4-6` as the illustrative *alias-resolution* output reflect the new value. The `claude-sonnet-4-20250514` pass-through examples (lines 24, 55) stay unchanged — they illustrate dated-ID pass-through, not alias resolution.
+- R4: `bun test` passes.
+
+## Implementation Units
+
+### U1. Bump the alias map and docstring examples in `src/utils/model.ts`
+
+- **Goal:** Update the two stale alias values and the docstrings that illustrate alias resolution.
+- **Requirements:** R1, R3
+- **Files:** `src/utils/model.ts`
+- **Approach:**
+  - Line 15: `sonnet: "claude-sonnet-4-6"` → `sonnet: "claude-sonnet-5"`
+  - Line 16: `opus: "claude-opus-4-6"` → `opus: "claude-opus-4-8"`
+  - Line 23 docstring (`"sonnet" -> "claude-sonnet-4-6"`) → `"sonnet" -> "claude-sonnet-5"`
+  - Line 34 docstring (`"claude-sonnet-4-6" -> "anthropic/claude-sonnet-4-6"`) → use `claude-sonnet-5`
+  - Line 54 docstring (`"sonnet" -> "anthropic/claude-sonnet-4-6"`) → use `anthropic/claude-sonnet-5`
+  - Leave lines 24 and 55 (`claude-sonnet-4-20250514` pass-through examples) untouched.
+- **Test scenarios:** Covered by U2 (assertions live in the test file, not this module).
+- **Verification:** File compiles; `resolveClaudeFamilyAlias` returns the new canonical names for `sonnet`/`opus`.
+
+### U2. Update assertions in `tests/model-utils.test.ts`
+
+- **Goal:** Keep the alias-resolution assertions in sync with the new map values.
+- **Requirements:** R1, R2, R4
+- **Dependencies:** U1
+- **Files:** `tests/model-utils.test.ts`
+- **Approach:**
+  - Line 12: expect `resolveClaudeFamilyAlias("sonnet")` → `claude-sonnet-5`
+  - Line 13: expect `resolveClaudeFamilyAlias("opus")` → `claude-opus-4-8`
+  - Line 25: expect `addProviderPrefix("claude-sonnet-4-6")` — this asserts prefixing behavior on an arbitrary Claude ID, not alias resolution. Either leave it (still valid — any `claude-*` gets the `anthropic/` prefix) or update the literal to `claude-sonnet-5` for freshness. Update it to `claude-sonnet-5` so the test file carries no stale generation references.
+  - Line 63: expect `normalizeModelWithProvider("sonnet")` → `anthropic/claude-sonnet-5`
+  - Line 65: expect `normalizeModelWithProvider("opus")` → `anthropic/claude-opus-4-8`
+  - Do NOT change lines 17 and 69 (`claude-sonnet-4-20250514` pass-through assertions) — they prove dated IDs forward unchanged.
+  - The `CLAUDE_FAMILY_ALIASES covers all three tiers` test (line 80) asserts on keys only, not values — no change needed.
+- **Test scenarios:**
+  - `resolveClaudeFamilyAlias("sonnet")` → `claude-sonnet-5` (happy path)
+  - `resolveClaudeFamilyAlias("opus")` → `claude-opus-4-8` (happy path)
+  - `normalizeModelWithProvider("sonnet")` → `anthropic/claude-sonnet-5` (compose with prefix)
+  - `normalizeModelWithProvider("opus")` → `anthropic/claude-opus-4-8` (compose with prefix)
+  - Regression guard: `resolveClaudeFamilyAlias("claude-sonnet-4-20250514")` still passes through unchanged (line 17 untouched).
+- **Verification:** `bun test` passes with zero failures; no unintended edits to pass-through fixture assertions.
+
+## Verification Contract
+
+- `bun test` passes (specifically `tests/model-utils.test.ts`).
+- Grep confirms no remaining `claude-sonnet-4-6` or `claude-opus-4-6` in `src/utils/model.ts` or `tests/model-utils.test.ts`.
+- Grep confirms `claude-sonnet-4-20250514` pass-through fixtures are unchanged across `tests/`.
+
+## Definition of Done
+
+- `src/utils/model.ts` alias map reads `sonnet: "claude-sonnet-5"`, `opus: "claude-opus-4-8"`, `haiku` unchanged; docstrings updated.
+- `tests/model-utils.test.ts` assertions updated; pass-through assertions untouched.
+- `bun test` green.
+- No changes to converter fixtures, historical docs/plans, or the historical solution doc.

--- a/docs/solutions/integrations/opencode-temperature-rejected-by-sonnet5-opus48.md
+++ b/docs/solutions/integrations/opencode-temperature-rejected-by-sonnet5-opus48.md
@@ -1,0 +1,120 @@
+---
+title: OpenCode converter emits a temperature that Sonnet 5 / Opus 4.8 reject
+module: src/converters/claude-to-opencode.ts
+date: 2026-07-08
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - Converted OpenCode primary agent fails at runtime with HTTP 400 from Anthropic
+  - Breakage appears only after bumping the Claude family alias map to claude-sonnet-5 / claude-opus-4-8
+  - inferTemperature (CLI default) emits a temperature (0.1-0.6) on every converted agent
+  - Primary agents pinned to claude-sonnet-5 or claude-opus-4-8 reject non-default temperature/top_p/top_k
+  - The same conversion worked previously under claude-sonnet-4-6, which accepts temperature
+root_cause: config_error
+resolution_type: code_fix
+related_components:
+  - src/utils/model.ts
+  - tests/model-utils.test.ts
+  - tests/converter.test.ts
+tags:
+  - opencode
+  - converter
+  - temperature
+  - sampling-params
+  - claude-sonnet-5
+  - claude-opus-4-8
+  - model-alias
+---
+
+# OpenCode converter emits a temperature that Sonnet 5 / Opus 4.8 reject
+
+## Problem
+
+Bumping the `sonnet`/`opus` aliases to a newer Claude generation (Sonnet 5, Opus 4.8) made the OpenCode converter emit an inferred `temperature` into primary-agent configs for models that reject non-default sampling params, producing configs the target runtime rejects with HTTP 400.
+
+## Symptoms
+
+- Converted OpenCode primary-agent configs carried an explicit `temperature` for agents pinned to Sonnet 5 (and Opus 4.7/4.8).
+- The generated config triggers an HTTP 400 from Anthropic at runtime because Sonnet 5 / Opus 4.7+ reject non-default `temperature`/`top_p`/`top_k`.
+- No test failed — no existing test exercised a primary OpenCode agent on a new-generation model, so the breakage was invisible in the suite.
+
+## What Didn't Work
+
+The regression is easy to miss because cause and effect live in different files with no obvious link:
+
+- The triggering change — bumping the `sonnet` alias to Sonnet 5 — looks purely mechanical: a single string swap in an alias map (`CLAUDE_FAMILY_ALIASES` in `src/utils/model.ts`). Nothing at the edit site hints that temperature emission is affected.
+- The failing behavior lives elsewhere: the converter's `inferTemperature` emission is in `src/converters/claude-to-opencode.ts`. Reviewing the alias bump in isolation gives no signal.
+- No existing test exercised a primary OpenCode agent on a new-generation model, so the suite stayed green.
+
+A naive fix would over- or under-reach:
+
+- Dropping `temperature` for **all** agents over-reaches — models that still accept sampling params (Sonnet 4, Haiku) would lose a valid inferred temperature.
+- String-matching `"sonnet"` under-reaches and misclassifies — it would wrongly suppress temperature for older accepting Sonnets (`claude-sonnet-4-20250514`) while missing rejecting Opus generations (`claude-opus-4-7`, `claude-opus-4-8`) entirely.
+
+## Solution
+
+Introduce a precise, canonical-ID-based predicate for "this model rejects sampling params," and gate the converter's temperature emission on it.
+
+Added `rejectsSamplingParams` in `src/utils/model.ts`, backed by a set of canonical IDs. It resolves bare aliases via `resolveClaudeFamilyAlias` and strips the `anthropic/` provider prefix, so every spelling of the same model matches:
+
+```ts
+const SAMPLING_PARAM_REJECTING_MODELS: ReadonlySet<string> = new Set([
+  "claude-sonnet-5",
+  "claude-opus-4-7",
+  "claude-opus-4-8",
+])
+
+export function rejectsSamplingParams(model: string): boolean {
+  const canonical = resolveClaudeFamilyAlias(model).replace(/^anthropic\//, "")
+  return SAMPLING_PARAM_REJECTING_MODELS.has(canonical)
+}
+```
+
+This matches `sonnet`, `claude-sonnet-5`, and `anthropic/claude-sonnet-5`; it does **not** match `claude-sonnet-4-20250514` or `haiku`.
+
+In `convertAgent` (`src/converters/claude-to-opencode.ts`), the temperature emission is gated so it is skipped only when a rejecting model was actually written to the config. The converter writes `model` only for primary agents, so the `frontmatter.model !== undefined` guard scopes this to primary agents; subagents (no model written — they inherit the parent session's model) keep existing behavior, out of scope because the runtime model is unknown at convert time.
+
+Before:
+
+```ts
+if (options.inferTemperature) {
+  const temperature = inferTemperature(agent)
+  if (temperature !== undefined) {
+    frontmatter.temperature = temperature
+  }
+}
+```
+
+After:
+
+```ts
+if (options.inferTemperature) {
+  const temperature = inferTemperature(agent)
+  const modelRejectsTemperature =
+    frontmatter.model !== undefined &&
+    typeof agent.model === "string" &&
+    rejectsSamplingParams(agent.model)
+  if (temperature !== undefined && !modelRejectsTemperature) {
+    frontmatter.temperature = temperature
+  }
+}
+```
+
+## Why This Works
+
+Sonnet 5 and Opus 4.7/4.8 return HTTP 400 for any non-default `temperature`/`top_p`/`top_k` (per Anthropic's Sonnet 5 and Opus 4.8 migration notes). The converter only writes `model` into the config for primary agents, so tying suppression to "we wrote a rejecting model" (`frontmatter.model !== undefined && rejectsSamplingParams(agent.model)`) targets exactly the case that would fail at runtime — a primary agent pinned to a rejecting model — without touching subagents or any model that still accepts sampling params.
+
+## Prevention
+
+The compounding lesson: **a model alias bump is never purely mechanical.** When you point an alias at a newer Claude generation, the model ID string is the smallest part of the change — audit every downstream emitter for API constraints that shifted with the generation. Newer generations (Sonnet 5+, Opus 4.7+) reject non-default sampling params, so any code path that emits `temperature`/`top_p`/`top_k` for a resolved Claude model must gate on model compatibility.
+
+Concrete guardrails:
+
+- Keep `SAMPLING_PARAM_REJECTING_MODELS` in sync with `CLAUDE_FAMILY_ALIASES` whenever a new generation is added — both live in `src/utils/model.ts` and are co-located intentionally so the two are edited together.
+- Test both directions so neither over- nor under-reach regresses: a rejecting model (temperature suppressed) and an accepting model (temperature still inferred). The tests added are `rejectsSamplingParams` unit tests in `tests/model-utils.test.ts` (alias resolution, the `anthropic/` prefix, and the accepting cases `claude-sonnet-4-20250514` / `haiku`), plus a converter test in `tests/converter.test.ts` asserting temperature is suppressed for a Sonnet 5 primary agent but still inferred (0.1) for a Haiku agent.
+- Verify bot-sourced API claims against the source of truth. An automated cross-model code-review bot (Codex) caught this before merge, but its factual claim about the HTTP 400 was confirmed against authoritative Anthropic migration docs before building the fix — the claim was true, but bot claims about API behavior must always be verified first.
+
+## Related
+
+- [`cross-platform-model-field-normalization.md`](cross-platform-model-field-normalization.md) — the sibling doc covering how bare Claude aliases resolve to provider-prefixed canonical IDs across target platforms. That doc owns the alias-to-provider normalization *mechanism* (`CLAUDE_FAMILY_ALIASES`, `normalizeModelWithProvider`); this doc covers a distinct downstream constraint (sampling-param API limits of newer generations). Both live in `src/utils/model.ts`.

--- a/src/converters/claude-to-opencode.ts
+++ b/src/converters/claude-to-opencode.ts
@@ -1,5 +1,5 @@
 import { formatFrontmatter } from "../utils/frontmatter"
-import { normalizeModelWithProvider } from "../utils/model"
+import { normalizeModelWithProvider, rejectsSamplingParams } from "../utils/model"
 import { commandNameToRelativePath } from "../utils/files"
 import {
   type ClaudeAgent,
@@ -142,7 +142,15 @@ function convertAgent(agent: ClaudeAgent, options: ClaudeToOpenCodeOptions) {
 
   if (options.inferTemperature) {
     const temperature = inferTemperature(agent)
-    if (temperature !== undefined) {
+    // A written model that rejects non-default sampling params (Sonnet 5, Opus
+    // 4.7+) returns HTTP 400 if paired with a temperature. We only write model
+    // for primary agents, so suppression only applies there; subagents inherit
+    // the parent session's model and are out of scope.
+    const modelRejectsTemperature =
+      frontmatter.model !== undefined &&
+      typeof agent.model === "string" &&
+      rejectsSamplingParams(agent.model)
+    if (temperature !== undefined && !modelRejectsTemperature) {
       frontmatter.temperature = temperature
     }
   }

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -12,15 +12,15 @@
  */
 export const CLAUDE_FAMILY_ALIASES: Record<string, string> = {
   haiku: "claude-haiku-4-5",
-  sonnet: "claude-sonnet-4-6",
-  opus: "claude-opus-4-6",
+  sonnet: "claude-sonnet-5",
+  opus: "claude-opus-4-8",
 }
 
 /**
  * Resolve a bare Claude family alias to its canonical model name.
  * Returns the input unchanged if not a recognized alias.
  *
- * "sonnet" -> "claude-sonnet-4-6"
+ * "sonnet" -> "claude-sonnet-5"
  * "claude-sonnet-4-20250514" -> "claude-sonnet-4-20250514" (unchanged)
  */
 export function resolveClaudeFamilyAlias(model: string): string {
@@ -31,7 +31,7 @@ export function resolveClaudeFamilyAlias(model: string): string {
  * Add a provider prefix based on model naming conventions.
  * Returns the input unchanged if already prefixed (contains "/").
  *
- * "claude-sonnet-4-6" -> "anthropic/claude-sonnet-4-6"
+ * "claude-sonnet-5" -> "anthropic/claude-sonnet-5"
  * "gpt-5.4"           -> "openai/gpt-5.4"
  * "gemini-2.0"        -> "google/gemini-2.0"
  * "minimax-m3"        -> "minimax/minimax-m3"
@@ -51,7 +51,7 @@ export function addProviderPrefix(model: string): string {
  * Normalize a model for targets that use provider-prefixed IDs.
  * Resolves bare aliases and adds provider prefix.
  *
- * "sonnet"                  -> "anthropic/claude-sonnet-4-6"
+ * "sonnet"                  -> "anthropic/claude-sonnet-5"
  * "claude-sonnet-4-20250514" -> "anthropic/claude-sonnet-4-20250514"
  * "anthropic/claude-opus"    -> "anthropic/claude-opus" (unchanged)
  */

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -17,6 +17,19 @@ export const CLAUDE_FAMILY_ALIASES: Record<string, string> = {
 }
 
 /**
+ * Canonical Claude model IDs that reject non-default sampling params
+ * (`temperature`/`top_p`/`top_k`) with HTTP 400. Emitting an inferred
+ * temperature alongside one of these produces a config that fails at runtime.
+ * Keep in sync with CLAUDE_FAMILY_ALIASES when new generations are released.
+ * See the Sonnet 5 and Opus 4.7/4.8 migration notes.
+ */
+const SAMPLING_PARAM_REJECTING_MODELS: ReadonlySet<string> = new Set([
+  "claude-sonnet-5",
+  "claude-opus-4-7",
+  "claude-opus-4-8",
+])
+
+/**
  * Resolve a bare Claude family alias to its canonical model name.
  * Returns the input unchanged if not a recognized alias.
  *
@@ -65,4 +78,17 @@ export function normalizeModelWithProvider(model: string): string {
     )
   }
   return addProviderPrefix(resolved)
+}
+
+/**
+ * Whether a model rejects non-default sampling params. Accepts a bare alias,
+ * a canonical ID, or a provider-prefixed ID; resolves aliases and strips the
+ * provider prefix so `sonnet` and `anthropic/claude-sonnet-5` both match.
+ *
+ * "sonnet"                     -> true  (resolves to claude-sonnet-5)
+ * "claude-sonnet-4-20250514"   -> false (dated Sonnet 4 accepts sampling params)
+ */
+export function rejectsSamplingParams(model: string): boolean {
+  const canonical = resolveClaudeFamilyAlias(model).replace(/^anthropic\//, "")
+  return SAMPLING_PARAM_REJECTING_MODELS.has(canonical)
 }

--- a/tests/converter.test.ts
+++ b/tests/converter.test.ts
@@ -244,6 +244,48 @@ describe("convertClaudeToOpenCode", () => {
     expect(parsed.data.model).toBe("anthropic/claude-haiku-4-5")
   })
 
+  test("suppresses inferred temperature for primary agents on sampling-param-rejecting models", () => {
+    const plugin: ClaudePlugin = {
+      root: "/tmp/plugin",
+      manifest: { name: "fixture", version: "1.0.0" },
+      agents: [
+        {
+          name: "security-guardian",
+          description: "Reviews code for security issues",
+          body: "Test agent.",
+          sourcePath: "/tmp/plugin/agents/security-guardian.md",
+          model: "sonnet",
+        },
+        {
+          name: "haiku-guardian",
+          description: "Reviews code cheaply",
+          body: "Test agent.",
+          sourcePath: "/tmp/plugin/agents/haiku-guardian.md",
+          model: "haiku",
+        },
+      ],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToOpenCode(plugin, {
+      agentMode: "primary",
+      inferTemperature: true,
+      permissions: "none",
+    })
+
+    // Sonnet 5 rejects non-default temperature with HTTP 400, so the converter
+    // must write the model but omit the inferred temperature.
+    const sonnetAgent = parseFrontmatter(bundle.agents.find((a) => a.name === "security-guardian")!.content)
+    expect(sonnetAgent.data.model).toBe("anthropic/claude-sonnet-5")
+    expect(sonnetAgent.data.temperature).toBeUndefined()
+
+    // Haiku still accepts sampling params, so temperature is inferred as usual.
+    const haikuAgent = parseFrontmatter(bundle.agents.find((a) => a.name === "haiku-guardian")!.content)
+    expect(haikuAgent.data.model).toBe("anthropic/claude-haiku-4-5")
+    expect(haikuAgent.data.temperature).toBe(0.1)
+  })
+
   test("omits model for subagents to allow provider inheritance (#477)", () => {
     const plugin: ClaudePlugin = {
       root: "/tmp/plugin",

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -9,8 +9,8 @@ import {
 describe("resolveClaudeFamilyAlias", () => {
   test("resolves bare aliases to full Claude model names", () => {
     expect(resolveClaudeFamilyAlias("haiku")).toBe("claude-haiku-4-5")
-    expect(resolveClaudeFamilyAlias("sonnet")).toBe("claude-sonnet-4-6")
-    expect(resolveClaudeFamilyAlias("opus")).toBe("claude-opus-4-6")
+    expect(resolveClaudeFamilyAlias("sonnet")).toBe("claude-sonnet-5")
+    expect(resolveClaudeFamilyAlias("opus")).toBe("claude-opus-4-8")
   })
 
   test("passes through non-alias model names unchanged", () => {
@@ -22,7 +22,7 @@ describe("resolveClaudeFamilyAlias", () => {
 
 describe("addProviderPrefix", () => {
   test("prefixes Claude models with anthropic/", () => {
-    expect(addProviderPrefix("claude-sonnet-4-6")).toBe("anthropic/claude-sonnet-4-6")
+    expect(addProviderPrefix("claude-sonnet-5")).toBe("anthropic/claude-sonnet-5")
     expect(addProviderPrefix("claude-haiku-4-5")).toBe("anthropic/claude-haiku-4-5")
   })
 
@@ -60,9 +60,9 @@ describe("addProviderPrefix", () => {
 
 describe("normalizeModelWithProvider", () => {
   test("resolves bare aliases and adds provider prefix", () => {
-    expect(normalizeModelWithProvider("sonnet")).toBe("anthropic/claude-sonnet-4-6")
+    expect(normalizeModelWithProvider("sonnet")).toBe("anthropic/claude-sonnet-5")
     expect(normalizeModelWithProvider("haiku")).toBe("anthropic/claude-haiku-4-5")
-    expect(normalizeModelWithProvider("opus")).toBe("anthropic/claude-opus-4-6")
+    expect(normalizeModelWithProvider("opus")).toBe("anthropic/claude-opus-4-8")
   })
 
   test("adds provider prefix to full Claude model names", () => {

--- a/tests/model-utils.test.ts
+++ b/tests/model-utils.test.ts
@@ -3,6 +3,7 @@ import {
   resolveClaudeFamilyAlias,
   normalizeModelWithProvider,
   addProviderPrefix,
+  rejectsSamplingParams,
   CLAUDE_FAMILY_ALIASES,
 } from "../src/utils/model"
 
@@ -72,6 +73,25 @@ describe("normalizeModelWithProvider", () => {
   test("passes through already-prefixed models unchanged", () => {
     expect(normalizeModelWithProvider("anthropic/claude-opus")).toBe("anthropic/claude-opus")
     expect(normalizeModelWithProvider("google/gemini-2.0")).toBe("google/gemini-2.0")
+  })
+})
+
+describe("rejectsSamplingParams", () => {
+  test("flags models that reject non-default sampling params", () => {
+    expect(rejectsSamplingParams("sonnet")).toBe(true)
+    expect(rejectsSamplingParams("opus")).toBe(true)
+    expect(rejectsSamplingParams("claude-sonnet-5")).toBe(true)
+    expect(rejectsSamplingParams("claude-opus-4-8")).toBe(true)
+    expect(rejectsSamplingParams("claude-opus-4-7")).toBe(true)
+    expect(rejectsSamplingParams("anthropic/claude-sonnet-5")).toBe(true)
+  })
+
+  test("passes models that still accept sampling params", () => {
+    expect(rejectsSamplingParams("haiku")).toBe(false)
+    expect(rejectsSamplingParams("claude-haiku-4-5")).toBe(false)
+    expect(rejectsSamplingParams("claude-sonnet-4-20250514")).toBe(false)
+    expect(rejectsSamplingParams("claude-opus-4-6")).toBe(false)
+    expect(rejectsSamplingParams("gpt-5.4")).toBe(false)
   })
 })
 


### PR DESCRIPTION
When a plugin is converted to a multi-provider target (OpenCode, Qwen, OpenClaw), a skill or agent declaring `model: sonnet` now resolves to the current generation `claude-sonnet-5` instead of the previous `claude-sonnet-4-6`, and `opus` to `claude-opus-4-8` instead of the two-generations-behind `claude-opus-4-6`. `CLAUDE_FAMILY_ALIASES` in `src/utils/model.ts` is the single source of truth for that resolution, and its own comment says to bump it when new generations ship — it had drifted. `haiku` was already current (`claude-haiku-4-5`) and is unchanged, as are the dated pass-through IDs (e.g. `claude-sonnet-4-20250514`) that tests use to prove arbitrary model IDs forward untouched.

Validation: `bun test` passes 1868/0. The alias-resolution assertions were updated to expect the new IDs and confirmed failing against the old map first, then green after the bump.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
