### PR TITLE
fix(codex): preserve native subagent delegation

### DIFF
--- a/src/utils/codex-agents.ts
+++ b/src/utils/codex-agents.ts
@@ -19,7 +19,7 @@ Tool mapping:
 - LS: use ls via shell_command
 - WebFetch/WebSearch: use curl or Context7 for library docs
 - AskUserQuestion/Question: present choices as a numbered list in chat and wait for a reply number. For multi-select (multiSelect: true), accept comma-separated numbers. Never skip or auto-configure — always wait for the user's response before proceeding.
-- Task (subagent dispatch) / Subagent / Parallel: run sequentially in main thread; use multi_tool_use.parallel for tool calls
+- Task (subagent dispatch) / Subagent / Parallel: use native Codex sub-agents; preserve requested delegation and parallelism within the available concurrency limit
 - TaskCreate/TaskUpdate/TaskList/TaskGet/TaskStop/TaskOutput (Claude Code task-tracking, current): use update_plan (Codex's task-tracking primitive)
 - TodoWrite/TodoRead (Claude Code task-tracking, legacy — deprecated, replaced by Task* tools): use update_plan
 - Skill: open the referenced SKILL.md and follow it

--- a/tests/codex-agents.test.ts
+++ b/tests/codex-agents.test.ts
@@ -21,6 +21,8 @@ describe("ensureCodexAgentsFile", () => {
     const content = await readFile(agentsPath)
     expect(content).toContain(CODEX_AGENTS_BLOCK_START)
     expect(content).toContain("Tool mapping")
+    expect(content).toContain("use native Codex sub-agents")
+    expect(content).not.toContain("run sequentially in main thread")
     expect(content).toContain("TaskCreate/TaskUpdate/TaskList/TaskGet/TaskStop/TaskOutput")
     expect(content).toContain("use update_plan")
     expect(content).toContain(CODEX_AGENTS_BLOCK_END)


### PR DESCRIPTION
Codex installs no longer collapse Compound Engineering workflows that explicitly request delegated or parallel agents into sequential main-thread work. The generated `AGENTS.md` mapping now uses native Codex sub-agents and respects the available runtime concurrency limit, preserving reviewer fan-out while letting Codex enforce capacity. Regression coverage rejects the previous sequential fallback; the full 1,926-test suite and release metadata validation pass.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)
