### PR TITLE
fix(ce-test-browser): prefer host-native browser drivers

### DIFF
--- a/docs/plans/2026-07-09-001-fix-ce-test-browser-native-driver-plan.md
+++ b/docs/plans/2026-07-09-001-fix-ce-test-browser-native-driver-plan.md
@@ -1,0 +1,95 @@
+# Native Browser Driver Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `ce-test-browser` prefer a capable host-native integrated browser, fall back to `agent-browser`, and continue rejecting ad hoc standalone browser automation.
+
+**Architecture:** Separate browser-driver selection from manual versus pipeline orchestration. Select one qualifying driver before testing, express the test loop in driver-neutral operations, and keep `agent-browser` commands in a conditional reference used only by the fallback path.
+
+**Tech Stack:** Markdown skill instructions, Bun contract tests.
+
+## Global Constraints
+
+- Host-native means a browser-control surface embedded in or directly owned by the active harness, not a separately configured browser extension or MCP or a newly installed automation stack.
+- A host-native API named Playwright remains host-native; standalone Playwright and Puppeteer are prohibited substitutes.
+- Pipeline mode controls prompting and server orchestration, not driver choice or visibility.
+- Once selected, one browser driver owns the entire run.
+
+---
+
+### Task 1: Pin the browser-driver policy
+
+**Files:**
+- Create: `tests/ce-test-browser-driver-policy.test.ts`
+- Modify: `skills/ce-test-browser/SKILL.md`
+- Modify: `skills/ce-test-browser/references/pipeline-orchestration.md`
+
+**Interfaces:**
+- Consumes: the existing `ce-test-browser` manual and `mode:pipeline` workflows.
+- Produces: a native-first, `agent-browser`-fallback driver-selection contract used by every browser action.
+
+- [ ] **Step 1: Write the failing contract tests**
+
+Assert that the skill prefers a capable host-native browser, falls back to `agent-browser`, treats embedded Playwright APIs as native, prohibits standalone alternatives, keeps one driver per run, and does not make pipeline mode force `agent-browser` or hidden execution.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run: `bun test tests/ce-test-browser-driver-policy.test.ts`
+
+Expected: failures showing the current categorical `agent-browser` mandate and pipeline-specific command wording violate the new contract.
+
+- [ ] **Step 3: Implement the minimal skill policy**
+
+Replace the categorical mandate with capability-based selection, rewrite browser actions as driver-neutral operations, and move CLI-specific command recipes into a new conditional reference.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run: `bun test tests/ce-test-browser-driver-policy.test.ts`
+
+Expected: all policy tests pass.
+
+### Task 2: Align user-facing documentation
+
+**Files:**
+- Modify: `docs/skills/ce-test-browser.md`
+- Modify: `docs/skills/README.md`
+
+**Interfaces:**
+- Consumes: the driver-selection contract from Task 1.
+- Produces: accurate skill catalog and detailed documentation for native and fallback behavior.
+
+- [ ] **Step 1: Remove exclusive-agent-browser claims**
+
+Document host-native selection, the portable fallback, one-driver-per-run behavior, and visible-but-non-blocking integrated browser execution.
+
+- [ ] **Step 2: Run focused and convention tests**
+
+Run: `bun test tests/ce-test-browser-driver-policy.test.ts tests/skill-conventions.test.ts`
+
+Expected: all tests pass.
+
+### Task 3: Verify and compound the learning
+
+**Files:**
+- Create: `docs/solutions/architecture-patterns/host-native-browser-driver-selection.md`
+- Optionally update: `CONCEPTS.md` when `ce-compound` vocabulary criteria qualify a term.
+
+**Interfaces:**
+- Consumes: verified implementation and the design decisions from this plan.
+- Produces: grounded durable guidance about separating harness-native capabilities from substitute automation tools.
+
+- [ ] **Step 1: Run repository validation**
+
+Run: `bun test` and `bun run release:validate`
+
+Expected: both commands exit successfully.
+
+- [ ] **Step 2: Run `ce-compound` in headless mode**
+
+Capture one knowledge-track learning: browser-driver policy should distinguish first-class host-native capabilities from ad hoc substitute tooling, while keeping orchestration mode independent from driver visibility.
+
+- [ ] **Step 3: Validate the compounded document**
+
+Run the `ce-compound` frontmatter and grounded-claim validators required by that skill, then re-run the focused contract test.
+
+Expected: documentation validation and the focused policy test pass.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -120,7 +120,7 @@ Invoked when a specific need arises — not part of any chain.
 | [`/ce-promote`](./ce-promote.md) | Draft user-facing announcement copy for a shipped feature (X, changelog, LinkedIn, email) — voice-matched via the optional Spiral CLI, a lite layer of editorial & social expertise without it, drafts only |
 | [`/ce-resolve-pr-feedback`](./ce-resolve-pr-feedback.md) | Evaluate, fix, and reply to PR review feedback in parallel — including nitpicks |
 | [`/ce-dogfood`](./ce-dogfood.md) | Hands-off diff-scoped browser QA of the active branch — maps flows, autonomously fixes small breakages with regression tests and commits, writes a durable report (manual invocation only) |
-| [`/ce-test-browser`](./ce-test-browser.md) | End-to-end browser tests on PR / branch-affected pages using `agent-browser` exclusively |
+| [`/ce-test-browser`](./ce-test-browser.md) | End-to-end browser tests using a host-native browser with `agent-browser` fallback |
 | [`/ce-test-xcode`](./ce-test-xcode.md) | Build and test iOS apps on simulator using XcodeBuildMCP — screenshots, logs, human verification |
 | [`/ce-setup`](./ce-setup.md) | Diagnose optional tool capabilities and bootstrap safe project-local config |
 

