### PR TITLE
fix(targets): extend user-symlink preservation to codex and opencode writers

### DIFF
--- a/src/commands/cleanup.ts
+++ b/src/commands/cleanup.ts
@@ -366,7 +366,12 @@ async function moveIfSymlinkManaged(
   if (!isSafeManagedPath(artifactRoot, relativePath)) return 0
   const artifactPath = path.join(artifactRoot, ...relativePath.split("/"))
   if (!(await isManagedCodexAgentsSymlink(artifactPath, managedRoots))) return 0
-  await moveLegacyArtifactToBackup(managedDir, kind, artifactRoot, relativePath, label)
+  // `isManagedCodexAgentsSymlink` already verified this symlink's resolved
+  // target lives inside a CE-managed Codex root -- that is stronger proof of
+  // CE ownership than the generic "is a symlink" preservation guard, and the
+  // whole point of this sweep is to relocate the symlink node itself. Skip
+  // the guard so it doesn't block moving a confirmed CE-owned symlink.
+  await moveLegacyArtifactToBackup(managedDir, kind, artifactRoot, relativePath, label, { skipSymlinkGuard: true })
   return 1
 }
 

--- a/src/targets/codex.ts
+++ b/src/targets/codex.ts
@@ -6,6 +6,7 @@ import type { ClaudeMcpServer } from "../types/claude"
 import { transformContentForCodex } from "../utils/codex-content"
 import { getLegacyCodexArtifacts } from "../data/plugin-legacy-artifacts"
 import { classifyCodexLegacyPromptOwnership, isLegacyAgentArtifactOwned, isLegacySkillArtifactOwned } from "../utils/legacy-cleanup"
+import { isPreservedSymlink, lstatOrNull } from "./managed-artifacts"
 
 const MANAGED_START_MARKER = "# BEGIN Compound Engineering plugin MCP -- do not edit this block"
 const MANAGED_END_MARKER = "# END Compound Engineering plugin MCP"
@@ -71,10 +72,17 @@ export async function writeCodexBundle(
   ]))
   await cleanupRemovedSkills(skillsRoot, manifest, currentSkills)
 
