### PR TITLE
fix(ce-test-browser): correct review mode guidance

### DIFF
--- a/docs/skills/ce-test-browser.md
+++ b/docs/skills/ce-test-browser.md
@@ -172,7 +172,7 @@ Skip `ce-test-browser` when:
 - **`/ce-code-review` Tier 2** — for browser-affecting PRs, can spawn this skill to verify behavior in addition to static review
 - **`/ce-work` Phase 3** — appropriate before opening the PR for UI-heavy work; the test summary becomes part of the PR description's verification narrative
 
-`mode:report-only` for `ce-code-review` is the only review mode safe to run concurrently with this skill on the same checkout — other modes mutate, which would interfere with the running dev server's state.
+`mode:agent` for `ce-code-review` is the only review mode safe to run concurrently with this skill on the same checkout — interactive review may mutate the checkout, which would interfere with the running dev server's state.
 
 ---
 
@@ -225,13 +225,13 @@ The mapping table is a starting point. The skill applies judgment for project-sp
 Manual mode informs you with the right start command and stops. Pipeline mode auto-starts it via `bin/dev`, `bin/rails server`, or `npm run dev` (project-detected) and waits up to 30 seconds for the server to come up.
 
 **Can it run concurrent with `ce-code-review`?**
-Only when code review uses `mode:report-only` (read-only). Other review modes mutate the checkout, which would break the running dev server's state. Pair browser tests with read-only review, or run code review separately in an isolated worktree.
+Only when code review uses `mode:agent` (read-only). Interactive review may mutate the checkout, which would break the running dev server's state. Pair browser tests with read-only review, or run code review separately in an isolated worktree.
 
 ---
 
 ## See Also
 
-- [`ce-code-review`](./ce-code-review.md) — can spawn this skill for browser-affecting PRs (use `mode:report-only` for concurrent runs on the same checkout)
+- [`ce-code-review`](./ce-code-review.md) — can spawn this skill for browser-affecting PRs (use `mode:agent` for concurrent runs on the same checkout)
 - [`ce-test-xcode`](./ce-test-xcode.md) — sibling skill for iOS simulator testing
 - [`ce-commit-push-pr`](./ce-commit-push-pr.md) — can include user-supplied evidence or summarize validation in PR descriptions
 - [`ce-work`](./ce-work.md) — orchestrator that may invoke this skill during Phase 3 verification


### PR DESCRIPTION
## Summary

- Replace stale `ce-code-review mode:report-only` guidance in `ce-test-browser` docs with `mode:agent`.
- Clarify that interactive review may mutate the checkout, so `mode:agent` is the safe concurrent option for browser testing.

## Root Cause

`ce-test-browser` documentation still referenced the old `mode:report-only` contract even though `ce-code-review` now treats that mode as deprecated and ignored. Following the old guidance could run interactive review while browser testing is active on the same checkout.

## Validation

- `rg -n "mode:report-only|report-only" docs/skills/ce-test-browser.md -S` returned no matches.
- `git diff --check origin/main...HEAD` passed.

Docs-only change; full Bun suite not run.