--- a/docs/skills/ce-dogfood.md
+++ b/docs/skills/ce-dogfood.md
@@ -73,7 +73,7 @@ A green browser matrix with a red test suite is not "ready." Before the verdict,
 
 ## `ce-dogfood` vs `ce-test-browser`
 
-Both take a PR / branch and drive `agent-browser` over diff-affected pages. Pick by what you want at the end:
+Both take a PR / branch and drive a browser over diff-affected pages. `ce-test-browser` prefers a capable host-native browser and falls back to `agent-browser`; `ce-dogfood` currently requires `agent-browser`. Pick by what you want at the end:
 
 | | `ce-test-browser` | `ce-dogfood` |
 |---|---|---|

--- a/docs/skills/ce-setup.md
+++ b/docs/skills/ce-setup.md
@@ -125,6 +125,6 @@ Yes. When the bundled health script is not directly runnable, the skill falls ba
 
 ## See Also
 
-- [`/ce-test-browser`](./ce-test-browser.md) — uses `agent-browser` for browser testing
+- [`/ce-test-browser`](./ce-test-browser.md) — uses `agent-browser` when no capable host-native browser is available
 - [`/ce-dogfood`](./ce-dogfood.md) — uses `agent-browser` for diff-scoped QA
 - [`/ce-product-pulse`](./ce-product-pulse.md) — uses `.compound-engineering/config.local.yaml` for pulse settings

--- a/docs/skills/ce-test-browser.md
+++ b/docs/skills/ce-test-browser.md
@@ -1,8 +1,8 @@
 # `ce-test-browser`
 
-> Run end-to-end browser tests on pages affected by current PR or branch — uses `agent-browser` exclusively.
+> Run end-to-end browser tests on pages affected by the current PR or branch using the best approved browser driver available.
 
-`ce-test-browser` is the **end-to-end browser testing** skill. It maps changed files to testable routes, starts (or verifies) the dev server, navigates to each affected page via `agent-browser`, captures snapshots and screenshots, exercises critical interactions, pauses for human verification on flows that require external interaction (OAuth, email, payments, SMS), and produces a structured test summary. Headed mode lets you watch tests run; headless is faster and runs in the background.
+`ce-test-browser` is the **end-to-end browser testing** skill. It maps changed files to testable routes, starts (or verifies) the dev server, drives each affected page through a host-native integrated browser when available, and falls back to `agent-browser` elsewhere. It captures rendered state and screenshots, exercises critical interactions, pauses for human verification on external flows, and produces a structured test summary.
 
 ---
 
@@ -10,7 +10,7 @@
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Maps changed files to routes, navigates each via agent-browser, captures snapshots and screenshots, asks for human verification on external-flow steps |
+| What does it do? | Maps changed files to routes, selects an approved browser driver, captures rendered state and screenshots, and asks for human verification on external-flow steps |
 | When to use it | After UI changes, before opening a PR, when verifying page behavior on a branch or PR |
 | What it produces | Per-page status table, console errors, human verifications confirmed, screenshots, overall result (PASS / FAIL / PARTIAL) |
 | Modes | Manual (default; user controls server), Pipeline (`mode:pipeline` — auto-starts server, scans for free port) |
@@ -21,7 +21,7 @@
 
 End-to-end browser testing is fragmented across tools and easy to skip:
 
-- **Wrong browser tool** — Playwright, Puppeteer, MCP Chrome, IDE built-ins; each works differently
+- **Wrong browser fallback** — a missing preferred driver can tempt agents to install standalone Playwright, Puppeteer, or ad hoc automation instead of using a supported host capability
 - **Manual test mapping** — figuring out "which routes did this PR affect" is its own task
 - **Server orchestration** — tests fail because the dev server wasn't running, or the wrong port, or stale state
 - **Console errors silently slip through** — the page renders fine but JS errors pile up unnoticed
@@ -32,7 +32,7 @@ End-to-end browser testing is fragmented across tools and easy to skip:
 
 `ce-test-browser` runs end-to-end tests as a structured flow:
 
-- **`agent-browser` exclusively** — one tool, predictable behavior; never falls back to Chrome MCP or IDE-specific browser tools
+- **Approved driver hierarchy** — prefer a host-native integrated browser, then fall back to `agent-browser`; never introduce a third standalone automation stack
 - **File-to-route mapping** translates changed files into the URLs that need testing
 - **Server orchestration** — manual mode requires the user-started server; pipeline mode auto-starts and scans for a free port
 - **Per-page test loop** — navigate, snapshot, verify elements, exercise critical interactions, capture screenshots
@@ -44,16 +44,16 @@ End-to-end browser testing is fragmented across tools and easy to skip:
 
 ## What Makes It Novel
 
-### 1. `agent-browser` exclusively
+### 1. Host-native first, portable fallback
 
-The skill enforces a single browser-automation substrate: **the `agent-browser` CLI**. Not Chrome MCP, not IDE built-ins, not alternative browser-control tools. Specific reasons:
+The skill distinguishes browser surfaces embedded in or directly owned by the active harness from separately configured substitute tooling:
 
