### PR TITLE
fix(pi): preserve user-managed symlinks and unmanaged paths on install

### DIFF
--- a/src/targets/pi.ts
+++ b/src/targets/pi.ts
@@ -555,6 +555,10 @@ async function moveLegacyArtifactToBackup(
   kind: LegacyArtifactKind,
   artifactPath: string,
 ): Promise<void> {
+  // Ownership fingerprinting reads THROUGH a symlink, so a user fork of a
+  // legacy-named artifact still matches — never move the symlink node into
+  // legacy-backup, or the user's override is silently deactivated.
+  if (await isPreservedSymlink(artifactPath)) return
   if (!(await pathExists(artifactPath))) return
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const backupDir = path.join(managedDir, "legacy-backup", timestamp, kind)

--- a/src/targets/pi.ts
+++ b/src/targets/pi.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises"
+import type { Stats } from "fs"
 import path from "path"
 import {
   backupFile,
@@ -85,24 +86,40 @@ export async function writePiBundle(outputRoot: string, bundle: PiBundle): Promi
     await writeText(path.join(paths.promptsDir, `${sanitizePathName(prompt.name)}.md`), prompt.content + "\n")
   }
 
+  const preservedSkillNames = new Set<string>()
+
   for (const skill of bundle.skillDirs) {
     const skillName = sanitizePathName(skill.name)
     const targetDir = path.join(paths.skillsDir, skillName)
-    await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
+    const preserved = await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
+    if (preserved) {
+      preservedSkillNames.add(skillName)
+      continue
+    }
     await copySkillDir(skill.sourceDir, targetDir, transformContentForPi)
   }
 
   for (const skill of bundle.generatedSkills) {
     const skillName = sanitizePathName(skill.name)
     const targetDir = path.join(paths.skillsDir, skillName)
-    await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
+    const preserved = await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
+    if (preserved) {
+      preservedSkillNames.add(skillName)
+      continue
+    }
     await writeText(path.join(targetDir, "SKILL.md"), skill.content + "\n")
   }
+
+  const preservedAgentNames = new Set<string>()
 
   for (const agent of bundle.agents) {
     const agentFileName = `${sanitizePathName(agent.name)}.md`
     const targetPath = path.join(paths.agentsDir, agentFileName)
-    await cleanupCurrentManagedAgentFile(targetPath, manifest, agentFileName)
+    const preserved = await cleanupCurrentManagedAgentFile(targetPath, manifest, agentFileName)
+    if (preserved) {
+      preservedAgentNames.add(agentFileName)
+      continue
+    }
     await writeText(targetPath, agent.content + "\n")
   }
 
@@ -121,13 +138,16 @@ export async function writePiBundle(outputRoot: string, bundle: PiBundle): Promi
   await ensurePiAgentsBlock(paths.agentsPath)
 
   if (pluginName) {
+    // Preserved skills/agents (user symlinks or unmanaged dirs/files this
+    // install skipped) must not be recorded as owned -- the plugin never
+    // claims a path it didn't write.
     await writeInstallManifest(paths.managedDir, {
       version: 1,
       pluginName,
-      skills: currentSkills,
+      skills: currentSkills.filter((name) => !preservedSkillNames.has(name)),
       prompts: currentPrompts,
       extensions: currentExtensions,
-      agents: currentAgents,
+      agents: currentAgents.filter((name) => !preservedAgentNames.has(name)),
     })
     await archiveLegacyInstallManifestIfOwned(paths.managedDir, pluginName)
     await cleanupKnownLegacyPiArtifacts(paths, bundle)
@@ -348,7 +368,13 @@ async function cleanupRemovedSkills(
     // but re-check before any out-of-tree fs.rm can be issued from a future
     // caller that bypasses the read layer.
     if (!isSafeManagedPath(skillsDir, skillName)) continue
-    await fs.rm(path.join(skillsDir, skillName), { recursive: true, force: true })
+    const targetDir = path.join(skillsDir, skillName)
+    // The manifest can lag reality: a prior install owned this name, but the
+    // user has since replaced it with a symlink (e.g. into a personal fork).
+    // Never delete through a symlink node even when the stale manifest still
+    // claims ownership.
+    if (await isPreservedSymlink(targetDir)) continue
+    await fs.rm(targetDir, { recursive: true, force: true })
   }
 }
 
@@ -390,26 +416,67 @@ async function cleanupRemovedAgents(
   for (const agentFile of manifest.agents) {
     if (current.has(agentFile)) continue
     if (!isSafeManagedPath(agentsDir, agentFile)) continue
-    await fs.rm(path.join(agentsDir, agentFile), { force: true })
+    const targetPath = path.join(agentsDir, agentFile)
+    if (await isPreservedSymlink(targetPath)) continue
+    await fs.rm(targetPath, { force: true })
   }
 }
 
+async function lstatOrNull(targetPath: string): Promise<Stats | null> {
+  try {
+    return await fs.lstat(targetPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null
+    throw err
+  }
+}
+
+async function isPreservedSymlink(targetPath: string): Promise<boolean> {
+  const stat = await lstatOrNull(targetPath)
+  if (!stat?.isSymbolicLink()) return false
+  console.warn(`Skipping ${targetPath}: existing user-managed symlink (not overwritten)`)
+  return true
+}
+
+// Returns true when the existing path was preserved (skip cleanup AND the
+// subsequent copy/write -- writing through a preserved symlink would clobber
+// the user's fork, which is worse than not cleaning up at all).
 async function cleanupCurrentManagedSkillDir(
   targetDir: string,
   manifest: PiInstallManifest | null,
   skillName: string,
-): Promise<void> {
-  if (!manifest?.skills.includes(skillName)) return
+): Promise<boolean> {
+  const stat = await lstatOrNull(targetDir)
+  if (!stat) return false
+  if (stat.isSymbolicLink()) {
+    console.warn(`Skipping ${targetDir}: existing user-managed symlink (not overwritten)`)
+    return true
+  }
+  if (!manifest?.skills.includes(skillName)) {
+    console.warn(`Skipping ${targetDir}: existing unmanaged directory (not overwritten)`)
+    return true
+  }
   await fs.rm(targetDir, { recursive: true, force: true })
+  return false
 }
 
 async function cleanupCurrentManagedAgentFile(
   targetPath: string,
   manifest: PiInstallManifest | null,
   agentFileName: string,
-): Promise<void> {
-  if (!manifest?.agents.includes(agentFileName)) return
+): Promise<boolean> {
+  const stat = await lstatOrNull(targetPath)
+  if (!stat) return false
+  if (stat.isSymbolicLink()) {
+    console.warn(`Skipping ${targetPath}: existing user-managed symlink (not overwritten)`)
+    return true
+  }
+  if (!manifest?.agents.includes(agentFileName)) {
+    console.warn(`Skipping ${targetPath}: existing unmanaged file (not overwritten)`)
+    return true
+  }
   await fs.rm(targetPath, { force: true })
+  return false
 }
 
 // Explicit legacy Pi extension names this plugin has historically shipped and

--- a/tests/pi-writer.test.ts
+++ b/tests/pi-writer.test.ts
@@ -745,6 +745,48 @@ describe("writePiBundle preserves user-managed skill paths", () => {
   )
 
   test.skipIf(!canDirSymlink)(
+    "a legacy-named skill symlinked to a user fork is not swept into legacy-backup",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-legacy-skill-symlink-"))
+      const outputRoot = path.join(tempRoot, ".pi")
+
+      // Worst case: the fork keeps the CE fingerprint (name + description), so
+      // the readFile-based ownership check follows the symlink and matches.
+      const forkDir = path.join(tempRoot, "user-fork", "reproduce-bug")
+      await fs.mkdir(forkDir, { recursive: true })
+      const forkContent = skillContent("reproduce-bug", REPRODUCE_BUG_DESCRIPTION)
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), forkContent)
+
+      await fs.mkdir(path.join(outputRoot, "skills"), { recursive: true })
+      await fs.symlink(forkDir, path.join(outputRoot, "skills", "reproduce-bug"), "junction")
+
+      const bundle: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [],
+        generatedSkills: [],
+        agents: [],
+        extensions: [],
+      }
+
+      await writePiBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills", "reproduce-bug"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe(forkContent)
+
+      const legacyBackupRoot = path.join(outputRoot, "compound-engineering", "legacy-backup")
+      if (await exists(legacyBackupRoot)) {
+        for (const timestamp of await fs.readdir(legacyBackupRoot)) {
+          const skillsBackup = path.join(legacyBackupRoot, timestamp, "skills")
+          if (!(await exists(skillsBackup))) continue
+          expect(await fs.readdir(skillsBackup)).not.toContain("reproduce-bug")
+        }
+      }
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
     "preserves a dangling skill symlink whose target no longer exists",
     async () => {
       const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-skill-symlink-dangling-"))

--- a/tests/pi-writer.test.ts
+++ b/tests/pi-writer.test.ts
@@ -418,3 +418,368 @@ Run these research agents:
     expect(await exists(path.join(outputRoot, "compound-engineering", "legacy-backup"))).toBe(true)
   })
 })