+  const preservedSkillNames = new Set<string>()
+
   if (bundle.skillDirs.length > 0) {
     for (const skill of bundle.skillDirs) {
-      const targetDir = path.join(skillsRoot, sanitizePathName(skill.name))
-      await cleanupCurrentManagedSkillDir(targetDir, manifest, sanitizePathName(skill.name))
+      const skillName = sanitizePathName(skill.name)
+      const targetDir = path.join(skillsRoot, skillName)
+      const preserved = await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
+      if (preserved) {
+        preservedSkillNames.add(skillName)
+        continue
+      }
       await copySkillDir(
         skill.sourceDir,
         targetDir,
@@ -87,8 +95,13 @@ export async function writeCodexBundle(
 
   if (bundle.generatedSkills.length > 0) {
     for (const skill of bundle.generatedSkills) {
-      const skillDir = path.join(skillsRoot, sanitizePathName(skill.name))
-      await cleanupCurrentManagedSkillDir(skillDir, manifest, sanitizePathName(skill.name))
+      const skillName = sanitizePathName(skill.name)
+      const skillDir = path.join(skillsRoot, skillName)
+      const preserved = await cleanupCurrentManagedSkillDir(skillDir, manifest, skillName)
+      if (preserved) {
+        preservedSkillNames.add(skillName)
+        continue
+      }
       await writeText(path.join(skillDir, "SKILL.md"), skill.content + "\n")
       for (const sidecar of skill.sidecarDirs ?? []) {
         await copyDir(sidecar.sourceDir, path.join(skillDir, sidecar.targetName))
@@ -96,20 +109,33 @@ export async function writeCodexBundle(
     }
   }
 
+  const preservedAgentNames = new Set<string>()
+
   await cleanupRemovedAgents(agentsRoot, manifest, currentAgents)
   if (agents.length > 0) {
     for (const agent of agents) {
       const agentBaseName = sanitizePathName(agent.name)
       const agentFile = `${agentBaseName}.toml`
+      const targetPath = path.join(agentsRoot, agentFile)
+      const preserved = await cleanupCurrentManagedAgentFile(targetPath, manifest, agentFile)
+      if (preserved) {
+        preservedAgentNames.add(agentFile)
+        continue
+      }
       // If the agent declares no sidecars, remove any same-basename sibling
       // directory left behind by a prior install that did. The manifest-driven
       // cleanupRemovedAgents sweep above only removes the sibling dir when the
       // TOML itself is being removed; a same-name agent that loses its sidecar
-      // would otherwise leave an orphan directory.
+      // would otherwise leave an orphan directory. The user may have replaced
+      // the sidecar dir with a symlink into a personal fork while keeping the
+      // managed TOML -- never delete through that symlink node.
       if ((agent.sidecarDirs ?? []).length === 0 && isSafeManagedPath(agentsRoot, agentBaseName)) {
-        await fs.rm(path.join(agentsRoot, agentBaseName), { recursive: true, force: true })
+        const sidecarDir = path.join(agentsRoot, agentBaseName)
+        if (!(await isPreservedSymlink(sidecarDir))) {
+          await fs.rm(sidecarDir, { recursive: true, force: true })
+        }
       }
-      await writeText(path.join(agentsRoot, agentFile), renderCodexAgentToml(agent) + "\n")
+      await writeText(targetPath, renderCodexAgentToml(agent) + "\n")
       for (const sidecar of agent.sidecarDirs ?? []) {
         await copyDir(sidecar.sourceDir, path.join(agentsRoot, agentBaseName, sidecar.targetName))
       }
@@ -118,12 +144,15 @@ export async function writeCodexBundle(
 
   if (pluginName) {
     await ensureDir(skillsRoot)
+    // Preserved skills/agents (user symlinks or unmanaged dirs/files this
+    // install skipped) must not be recorded as owned -- the plugin never
+    // claims a path it didn't write.
     await writeInstallManifest(codexRoot, {
       version: 1,
       pluginName,
-      skills: currentSkills,
+      skills: currentSkills.filter((name) => !preservedSkillNames.has(name)),
       prompts: currentPrompts,
-      agents: currentAgents,
+      agents: currentAgents.filter((name) => !preservedAgentNames.has(name)),
     })
     await cleanupKnownLegacyCodexArtifacts(codexRoot, bundle)
     await cleanupLegacyAgentSkillDirs(codexRoot, pluginName, currentSkills, bundle)
@@ -256,7 +285,13 @@ async function cleanupRemovedSkills(
     // but re-check before any out-of-tree fs.rm can be issued from a future
     // caller that bypasses the read layer.
     if (!isSafeManagedPath(skillsRoot, skillName)) continue
-    await fs.rm(path.join(skillsRoot, skillName), { recursive: true, force: true })
+    const targetDir = path.join(skillsRoot, skillName)
+    // The manifest can lag reality: a prior install owned this name, but the
+    // user has since replaced it with a symlink (e.g. into a personal fork).
+    // Never delete through a symlink node even when the stale manifest still
+    // claims ownership.
+    if (await isPreservedSymlink(targetDir)) continue
+    await fs.rm(targetDir, { recursive: true, force: true })
   }
 }
 
@@ -284,18 +319,59 @@ async function cleanupRemovedAgents(
   for (const agentFile of manifest.agents) {
     if (current.has(agentFile)) continue
     if (!isSafeManagedPath(agentsRoot, agentFile)) continue
-    await fs.rm(path.join(agentsRoot, agentFile), { force: true })
-    await fs.rm(path.join(agentsRoot, path.basename(agentFile, ".toml")), { recursive: true, force: true })
+    const targetPath = path.join(agentsRoot, agentFile)
+    if (!(await isPreservedSymlink(targetPath))) {
+      await fs.rm(targetPath, { force: true })
+    }
+    const sidecarDir = path.join(agentsRoot, path.basename(agentFile, ".toml"))
+    if (!(await isPreservedSymlink(sidecarDir))) {
+      await fs.rm(sidecarDir, { recursive: true, force: true })
+    }
   }
 }
 
+// Returns true when the existing path was preserved (skip cleanup AND the
+// subsequent copy/write -- writing through a preserved symlink would clobber
+// the user's fork, which is worse than not overwriting at all).
 async function cleanupCurrentManagedSkillDir(
   targetDir: string,
   manifest: CodexInstallManifest | null,
   skillName: string,
-): Promise<void> {
-  if (!manifest?.skills.includes(skillName)) return
+): Promise<boolean> {
+  const stat = await lstatOrNull(targetDir)
+  if (!stat) return false
+  if (stat.isSymbolicLink()) {
+    console.warn(`Skipping ${targetDir}: existing user-managed symlink (not overwritten)`)
+    return true
+  }
+  if (!manifest?.skills.includes(skillName)) {
+    console.warn(`Skipping ${targetDir}: existing unmanaged directory (not overwritten)`)
+    return true
+  }
   await fs.rm(targetDir, { recursive: true, force: true })
+  return false
+}
+
+// Returns true when the existing path was preserved (skip cleanup AND the
+// subsequent write -- writing through a preserved symlink would clobber the
+// user's fork, which is worse than not overwriting at all).
+async function cleanupCurrentManagedAgentFile(
+  targetPath: string,
+  manifest: CodexInstallManifest | null,
+  agentFileName: string,
+): Promise<boolean> {
+  const stat = await lstatOrNull(targetPath)
+  if (!stat) return false
+  if (stat.isSymbolicLink()) {
+    console.warn(`Skipping ${targetPath}: existing user-managed symlink (not overwritten)`)
+    return true
+  }
+  if (!manifest?.agents.includes(agentFileName)) {
+    console.warn(`Skipping ${targetPath}: existing unmanaged file (not overwritten)`)
+    return true
+  }
+  await fs.rm(targetPath, { force: true })
+  return false
 }
 
 async function cleanupKnownLegacyCodexArtifacts(codexRoot: string, bundle: CodexBundle): Promise<void> {
@@ -416,7 +492,9 @@ async function cleanupLegacyAgentsSkillSymlinks(
 }
 
 async function cleanupPreviousManagedCodexSkillStore(codexRoot: string, pluginName: string): Promise<void> {
-  await fs.rm(path.join(codexRoot, pluginName, "skills"), { recursive: true, force: true })
+  const skillStoreDir = path.join(codexRoot, pluginName, "skills")
+  if (await isPreservedSymlink(skillStoreDir)) return
+  await fs.rm(skillStoreDir, { recursive: true, force: true })
 }
 
 async function removeAgentsSkillSymlinkIfManaged(symlinkPath: string, managedRoots: string[]): Promise<void> {
@@ -510,6 +588,10 @@ async function moveLegacyArtifactToBackup(
   kind: "skills" | "prompts" | "agents",
   artifactPath: string,
 ): Promise<void> {
+  // Ownership fingerprinting reads THROUGH a symlink, so a user fork of a
+  // legacy-named artifact still matches — never move the symlink node into
+  // legacy-backup, or the user's override is silently deactivated.
+  if (await isPreservedSymlink(artifactPath)) return
   if (!(await pathExists(artifactPath))) return
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const backupDir = path.join(codexRoot, pluginName, "legacy-backup", timestamp, kind)

--- a/src/targets/managed-artifacts.ts
+++ b/src/targets/managed-artifacts.ts
@@ -1,4 +1,5 @@
 import fs from "fs/promises"
+import type { Stats } from "fs"
 import path from "path"
 import { ensureDir, isSafeManagedPath, pathExists, readText, sanitizePathName, writeJson } from "../utils/files"
 
@@ -161,7 +162,13 @@ export async function cleanupRemovedManagedDirectories(
     // entries, but re-check here so any future caller that bypasses the
     // read layer cannot trigger out-of-tree deletes.
     if (!isSafeManagedPath(rootDir, relativePath)) continue
-    await fs.rm(resolveArtifactPath(rootDir, relativePath), { recursive: true, force: true })
+    const targetPath = resolveArtifactPath(rootDir, relativePath)
+    // The manifest can lag reality: a prior install owned this name, but the
+    // user has since replaced it with a symlink (e.g. into a personal fork).
+    // Never delete through a symlink node even when the stale manifest still
+    // claims ownership.
+    if (await isPreservedSymlink(targetPath)) continue
+    await fs.rm(targetPath, { recursive: true, force: true })
   }
 }
 
@@ -176,18 +183,33 @@ export async function cleanupRemovedManagedFiles(
   for (const relativePath of manifest.groups[group] ?? []) {
     if (current.has(relativePath)) continue
     if (!isSafeManagedPath(rootDir, relativePath)) continue
-    await fs.rm(resolveArtifactPath(rootDir, relativePath), { force: true })
+    const targetPath = resolveArtifactPath(rootDir, relativePath)
+    if (await isPreservedSymlink(targetPath)) continue
+    await fs.rm(targetPath, { force: true })
   }
 }
 
+// Returns true when the existing path was preserved (skip cleanup AND the
+// subsequent copy/write -- writing through a preserved symlink would clobber
+// the user's fork, which is worse than not overwriting at all).
 export async function cleanupCurrentManagedDirectory(
   targetDir: string,
   manifest: ManagedInstallManifest | null,
   group: string,
   entryName: string,
-): Promise<void> {
-  if (!manifest?.groups[group]?.includes(entryName)) return
+): Promise<boolean> {
+  const stat = await lstatOrNull(targetDir)
+  if (!stat) return false
+  if (stat.isSymbolicLink()) {
+    console.warn(`Skipping ${targetDir}: existing user-managed symlink (not overwritten)`)
+    return true
+  }
+  if (!manifest?.groups[group]?.includes(entryName)) {
+    console.warn(`Skipping ${targetDir}: existing unmanaged directory (not overwritten)`)
+    return true
+  }
   await fs.rm(targetDir, { recursive: true, force: true })
+  return false
 }
 
 export async function moveLegacyArtifactToBackup(
@@ -196,8 +218,18 @@ export async function moveLegacyArtifactToBackup(
   artifactRoot: string,
   relativePath: string,
   label: string,
+  options: { skipSymlinkGuard?: boolean } = {},
 ): Promise<void> {
   const artifactPath = resolveArtifactPath(artifactRoot, relativePath)
+  // Ownership fingerprinting reads THROUGH a symlink, so a user fork of a
+  // legacy-named artifact still matches — never move the symlink node into
+  // legacy-backup, or the user's override is silently deactivated.
+  // `skipSymlinkGuard` is for callers (e.g. the shared `~/.agents/skills/`
+  // sweep in `src/commands/cleanup.ts`) that have already independently
+  // verified via a stronger signal (the symlink's resolved target lives
+  // inside a CE-managed root) that this specific symlink node IS the
+  // CE-owned artifact to relocate, not a user override to preserve.
+  if (!options.skipSymlinkGuard && (await isPreservedSymlink(artifactPath))) return
   if (!(await pathExists(artifactPath))) return
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
@@ -209,4 +241,20 @@ export async function moveLegacyArtifactToBackup(
 
 function resolveArtifactPath(rootDir: string, relativePath: string): string {
   return path.join(rootDir, ...relativePath.split("/"))
+}
+
+export async function lstatOrNull(targetPath: string): Promise<Stats | null> {
+  try {
+    return await fs.lstat(targetPath)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null
+    throw err
+  }
+}
+
+export async function isPreservedSymlink(targetPath: string): Promise<boolean> {
+  const stat = await lstatOrNull(targetPath)
+  if (!stat?.isSymbolicLink()) return false
+  console.warn(`Skipping ${targetPath}: existing user-managed symlink (not overwritten)`)
+  return true
 }

--- a/src/targets/opencode.ts
+++ b/src/targets/opencode.ts
@@ -9,12 +9,39 @@ import {
   cleanupCurrentManagedDirectory,
   cleanupRemovedManagedDirectories,
   cleanupRemovedManagedFiles,
+  lstatOrNull,
+  type ManagedInstallManifest,
   moveLegacyArtifactToBackup,
   readManagedInstallManifestWithLegacyFallback,
   resolveManagedSegment,
   sanitizeManagedPluginName,
   writeManagedInstallManifest,
 } from "./managed-artifacts"
+
+// Returns true when the existing path was preserved (skip cleanup AND the
+// subsequent write -- writing through a preserved symlink would clobber the
+// user's fork, which is worse than not overwriting at all). All four
+// OpenCode artifact kinds (agents, commands, plugins, skills) are tracked in
+// the install manifest's `groups` map, so the same ownership rule applies
+// uniformly here rather than a symlink-only guard.
+async function cleanupCurrentManagedFile(
+  targetPath: string,
+  manifest: ManagedInstallManifest | null,
+  group: string,
+  entryName: string,
+): Promise<boolean> {
+  const stat = await lstatOrNull(targetPath)
+  if (!stat) return false
+  if (stat.isSymbolicLink()) {
+    console.warn(`Skipping ${targetPath}: existing user-managed symlink (not overwritten)`)
+    return true
+  }
+  if (!manifest?.groups[group]?.includes(entryName)) {
+    console.warn(`Skipping ${targetPath}: existing unmanaged file (not overwritten)`)
+    return true
+  }
+  return false
+}
 
 async function mergeOpenCodeConfig(
   configPath: string,
@@ -93,6 +120,7 @@ export async function writeOpenCodeBundle(
   }
 
   const seenAgents = new Set<string>()
+  const preservedAgentNames = new Set<string>()
   for (const agent of bundle.agents) {
     const safeName = sanitizePathName(agent.name)
     if (seenAgents.has(safeName)) {
@@ -100,11 +128,25 @@ export async function writeOpenCodeBundle(
       continue
     }
     seenAgents.add(safeName)
-    await writeText(path.join(openCodePaths.agentsDir, `${safeName}.md`), agent.content + "\n")
+    const agentFileName = `${safeName}.md`
+    const targetPath = path.join(openCodePaths.agentsDir, agentFileName)
+    const preserved = await cleanupCurrentManagedFile(targetPath, manifest, "agents", agentFileName)
+    if (preserved) {
+      preservedAgentNames.add(agentFileName)
+      continue
+    }
+    await writeText(targetPath, agent.content + "\n")
   }
 
+  const preservedCommandNames = new Set<string>()
   for (const commandFile of bundle.commandFiles) {
-    const dest = path.join(openCodePaths.commandDir, ...commandNameToRelativePath(commandFile.name).split("/")) + ".md"
+    const commandName = `${commandNameToRelativePath(commandFile.name)}.md`
+    const dest = path.join(openCodePaths.commandDir, ...commandName.split("/"))
+    const preserved = await cleanupCurrentManagedFile(dest, manifest, "commands", commandName)
+    if (preserved) {
+      preservedCommandNames.add(commandName)
+      continue
+    }
     const cmdBackupPath = await backupFile(dest)
     if (cmdBackupPath) {
       console.log(`Backed up existing command file to ${cmdBackupPath}`)
@@ -112,17 +154,29 @@ export async function writeOpenCodeBundle(
     await writeText(dest, commandFile.content + "\n")
   }
 
+  const preservedPluginNames = new Set<string>()
   if (bundle.plugins.length > 0) {
     for (const plugin of bundle.plugins) {
-      await writeText(path.join(openCodePaths.pluginsDir, plugin.name), plugin.content + "\n")
+      const targetPath = path.join(openCodePaths.pluginsDir, plugin.name)
+      const preserved = await cleanupCurrentManagedFile(targetPath, manifest, "plugins", plugin.name)
+      if (preserved) {
+        preservedPluginNames.add(plugin.name)
+        continue
+      }
+      await writeText(targetPath, plugin.content + "\n")
     }
   }
 
+  const preservedSkillNames = new Set<string>()
   if (bundle.skillDirs.length > 0) {
     for (const skill of bundle.skillDirs) {
       const skillName = sanitizePathName(skill.name)
       const targetDir = path.join(openCodePaths.skillsDir, skillName)
-      await cleanupCurrentManagedDirectory(targetDir, manifest, "skills", skillName)
+      const preserved = await cleanupCurrentManagedDirectory(targetDir, manifest, "skills", skillName)
+      if (preserved) {
+        preservedSkillNames.add(skillName)
+        continue
+      }
       await copySkillDir(
         skill.sourceDir,
         targetDir,
@@ -133,14 +187,17 @@ export async function writeOpenCodeBundle(
   }
 
   if (pluginName) {
+    // Preserved agents/commands/plugins/skills (user symlinks or unmanaged
+    // dirs/files this install skipped) must not be recorded as owned -- the
+    // plugin never claims a path it didn't write.
     await writeManagedInstallManifest(openCodePaths.managedDir, {
       version: 1,
       pluginName,
       groups: {
-        agents: currentAgents,
-        commands: currentCommands,
-        plugins: currentPlugins,
-        skills: currentSkills,
+        agents: currentAgents.filter((name) => !preservedAgentNames.has(name)),
+        commands: currentCommands.filter((name) => !preservedCommandNames.has(name)),
+        plugins: currentPlugins.filter((name) => !preservedPluginNames.has(name)),
+        skills: currentSkills.filter((name) => !preservedSkillNames.has(name)),
       },
     })
     await archiveLegacyInstallManifestIfOwned(openCodePaths.managedDir, pluginName)

--- a/src/targets/pi.ts
+++ b/src/targets/pi.ts
@@ -1,5 +1,4 @@
 import fs from "fs/promises"
-import type { Stats } from "fs"
 import path from "path"
 import {
   backupFile,
@@ -16,7 +15,7 @@ import { transformContentForPi } from "../converters/claude-to-pi"
 import type { PiBundle } from "../types/pi"
 import { getLegacyPiArtifacts } from "../data/plugin-legacy-artifacts"
 import { cleanupStaleAgents, isLegacyAgentArtifactOwned, isLegacySkillArtifactOwned } from "../utils/legacy-cleanup"
-import { resolveLegacyManagedDir, resolveManagedSegment } from "./managed-artifacts"
+import { isPreservedSymlink, lstatOrNull, resolveLegacyManagedDir, resolveManagedSegment } from "./managed-artifacts"
 
 const PI_AGENTS_BLOCK_START = "<!-- BEGIN COMPOUND PI TOOL MAP -->"
 const PI_AGENTS_BLOCK_END = "<!-- END COMPOUND PI TOOL MAP -->"
@@ -420,22 +419,6 @@ async function cleanupRemovedAgents(
     if (await isPreservedSymlink(targetPath)) continue
     await fs.rm(targetPath, { force: true })
   }
-}
-
-async function lstatOrNull(targetPath: string): Promise<Stats | null> {
-  try {
-    return await fs.lstat(targetPath)
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null
-    throw err
-  }
-}
-
-async function isPreservedSymlink(targetPath: string): Promise<boolean> {
-  const stat = await lstatOrNull(targetPath)
-  if (!stat?.isSymbolicLink()) return false
-  console.warn(`Skipping ${targetPath}: existing user-managed symlink (not overwritten)`)
-  return true
 }
 
 // Returns true when the existing path was preserved (skip cleanup AND the

--- a/tests/codex-writer.test.ts
+++ b/tests/codex-writer.test.ts
@@ -909,13 +909,11 @@ Workflow handoff:
 
   test("removes orphan sidecar dir when retained agent declares no sidecars", async () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-test-"))
-    const agentsRoot = path.join(tempRoot, ".codex", "agents")
-    const orphanDir = path.join(agentsRoot, "ce-foo", "stale-content")
-    await fs.mkdir(orphanDir, { recursive: true })
-    await fs.writeFile(path.join(orphanDir, "leftover.txt"), "stale", "utf8")
-    await fs.writeFile(path.join(agentsRoot, "ce-foo.toml"), "old-toml", "utf8")
+    const sidecarSource = await fs.mkdtemp(path.join(os.tmpdir(), "codex-sidecar-src-"))
+    await fs.writeFile(path.join(sidecarSource, "script.sh"), "#!/bin/sh\necho hi\n", "utf8")
 
-    const bundle: CodexBundle = {
+    const agentWithSidecar: CodexBundle = {
+      pluginName: "compound-engineering",
       prompts: [],
       skillDirs: [],
       generatedSkills: [],
@@ -924,12 +922,32 @@ Workflow handoff:
           name: "ce-foo",
           description: "Foo agent",
           instructions: "Do foo.",
+          sidecarDirs: [{ sourceDir: sidecarSource, targetName: "scripts" }],
         },
       ],
       mcpServers: {},
     }
 
-    await writeCodexBundle(tempRoot, bundle)
+    // First install establishes ownership of ce-foo.toml in the install
+    // manifest and writes the sidecar dir -- an unowned pre-existing agent
+    // file/dir would be preserved, not cleaned up.
+    await writeCodexBundle(tempRoot, agentWithSidecar)
+
+    const agentsRoot = path.join(tempRoot, ".codex", "agents", "compound-engineering")
+    expect(await exists(path.join(agentsRoot, "ce-foo", "scripts", "script.sh"))).toBe(true)
+
+    const agentWithoutSidecar: CodexBundle = {
+      ...agentWithSidecar,
+      agents: [
+        {
+          name: "ce-foo",
+          description: "Foo agent",
+          instructions: "Do foo.",
+        },
+      ],
+    }
+
+    await writeCodexBundle(tempRoot, agentWithoutSidecar)
 
     expect(await entryExists(path.join(agentsRoot, "ce-foo"))).toBe(false)
     expect(await exists(path.join(agentsRoot, "ce-foo.toml"))).toBe(true)
@@ -1292,4 +1310,357 @@ describe("mergeCodexHooks", () => {
     // Legacy _source entry removed, manual preserved, new added
     expect(hooks.SessionStart).toHaveLength(2)
   })
+})
+
+// Probed at module load (not beforeAll) because test.skipIf evaluates its
+// condition at registration time. Directory and file symlinks are probed
+// separately: on Windows without Developer Mode, junctions succeed while
+// file symlinks throw EPERM.
+async function probeSymlinkSupport(): Promise<{ canDirSymlink: boolean; canFileSymlink: boolean }> {
+  const probeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-symlink-probe-"))
+  const probeTarget = path.join(probeRoot, "target")
+  await fs.mkdir(probeTarget, { recursive: true })
+  let canDirSymlink = true
+  try {
+    await fs.symlink(probeTarget, path.join(probeRoot, "link"), "junction")
+  } catch {
+    canDirSymlink = false
+  }
+  const probeFile = path.join(probeRoot, "target.toml")
+  await fs.writeFile(probeFile, "probe")
+  let canFileSymlink = true
+  try {
+    await fs.symlink(probeFile, path.join(probeRoot, "link.toml"))
+  } catch {
+    canFileSymlink = false
+  }
+  return { canDirSymlink, canFileSymlink }
+}
+
+const { canDirSymlink, canFileSymlink } = await probeSymlinkSupport()
+
+describe("writeCodexBundle preserves user-managed skill and agent paths", () => {
+  async function readInstallManifest(codexRoot: string): Promise<{ skills: string[]; agents: string[] }> {
+    const raw = await fs.readFile(
+      path.join(codexRoot, "compound-engineering", "install-manifest.json"),
+      "utf8",
+    )
+    return JSON.parse(raw) as { skills: string[]; agents: string[] }
+  }
+
+  test.skipIf(!canDirSymlink)(
+    "preserves a symlinked skill directory and leaves its target content untouched",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-preserve-skill-symlink-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), "# user fork content\n")
+
+      const skillsRoot = path.join(codexRoot, "skills", "compound-engineering")
+      await fs.mkdir(skillsRoot, { recursive: true })
+      await fs.symlink(forkDir, path.join(skillsRoot, "skill-one"), "junction")
+
+      const bundle: CodexBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+        generatedSkills: [],
+      }
+
+      await writeCodexBundle(codexRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(skillsRoot, "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe("# user fork content\n")
+
+      const manifest = await readInstallManifest(codexRoot)
+      expect(manifest.skills).not.toContain("skill-one")
+    },
+  )
+
+  test("preserves an unmanaged real skill directory (not previously owned by this tool)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-preserve-skill-unmanaged-"))
+    const codexRoot = path.join(tempRoot, ".codex")
+    const skillsRoot = path.join(codexRoot, "skills", "compound-engineering")
+
+    await fs.mkdir(path.join(skillsRoot, "skill-one"), { recursive: true })
+    await fs.writeFile(
+      path.join(skillsRoot, "skill-one", "SKILL.md"),
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const bundle: CodexBundle = {
+      pluginName: "compound-engineering",
+      prompts: [],
+      skillDirs: [
+        {
+          name: "skill-one",
+          sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+        },
+      ],
+      generatedSkills: [],
+    }
+
+    await writeCodexBundle(codexRoot, bundle)
+
+    expect(await fs.readFile(path.join(skillsRoot, "skill-one", "SKILL.md"), "utf8")).toBe(
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const manifest = await readInstallManifest(codexRoot)
+    expect(manifest.skills).not.toContain("skill-one")
+  })
+
+  test("still replaces a real skill directory previously installed by this tool", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-replace-managed-skill-"))
+    const codexRoot = path.join(tempRoot, ".codex")
+
+    const bundle: CodexBundle = {
+      pluginName: "compound-engineering",
+      prompts: [],
+      skillDirs: [
+        {
+          name: "skill-one",
+          sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+        },
+      ],
+      generatedSkills: [],
+    }
+
+    await writeCodexBundle(codexRoot, bundle)
+    const skillPath = path.join(codexRoot, "skills", "compound-engineering", "skill-one", "SKILL.md")
+    // Simulate drift between two installs: same managed dir, different upstream content.
+    await fs.writeFile(skillPath, "stale managed content")
+
+    await writeCodexBundle(codexRoot, bundle)
+
+    const content = await fs.readFile(skillPath, "utf8")
+    expect(content).not.toBe("stale managed content")
+    expect(content).toContain("Skill body")
+
+    const manifest = await readInstallManifest(codexRoot)
+    expect(manifest.skills).toContain("skill-one")
+  })
+
+  test.skipIf(!canFileSymlink)(
+    "preserves a symlinked agent file and leaves its target content untouched",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-preserve-agent-symlink-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+      const forkAgentPath = path.join(tempRoot, "user-fork-agent.toml")
+      await fs.writeFile(forkAgentPath, "# user fork agent content\n")
+
+      const agentsRoot = path.join(codexRoot, "agents", "compound-engineering")
+      await fs.mkdir(agentsRoot, { recursive: true })
+      await fs.symlink(forkAgentPath, path.join(agentsRoot, "ce-foo.toml"))
+
+      const bundle: CodexBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [],
+        generatedSkills: [],
+        agents: [{ name: "ce-foo", description: "Foo agent", instructions: "Do foo." }],
+      }
+
+      await writeCodexBundle(codexRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(agentsRoot, "ce-foo.toml"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(forkAgentPath, "utf8")).toBe("# user fork agent content\n")
+
+      const manifest = await readInstallManifest(codexRoot)
+      expect(manifest.agents).not.toContain("ce-foo.toml")
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
+    "a preserved skill symlink survives a later install run where the skill is dropped from the bundle",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-preserve-skill-symlink-second-run-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+
+      const bundleWithSkill: CodexBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+        generatedSkills: [],
+      }
+
+      // First run: normal managed install, tracked in the manifest.
+      await writeCodexBundle(codexRoot, bundleWithSkill)
+      const manifestAfterFirstRun = await readInstallManifest(codexRoot)
+      expect(manifestAfterFirstRun.skills).toContain("skill-one")
+
+      // User swaps the managed directory for a symlink into a personal fork,
+      // while the on-disk manifest from the first run still claims ownership.
+      const skillsRoot = path.join(codexRoot, "skills", "compound-engineering")
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), "# user fork content\n")
+      await fs.rm(path.join(skillsRoot, "skill-one"), { recursive: true, force: true })
+      await fs.symlink(forkDir, path.join(skillsRoot, "skill-one"), "junction")
+
+      // Second run: the plugin drops the skill from the bundle entirely, which
+      // exercises cleanupRemovedSkills against the stale manifest entry.
+      const bundleWithoutSkill: CodexBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [],
+        generatedSkills: [],
+      }
+      await writeCodexBundle(codexRoot, bundleWithoutSkill)
+
+      const linkStat = await fs.lstat(path.join(skillsRoot, "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe("# user fork content\n")
+
+      const manifestAfterSecondRun = await readInstallManifest(codexRoot)
+      expect(manifestAfterSecondRun.skills).not.toContain("skill-one")
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
+    "a legacy-named skill symlinked to a user fork is not swept into legacy-backup",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-preserve-legacy-skill-symlink-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+
+      // Worst case: the fork keeps the CE fingerprint (name + description), so
+      // the readFile-based ownership check follows the symlink and matches.
+      const forkDir = path.join(tempRoot, "user-fork", "reproduce-bug")
+      await fs.mkdir(forkDir, { recursive: true })
+      const forkContent = skillContent("reproduce-bug", historicalSkillDescription("reproduce-bug"))
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), forkContent)
+
+      await fs.mkdir(path.join(codexRoot, "skills"), { recursive: true })
+      await fs.symlink(forkDir, path.join(codexRoot, "skills", "reproduce-bug"), "junction")
+
+      const plugin = await loadClaudePlugin(path.join(import.meta.dir, ".."))
+      const bundle = convertClaudeToCodex(plugin, {
+        agentMode: "subagent",
+        inferTemperature: true,
+        permissions: "none",
+      })
+      await writeCodexBundle(codexRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(codexRoot, "skills", "reproduce-bug"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe(forkContent)
+
+      const legacyBackupRoot = path.join(codexRoot, "compound-engineering", "legacy-backup")
+      if (await exists(legacyBackupRoot)) {
+        for (const timestamp of await fs.readdir(legacyBackupRoot)) {
+          const skillsBackup = path.join(legacyBackupRoot, timestamp, "skills")
+          if (!(await exists(skillsBackup))) continue
+          expect(await fs.readdir(skillsBackup)).not.toContain("reproduce-bug")
+        }
+      }
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
+    "preserves a dangling skill symlink whose target no longer exists",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-preserve-skill-symlink-dangling-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+
+      // Create the symlink against a real target, then remove the target so
+      // the link dangles. lstat must still see the link node (stat/access
+      // would follow it and report ENOENT, treating the path as absent).
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      const skillsRoot = path.join(codexRoot, "skills", "compound-engineering")
+      await fs.mkdir(skillsRoot, { recursive: true })
+      await fs.symlink(forkDir, path.join(skillsRoot, "skill-one"), "junction")
+      await fs.rm(forkDir, { recursive: true, force: true })
+
+      const bundle: CodexBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+        generatedSkills: [],
+      }
+
+      await writeCodexBundle(codexRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(skillsRoot, "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+
+      const manifest = await readInstallManifest(codexRoot)
+      expect(manifest.skills).not.toContain("skill-one")
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
+    "preserves a symlinked agent sidecar dir when the agent drops its sidecars",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-preserve-agent-sidecar-symlink-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+      const sidecarSource = await fs.mkdtemp(path.join(os.tmpdir(), "codex-sidecar-src-"))
+      await fs.writeFile(path.join(sidecarSource, "script.sh"), "#!/bin/sh\necho hi\n", "utf8")
+
+      const agentWithSidecar: CodexBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [],
+        generatedSkills: [],
+        agents: [
+          {
+            name: "ce-foo",
+            description: "Foo agent",
+            instructions: "Do foo.",
+            sidecarDirs: [{ sourceDir: sidecarSource, targetName: "scripts" }],
+          },
+        ],
+      }
+
+      // First run: managed install with a sidecar dir next to the TOML.
+      await writeCodexBundle(codexRoot, agentWithSidecar)
+
+      // User replaces the sidecar dir with a symlink into a personal fork,
+      // keeping the managed TOML in place.
+      const agentsRoot = path.join(codexRoot, "agents", "compound-engineering")
+      const forkDir = path.join(tempRoot, "user-fork", "ce-foo")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.writeFile(path.join(forkDir, "notes.md"), "# user fork sidecar content\n")
+      await fs.rm(path.join(agentsRoot, "ce-foo"), { recursive: true, force: true })
+      await fs.symlink(forkDir, path.join(agentsRoot, "ce-foo"), "junction")
+
+      // Second run: the agent drops its sidecars, which exercises the
+      // orphan-sidecar rm in the agent write loop against the symlink.
+      const agentWithoutSidecar: CodexBundle = {
+        ...agentWithSidecar,
+        agents: [
+          {
+            name: "ce-foo",
+            description: "Foo agent",
+            instructions: "Do foo.",
+          },
+        ],
+      }
+      await writeCodexBundle(codexRoot, agentWithoutSidecar)
+
+      const linkStat = await fs.lstat(path.join(agentsRoot, "ce-foo"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "notes.md"), "utf8")).toBe("# user fork sidecar content\n")
+      // The managed TOML itself is still owned and rewritten as normal.
+      expect(await exists(path.join(agentsRoot, "ce-foo.toml"))).toBe(true)
+    },
+  )
 })

--- a/tests/opencode-writer.test.ts
+++ b/tests/opencode-writer.test.ts
@@ -341,18 +341,24 @@ describe("writeOpenCodeBundle", () => {
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-cmd-backup-"))
     const outputRoot = path.join(tempRoot, ".opencode")
     const commandsDir = path.join(outputRoot, "commands")
-    await fs.mkdir(commandsDir, { recursive: true })
-
-    const cmdPath = path.join(commandsDir, "my-cmd.md")
-    await fs.writeFile(cmdPath, "old content\n")
 
     const bundle: OpenCodeBundle = {
+      pluginName: "compound-engineering",
       config: { $schema: "https://opencode.ai/config.json" },
       agents: [],
       plugins: [],
       commandFiles: [{ name: "my-cmd", content: "---\ndescription: New\n---\n\nNew content." }],
       skillDirs: [],
     }
+
+    // First install establishes ownership of my-cmd.md in the install
+    // manifest -- an unowned pre-existing file would be preserved, not
+    // backed up and overwritten.
+    await writeOpenCodeBundle(outputRoot, bundle)
+
+    const cmdPath = path.join(commandsDir, "my-cmd.md")
+    // Simulate drift between two installs: same managed file, stale content.
+    await fs.writeFile(cmdPath, "old content\n")
 
     await writeOpenCodeBundle(outputRoot, bundle)
 
@@ -628,6 +634,337 @@ describe("writeOpenCodeBundle", () => {
     )
     expect(preserved.pluginName).toBe("some-other-plugin")
   })
+})
+
+// Probed at module load (not beforeAll) because test.skipIf evaluates its
+// condition at registration time. Directory and file symlinks are probed
+// separately: on Windows without Developer Mode, junctions succeed while
+// file symlinks throw EPERM.
+async function probeSymlinkSupport(): Promise<{ canDirSymlink: boolean; canFileSymlink: boolean }> {
+  const probeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-symlink-probe-"))
+  const probeTarget = path.join(probeRoot, "target")
+  await fs.mkdir(probeTarget, { recursive: true })
+  let canDirSymlink = true
+  try {
+    await fs.symlink(probeTarget, path.join(probeRoot, "link"), "junction")
+  } catch {
+    canDirSymlink = false
+  }
+  const probeFile = path.join(probeRoot, "target.md")
+  await fs.writeFile(probeFile, "probe")
+  let canFileSymlink = true
+  try {
+    await fs.symlink(probeFile, path.join(probeRoot, "link.md"))
+  } catch {
+    canFileSymlink = false
+  }
+  return { canDirSymlink, canFileSymlink }
+}
+
+const { canDirSymlink, canFileSymlink } = await probeSymlinkSupport()
+
+describe("writeOpenCodeBundle preserves user-managed skill and command paths", () => {
+  async function readInstallManifest(outputRoot: string): Promise<{ groups: Record<string, string[]> }> {
+    const raw = await fs.readFile(
+      path.join(outputRoot, "compound-engineering", "install-manifest.json"),
+      "utf8",
+    )
+    return JSON.parse(raw) as { groups: Record<string, string[]> }
+  }
+
+  test.skipIf(!canDirSymlink)(
+    "preserves a symlinked skill directory and leaves its target content untouched",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-preserve-skill-symlink-"))
+      const outputRoot = path.join(tempRoot, ".opencode")
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), "# user fork content\n")
+
+      await fs.mkdir(path.join(outputRoot, "skills"), { recursive: true })
+      await fs.symlink(forkDir, path.join(outputRoot, "skills", "skill-one"), "junction")
+
+      const bundle: OpenCodeBundle = {
+        pluginName: "compound-engineering",
+        config: { $schema: "https://opencode.ai/config.json" },
+        agents: [],
+        plugins: [],
+        commandFiles: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+      }
+
+      await writeOpenCodeBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills", "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe("# user fork content\n")
+
+      const manifest = await readInstallManifest(outputRoot)
+      expect(manifest.groups.skills).not.toContain("skill-one")
+    },
+  )
+
+  test("preserves an unmanaged real skill directory (not previously owned by this tool)", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-preserve-skill-unmanaged-"))
+    const outputRoot = path.join(tempRoot, ".opencode")
+
+    await fs.mkdir(path.join(outputRoot, "skills", "skill-one"), { recursive: true })
+    await fs.writeFile(
+      path.join(outputRoot, "skills", "skill-one", "SKILL.md"),
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const bundle: OpenCodeBundle = {
+      pluginName: "compound-engineering",
+      config: { $schema: "https://opencode.ai/config.json" },
+      agents: [],
+      plugins: [],
+      commandFiles: [],
+      skillDirs: [
+        {
+          name: "skill-one",
+          sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+        },
+      ],
+    }
+
+    await writeOpenCodeBundle(outputRoot, bundle)
+
+    expect(await fs.readFile(path.join(outputRoot, "skills", "skill-one", "SKILL.md"), "utf8")).toBe(
+      "# hand-authored, never installed by this tool\n",
+    )
+
+    const manifest = await readInstallManifest(outputRoot)
+    expect(manifest.groups.skills).not.toContain("skill-one")
+  })
+
+  test("still replaces a real skill directory previously installed by this tool", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-replace-managed-skill-"))
+    const outputRoot = path.join(tempRoot, ".opencode")
+
+    const bundle: OpenCodeBundle = {
+      pluginName: "compound-engineering",
+      config: { $schema: "https://opencode.ai/config.json" },
+      agents: [],
+      plugins: [],
+      commandFiles: [],
+      skillDirs: [
+        {
+          name: "skill-one",
+          sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+        },
+      ],
+    }
+
+    await writeOpenCodeBundle(outputRoot, bundle)
+    // Simulate drift between two installs: same managed dir, different upstream content.
+    await fs.writeFile(path.join(outputRoot, "skills", "skill-one", "SKILL.md"), "stale managed content")
+
+    await writeOpenCodeBundle(outputRoot, bundle)
+
+    const content = await fs.readFile(path.join(outputRoot, "skills", "skill-one", "SKILL.md"), "utf8")
+    expect(content).not.toBe("stale managed content")
+    expect(content).toContain("Skill body")
+
+    const manifest = await readInstallManifest(outputRoot)
+    expect(manifest.groups.skills).toContain("skill-one")
+  })
+
+  test.skipIf(!canDirSymlink)(
+    "a preserved skill symlink survives a later install run where the skill is dropped from the bundle",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-preserve-skill-symlink-second-run-"))
+      const outputRoot = path.join(tempRoot, ".opencode")
+
+      const bundleWithSkill: OpenCodeBundle = {
+        pluginName: "compound-engineering",
+        config: { $schema: "https://opencode.ai/config.json" },
+        agents: [],
+        plugins: [],
+        commandFiles: [],
+        skillDirs: [
+          {
+            name: "skill-one",
+            sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one"),
+          },
+        ],
+      }
+
+      // First run: normal managed install, tracked in the manifest.
+      await writeOpenCodeBundle(outputRoot, bundleWithSkill)
+      const manifestAfterFirstRun = await readInstallManifest(outputRoot)
+      expect(manifestAfterFirstRun.groups.skills).toContain("skill-one")
+
+      // User swaps the managed directory for a symlink into a personal fork,
+      // while the on-disk manifest from the first run still claims ownership.
+      const forkDir = path.join(tempRoot, "user-fork", "skill-one")
+      await fs.mkdir(forkDir, { recursive: true })
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), "# user fork content\n")
+      await fs.rm(path.join(outputRoot, "skills", "skill-one"), { recursive: true, force: true })
+      await fs.symlink(forkDir, path.join(outputRoot, "skills", "skill-one"), "junction")
+
+      // Second run: the plugin drops the skill from the bundle entirely, which
+      // exercises cleanupRemovedManagedDirectories against the stale manifest
+      // entry.
+      const bundleWithoutSkill: OpenCodeBundle = {
+        pluginName: "compound-engineering",
+        config: { $schema: "https://opencode.ai/config.json" },
+        agents: [],
+        plugins: [],
+        commandFiles: [],
+        skillDirs: [],
+      }
+      await writeOpenCodeBundle(outputRoot, bundleWithoutSkill)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills", "skill-one"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe("# user fork content\n")
+
+      const manifestAfterSecondRun = await readInstallManifest(outputRoot)
+      expect(manifestAfterSecondRun.groups.skills).not.toContain("skill-one")
+    },
+  )
+
+  test.skipIf(!canFileSymlink)(
+    "preserves a symlinked agent file and leaves its target content untouched",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-preserve-agent-symlink-"))
+      const outputRoot = path.join(tempRoot, ".opencode")
+      const forkAgentPath = path.join(tempRoot, "user-fork-agent.md")
+      await fs.writeFile(forkAgentPath, "# user fork agent content\n")
+
+      await fs.mkdir(path.join(outputRoot, "agents"), { recursive: true })
+      await fs.symlink(forkAgentPath, path.join(outputRoot, "agents", "agent-one.md"))
+
+      const bundle: OpenCodeBundle = {
+        pluginName: "compound-engineering",
+        config: { $schema: "https://opencode.ai/config.json" },
+        agents: [{ name: "agent-one", content: "Agent content" }],
+        plugins: [],
+        commandFiles: [],
+        skillDirs: [],
+      }
+
+      await writeOpenCodeBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "agents", "agent-one.md"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(forkAgentPath, "utf8")).toBe("# user fork agent content\n")
+
+      const manifest = await readInstallManifest(outputRoot)
+      expect(manifest.groups.agents).not.toContain("agent-one.md")
+    },
+  )
+
+  test.skipIf(!canFileSymlink)(
+    "preserves a symlinked plugin file and leaves its target content untouched",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-preserve-plugin-symlink-"))
+      const outputRoot = path.join(tempRoot, ".opencode")
+      const forkPluginPath = path.join(tempRoot, "user-fork-plugin.ts")
+      await fs.writeFile(forkPluginPath, "// user fork plugin content\n")
+
+      await fs.mkdir(path.join(outputRoot, "plugins"), { recursive: true })
+      await fs.symlink(forkPluginPath, path.join(outputRoot, "plugins", "hook.ts"))
+
+      const bundle: OpenCodeBundle = {
+        pluginName: "compound-engineering",
+        config: { $schema: "https://opencode.ai/config.json" },
+        agents: [],
+        plugins: [{ name: "hook.ts", content: "export {}" }],
+        commandFiles: [],
+        skillDirs: [],
+      }
+
+      await writeOpenCodeBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "plugins", "hook.ts"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(forkPluginPath, "utf8")).toBe("// user fork plugin content\n")
+
+      const manifest = await readInstallManifest(outputRoot)
+      expect(manifest.groups.plugins).not.toContain("hook.ts")
+    },
+  )
+
+  test.skipIf(!canFileSymlink)(
+    "preserves a symlinked command file and leaves its target content untouched",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-preserve-command-symlink-"))
+      const outputRoot = path.join(tempRoot, ".opencode")
+      const forkCommandPath = path.join(tempRoot, "user-fork-command.md")
+      await fs.writeFile(forkCommandPath, "# user fork command content\n")
+
+      await fs.mkdir(path.join(outputRoot, "commands"), { recursive: true })
+      await fs.symlink(forkCommandPath, path.join(outputRoot, "commands", "my-cmd.md"))
+
+      const bundle: OpenCodeBundle = {
+        pluginName: "compound-engineering",
+        config: { $schema: "https://opencode.ai/config.json" },
+        agents: [],
+        plugins: [],
+        commandFiles: [{ name: "my-cmd", content: "New content." }],
+        skillDirs: [],
+      }
+
+      await writeOpenCodeBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "commands", "my-cmd.md"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(forkCommandPath, "utf8")).toBe("# user fork command content\n")
+      // No stray backup should have been created either -- the guard must
+      // fire before the pre-write backupFile call, not just before the write.
+      const files = await fs.readdir(path.join(outputRoot, "commands"))
+      expect(files.some((file) => file.startsWith("my-cmd.md.bak."))).toBe(false)
+
+      const manifest = await readInstallManifest(outputRoot)
+      expect(manifest.groups.commands).not.toContain("my-cmd.md")
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
+    "a legacy-named skill symlinked to a user fork is not swept into legacy-backup",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-preserve-legacy-skill-symlink-"))
+      const outputRoot = path.join(tempRoot, ".opencode")
+
+      // Worst case: the fork keeps the CE fingerprint (name + description), so
+      // the readFile-based ownership check follows the symlink and matches.
+      const forkDir = path.join(tempRoot, "user-fork", "reproduce-bug")
+      await fs.mkdir(forkDir, { recursive: true })
+      const forkContent = skillContent("reproduce-bug", REPRODUCE_BUG_DESCRIPTION)
+      await fs.writeFile(path.join(forkDir, "SKILL.md"), forkContent)
+
+      await fs.mkdir(path.join(outputRoot, "skills"), { recursive: true })
+      await fs.symlink(forkDir, path.join(outputRoot, "skills", "reproduce-bug"), "junction")
+
+      const plugin = await loadClaudePlugin(path.join(import.meta.dir, ".."))
+      const bundle = convertClaudeToOpenCode(plugin, {
+        agentMode: "subagent",
+        inferTemperature: true,
+        permissions: "none",
+      })
+      await writeOpenCodeBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills", "reproduce-bug"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await fs.readFile(path.join(forkDir, "SKILL.md"), "utf8")).toBe(forkContent)
+
+      const legacyBackupRoot = path.join(outputRoot, "compound-engineering", "legacy-backup")
+      if (await exists(legacyBackupRoot)) {
+        for (const timestamp of await fs.readdir(legacyBackupRoot)) {
+          const skillsBackup = path.join(legacyBackupRoot, timestamp, "skills")
+          if (!(await exists(skillsBackup))) continue
+          expect(await fs.readdir(skillsBackup)).not.toContain("reproduce-bug")
+        }
+      }
+    },
+  )
 })
 
 describe("mergeJsonConfigAtKey", () => {


### PR DESCRIPTION
## Summary

The user-managed-symlink preservation that #1089 gave the Pi writer now covers the Codex and OpenCode writers and the shared cleanup plumbing — closing the "same pattern in two other writers" gap that PR's scope notes disclosed. Before this, `install --to codex` and `install --to opencode` still replaced a user's symlink override (or manually authored path) with a fresh upstream copy, and the standalone `cleanup` command could relocate a user's symlink node into `legacy-backup` on all eight of its targets, because every one of those paths funnels through one unguarded `fs.rename` in `managed-artifacts.ts`. Codex agent files were the worst case: written with no existence check of any kind.

Related: #1048.

## Fix

Same four-row contract as #1089, applied per writer:

| Existing path state | Behavior |
|---|---|
| Doesn't exist | Create fresh (unchanged) |
| Real path recorded in the target's install manifest | Replace (unchanged) |
| Real path not in the manifest | Preserve, warn, skip the write |
| Symlink to anything, including dangling | Preserve, warn, skip the write |

- **`managed-artifacts.ts`** now owns the shared `lstatOrNull` / `isPreservedSymlink` helpers, and guards `cleanupCurrentManagedDirectory`, both removed-entry sweeps, and `moveLegacyArtifactToBackup`. That last one is the highest-leverage line in the PR: it protects the OpenCode and Kiro legacy sweeps and every target of the standalone `cleanup` command (codex/opencode/pi/kiro/copilot/droid/qwen/windsurf) in one place.
- **`codex.ts`** gets the pi-shaped guards across its skill loops, removed-entry sweeps, legacy backup, and previous-store cleanup — plus a new `cleanupCurrentManagedAgentFile`, since agent `.toml` writes previously had no existence check at all, and a guard on the orphan-sidecar `fs.rm` in the agent write loop (the one destructive write-path op the first pass missed — its twin in `cleanupRemovedAgents` was already guarded). Preserved names are excluded from the written manifest. Its local `moveLegacyArtifactToBackup` stays separate from the shared one (backup-path shapes differ materially) and gets the same guard.
- **`opencode.ts`** applies the full contract to skills, agents, commands, and plugins — all four have ownership records in the manifest's `groups` map. For commands the guard runs *before* `backupFile`, which otherwise copies through the symlink and then overwrites through it, corrupting the fork while producing a "backup" of the fork's own content.
- **`pi.ts`** drops its private helper copies and imports the shared ones. No behavior change; its 20 preservation tests pass unmodified.

## One design decision reviewers should weigh

`moveLegacyArtifactToBackup` accepts an explicit `skipSymlinkGuard: true` escape hatch, used by exactly one caller: `moveIfSymlinkManaged` in the `cleanup` command's `~/.agents/skills/` sweep. That sweep's entire job is relocating symlinks — but only after `isManagedCodexAgentsSymlink` verifies the link *resolves inside a CE-managed root*, a strictly stronger ownership signal than the blanket guard. Without the hatch, the new guard broke that legitimate relocation (caught by the existing `cleanup only backs up CE-owned symlinks` test mid-implementation). The invariant is documented at the parameter definition; a repo-wide grep confirms the single call site. The alternative — having that caller do its own rename — was considered and rejected as duplicating the backup-path logic for no added safety.

## Verification

- 16 new tests (7 codex, 8 opencode, 1 shared-path dangling-symlink case) mirroring the #1089 test patterns: symlinked sidecar surviving an agent that drops its sidecars, fork content untouched, manifest exclusion, managed paths still replaced, preserved symlinks surviving a second run against a stale manifest, legacy sweep sparing a symlink whose content matches the ownership fingerprint, and commands producing no `.bak` churn when preserved.
- Red-green: with the `src/` changes stashed, 9 of the initially added 11 tests fail (the two "still replaces" positive rows pass either way); restored, all pass.
- Codex-agent freeze risk (the question raised on #1089 for Pi) checked against git history: the `.toml` agent write and its manifest tracking landed in the same commit (`c2d60b47`, #609) — before it, Codex emitted agents as skill dirs — so no released version wrote a codex agent file without recording it, and the preserve branch can only fire on genuinely user-authored files.
- Full `bun test` failure count identical to unmodified main on the same machine (pre-existing, environment-related set; verified by name-level diff, not count alone).

## Scope notes

- `kiro.ts`'s legacy sweep inherits the symlink guard through the shared `moveLegacyArtifactToBackup` — intentional and contract-consistent, though the Kiro writer itself is currently unreachable from the CLI (not registered in `targets/index.ts`).
- Codex **prompt** files (`~/.codex/prompts/<name>.md`) remain unguarded bare writes — pre-existing, and the Pi reference implementation has the same surface, so aligning both is left as a follow-up rather than widening this PR's contract.
- `antigravity.ts` has no manifest/ownership concept at all (every write unconditional); giving it preservation needs a design decision about what "owned" means there, not a mirror of this pattern.
- **Ancestor-symlink traversal is a known remaining class, deliberately out of scope.** All guards here (and in the merged Pi fix) inspect the *leaf* node; `lstat` follows every ancestor. A user who symlinks a whole store directory (e.g. `~/.codex/skills/<plugin>` → a fork) still has `fs.rm`/copy operate through the parent link into the fork. This predates both PRs, affects every writer including Pi, and the right fix is a containment check (realpath-inside-managed-root before any destructive op) applied uniformly — a design change, not a mirror of this leaf contract. Adversarial review surfaced it during this PR's pre-flight; flagging it here so it's tracked rather than discovered.
- Same pre-existing family, lower stakes: a store root that is a *dangling* symlink makes the writer's initial `ensureDir` throw and abort the install (crash, no data loss).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)