-- Predictable behavior — one tool's quirks, not three
-- Same commands work in headed and headless modes
-- Same snapshot/click/screenshot pattern across all tests
-- Platform-specific hints (e.g., "in Claude Code, do not use `mcp__claude-in-chrome__*`") are explicit
+- A capable host-native integrated browser is preferred because it keeps testing inside the harness and can provide a visible, non-blocking surface the user may watch.
+- Harnesses without that capability fall back to the portable `agent-browser` CLI.
+- Once selected, one driver owns navigation, element state, screenshots, console inspection, and authentication for the entire run.
+- Standalone Playwright, Puppeteer, separately configured browser extensions or MCPs, and ad hoc browser automation remain prohibited substitutes.
 
-When `agent-browser` isn't installed, the skill stops and points to `/ce-setup` for the current install command — it doesn't try to fall back.
+A Playwright API exposed by a host-native browser remains part of that integrated capability; it is not standalone Playwright. When no qualifying native browser exists and `agent-browser` is not installed, the skill stops and points to `/ce-setup`.
 
 ### 2. File-to-route mapping table
 
@@ -74,10 +74,10 @@ This is a starting point, not exhaustive — the skill applies judgment for proj
 
 ### 3. Two modes — Manual (default) and Pipeline
 
-| Mode | Server | Port | Browser default |
+| Mode | Server | Port | Browser behavior |
 |------|--------|------|-----------------|
-| **Manual** _(default)_ | User-started | Use preferred port as-is; user controls | Asks: headed or headless |
-| **Pipeline** _(`mode:pipeline`)_ | Auto-started in background | Scans for free port; never assumes 3000 is free | Defaults to headless |
+| **Manual** _(default)_ | User-started | Use preferred port as-is; user controls | Native browser stays integrated and observable; `agent-browser` asks headed or headless |
+| **Pipeline** _(`mode:pipeline`)_ | Auto-started in background | Scans for free port; never assumes 3000 is free | No prompts; native browser remains visible and non-blocking, while `agent-browser` runs headless |
 
 Pipeline mode exists for LFG and other automated runners where multiple agents may be on the same machine and 3000 might be claimed.
 
@@ -93,9 +93,9 @@ The preferred port comes from a priority list:
 
 In pipeline mode, the skill verifies that port is actually free and scans upward if not. In manual mode, it uses the preferred port as-is — the user controls their own server.
 
-### 5. Headed vs headless choice
+### 5. Visibility is separate from orchestration
 
-In manual mode, the skill asks whether to run **headed** (visible browser, watch tests run) or **headless** (faster, runs in background). Headed mode is useful when you're iterating on a tricky interaction and need to see what's happening. Headless is faster for routine sweeps.
+Unattended does not mean hidden. A host-native integrated browser keeps its normal visible and non-blocking experience in both manual and pipeline runs, so the user can watch without interrupting progress. Only the `agent-browser` fallback needs a headed/headless choice in manual mode; pipeline mode runs that fallback headless without asking.
 
 ### 6. Human verification for external flows
 
@@ -135,11 +135,11 @@ Suitable for pasting into a PR description as test evidence.
 
 You finish a notification settings page and a layout change. You invoke `/ce-test-browser`.
 
-The skill verifies `agent-browser` is installed. Asks whether to run headed or headless — you pick headed (you want to watch). Determines test scope from `git diff --name-only main...HEAD`: `app/views/layouts/application.html.erb`, `app/views/settings/notifications.html.erb`, `app/javascript/controllers/notification_toggle_controller.js`.
+The skill detects a capable host-native integrated browser and selects it for the run. It determines test scope from `git diff --name-only main...HEAD`: `app/views/layouts/application.html.erb`, `app/views/settings/notifications.html.erb`, `app/javascript/controllers/notification_toggle_controller.js`.
 
 Maps to routes: `/` (layout change affects every page; test homepage), `/settings/notifications` (the new page), and other pages that render the toggle controller. Detects port 3000 from `bin/dev` config; verifies the user's dev server is running on that port.
 
-Tests each route: opens with `agent-browser open`, calls `agent-browser snapshot -i` for the interactive element list, verifies primary content rendered. Takes screenshots. Exercises the toggle on `/settings/notifications` (`agent-browser click @e3`).
+It tests each route in the integrated browser: navigates, inspects the rendered and interactive state, verifies primary content, checks console errors, takes screenshots, and exercises the notification toggle. The browser remains visible and non-blocking, so you can switch to it and watch without pausing the run.
 
 The settings flow includes an OAuth sign-in step in this app — when the test reaches a protected route, the skill pauses for human verification: "Please sign in with Google and confirm the redirect back works." You do it on the visible browser; answer yes.
 
@@ -159,7 +159,7 @@ Reach for `ce-test-browser` when:
 Skip `ce-test-browser` when:
 
 - The change is backend-only (no observable browser-visible behavior)
-- `agent-browser` isn't installed → run `/ce-setup` first
+- Neither a capable host-native browser nor `agent-browser` is available
 - You want unit / integration tests, not E2E → use the project's test runner
 - The dev server can't be brought up locally (cloud-only setup) → use a different testing approach
 
@@ -199,24 +199,24 @@ When the dev server isn't running in manual mode, the skill informs the user wit
 | `<branch name>` | Tests that branch's affected routes |
 | `current` | Tests current branch (explicit) |
 | `--port <number>` | Override port detection |
-| `mode:pipeline` | Auto-start server, scan for free port, default headless |
+| `mode:pipeline` | Auto-start server, scan for free port, suppress browser questions |
 