+
+// Probed at module load (not beforeAll) because test.skipIf evaluates its
+// condition at registration time. Directory and file symlinks are probed
+// separately: on Windows without Developer Mode, junctions succeed while
+// file symlinks throw EPERM.
+async function probeSymlinkSupport(): Promise<{ canDirSymlink: boolean; canFileSymlink: boolean }> {
+  const probeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-symlink-probe-"))
+  const probeTarget = path.join(probeRoot, "target")
+  await fs.mkdir(probeTarget, { recursive: true })
+  let canDirSymlink = true
+  try {
+    await fs.symlink(probeTarget, path.join(probeRoot, "link"), "junction")
+  } catch {
+    canDirSymlink = false
+  }
+  const probeFile = path.join(probeRoot, "target.md")
+  await fs.writeFile(probeFile, "probe")
+  let canFileSymlink = true
+  try {
+    await fs.symlink(probeFile, path.join(probeRoot, "link.md"))
+  } catch {
+    canFileSymlink = false
+  }
+  return { canDirSymlink, canFileSymlink }
+}
+
+const { canDirSymlink, canFileSymlink } = await probeSymlinkSupport()
+
+describe("writePiBundle preserves user-managed skill paths", () => {
+  async function readInstallManifest(outputRoot: string): Promise<{ skills: string[]; agents: string[] }> {
+    const raw = await fs.readFile(
+      path.join(outputRoot, "compound-engineering", "install-manifest.json"),
+      "utf8",
+    )
+    return JSON.parse(raw) as { skills: string[]; agents: string[] }
+  }
+
+  test.skipIf(!canDirSymlink)(
+    "preserves a symlinked skill directory and leaves its target content untouched",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-skill-symlink-"))
+      const outputRoot = path.join(tempRoot, ".pi")
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), "# user fork content\n")
+
+      await fs.mkdir(path.join(outputRoot, "skills"), { recursive: true })
+      await fs.symlink(forkDir, path.join(outputRoot, "skills", "skill-one"), "junction")
+
+      const bundle: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+        generatedSkills: [],
+        agents: [],
+        extensions: [],
+      }
+
+      await writePiBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills", "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe("# user fork content\n")
+
+      const manifest = await readInstallManifest(outputRoot)
+      expect(manifest.skills).not.toContain("skill-one")
+    },
+  )
+
+  test("preserves an unmanaged real skill directory (not previously owned by this tool)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-skill-unmanaged-"))
+    const outputRoot = path.join(tempRoot, ".pi")
+
+    await fs.mkdir(path.join(outputRoot, "skills", "skill-one"), { recursive: true })
+    await fs.writeFile(
+      path.join(outputRoot, "skills", "skill-one", "SKILL.md"),
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const bundle: PiBundle = {
+      pluginName: "compound-engineering",
+      prompts: [],
+      skillDirs: [
+        {
+          name: "skill-one",
+          sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+        },
+      ],
+      generatedSkills: [],
+      agents: [],
+      extensions: [],
+    }
+
+    await writePiBundle(outputRoot, bundle)
+
+    expect(await fs.readFile(path.join(outputRoot, "skills", "skill-one", "SKILL.md"), "utf8")).toBe(
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const manifest = await readInstallManifest(outputRoot)
+    expect(manifest.skills).not.toContain("skill-one")
+  })
+
+  test("still replaces a real skill directory previously installed by this tool", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-replace-managed-skill-"))
+    const outputRoot = path.join(tempRoot, ".pi")
+
+    const bundle: PiBundle = {
+      pluginName: "compound-engineering",
+      prompts: [],
+      skillDirs: [
+        {
+          name: "skill-one",
+          sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+        },
+      ],
+      generatedSkills: [],
+      agents: [],
+      extensions: [],
+    }
+
+    await writePiBundle(outputRoot, bundle)
+    // Simulate drift between two installs: same managed dir, different upstream content.
+    await fs.writeFile(path.join(outputRoot, "skills", "skill-one", "SKILL.md"), "stale managed content")
+
+    await writePiBundle(outputRoot, bundle)
+
+    const content = await fs.readFile(path.join(outputRoot, "skills", "skill-one", "SKILL.md"), "utf8")
+    expect(content).not.toBe("stale managed content")
+    expect(content).toContain("Skill body")
+
+    const manifest = await readInstallManifest(outputRoot)
+    expect(manifest.skills).toContain("skill-one")
+  })
+
+  test.skipIf(!canDirSymlink)(
+    "a preserved skill symlink survives a later install run where the skill is dropped from the bundle",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-skill-symlink-second-run-"))
+      const outputRoot = path.join(tempRoot, ".pi")
+
+      const bundleWithSkill: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+        generatedSkills: [],
+        agents: [],
+        extensions: [],
+      }
+
+      // First run: normal managed install, tracked in the manifest.
+      await writePiBundle(outputRoot, bundleWithSkill)
+      const manifestAfterFirstRun = await readInstallManifest(outputRoot)
+      expect(manifestAfterFirstRun.skills).toContain("skill-one")
+
+      // User swaps the managed directory for a symlink into a personal fork,
+      // while the on-disk manifest from the first run still claims ownership.
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), "# user fork content\n")
+      await fs.rm(path.join(outputRoot, "skills", "skill-one"), { recursive: true, force: true })
+      await fs.symlink(forkDir, path.join(outputRoot, "skills", "skill-one"), "junction")
+
+      // Second run: the plugin drops the skill from the bundle entirely, which
+      // exercises cleanupRemovedSkills against the stale manifest entry.
+      const bundleWithoutSkill: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [],
+        generatedSkills: [],
+        agents: [],
+        extensions: [],
+      }
+      await writePiBundle(outputRoot, bundleWithoutSkill)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills", "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe("# user fork content\n")
+
+      const manifestAfterSecondRun = await readInstallManifest(outputRoot)
+      expect(manifestAfterSecondRun.skills).not.toContain("skill-one")
+    },
+  )
+
+  test.skipIf(!canFileSymlink)("preserves a symlinked agent file and leaves its target content untouched", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-agent-symlink-"))
+    const outputRoot = path.join(tempRoot, ".pi")
+    const forkAgentPath = path.join(tempRoot, "user-fork-agent.md")
+    await fs.writeFile(forkAgentPath, "# user fork agent content\n")
+
+    await fs.mkdir(path.join(outputRoot, "agents"), { recursive: true })
+    await fs.symlink(forkAgentPath, path.join(outputRoot, "agents", "repo-research-analyst.md"))
+
+    const bundle: PiBundle = {
+      pluginName: "compound-engineering",
+      prompts: [],
+      skillDirs: [],
+      generatedSkills: [],
+      agents: [{ name: "repo-research-analyst", content: "---\nname: repo-research-analyst\n---\n\nBody" }],
+      extensions: [],
+    }
+
+    await writePiBundle(outputRoot, bundle)
+
+    const linkStat = await fs.lstat(path.join(outputRoot, "agents", "repo-research-analyst.md"))
+    expect(linkStat.isSymbolicLink()).toBe(true)
+    expect(await fs.readFile(forkAgentPath, "utf8")).toBe("# user fork agent content\n")
+
+    const manifest = await readInstallManifest(outputRoot)
+    expect(manifest.agents).not.toContain("repo-research-analyst.md")
+  })
+
+  test("preserves an unmanaged real agent file (not previously owned by this tool)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-agent-unmanaged-"))
+    const outputRoot = path.join(tempRoot, ".pi")
+
+    await fs.mkdir(path.join(outputRoot, "agents"), { recursive: true })
+    await fs.writeFile(
+      path.join(outputRoot, "agents", "repo-research-analyst.md"),
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const bundle: PiBundle = {
+      pluginName: "compound-engineering",
+      prompts: [],
+      skillDirs: [],
+      generatedSkills: [],
+      agents: [{ name: "repo-research-analyst", content: "---\nname: repo-research-analyst\n---\n\nBody" }],
+      extensions: [],
+    }
+
+    await writePiBundle(outputRoot, bundle)
+
+    expect(await fs.readFile(path.join(outputRoot, "agents", "repo-research-analyst.md"), "utf8")).toBe(
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const manifest = await readInstallManifest(outputRoot)
+    expect(manifest.agents).not.toContain("repo-research-analyst.md")
+  })
+
+  test("still replaces a real agent file previously installed by this tool", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-replace-managed-agent-"))
+    const outputRoot = path.join(tempRoot, ".pi")
+
+    const bundle: PiBundle = {
+      pluginName: "compound-engineering",
+      prompts: [],
+      skillDirs: [],
+      generatedSkills: [],
+      agents: [{ name: "repo-research-analyst", content: "---\nname: repo-research-analyst\n---\n\nBody" }],
+      extensions: [],
+    }
+
+    await writePiBundle(outputRoot, bundle)
+    // Simulate drift between two installs: same managed file, different upstream content.
+    await fs.writeFile(path.join(outputRoot, "agents", "repo-research-analyst.md"), "stale managed content")
+
+    await writePiBundle(outputRoot, bundle)
+
+    const content = await fs.readFile(path.join(outputRoot, "agents", "repo-research-analyst.md"), "utf8")
+    expect(content).not.toBe("stale managed content")
+    expect(content).toContain("Body")
+
+    const manifest = await readInstallManifest(outputRoot)
+    expect(manifest.agents).toContain("repo-research-analyst.md")
+  })
+
+  test.skipIf(!canFileSymlink)(
+    "a preserved agent symlink survives a later install run where the agent is dropped from the bundle",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-agent-symlink-second-run-"))
+      const outputRoot = path.join(tempRoot, ".pi")
+
+      const bundleWithAgent: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [],
+        generatedSkills: [],
+        agents: [{ name: "repo-research-analyst", content: "---\nname: repo-research-analyst\n---\n\nBody" }],
+        extensions: [],
+      }
+
+      // First run: normal managed install, tracked in the manifest.
+      await writePiBundle(outputRoot, bundleWithAgent)
+      const manifestAfterFirstRun = await readInstallManifest(outputRoot)
+      expect(manifestAfterFirstRun.agents).toContain("repo-research-analyst.md")
+
+      // User swaps the managed file for a symlink into a personal fork, while
+      // the on-disk manifest from the first run still claims ownership.
+      const forkAgentPath = path.join(tempRoot, "user-fork-agent.md")
+      await fs.writeFile(forkAgentPath, "# user fork agent content\n")
+      await fs.rm(path.join(outputRoot, "agents", "repo-research-analyst.md"), { force: true })
+      await fs.symlink(forkAgentPath, path.join(outputRoot, "agents", "repo-research-analyst.md"))
+
+      // Second run: the plugin drops the agent from the bundle entirely, which
+      // exercises cleanupRemovedAgents against the stale manifest entry.
+      const bundleWithoutAgent: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [],
+        generatedSkills: [],
+        agents: [],
+        extensions: [],
+      }
+      await writePiBundle(outputRoot, bundleWithoutAgent)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "agents", "repo-research-analyst.md"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(forkAgentPath, "utf8")).toBe("# user fork agent content\n")
+
+      const manifestAfterSecondRun = await readInstallManifest(outputRoot)
+      expect(manifestAfterSecondRun.agents).not.toContain("repo-research-analyst.md")
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
+    "preserves a dangling skill symlink whose target no longer exists",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-preserve-skill-symlink-dangling-"))
+      const outputRoot = path.join(tempRoot, ".pi")
+
+      // Create the symlink against a real target, then remove the target so
+      // the link dangles. lstat must still see the link node (stat/access
+      // would follow it and report ENOENT, treating the path as absent).
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.mkdir(path.join(outputRoot, "skills"), { recursive: true })
+      await fs.symlink(forkDir, path.join(outputRoot, "skills", "skill-one"), "junction")
+      await fs.rm(forkDir, { recursive: true, force: true })
+
+      const bundle: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+        generatedSkills: [],
+        agents: [],
+        extensions: [],
+      }
+
+      await writePiBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills", "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+
+      const manifest = await readInstallManifest(outputRoot)
+      expect(manifest.skills).not.toContain("skill-one")
+    },
+  )
+})


