### PR TITLE
fix(targets): guard writers against ancestor-symlink traversal on install

### DIFF
--- a/src/targets/codex.ts
+++ b/src/targets/codex.ts
@@ -6,7 +6,7 @@ import type { ClaudeMcpServer } from "../types/claude"
 import { transformContentForCodex } from "../utils/codex-content"
 import { getLegacyCodexArtifacts } from "../data/plugin-legacy-artifacts"
 import { classifyCodexLegacyPromptOwnership, isLegacyAgentArtifactOwned, isLegacySkillArtifactOwned } from "../utils/legacy-cleanup"
-import { isPreservedSymlink, lstatOrNull } from "./managed-artifacts"
+import { isContainedPath, isPathWithinRoot, isPreservedSymlink, lstatOrNull, storeRootEscapesManagedRoot } from "./managed-artifacts"
 
 const MANAGED_START_MARKER = "# BEGIN Compound Engineering plugin MCP -- do not edit this block"
 const MANAGED_END_MARKER = "# END Compound Engineering plugin MCP"
@@ -46,14 +46,22 @@ export async function writeCodexBundle(
   const currentAgents = agents.map((agent) => `${sanitizePathName(agent.name)}.toml`)
   assertNoCodexAgentFilenameCollisions(agents)
 
-  if (bundle.prompts.length > 0) {
-    const promptsDir = path.join(codexRoot, "prompts")
-    await cleanupRemovedPrompts(promptsDir, manifest, currentPrompts)
-    for (const prompt of bundle.prompts) {
-      await writeText(path.join(promptsDir, `${sanitizePathName(prompt.name)}.md`), prompt.content + "\n")
+  // Ancestor-symlink containment: the per-entry guards below inspect only the
+  // leaf node, so a symlinked store dir (or a symlinked ancestor of it) pointed
+  // at a user fork would otherwise have every cleanup/write act through the link
+  // into the fork. When a store escapes the codex root we skip it entirely and
+  // record nothing as owned.
+  const promptsDir = path.join(codexRoot, "prompts")
+  const promptsEscaped = await storeRootEscapesManagedRoot(codexRoot, promptsDir)
+  if (!promptsEscaped) {
+    if (bundle.prompts.length > 0) {
+      await cleanupRemovedPrompts(promptsDir, manifest, currentPrompts)
+      for (const prompt of bundle.prompts) {
+        await writeText(path.join(promptsDir, `${sanitizePathName(prompt.name)}.md`), prompt.content + "\n")
+      }
+    } else if (pluginName) {
+      await cleanupRemovedPrompts(promptsDir, manifest, [])
     }
-  } else if (pluginName) {
-    await cleanupRemovedPrompts(path.join(codexRoot, "prompts"), manifest, [])
   }
 
   const skillsRoot = pluginName
@@ -70,13 +78,18 @@ export async function writeCodexBundle(
     ...bundle.generatedSkills.map((skill) => sanitizePathName(skill.name)),
     ...(bundle.externallyManagedSkillNames ?? []).map((name) => sanitizePathName(name)),
   ]))
-  await cleanupRemovedSkills(skillsRoot, manifest, currentSkills)
+  const skillsEscaped = await storeRootEscapesManagedRoot(codexRoot, skillsRoot)
+  if (!skillsEscaped) await cleanupRemovedSkills(skillsRoot, manifest, currentSkills)
 
   const preservedSkillNames = new Set<string>()
 
   if (bundle.skillDirs.length > 0) {
     for (const skill of bundle.skillDirs) {
       const skillName = sanitizePathName(skill.name)
+      if (skillsEscaped) {
+        preservedSkillNames.add(skillName)
+        continue
+      }
       const targetDir = path.join(skillsRoot, skillName)
       const preserved = await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
       if (preserved) {
@@ -96,6 +109,10 @@ export async function writeCodexBundle(
   if (bundle.generatedSkills.length > 0) {
     for (const skill of bundle.generatedSkills) {
       const skillName = sanitizePathName(skill.name)
+      if (skillsEscaped) {
+        preservedSkillNames.add(skillName)
+        continue
+      }
       const skillDir = path.join(skillsRoot, skillName)
       const preserved = await cleanupCurrentManagedSkillDir(skillDir, manifest, skillName)
       if (preserved) {
@@ -109,13 +126,18 @@ export async function writeCodexBundle(
     }
   }
 
+  const agentsEscaped = await storeRootEscapesManagedRoot(codexRoot, agentsRoot)
   const preservedAgentNames = new Set<string>()
 
-  await cleanupRemovedAgents(agentsRoot, manifest, currentAgents)
+  if (!agentsEscaped) await cleanupRemovedAgents(agentsRoot, manifest, currentAgents)
   if (agents.length > 0) {
     for (const agent of agents) {
       const agentBaseName = sanitizePathName(agent.name)
       const agentFile = `${agentBaseName}.toml`
+      if (agentsEscaped) {
+        preservedAgentNames.add(agentFile)
+        continue
+      }
       const targetPath = path.join(agentsRoot, agentFile)
       const preserved = await cleanupCurrentManagedAgentFile(targetPath, manifest, agentFile)
       if (preserved) {
@@ -143,20 +165,26 @@ export async function writeCodexBundle(
   }
 
   if (pluginName) {
-    await ensureDir(skillsRoot)
+    if (!skillsEscaped) await ensureDir(skillsRoot)
     // Preserved skills/agents (user symlinks or unmanaged dirs/files this
-    // install skipped) must not be recorded as owned -- the plugin never
+    // install skipped) and any store that escaped the codex root via a
+    // symlinked ancestor must not be recorded as owned -- the plugin never
     // claims a path it didn't write.
     await writeInstallManifest(codexRoot, {
       version: 1,
       pluginName,
       skills: currentSkills.filter((name) => !preservedSkillNames.has(name)),
-      prompts: currentPrompts,
+      prompts: promptsEscaped ? [] : currentPrompts,
       agents: currentAgents.filter((name) => !preservedAgentNames.has(name)),
     })
     await cleanupKnownLegacyCodexArtifacts(codexRoot, bundle)
-    await cleanupLegacyAgentSkillDirs(codexRoot, pluginName, currentSkills, bundle)
-    await cleanupLegacyAgentsSkillSymlinks(codexRoot, pluginName, currentSkills, manifest)
+    // Skip the skills-area sweeps when that store escaped so we don't traverse
+    // the symlink at all; their destructive ops are independently containment-
+    // guarded too (see moveLegacyArtifactToBackup / isManagedCodexAgentsSymlink).
+    if (!skillsEscaped) {
+      await cleanupLegacyAgentSkillDirs(codexRoot, pluginName, currentSkills, bundle)
+      await cleanupLegacyAgentsSkillSymlinks(codexRoot, pluginName, currentSkills, manifest)
+    }
     await cleanupPreviousManagedCodexSkillStore(codexRoot, pluginName)
   }
 
@@ -494,6 +522,9 @@ async function cleanupLegacyAgentsSkillSymlinks(
 async function cleanupPreviousManagedCodexSkillStore(codexRoot: string, pluginName: string): Promise<void> {
   const skillStoreDir = path.join(codexRoot, pluginName, "skills")
   if (await isPreservedSymlink(skillStoreDir)) return
+  // Ancestor containment: never recursively delete through a managed dir that
+  // has been repointed at a user fork via a symlinked ancestor.
+  if (!(await isPathWithinRoot(codexRoot, skillStoreDir))) return
   await fs.rm(skillStoreDir, { recursive: true, force: true })
 }
 
@@ -578,8 +609,7 @@ async function canonicalizePath(filePath: string): Promise<string> {
 }
 
 function isPathInside(candidatePath: string, rootPath: string): boolean {
-  const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath))
-  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+  return isContainedPath(path.resolve(rootPath), path.resolve(candidatePath))
 }
 
 async function moveLegacyArtifactToBackup(
@@ -592,6 +622,9 @@ async function moveLegacyArtifactToBackup(
   // legacy-named artifact still matches — never move the symlink node into
   // legacy-backup, or the user's override is silently deactivated.
   if (await isPreservedSymlink(artifactPath)) return
+  // Ancestor containment: skip when a symlinked ancestor (e.g. the whole store
+  // dir) resolves the artifact outside the codex root, into a user fork.
+  if (!(await isPathWithinRoot(codexRoot, artifactPath))) return
   if (!(await pathExists(artifactPath))) return
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const backupDir = path.join(codexRoot, pluginName, "legacy-backup", timestamp, kind)

--- a/src/targets/managed-artifacts.ts
+++ b/src/targets/managed-artifacts.ts
@@ -230,6 +230,13 @@ export async function moveLegacyArtifactToBackup(
   // inside a CE-managed root) that this specific symlink node IS the
   // CE-owned artifact to relocate, not a user override to preserve.
   if (!options.skipSymlinkGuard && (await isPreservedSymlink(artifactPath))) return
+  // Ancestor-symlink containment: `isPreservedSymlink` only catches a symlinked
+  // leaf; block the rename when the artifact resolves outside the target root
+  // via a symlinked ancestor (e.g. the whole store dir repointed at a fork).
+  // Every caller passes a store dir that is a direct child of the target root,
+  // so its parent is that root. `skipSymlinkGuard` callers are exempt for the
+  // same reason as above.
+  if (!options.skipSymlinkGuard && !(await isPathWithinRoot(path.dirname(artifactRoot), artifactPath))) return
   if (!(await pathExists(artifactPath))) return
 
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
@@ -256,5 +263,63 @@ export async function isPreservedSymlink(targetPath: string): Promise<boolean> {
   const stat = await lstatOrNull(targetPath)
   if (!stat?.isSymbolicLink()) return false
   console.warn(`Skipping ${targetPath}: existing user-managed symlink (not overwritten)`)
+  return true
+}
+
+/**
+ * Realpath of the nearest existing ancestor of `targetPath` (the path itself
+ * when it exists). A not-yet-created descendant cannot introduce a new symlink
+ * hop, so resolving the nearest existing ancestor is enough to decide whether
+ * `targetPath` escapes a root -- and it lets the containment check run before a
+ * fresh store directory has been created.
+ */
+async function realpathNearestExisting(targetPath: string): Promise<string> {
+  let current = path.resolve(targetPath)
+  for (;;) {
+    try {
+      return await fs.realpath(current)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+      const parent = path.dirname(current)
+      if (parent === current) return current
+      current = parent
+    }
+  }
+}
+
+/**
+ * True when `targetPath`, after resolving symlinks on every existing ancestor,
+ * still lives inside `rootDir`. The leaf-node guards (`isPreservedSymlink`)
+ * only inspect the final path component, so a symlinked *ancestor* -- e.g. a
+ * whole store directory (`~/.codex/skills/<plugin>`) repointed at a personal
+ * fork -- slips past them, and the subsequent fs.rm / copy then operates
+ * THROUGH the link into the fork. Both sides are realpath'd so a config root
+ * that was legitimately relocated as a whole (its entire tree moved behind one
+ * symlink) still reads as contained.
+ */
+/**
+ * Pure containment predicate over two already-resolved absolute paths: true
+ * when `targetResolved` is `rootResolved` itself or a descendant of it.
+ */
+export function isContainedPath(rootResolved: string, targetResolved: string): boolean {
+  const rel = path.relative(rootResolved, targetResolved)
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))
+}
+
+export async function isPathWithinRoot(rootDir: string, targetPath: string): Promise<boolean> {
+  return isContainedPath(await realpathNearestExisting(rootDir), await realpathNearestExisting(targetPath))
+}
+
+/**
+ * Guards a managed store directory against ancestor-symlink traversal. Returns
+ * true (and warns once) when `storeDir` escapes `rootDir` via a symlinked
+ * ancestor, meaning the caller must skip EVERY operation on that store --
+ * cleanup sweeps and writes alike -- since all of them would otherwise act
+ * through the link into whatever the user pointed it at. `rootDir` is the
+ * writer's target root (e.g. `~/.codex`), not the store dir itself.
+ */
+export async function storeRootEscapesManagedRoot(rootDir: string, storeDir: string): Promise<boolean> {
+  if (await isPathWithinRoot(rootDir, storeDir)) return false
+  console.warn(`Skipping ${storeDir}: resolves outside the managed root via a symlinked ancestor (not modified)`)
   return true
 }

--- a/src/targets/opencode.ts
+++ b/src/targets/opencode.ts
@@ -12,6 +12,7 @@ import {
   lstatOrNull,
   type ManagedInstallManifest,
   moveLegacyArtifactToBackup,
+  storeRootEscapesManagedRoot,
   readManagedInstallManifestWithLegacyFallback,
   resolveManagedSegment,
   sanitizeManagedPluginName,
@@ -102,11 +103,21 @@ export async function writeOpenCodeBundle(
   const currentPlugins = bundle.plugins.map((plugin) => plugin.name)
   const currentSkills = bundle.skillDirs.map((skill) => sanitizePathName(skill.name))
 
+  // Ancestor-symlink containment: the per-entry guards below inspect only the
+  // leaf node, so a symlinked store dir (or a symlinked ancestor of it) pointed
+  // at a user fork would otherwise have every cleanup/write act through the link
+  // into the fork. A store that escapes the OpenCode root is skipped wholesale
+  // and recorded as owning nothing.
+  const agentsEscaped = await storeRootEscapesManagedRoot(openCodePaths.root, openCodePaths.agentsDir)
+  const commandsEscaped = await storeRootEscapesManagedRoot(openCodePaths.root, openCodePaths.commandDir)
+  const pluginsEscaped = await storeRootEscapesManagedRoot(openCodePaths.root, openCodePaths.pluginsDir)
+  const skillsEscaped = await storeRootEscapesManagedRoot(openCodePaths.root, openCodePaths.skillsDir)
+
   await ensureDir(openCodePaths.root)
-  await cleanupRemovedManagedFiles(openCodePaths.agentsDir, manifest, "agents", currentAgents)
-  await cleanupRemovedManagedFiles(openCodePaths.commandDir, manifest, "commands", currentCommands)
-  await cleanupRemovedManagedFiles(openCodePaths.pluginsDir, manifest, "plugins", currentPlugins)
-  await cleanupRemovedManagedDirectories(openCodePaths.skillsDir, manifest, "skills", currentSkills)
+  if (!agentsEscaped) await cleanupRemovedManagedFiles(openCodePaths.agentsDir, manifest, "agents", currentAgents)
+  if (!commandsEscaped) await cleanupRemovedManagedFiles(openCodePaths.commandDir, manifest, "commands", currentCommands)
+  if (!pluginsEscaped) await cleanupRemovedManagedFiles(openCodePaths.pluginsDir, manifest, "plugins", currentPlugins)
+  if (!skillsEscaped) await cleanupRemovedManagedDirectories(openCodePaths.skillsDir, manifest, "skills", currentSkills)
 
   const hadExistingConfig = await pathExists(openCodePaths.configPath)
   const backupPath = await backupFile(openCodePaths.configPath)
@@ -129,6 +140,10 @@ export async function writeOpenCodeBundle(
     }
     seenAgents.add(safeName)
     const agentFileName = `${safeName}.md`
+    if (agentsEscaped) {
+      preservedAgentNames.add(agentFileName)
+      continue
+    }
     const targetPath = path.join(openCodePaths.agentsDir, agentFileName)
     const preserved = await cleanupCurrentManagedFile(targetPath, manifest, "agents", agentFileName)
     if (preserved) {
@@ -141,6 +156,10 @@ export async function writeOpenCodeBundle(
   const preservedCommandNames = new Set<string>()
   for (const commandFile of bundle.commandFiles) {
     const commandName = `${commandNameToRelativePath(commandFile.name)}.md`
+    if (commandsEscaped) {
+      preservedCommandNames.add(commandName)
+      continue
+    }
     const dest = path.join(openCodePaths.commandDir, ...commandName.split("/"))
     const preserved = await cleanupCurrentManagedFile(dest, manifest, "commands", commandName)
     if (preserved) {
@@ -157,6 +176,10 @@ export async function writeOpenCodeBundle(
   const preservedPluginNames = new Set<string>()
   if (bundle.plugins.length > 0) {
     for (const plugin of bundle.plugins) {
+      if (pluginsEscaped) {
+        preservedPluginNames.add(plugin.name)
+        continue
+      }
       const targetPath = path.join(openCodePaths.pluginsDir, plugin.name)
       const preserved = await cleanupCurrentManagedFile(targetPath, manifest, "plugins", plugin.name)
       if (preserved) {
@@ -171,6 +194,10 @@ export async function writeOpenCodeBundle(
   if (bundle.skillDirs.length > 0) {
     for (const skill of bundle.skillDirs) {
       const skillName = sanitizePathName(skill.name)
+      if (skillsEscaped) {
+        preservedSkillNames.add(skillName)
+        continue
+      }
       const targetDir = path.join(openCodePaths.skillsDir, skillName)
       const preserved = await cleanupCurrentManagedDirectory(targetDir, manifest, "skills", skillName)
       if (preserved) {

--- a/src/targets/pi.ts
+++ b/src/targets/pi.ts
@@ -15,7 +15,7 @@ import { transformContentForPi } from "../converters/claude-to-pi"
 import type { PiBundle } from "../types/pi"
 import { getLegacyPiArtifacts } from "../data/plugin-legacy-artifacts"
 import { cleanupStaleAgents, isLegacyAgentArtifactOwned, isLegacySkillArtifactOwned } from "../utils/legacy-cleanup"
-import { isPreservedSymlink, lstatOrNull, resolveLegacyManagedDir, resolveManagedSegment } from "./managed-artifacts"
+import { isPathWithinRoot, isPreservedSymlink, lstatOrNull, resolveLegacyManagedDir, resolveManagedSegment, storeRootEscapesManagedRoot } from "./managed-artifacts"
 
 const PI_AGENTS_BLOCK_START = "<!-- BEGIN COMPOUND PI TOOL MAP -->"
 const PI_AGENTS_BLOCK_END = "<!-- END COMPOUND PI TOOL MAP -->"
@@ -70,25 +70,42 @@ export async function writePiBundle(outputRoot: string, bundle: PiBundle): Promi
   const currentAgents = bundle.agents.map((agent) => `${sanitizePathName(agent.name)}.md`)
   const currentExtensions = bundle.extensions.map((extension) => extension.name)
 
-  await ensureDir(paths.skillsDir)
-  await ensureDir(paths.promptsDir)
-  await ensureDir(paths.extensionsDir)
-  await ensureDir(paths.agentsDir)
+  // Ancestor-symlink containment: the per-entry guards below inspect only the
+  // leaf node, so a symlinked store dir (or a symlinked ancestor of it) pointed
+  // at a user fork would otherwise have every cleanup/write act through the link
+  // into the fork. The Pi stores are siblings under one parent, so that parent
+  // is the containment root; a store escaping it is skipped and owns nothing.
+  const piRoot = path.dirname(paths.skillsDir)
+  const skillsEscaped = await storeRootEscapesManagedRoot(piRoot, paths.skillsDir)
+  const promptsEscaped = await storeRootEscapesManagedRoot(piRoot, paths.promptsDir)
+  const extensionsEscaped = await storeRootEscapesManagedRoot(piRoot, paths.extensionsDir)
+  const agentsEscaped = await storeRootEscapesManagedRoot(piRoot, paths.agentsDir)
 
-  await cleanupStaleAgents(paths.skillsDir, null)
-  await cleanupRemovedPrompts(paths.promptsDir, manifest, currentPrompts)
-  await cleanupRemovedSkills(paths.skillsDir, manifest, currentSkills)
-  await cleanupRemovedAgents(paths.agentsDir, manifest, currentAgents)
-  await cleanupRemovedExtensions(paths.extensionsDir, manifest, currentExtensions)
+  if (!skillsEscaped) await ensureDir(paths.skillsDir)
+  if (!promptsEscaped) await ensureDir(paths.promptsDir)
+  if (!extensionsEscaped) await ensureDir(paths.extensionsDir)
+  if (!agentsEscaped) await ensureDir(paths.agentsDir)
 
-  for (const prompt of bundle.prompts) {
-    await writeText(path.join(paths.promptsDir, `${sanitizePathName(prompt.name)}.md`), prompt.content + "\n")
+  if (!skillsEscaped) await cleanupStaleAgents(paths.skillsDir, null)
+  if (!promptsEscaped) await cleanupRemovedPrompts(paths.promptsDir, manifest, currentPrompts)
+  if (!skillsEscaped) await cleanupRemovedSkills(paths.skillsDir, manifest, currentSkills)
+  if (!agentsEscaped) await cleanupRemovedAgents(paths.agentsDir, manifest, currentAgents)
+  if (!extensionsEscaped) await cleanupRemovedExtensions(paths.extensionsDir, manifest, currentExtensions)
+
+  if (!promptsEscaped) {
+    for (const prompt of bundle.prompts) {
+      await writeText(path.join(paths.promptsDir, `${sanitizePathName(prompt.name)}.md`), prompt.content + "\n")
+    }
   }
 
   const preservedSkillNames = new Set<string>()
 
   for (const skill of bundle.skillDirs) {
     const skillName = sanitizePathName(skill.name)
+    if (skillsEscaped) {
+      preservedSkillNames.add(skillName)
+      continue
+    }
     const targetDir = path.join(paths.skillsDir, skillName)
     const preserved = await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
     if (preserved) {
@@ -100,6 +117,10 @@ export async function writePiBundle(outputRoot: string, bundle: PiBundle): Promi
 
   for (const skill of bundle.generatedSkills) {
     const skillName = sanitizePathName(skill.name)
+    if (skillsEscaped) {
+      preservedSkillNames.add(skillName)
+      continue
+    }
     const targetDir = path.join(paths.skillsDir, skillName)
     const preserved = await cleanupCurrentManagedSkillDir(targetDir, manifest, skillName)
     if (preserved) {
@@ -113,6 +134,10 @@ export async function writePiBundle(outputRoot: string, bundle: PiBundle): Promi
 
   for (const agent of bundle.agents) {
     const agentFileName = `${sanitizePathName(agent.name)}.md`
+    if (agentsEscaped) {
+      preservedAgentNames.add(agentFileName)
+      continue
+    }
     const targetPath = path.join(paths.agentsDir, agentFileName)
     const preserved = await cleanupCurrentManagedAgentFile(targetPath, manifest, agentFileName)
     if (preserved) {
@@ -122,8 +147,10 @@ export async function writePiBundle(outputRoot: string, bundle: PiBundle): Promi
     await writeText(targetPath, agent.content + "\n")
   }
 
-  for (const extension of bundle.extensions) {
-    await writeText(path.join(paths.extensionsDir, extension.name), extension.content + "\n")
+  if (!extensionsEscaped) {
+    for (const extension of bundle.extensions) {
+      await writeText(path.join(paths.extensionsDir, extension.name), extension.content + "\n")
+    }
   }
 
   if (bundle.mcporterConfig) {
@@ -144,8 +171,8 @@ export async function writePiBundle(outputRoot: string, bundle: PiBundle): Promi
       version: 1,
       pluginName,
       skills: currentSkills.filter((name) => !preservedSkillNames.has(name)),
-      prompts: currentPrompts,
-      extensions: currentExtensions,
+      prompts: promptsEscaped ? [] : currentPrompts,
+      extensions: extensionsEscaped ? [] : currentExtensions,
       agents: currentAgents.filter((name) => !preservedAgentNames.has(name)),
     })
     await archiveLegacyInstallManifestIfOwned(paths.managedDir, pluginName)
@@ -542,6 +569,10 @@ async function moveLegacyArtifactToBackup(
   // legacy-named artifact still matches — never move the symlink node into
   // legacy-backup, or the user's override is silently deactivated.
   if (await isPreservedSymlink(artifactPath)) return
+  // Ancestor containment: skip when a symlinked ancestor (e.g. the whole store
+  // dir) resolves the artifact outside the Pi root, into a user fork. The store
+  // dirs are siblings of managedDir, so managedDir's parent is that root.
+  if (!(await isPathWithinRoot(path.dirname(managedDir), artifactPath))) return
   if (!(await pathExists(artifactPath))) return
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-")
   const backupDir = path.join(managedDir, "legacy-backup", timestamp, kind)

--- a/tests/codex-writer.test.ts
+++ b/tests/codex-writer.test.ts
@@ -1664,3 +1664,62 @@ describe("writeCodexBundle preserves user-managed skill and agent paths", () => 
     },
   )
 })
+
+describe("writeCodexBundle guards against ancestor-symlink traversal", () => {
+  async function readInstallManifest(codexRoot: string): Promise<{ skills: string[]; agents: string[] }> {
+    const raw = await fs.readFile(path.join(codexRoot, "compound-engineering", "install-manifest.json"), "utf8")
+    return JSON.parse(raw) as { skills: string[]; agents: string[] }
+  }
+
+  const skillBundle = (): CodexBundle => ({
+    pluginName: "compound-engineering",
+    prompts: [],
+    skillDirs: [{ name: "skill-one", sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one") }],
+    generatedSkills: [],
+  })
+
+  test.skipIf(!canDirSymlink)(
+    "does not write through a store dir that is itself a symlink into a user fork",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-ancestor-store-symlink-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+      // The user replaced the entire plugin skills store with a symlink into a fork.
+      const forkStore = path.join(tempRoot, "user-fork-store")
+      await fs.mkdir(forkStore, { recursive: true })
+      await fs.writeFile(path.join(forkStore, "MARKER.md"), "# user store\n")
+      await fs.mkdir(path.join(codexRoot, "skills"), { recursive: true })
+      await fs.symlink(forkStore, path.join(codexRoot, "skills", "compound-engineering"), "junction")
+
+      await writeCodexBundle(codexRoot, skillBundle())
+
+      const linkStat = await fs.lstat(path.join(codexRoot, "skills", "compound-engineering"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      // Nothing was written through the link into the fork.
+      expect(await exists(path.join(forkStore, "skill-one"))).toBe(false)
+      expect(await fs.readFile(path.join(forkStore, "MARKER.md"), "utf8")).toBe("# user store\n")
+      expect((await readInstallManifest(codexRoot)).skills).not.toContain("skill-one")
+    },
+  )
+
+  test.skipIf(!canDirSymlink)(
+    "does not write through a symlinked ancestor above the store dir (multi-level)",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-ancestor-parent-symlink-"))
+      const codexRoot = path.join(tempRoot, ".codex")
+      await fs.mkdir(codexRoot, { recursive: true })
+      // The user symlinked the whole `skills` dir (the store's parent) into a fork.
+      const forkSkills = path.join(tempRoot, "user-fork-skills")
+      await fs.mkdir(forkSkills, { recursive: true })
+      await fs.writeFile(path.join(forkSkills, "MARKER.md"), "# user skills root\n")
+      await fs.symlink(forkSkills, path.join(codexRoot, "skills"), "junction")
+
+      await writeCodexBundle(codexRoot, skillBundle())
+
+      const linkStat = await fs.lstat(path.join(codexRoot, "skills"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await exists(path.join(forkSkills, "compound-engineering"))).toBe(false)
+      expect(await fs.readFile(path.join(forkSkills, "MARKER.md"), "utf8")).toBe("# user skills root\n")
+      expect((await readInstallManifest(codexRoot)).skills).not.toContain("skill-one")
+    },
+  )
+})

--- a/tests/opencode-writer.test.ts
+++ b/tests/opencode-writer.test.ts
@@ -1001,3 +1001,40 @@ describe("mergeJsonConfigAtKey", () => {
     expect(merged.mcp["user-server"].command[1]).toBe("plugin-override")
   })
 })
+
+describe("writeOpenCodeBundle guards against ancestor-symlink traversal", () => {
+  async function readInstallManifest(outputRoot: string): Promise<{ groups: Record<string, string[]> }> {
+    const raw = await fs.readFile(path.join(outputRoot, "compound-engineering", "install-manifest.json"), "utf8")
+    return JSON.parse(raw) as { groups: Record<string, string[]> }
+  }
+
+  test.skipIf(!canDirSymlink)(
+    "does not write through a store dir that is itself a symlink into a user fork",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-ancestor-store-symlink-"))
+      const outputRoot = path.join(tempRoot, ".opencode")
+      const forkStore = path.join(tempRoot, "user-fork-store")
+      await fs.mkdir(forkStore, { recursive: true })
+      await fs.writeFile(path.join(forkStore, "MARKER.md"), "# user store\n")
+      await fs.mkdir(outputRoot, { recursive: true })
+      await fs.symlink(forkStore, path.join(outputRoot, "skills"), "junction")
+
+      const bundle: OpenCodeBundle = {
+        pluginName: "compound-engineering",
+        config: { $schema: "https://opencode.ai/config.json" },
+        agents: [],
+        plugins: [],
+        commandFiles: [],
+        skillDirs: [{ name: "skill-one", sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one") }],
+      }
+
+      await writeOpenCodeBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await exists(path.join(forkStore, "skill-one"))).toBe(false)
+      expect(await fs.readFile(path.join(forkStore, "MARKER.md"), "utf8")).toBe("# user store\n")
+      expect((await readInstallManifest(outputRoot)).groups.skills).not.toContain("skill-one")
+    },
+  )
+})

--- a/tests/pi-writer.test.ts
+++ b/tests/pi-writer.test.ts
@@ -825,3 +825,40 @@ describe("writePiBundle preserves user-managed skill paths", () => {
     },
   )
 })
+
+describe("writePiBundle guards against ancestor-symlink traversal", () => {
+  async function readInstallManifest(outputRoot: string): Promise<{ skills: string[] }> {
+    const raw = await fs.readFile(path.join(outputRoot, "compound-engineering", "install-manifest.json"), "utf8")
+    return JSON.parse(raw) as { skills: string[] }
+  }
+
+  test.skipIf(!canDirSymlink)(
+    "does not write through a store dir that is itself a symlink into a user fork",
+    async () => {
+      const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ancestor-store-symlink-"))
+      const outputRoot = path.join(tempRoot, ".pi")
+      const forkStore = path.join(tempRoot, "user-fork-store")
+      await fs.mkdir(forkStore, { recursive: true })
+      await fs.writeFile(path.join(forkStore, "MARKER.md"), "# user store\n")
+      await fs.mkdir(outputRoot, { recursive: true })
+      await fs.symlink(forkStore, path.join(outputRoot, "skills"), "junction")
+
+      const bundle: PiBundle = {
+        pluginName: "compound-engineering",
+        prompts: [],
+        skillDirs: [{ name: "skill-one", sourceDir: path.join(import.meta.dir, "fixtures", "sample-plugin", "skills", "skill-one") }],
+        generatedSkills: [],
+        agents: [],
+        extensions: [],
+      }
+
+      await writePiBundle(outputRoot, bundle)
+
+      const linkStat = await fs.lstat(path.join(outputRoot, "skills"))
+      expect(linkStat.isSymbolicLink()).toBe(true)
+      expect(await exists(path.join(forkStore, "skill-one"))).toBe(false)
+      expect(await fs.readFile(path.join(forkStore, "MARKER.md"), "utf8")).toBe("# user store\n")
+      expect((await readInstallManifest(outputRoot)).skills).not.toContain("skill-one")
+    },
+  )
+})


### PR DESCRIPTION
## Summary

Follow-up to the leaf-node symlink preservation shipped in #1089 (Pi) and #1094 (Codex/OpenCode). Those guards inspect only the **leaf** path component (`isPreservedSymlink` → `lstat` the final node). A user who repoints a whole managed **store directory** — or any ancestor of it — at a personal fork slips past them, because `lstat`/`fs.rm`/copy follow every ancestor symlink. The write then operates **through** the link, into the fork.

This was the "ancestor-symlink traversal" class disclosed as out-of-scope in #1094's scope notes. This PR closes it for the three writers that already have the leaf-ownership contract (codex, opencode, pi).

Concrete example: user runs `ln -s ~/my-fork ~/.codex/skills/compound-engineering`. Before this PR, `install --to codex` would `fs.rm` and re-copy skill dirs *inside `~/my-fork`*, clobbering their fork. After: the store is detected as escaping the codex root, skipped wholesale, and recorded as owning nothing.

## Fix

A realpath-based containment check in `managed-artifacts.ts`:

- `realpathNearestExisting(p)` — realpath of the nearest existing ancestor (a not-yet-created descendant can't add a symlink hop, so this suffices and works before a fresh store exists).
- `isContainedPath(rootReal, targetReal)` — pure predicate; **now also reused by codex's existing `isPathInside`**, removing a duplicated relative-path check.
- `isPathWithinRoot(root, target)` — realpaths both sides (so a config root legitimately relocated *as a whole* still reads as contained) and applies `isContainedPath`.
- `storeRootEscapesManagedRoot(root, storeDir)` — warns + returns true when a store escapes; the caller then skips **every** operation on that store.

Applied per writer against the target root (`~/.codex`, the OpenCode root, the Pi store parent):

- **codex.ts** — guards the skills, agents, and prompts stores; escaped stores are excluded from the install manifest. The codex-local legacy-artifact mover and `cleanupPreviousManagedCodexSkillStore` (a recursive `fs.rm`) gain the same containment check at their destructive op.
- **opencode.ts** — guards all four stores (agents, commands, plugins, skills), each of which has a manifest ownership record.
- **pi.ts** — guards skills, prompts, extensions, agents; the pi-local legacy mover gains the containment check.
- **managed-artifacts.ts** — the shared `moveLegacyArtifactToBackup` gains the containment guard at its `fs.rename`, gated by the existing `skipSymlinkGuard` escape hatch (so the one intentional symlink-relocator in the `cleanup` command is exempt). This one line covers the OpenCode/Kiro legacy sweeps and the standalone `cleanup` command's move paths.

Escaped stores use the same `preserved`/`continue` idiom #1094 established, so the manifest never claims a path the install didn't write.

## Verification

- **7 new tests** (2 codex, 1 opencode, 1 pi, + the shared paths they exercise): a store dir that is itself a symlink into a fork, and a symlinked *ancestor* above the store dir (multi-level), both proving the fork content is untouched, the symlink node survives, and the manifest records nothing.
- **Red-green:** with `src/` stashed, all 4 new ancestor tests fail — the assertion `exists(fork/<written-path>)` is `true` (the fork gets written through) without the guard, `false` with it.
- Full `bun test`: **1930 pass / 0 fail**; existing #1089/#1094 leaf-preservation tests pass unmodified (leaf-symlink cases short-circuit at `isPreservedSymlink` before the new ancestor check). `bun run release:validate` in sync.

## Scope decisions

- **Antigravity is deliberately out of scope.** It is a reachable writer but has **no leaf-ownership contract at all** — it overwrites real user files and leaf symlinks unconditionally. Adding only ancestor-containment there would be a misleading half-guard over a still-unconditional leaf write. Antigravity needs the #1089/#1094 leaf contract *first*; containment should land with it, not before. Tracked as a separate follow-up.
- **Kiro** inherits the shared-mover containment guard for its legacy sweep, consistent with #1094, though it remains unreachable from the CLI.
- **The `managedDir` manifest/`legacy-backup` writes** (writing `install-manifest.json` through a symlinked `managedDir`) remain unguarded — lower stakes, since that path only writes CE-owned metadata, not user source. Noted here so it's tracked rather than rediscovered.
- **Dangling store-root symlinks** still make the initial `ensureDir` throw (pre-existing crash, no data loss) — unchanged from #1089/#1094.