-Required: `agent-browser` CLI installed (run `/ce-setup` if missing). Local dev server running (manual mode) or available start command (pipeline mode).
+Required: a qualifying host-native integrated browser or the `agent-browser` CLI. The local dev server must be running in manual mode or have an available start command in pipeline mode.
 
-Key `agent-browser` commands the skill uses: `open <url>`, `snapshot -i` (interactive elements with refs `@e1`, `@e2`), `click @ref`, `fill @ref "text"`, `screenshot out.png`, `screenshot --full`, `--headed` flag for visible browser.
+The selected driver must support local navigation, rendered and interactive state inspection, click/fill/press actions, screenshots, and console-error inspection. Driver-specific mechanics come from the host-native browser's own instructions or the skill's `agent-browser` fallback reference.
 
 ---
 
 ## FAQ
 
-**Why `agent-browser` exclusively?**
-Predictable behavior across platforms and modes. Falling back to Chrome MCP or IDE built-ins means three tools' quirks instead of one. The skill is explicit about it: do not use `mcp__claude-in-chrome__*` in Claude Code; do not substitute unrelated browsing tools in Codex.
+**Why not require `agent-browser` everywhere?**
+A host-native integrated browser is materially different from an arbitrary substitute automation stack: it is embedded in or directly owned by the harness, follows that harness's browser instructions, and can provide a better observable experience. A separately configured browser extension or integration does not qualify. `agent-browser` remains the consistent fallback for CLI environments and harnesses without an integrated browser.
 
-**Headed or headless?**
-Headed when you're iterating on a tricky interaction and need to see what's happening. Headless when you want speed for a routine sweep. Manual mode asks; pipeline mode defaults to headless.
+**What alternatives remain prohibited?**
+The skill does not install or switch to standalone Playwright, Puppeteer, separately configured browser extensions or MCPs, or ad hoc browser automation. An API named Playwright inside the selected host-native browser is still part of that browser, not a standalone substitution.
 
 **What does pipeline mode do differently?**
-Pipeline mode is for automated runners (LFG, multi-agent on the same machine) where 3000 might be claimed. It scans for a free port starting from the preferred one, auto-starts the dev server in the background, defaults to headless, and skips the headed/headless question.
+Pipeline mode is for automated runners such as LFG where the preferred port might be claimed. It scans for a free port, auto-starts the dev server, suppresses blocking questions, and skips human-only flows. It does not change driver selection or force a host-native browser to be hidden.
 
 **What if my project layout doesn't match the file-to-route table?**
 The mapping table is a starting point. The skill applies judgment for project-specific layouts. You can also test specific routes directly by adjusting the test scope detection — e.g., reviewing a known-affected route by passing the branch name.

--- a/docs/skills/ce-test-xcode.md
+++ b/docs/skills/ce-test-xcode.md
@@ -215,6 +215,6 @@ The skill captures build errors and reports them with specific details. It doesn
 ## See Also
 
 - [`ce-code-review`](./ce-code-review.md) — can spawn this skill for iOS-touching PRs as a verification step
-- [`ce-test-browser`](./ce-test-browser.md) — sibling skill for web-app testing via agent-browser
+- [`ce-test-browser`](./ce-test-browser.md) — sibling skill for web-app testing via a host-native browser or `agent-browser` fallback
 - [`ce-commit-push-pr`](./ce-commit-push-pr.md) — can include user-supplied evidence or summarize validation in PR descriptions
 - [`ce-work`](./ce-work.md) — orchestrator that may invoke this skill during Phase 3 verification