### PR DESCRIPTION
Fixes #1048

## Summary

Installing to Pi no longer destroys local skill overrides. Previously, `compound-plugin install <plugin> --to pi` replaced whatever sat at each target skill/agent path with a fresh upstream copy — including user-managed symlinks pointing at a personal fork or worktree, and manually authored directories. A user following the standard symlink-override pattern (the basis of downstream patch projects like `agents-skills`) had their patches silently deactivated on every install, with no warning and nothing in the output to indicate it happened.

## Current behavior

From #1048, after creating the standard override symlink and reinstalling:

```bash
ln -sfn ~/agents-skills/skills/ce-session-inventory ~/.pi/agent/skills/ce-session-inventory
bunx @every-env/compound-plugin install compound-engineering --to pi

ls -la ~/.pi/agent/skills/ce-session-inventory
# drwxr-xr-x ... SKILL.md          <- real dir, NOT a symlink; local patch gone
```

The skill/agent cleanup helpers in `src/targets/pi.ts` run `fs.rm(..., { recursive: true, force: true })` and then copy, with no check for what the existing path is.

## Fix

The cleanup helpers now `lstat` the target before acting, implementing the contract from the issue:

| Existing path state | Behavior |
|---|---|
| Doesn't exist | Create fresh (unchanged) |
| Real path recorded in the install manifest | Replace (unchanged) |
| Real path **not** in the manifest (manually authored) | Preserve, warn, skip the copy |
| Symlink to anything, including dangling | Preserve, warn, skip the copy |