--- a/docs/solutions/architecture-patterns/host-native-browser-driver-selection.md
+++ b/docs/solutions/architecture-patterns/host-native-browser-driver-selection.md
@@ -1,0 +1,78 @@
+---
+title: "Separate host-native browser capabilities from portable fallbacks"
+date: 2026-07-09
+category: architecture-patterns
+module: skills/ce-test-browser
+problem_type: architecture_pattern
+component: development_workflow
+severity: medium
+applies_when:
+  - "A cross-platform skill needs browser automation across app and CLI harnesses"
+  - "An unattended workflow still runs inside a harness with an observable browser"
+  - "A host-native browser exposes an API whose implementation name resembles a prohibited standalone tool"
+tags:
+  - skill-design
+  - browser-automation
+  - host-native
+  - agent-browser
+  - pipeline
+  - cross-platform
+---
+
+# Separate host-native browser capabilities from portable fallbacks
+
+## Context
+
+`ce-test-browser` historically mandated `agent-browser` to prevent agents from drifting into standalone Playwright, Puppeteer, or arbitrary browser integrations. That guard also prohibited browser surfaces embedded in or directly owned by app harnesses, even when those surfaces provided the complete testing contract and a better integrated experience.
+
+The categorical rule also coupled unrelated decisions: `mode:pipeline` meant both "do not block on questions" and "hide the browser." An LFG run inside an app harness is unattended, but its integrated browser can remain observable without interrupting automation.
+
+## Guidance
+
+Treat browser choices as three distinct layers:
+
+1. Prefer a browser surface embedded in or directly owned by the active harness when it supports local navigation, rendered and interactive state inspection, interactions, screenshots, and console-error inspection (`skills/ce-test-browser/SKILL.md:20`). A separately configured browser extension or integration does not qualify as host-native.
+2. Fall back to the portable `agent-browser` CLI when no qualifying host-native capability exists (`skills/ce-test-browser/SKILL.md:21`).
+3. Continue prohibiting standalone Playwright, Puppeteer, separately configured browser extensions or MCPs, and ad hoc browser automation (`skills/ce-test-browser/SKILL.md:22`).
+
+An API named Playwright inside the selected host-native browser is still part of the host capability; implementation vocabulary does not turn it into a standalone Playwright substitution (`skills/ce-test-browser/SKILL.md:22`).
+
+Select one driver before testing and keep its session, element references, screenshots, and authentication state for the entire run. Permit fallback only during initialization, before the first route is tested (`skills/ce-test-browser/SKILL.md:24`). Put fallback-specific commands and troubleshooting in a conditional reference so host-native runs do not carry irrelevant CLI instructions (`skills/ce-test-browser/references/agent-browser-driver.md:3`).
+
+Keep orchestration policy independent from driver selection and visibility. Headless or pipeline mode means no blocking questions; it does not require hiding a host-native browser. Integrated browsers can remain visible and non-blocking, while a CLI fallback can run headless (`skills/ce-test-browser/references/pipeline-orchestration.md:3`, `skills/ce-test-browser/references/pipeline-orchestration.md:7`).
+
+## Why This Matters
+
+This preserves the original quality guard without handicapping app harnesses. CLI environments retain one portable fallback, while app environments can use the browser surface their harness is designed to control. Separating orchestration, visibility, and driver choice also prevents future mode flags from silently changing capabilities they do not own.
+
+The rule is testable as a contract rather than a preference. The regression test pins native-first selection, fallback behavior, embedded-Playwright classification, one-driver ownership, pipeline observability, and user-documentation parity (`tests/ce-test-browser-driver-policy.test.ts:9`).
+
+## When to Apply
+
+- A skill runs across both app and CLI harnesses.
+- A host provides an embedded or directly owned capability that is materially different from installing or separately configuring another tool.
+- A portability fallback remains valuable but should not override a better native experience.
+- An unattended mode controls questions or error handling but does not inherently require invisible execution.
+
+## Examples
+
+Before:
+
+```markdown
+Always use agent-browser. Do not use any built-in browser-control tool.
+Pipeline mode defaults every run to hidden/headless execution.
+```
+
+After:
+
+```markdown
+Prefer a qualifying host-native integrated browser. Otherwise fall back to
+agent-browser. Never introduce a third standalone automation stack.
+
+Pipeline mode suppresses blocking questions; it does not change driver
+selection or force an integrated browser to be hidden.
+```
+
+## Related
+
+- `docs/solutions/skill-design/compound-refresh-skill-improvements.md` — related capability-first skill-writing guidance; low overlap because it addresses question tools and autonomous maintenance rather than browser-driver selection.

--- a/skills/ce-test-browser/SKILL.md
+++ b/skills/ce-test-browser/SKILL.md
@@ -6,31 +6,28 @@ argument-hint: "[PR number, branch name, 'current', or --port PORT]"
 
 # Browser Test Skill
 
-Run end-to-end browser tests on pages affected by a PR or branch changes using the `agent-browser` CLI.
+Run end-to-end browser tests on pages affected by a PR or branch using the best approved browser driver available in the active harness.
 
 ## Modes
 
-- **Manual (default):** the user controls the dev server. Follow the steps below as written, including the headed/headless question.
-- **Pipeline (`mode:pipeline`):** invoked by LFG or another automated runner. The run is unattended — never block on a question. Read `references/pipeline-orchestration.md` from this skill's directory and follow it; it overrides the free-port scan (step 4), dev-server startup (step 5), and the headed/headless question (step 6). It still uses the preferred port that step 4 computes.
+- **Manual (default):** the user controls the dev server. When the fallback driver is `agent-browser`, ask whether to run headed or headless.
+- **Pipeline (`mode:pipeline`):** invoked by LFG or another automated runner. The run is unattended — never block on a question. Read `references/pipeline-orchestration.md` from this skill's directory and follow it; it overrides the free-port scan (step 4), dev-server startup (step 5), and visibility prompts (step 6). It still uses the preferred port that step 4 computes.
 
-## Use `agent-browser` Only
+## Browser Driver Policy
 
-Use the `agent-browser` CLI for every browser action in this skill — opening pages, clicking, filling forms, snapshots, screenshots — and use it exclusively. Do not use any other browser-automation tool, including a browser MCP integration, a built-in browser-control tool, Playwright, or Puppeteer. If the host offers several ways to drive a browser, always choose `agent-browser`.
+Select the driver before the first browser action:
 
-- Claude Code: do not use Chrome MCP tools (`mcp__claude-in-chrome__*`).
-- Codex: do not substitute unrelated browsing tools.
+1. **Prefer a host-native integrated browser.** Use a browser-control surface embedded in or directly owned by the active harness when it can navigate local URLs, inspect rendered and interactive state, click/fill/press, capture screenshots, and inspect console errors. A separately configured browser extension or integration is not host-native. Load and follow the selected capability's own instructions before browser work.
+2. **Otherwise fall back to `agent-browser`.** Read `references/agent-browser-driver.md` before running any command.
+3. **Do not introduce a third browser stack.** Never install or substitute standalone Playwright, Puppeteer, a separately configured browser extension or MCP, or other ad hoc browser automation. A Playwright API exposed inside the selected host-native browser remains host-native; it is not standalone Playwright.
+
+Use one driver for the entire run. A selected host-native driver may fall back to `agent-browser` only if initialization fails before the first route is tested. After testing begins, do not mix driver sessions, element references, screenshots, or authentication state.
 
 ## Workflow
 
-### 1. Verify `agent-browser` Is Installed
+### 1. Select the Browser Driver
 
-```bash
-command -v agent-browser >/dev/null 2>&1 && echo "Ready" || echo "NOT INSTALLED"
-```
-
-If not installed, tell the user: "`agent-browser` is not installed. Run `/ce-setup` for the current install command, then install agent-browser and retry." Then stop — this skill cannot function without it.
-
-This also requires a git repository with changes to test.
+Apply the Browser Driver Policy above and record the selected driver. This also requires a git repository with changes to test.
 
 ### 2. Determine Test Scope
 
@@ -109,60 +106,37 @@ fi
 
 In pipeline mode, do not stop here — `references/pipeline-orchestration.md` auto-starts the server in the background instead.
 
-### 6. Choose Headed or Headless
+### 6. Set Browser Visibility and Verify the Root
 
-Manual mode only — in pipeline mode, skip this step (see Modes; it defaults to headless).
+Visibility is independent from unattended execution:
 
-Ask the user whether to run headed or headless using the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question:
+- **Host-native integrated browser:** keep its normal integrated surface visible and non-blocking so the user can watch progress when useful. Do not repeatedly steal focus as routes change. This applies in both manual and pipeline modes.
+- **`agent-browser` fallback, pipeline mode:** run headless without asking.
+- **`agent-browser` fallback, manual mode:** ask the user whether to run headed or headless using the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors. Never silently skip the question:
 
-```
-Do you want to watch the browser tests run?
+  ```
+  Do you want to watch the browser tests run?
 
-1. Headed (watch) - Opens visible browser window so you can see tests run
-2. Headless (faster) - Runs in background, faster but invisible
-```
+  1. Headed (watch) - Opens a visible browser window
+  2. Headless (faster) - Runs without a visible window
+  ```
 
-Store the choice and use the `--headed` flag when the user selects option 1. Then confirm the server serves the root before iterating (add `--headed` if the user chose headed):
-
-```bash
-agent-browser open http://localhost:${PORT}
-agent-browser snapshot -i
-```
+Then use the selected driver to navigate to `http://localhost:<port>`, capture its rendered or interactive state, and confirm the root is served before iterating.
 
 ### 7. Test Each Affected Page
 
-For each affected route:
-
-**Navigate and capture snapshot:**
-```bash
-agent-browser open "http://localhost:${PORT}/[route]"
-agent-browser snapshot -i
-```
-
-**For headed mode:**
-```bash
-agent-browser --headed open "http://localhost:${PORT}/[route]"
-agent-browser --headed snapshot -i
-```
+For each affected route, use the selected driver to navigate and capture fresh rendered or interactive state.
 
 **Verify key elements:**
-- Use `agent-browser snapshot -i` to get interactive elements with refs
 - Page title/heading present
 - Primary content rendered
 - No error messages visible
 - Forms have expected fields
+- No new console errors attributable to the tested flow
 
-**Test critical interactions:**
-```bash
-agent-browser click @e1
-agent-browser snapshot -i
-```
+**Test critical interactions:** derive locators or element references from the selected driver's latest inspected state, perform the click/fill/press action, then inspect the resulting state. Do not guess selectors or reuse stale references.
 
-**Take screenshots:**
-```bash
-agent-browser screenshot page-name.png
-agent-browser screenshot --full page-name-full.png
-```
+**Take screenshots:** capture viewport and full-page evidence when the selected driver supports it. Materialize screenshots as local artifacts when a later workflow or report needs file paths; otherwise in-app evidence is sufficient.
 
 ### 8. Human Verification (When Required)
 
@@ -195,7 +169,7 @@ Did it work correctly?
 When a test fails (**pipeline mode:** do not ask how to proceed — capture the error screenshot and repro steps, log the failure, and continue):
 
 1. **Document the failure:**
-   - Screenshot the error state: `agent-browser screenshot error.png`
+   - Capture a screenshot of the error state with the selected driver
    - Note the exact reproduction steps
 
 2. **Ask the user how to proceed:**