Three decisions worth reviewer attention:

- Preservation skips **both** the `rm` and the subsequent copy/write. `copySkillDir` merges without pre-clearing, so writing through a preserved symlink would push upstream content into the user's fork — worse than the original bug.
- Preserved names are excluded from the freshly written install manifest, so the tool never claims ownership of a path it didn't write. The bookkeeping is self-healing: if the user later removes the symlink, the next install writes fresh content and resumes tracking it.
- `cleanupRemovedSkills` / `cleanupRemovedAgents` apply the same symlink guard, covering the case where a skill is dropped from the bundle while a stale manifest entry still claims a path the user has since converted to a symlink.

The guard covers the `skillDirs`, `generatedSkills`, and agents loops alike.

## Verification

- 9 new tests in `tests/pi-writer.test.ts`: symlinked skill dir / agent file preserved with fork content untouched and manifest exclusion; unmanaged real dir/file preserved; manifest-owned dir and agent file still replaced on reinstall; preserved symlink survives a later run where the skill/agent is dropped from the bundle; dangling symlink preserved (pins the `lstat`-not-`stat` behavior).
- Red then green: with `src/targets/pi.ts` restored to main, 7 of the new tests fail; with the fix, all 19 tests in the file pass.
- Symlink capability is probed at module load — directory junctions and file symlinks separately, since Windows grants them different privileges — and symlink-dependent tests skip where creation fails. On this Windows machine both succeeded, so all 19 ran.
- Full `bun test` baseline diff against main on this machine: zero new failures (the pre-existing failure set here is environment-related and identical on both).

## Scope notes

- **Pre-manifest installs freeze rather than update.** Pi skills were written before the install manifest existed (manifest landed in #609). An install from that era with no manifest now matches the "unmanaged" branch and is preserved with a warning instead of overwritten. "Not in the manifest" can't distinguish user-authored from pre-manifest tool-written, and erring toward preservation is the point of this fix; one reinstall after deleting the frozen dirs restores tracking.
- **Same pattern in two other writers.** `src/targets/codex.ts` (`cleanupCurrentManagedSkillDir`) and `src/targets/managed-artifacts.ts` (`cleanupCurrentManagedDirectory`, used by the OpenCode writer) share the unconditional rm-then-copy shape and would clobber symlinks the same way. Left untouched to keep this PR reviewable against the Pi repro in #1048; happy to file a follow-up or extend this fix if preferred.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