@@ -262,37 +236,6 @@ After all tests complete, present a summary:
 /ce-test-browser --port 5000
 ```
 
-## agent-browser CLI Reference
+## Driver Reference
 
-Run `agent-browser --help` for all commands.
-
-Key commands:
-
-```bash
-# Navigation
-agent-browser open <url>           # Navigate to URL
-agent-browser back                 # Go back
-agent-browser close                # Close browser
-
-# Snapshots (get element refs)
-agent-browser snapshot -i          # Interactive elements with refs (@e1, @e2, etc.)
-agent-browser snapshot -i --json   # JSON output
-
-# Interactions (use refs from snapshot)
-agent-browser click @e1            # Click element
-agent-browser fill @e1 "text"      # Fill input
-agent-browser type @e1 "text"      # Type without clearing
-agent-browser press Enter          # Press key
-
-# Screenshots
-agent-browser screenshot out.png       # Viewport screenshot
-agent-browser screenshot --full out.png # Full page screenshot
-
-# Headed mode (visible browser)
-agent-browser --headed open <url>      # Open with visible browser
-agent-browser --headed click @e1       # Click in visible browser
-
-# Wait
-agent-browser wait @e1             # Wait for element
-agent-browser wait 2000            # Wait milliseconds
-```
+When `agent-browser` is selected as the fallback, read `references/agent-browser-driver.md` from this skill's directory before running its commands. Host-native drivers follow their harness-provided instructions instead.

--- a/skills/ce-test-browser/references/agent-browser-driver.md
+++ b/skills/ce-test-browser/references/agent-browser-driver.md
@@ -1,0 +1,47 @@
+# `agent-browser` Fallback Driver
+
+Read this file only after the main skill selects `agent-browser` because no qualifying host-native integrated browser is available.
+
+## Bootstrap
+
+Verify the direct CLI is installed:
+
+```bash
+command -v agent-browser >/dev/null 2>&1 && echo "Ready" || echo "NOT INSTALLED"
+```
+
+If it is missing, tell the user: "`agent-browser` is not installed. Run `/ce-setup` for the current install command, then install agent-browser and retry." Then stop. An installed discovery skill does not imply that the CLI or its browser runtime is installed.
+
+Before running browser actions, load the workflow and troubleshooting content that matches the installed CLI:
+
+```bash
+agent-browser skills get core
+```
+
+If the CLI exists but cannot launch its browser, follow the current core troubleshooting instructions and report the exact launch failure. Do not misreport a missing browser runtime or launch error as a missing CLI.
+
+## Commands Used by This Skill
+
+Add `--headed` to commands when manual mode selected a visible browser. Pipeline mode defaults this fallback driver to headless.
+
+```bash
+# Navigate and inspect
+agent-browser open <url>
+agent-browser snapshot -i
+
+# Interact using refs from the latest snapshot
+agent-browser click @e1
+agent-browser fill @e1 "text"
+agent-browser type @e1 "text"
+agent-browser press Enter
+
+# Capture evidence
+agent-browser screenshot out.png
+agent-browser screenshot --full out-full.png
+
+# Navigation and waits
+agent-browser back
+agent-browser wait @e1
+```
+
+Use the installed core documentation for console-error inspection and any command not shown here. Do not switch to another browser driver after the first route is tested.

--- a/skills/ce-test-browser/references/agent-browser-driver.md
+++ b/skills/ce-test-browser/references/agent-browser-driver.md
@@ -10,7 +10,7 @@ Verify the direct CLI is installed:
 command -v agent-browser >/dev/null 2>&1 && echo "Ready" || echo "NOT INSTALLED"
 ```
 
-If it is missing, tell the user: "`agent-browser` is not installed. Run `/ce-setup` for the current install command, then install agent-browser and retry." Then stop. An installed discovery skill does not imply that the CLI or its browser runtime is installed.
+If it is missing, tell the user: "`agent-browser` is not installed. Use the `ce-setup` skill to print the current install command, then install `agent-browser` and retry." Then stop. An installed discovery skill does not imply that the CLI or its browser runtime is installed.
 
 Before running browser actions, load the workflow and troubleshooting content that matches the installed CLI:
 

--- a/skills/ce-test-browser/references/pipeline-orchestration.md
+++ b/skills/ce-test-browser/references/pipeline-orchestration.md
@@ -1,10 +1,13 @@
 # Pipeline-Mode Server Orchestration
 
-Read and follow this file only when invoked with `mode:pipeline` (LFG or another automated runner). It overrides three things in the main workflow: the headed/headless question, free-port selection, and dev-server startup. In pipeline mode you run unattended — never block on a question.
+Read and follow this file only when invoked with `mode:pipeline` (LFG or another automated runner). It overrides visibility prompts, free-port selection, and dev-server startup. It does not change browser-driver selection. In pipeline mode you run unattended — never block on a question.
 
-## 1. No headed/headless question
+## 1. No visibility question
 
-Default to headless. Do not ask. Skip the "Choose Headed or Headless" step entirely and never pass `--headed`.
+Unattended execution does not mean hidden execution. Do not ask a visibility question:
+
+- When a host-native integrated browser is selected, keep its normal integrated surface visible and non-blocking so the user can watch progress without interrupting the run. Do not repeatedly steal focus.
+- When the fallback `agent-browser` driver is selected, run it headless without passing `--headed`.
 
 ## 2. Claim a free port and start the server
 
@@ -46,4 +49,4 @@ if ! lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
 fi
 ```
 
-The scan may land on a different port than the preferred one, and `$PORT` does not survive into later Bash calls. Note the number this block echoes ("Using dev server port: N") and substitute that literal port into every subsequent `agent-browser` command — do not rely on `${PORT}` carrying over into the main workflow's snippets. Then return to the "Test Each Affected Page" step (open `http://localhost:<N>`, snapshot, then test each route).
+The scan may land on a different port than the preferred one, and `$PORT` does not survive into later shell calls. Note the number this block echoes ("Using dev server port: N") and use that literal port in every subsequent selected-driver navigation — do not rely on `${PORT}` carrying over. Then return to the "Test Each Affected Page" step, navigate to `http://localhost:<N>`, inspect the rendered state, and test each route.

--- a/tests/ce-test-browser-driver-policy.test.ts
+++ b/tests/ce-test-browser-driver-policy.test.ts
@@ -1,0 +1,68 @@
+import { readFile } from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return readFile(path.join(process.cwd(), relativePath), "utf8")
+}
+
+describe("ce-test-browser browser-driver policy", () => {
+  test("prefers a capable host-native browser and falls back to agent-browser", async () => {
+    const content = await readRepoFile("skills/ce-test-browser/SKILL.md")
+
+    expect(content).toMatch(/prefer.+host-native.+integrated browser/is)
+    expect(content).toMatch(/embedded in or directly owned by the active harness/i)
+    expect(content).toMatch(/fall back to `agent-browser`/i)
+    expect(content).toMatch(/one driver.+entire run/is)
+    expect(content).toContain("references/agent-browser-driver.md")
+
+    expect(content).not.toContain("## Use `agent-browser` Only")
+    expect(content).not.toContain("always choose `agent-browser`")
+    expect(content).not.toContain("this skill cannot function without it")
+  })
+
+  test("distinguishes host-native APIs from prohibited standalone substitutes", async () => {
+    const content = await readRepoFile("skills/ce-test-browser/SKILL.md")
+
+    expect(content).toMatch(/Playwright API.+host-native/is)
+    expect(content).toMatch(/standalone Playwright.+Puppeteer/is)
+    expect(content).toMatch(/separately configured browser extension/i)
+    expect(content).toMatch(/ad hoc browser automation/i)
+  })
+
+  test("keeps the agent-browser fallback operational and version-matched", async () => {
+    const fallback = await readRepoFile(
+      "skills/ce-test-browser/references/agent-browser-driver.md",
+    )
+
+    expect(fallback).toContain("command -v agent-browser")
+    expect(fallback).toContain("agent-browser skills get core")
+    expect(fallback).toMatch(/CLI exists but cannot launch its browser/i)
+    expect(fallback).toContain("agent-browser open <url>")
+  })
+
+  test("pipeline mode changes orchestration without forcing a driver or hiding it", async () => {
+    const content = await readRepoFile(
+      "skills/ce-test-browser/references/pipeline-orchestration.md",
+    )
+
+    expect(content).toMatch(/does not change browser-driver selection/i)
+    expect(content).toMatch(/unattended.+does not mean hidden/is)
+    expect(content).toMatch(/visible.+non-blocking/is)
+    expect(content).not.toContain("subsequent `agent-browser` command")
+    expect(content).not.toContain("never pass `--headed`")
+  })
+
+  test("user documentation describes the same hierarchy", async () => {
+    const docs = await readRepoFile("docs/skills/ce-test-browser.md")
+    const catalog = await readRepoFile("docs/skills/README.md")
+
+    expect(docs).toMatch(/host-native.+integrated browser/is)
+    expect(docs).toMatch(/embedded in or directly owned by the active harness/i)
+    expect(docs).toMatch(/fall back to `agent-browser`/i)
+    expect(docs).toMatch(/standalone Playwright.+Puppeteer/is)
+    expect(docs).toMatch(/separately configured browser extensions or MCPs/i)
+    expect(docs).toMatch(/visible.+non-blocking/is)
+    expect(catalog).toMatch(/host-native browser.+`agent-browser` fallback/i)
+  })
+})

--- a/tests/ce-test-browser-driver-policy.test.ts
+++ b/tests/ce-test-browser-driver-policy.test.ts
@@ -39,6 +39,8 @@ describe("ce-test-browser browser-driver policy", () => {
     expect(fallback).toContain("agent-browser skills get core")
     expect(fallback).toMatch(/CLI exists but cannot launch its browser/i)
     expect(fallback).toContain("agent-browser open <url>")
+    expect(fallback).toMatch(/use the `ce-setup` skill/i)
+    expect(fallback).not.toContain("/ce-setup")
   })
 
   test("pipeline mode changes orchestration without forcing a driver or hiding it", async () => {


### PR DESCRIPTION
## Summary

`ce-test-browser` can now use a browser embedded in or directly owned by the active app harness instead of failing because every run was forced through `agent-browser`. CLI harnesses and environments without a qualifying native browser retain `agent-browser` as the portable fallback.

Pipeline and LFG runs are still unattended, but unattended no longer means invisible: an integrated browser can remain visible and non-blocking while the run suppresses questions. The original quality guard remains intact -- standalone Playwright, Puppeteer, separately configured browser extensions or MCPs, and ad hoc automation are still rejected.

## Driver policy

- A native browser qualifies only when it supports local navigation, rendered and interactive state inspection, click/fill/press actions, screenshots, and console-error inspection.
- One driver owns the run's session, element state, screenshots, and authentication. Fallback is allowed only during initialization, before the first route is tested.
- The CLI fallback loads version-matched `agent-browser` guidance and distinguishes a missing CLI from a browser-runtime launch failure.

## Validation

- `bun test` -- 1,913 pass, 0 fail
- `bun test tests/ce-test-browser-driver-policy.test.ts tests/skill-conventions.test.ts` -- 206 pass, 0 fail
- `bun run release:validate` -- release metadata in sync
- Compounded-learning frontmatter and source-claim validators -- pass
- Installed Codex in-app browser contract checked directly for navigation, DOM/state inspection, interaction, screenshots, visibility control, and console logs
- Static routing scenarios covered app pipeline mode, CLI fallback, and an embedded API named Playwright; no live Cursor or CLI-only end-to-end run was performed

## New concepts

### Host-native capability with a portable fallback

A host-native capability is part of the harness running the agent, not merely another browser tool installed beside it. Preferring that surface lets the harness provide its intended observable experience without giving agents permission to improvise a new automation stack.

| Layer | Role | Boundary |
|---|---|---|
| Harness-native | Best integrated experience | Must be embedded in or directly owned by the harness and satisfy the full test contract |
| Portable fallback | Consistent coverage in CLI environments | Use `agent-browser` when no qualifying native surface exists |
| Rejected substitute | Uncontrolled third stack | Do not install or switch to standalone Playwright, Puppeteer, extensions, or arbitrary MCP browsers |

An API named Playwright can still be host-native when it is the harness's own browser API. Do not use this pattern when the native surface lacks a required capability; select the portable fallback before testing begins instead.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

