### PR TITLE
fix(skills): make SKILL_DIR script calls survive newline flattening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,9 +251,11 @@ How a bundled-file reference resolves depends on *who* resolves it and whether a
 
 ```
 # set inline in the SAME command (shell state does not persist between Bash calls):
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 bash "$SKILL_DIR/scripts/my-script.sh" ARG
 ```
+
+**Keep the trailing `;` on the assignment line.** Some hosts (observed on Codex) flatten a fenced multi-line block into a single line by replacing the newline with a space before executing it. Without the `;`, `SKILL_DIR="…"` + newline + `bash "$SKILL_DIR/…"` collapses to the env-var-prefix form `SKILL_DIR="…" bash "$SKILL_DIR/…"`, where the shell expands `$SKILL_DIR` *before* the prefix assignment takes effect — so it expands to empty and the script path becomes `/scripts/my-script.sh` (`No such file or directory`). The trailing `;` makes the assignment a complete statement that survives flattening; it is load-bearing, not a style choice, so do not remove it.
 
 An existence guard (`if [ -f "$SKILL_DIR/scripts/my-script.sh" ]; then … else echo "not found — re-check the SKILL.md path"; fi`) is optional — useful when there's a real fallback, but see the permission caveat below before guarding a pinned call.
 

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -157,7 +157,7 @@ Scan the repo before substantive brainstorming. Match depth to scope:
 *Constraint Check (inline)* — Source the agnostic orientation (STRATEGY summary, CONCEPTS vocabulary, conventions) from the shared repo-grounding profile cache instead of re-reading those files every run. Set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 

--- a/skills/ce-brainstorm/references/repo-profile-cache.md
+++ b/skills/ce-brainstorm/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-brainstorm/references/visual-probes.md
+++ b/skills/ce-brainstorm/references/visual-probes.md
@@ -71,14 +71,14 @@ Use the bundled display-only helper when the current platform can run a bundled 
 Start (detached):
 
 ```bash
-SKILL_DIR="<absolute path of the ce-brainstorm skill directory>"
+SKILL_DIR="<absolute path of the ce-brainstorm skill directory>";
 node "$SKILL_DIR/scripts/visual-probe-server.js" start --root /tmp/compound-engineering/ce-brainstorm-visual/<run-id>
 ```
 
 Append `--foreground` to that `start` command for foreground mode. Status and stop take the same anchor — and because `SKILL_DIR` does not persist between Bash invocations, each must re-set it in its own call rather than reuse the `start` block's value:
 
 ```bash
-SKILL_DIR="<absolute path of the ce-brainstorm skill directory>"
+SKILL_DIR="<absolute path of the ce-brainstorm skill directory>";
 node "$SKILL_DIR/scripts/visual-probe-server.js" status --root /tmp/compound-engineering/ce-brainstorm-visual/<run-id>
 # stop: the same command with `stop` in place of `status` (re-set SKILL_DIR again)
 ```

--- a/skills/ce-code-review/SKILL.md
+++ b/skills/ce-code-review/SKILL.md
@@ -361,7 +361,7 @@ If a plan is found, classify readiness before extraction (see "Plan Requirements
 Resolve the question-agnostic project profile (stack, dependency surface + licenses, conventions, structure) from the shared cache once, so the orchestrator's reviewer selection and the non-standards reviewers (`correctness`, `testing`, `maintainability`) share one cheap stack/conventions orientation instead of each re-deriving it from the diff. Set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 

--- a/skills/ce-code-review/references/cross-model-review.md
+++ b/skills/ce-code-review/references/cross-model-review.md
@@ -35,7 +35,7 @@ The script is a CLI shell-out, not a subagent, so it doesn't consume the subagen
 Invoke it via the skill-dir anchor — set `SKILL_DIR` to the absolute directory of **this** skill's `SKILL.md` (the one you read to run ce-code-review), because the Bash tool's CWD is the user's project, not the skill dir, on every host:
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the ce-code-review SKILL.md you read>"
+SKILL_DIR="<absolute path of the directory containing the ce-code-review SKILL.md you read>";
 bash "$SKILL_DIR/scripts/cross-model-adversarial-review.sh" "<peer>" "<base-ref>" "<run-dir>"
 ```
 

--- a/skills/ce-code-review/references/repo-profile-cache.md
+++ b/skills/ce-code-review/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-compound-refresh/references/per-action-flows.md
+++ b/skills/ce-compound-refresh/references/per-action-flows.md
@@ -84,7 +84,7 @@ Do not let replacement subagents invent frontmatter fields, enum values, or sect
 4. **Run the mechanical claims check on the successor doc.** The bundled `scripts/validate-doc-claims.py` flags cited repo paths missing from the tree, commit SHAs that do not resolve or are unreachable, relative doc links that do not resolve, and dangling drafting scaffold ("Learning 3", unresolved `{{...}}` tokens):
 
    ```bash
-   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
    python3 "$SKILL_DIR/scripts/validate-doc-claims.py" <new-learning-path>
    ```
 

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -259,14 +259,7 @@ Pass `{run_id}` (the resolved `$RUN_ID` value) into every Phase 1 subagent promp
 
    ```bash
    SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
-   if [ -f "$SKILL_DIR/scripts/session-history/discover-sessions.sh" ] && [ -f "$SKILL_DIR/scripts/session-history/extract-metadata.py" ]; then
-     REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-     REPO_NAME=$(basename "$REPO_ROOT")
-     SCAN_DAYS="7"
-     bash "$SKILL_DIR/scripts/session-history/discover-sessions.sh" "$REPO_NAME" "$SCAN_DAYS" --cwd "$REPO_ROOT" | tr '\n' '\0' | xargs -0 python3 "$SKILL_DIR/scripts/session-history/extract-metadata.py" --cwd-filter "$REPO_ROOT"
-   else
-     echo "Session history bundled scripts were not found in this skill's directory; skipping the session-history probe for this run."
-   fi
+   if [ -f "$SKILL_DIR/scripts/session-history/discover-sessions.sh" ] && [ -f "$SKILL_DIR/scripts/session-history/extract-metadata.py" ]; then REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd); REPO_NAME=$(basename "$REPO_ROOT"); SCAN_DAYS="7"; bash "$SKILL_DIR/scripts/session-history/discover-sessions.sh" "$REPO_NAME" "$SCAN_DAYS" --cwd "$REPO_ROOT" | tr '\n' '\0' | xargs -0 python3 "$SKILL_DIR/scripts/session-history/extract-metadata.py" --cwd-filter "$REPO_ROOT"; else echo "Session history bundled scripts were not found in this skill's directory; skipping the session-history probe for this run."; fi
    ```
 
    Pi sessions are included when present under `~/.pi/agent/sessions/`; they carry `cwd` like Codex but no git branch. If `_meta.files_processed` is `0`, return `no relevant prior sessions`. If the first pass finds no relevant branch matches, or if processing Codex or Pi sessions, derive 2-4 keywords from the topic and re-run metadata extraction with `--keyword K1,K2,...`. Keep at most 5 sessions across Claude Code, Codex, Cursor, and Pi, ranked by branch match, keyword match count, file size over 30KB, and recency. Exclude the current session.
@@ -277,11 +270,7 @@ Pass `{run_id}` (the resolved `$RUN_ID` value) into every Phase 1 subagent promp
 
    ```bash
    SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
-   if [ -f "$SKILL_DIR/scripts/session-history/extract-skeleton.py" ]; then
-     python3 "$SKILL_DIR/scripts/session-history/extract-skeleton.py" --output "$SCRATCH/<session-id>.skeleton.txt" < <session-file>
-   else
-     echo "Session history bundled scripts were not found in this skill's directory; skipping the session-history probe for this run."
-   fi
+   if [ -f "$SKILL_DIR/scripts/session-history/extract-skeleton.py" ]; then python3 "$SKILL_DIR/scripts/session-history/extract-skeleton.py" --output "$SCRATCH/<session-id>.skeleton.txt" < <session-file>; else echo "Session history bundled scripts were not found in this skill's directory; skipping the session-history probe for this run."; fi
    ```
 
    Use `extract-errors.py` selectively when dead ends or recurring errors are likely useful. Pass only the scratch file paths and metadata to the synthesis subagent.

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -131,7 +131,7 @@ mkdir -p "/tmp/compound-engineering/ce-compound/$RUN_ID"
 **Resolve the agnostic project orientation from the shared cache (before dispatching subagents).** The question-agnostic orientation the Context Analyzer and Related Docs Finder rely on — the project's `CONCEPTS.md` vocabulary and the root instruction-file conventions/digests — is identical for every run at this commit, so reuse it instead of re-deriving. Set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -258,7 +258,7 @@ Pass `{run_id}` (the resolved `$RUN_ID` value) into every Phase 1 subagent promp
    **Discovery pipeline.** Infer the scan window from the problem topic, starting with 7 days. Run discovery and metadata extraction:
 
    ```bash
-   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
    if [ -f "$SKILL_DIR/scripts/session-history/discover-sessions.sh" ] && [ -f "$SKILL_DIR/scripts/session-history/extract-metadata.py" ]; then
      REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
      REPO_NAME=$(basename "$REPO_ROOT")
@@ -276,7 +276,7 @@ Pass `{run_id}` (the resolved `$RUN_ID` value) into every Phase 1 subagent promp
    **Extraction pipeline.** Create `SCRATCH=$(mktemp -d -t ce-compound-sessions-XXXXXX)`. For each selected session, write extracted content to scratch files:
 
    ```bash
-   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
    if [ -f "$SKILL_DIR/scripts/session-history/extract-skeleton.py" ]; then
      python3 "$SKILL_DIR/scripts/session-history/extract-skeleton.py" --output "$SCRATCH/<session-id>.skeleton.txt" < <session-file>
    else
@@ -377,7 +377,7 @@ The doc (and any `CONCEPTS.md` entries from Phase 2.4) is about to become perman
 1. **Mechanical claims check (every mode, including headless).** Optionally run `git fetch --quiet` first (best-effort — skip silently offline; the network is never a correctness dependency). Then run the bundled validator against the written doc:
 
    ```bash
-   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+   SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
    python3 "$SKILL_DIR/scripts/validate-doc-claims.py" <doc-path>
    ```
 

--- a/skills/ce-compound/references/repo-profile-cache.md
+++ b/skills/ce-compound/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -69,7 +69,7 @@ Confirm the bug exists and understand its behavior. Run the test, trigger the er
 - **Writing the reproduction test:** Orient on the project's testing conventions before authoring the failing test. Resolve them from the shared repo-grounding cache first — set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
 
   ```bash
-  SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+  SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
   ```
 

--- a/skills/ce-debug/references/repo-profile-cache.md
+++ b/skills/ce-debug/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -52,7 +52,7 @@ echo "$RUN_DIR"
 **Repo-touching inputs** (a concept with footprint in this repo, a diff, a recap): resolve the question-agnostic project profile from the shared cache instead of re-deriving it. Set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 

--- a/skills/ce-explain/references/repo-profile-cache.md
+++ b/skills/ce-explain/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-ideate/SKILL.md
+++ b/skills/ce-ideate/SKILL.md
@@ -269,7 +269,7 @@ Run grounding agents in parallel in the **foreground** (do not background — re
 **Resolve the project profile from the shared cache first.** The question-agnostic profile (stack, top-level layout, conventions, root instruction files) is identical for every run at this commit, so reuse it instead of re-deriving it in the codebase scan. Set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 

--- a/skills/ce-ideate/references/repo-profile-cache.md
+++ b/skills/ce-ideate/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -244,7 +244,7 @@ mkdir -p .context/compound-engineering/ce-optimize/<spec-name>/
 **Bundled scripts.** Phases 1 and 3 call helper scripts that ship in this skill's `scripts/` directory (`measure.sh`, `parallel-probe.sh`, `experiment-worktree.sh`). The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. Every runnable block below already sets `SKILL_DIR` inline (shell state does not persist between Bash tool calls, so each block must carry it); just replace the `<absolute path …>` placeholder with the directory you loaded this `ce-optimize` SKILL.md from before running. The shape:
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 bash "$SKILL_DIR/scripts/<name>"
 ```
 
@@ -266,7 +266,7 @@ Filter the output against the scope paths. If any in-scope files have uncommitte
 **If user provides a measurement harness** (the `measurement.command` already exists):
 1. Run it once via the measurement script:
    ```bash
-   SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+   SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
    bash "$SKILL_DIR/scripts/measure.sh" "<measurement.command>" <timeout_seconds> "<measurement.working_directory or .>"
    ```
 2. Validate the JSON output:
@@ -310,7 +310,7 @@ If primary type is `judge`, also run the judge evaluation on baseline output to 
 
 Run the parallelism probe script:
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 bash "$SKILL_DIR/scripts/parallel-probe.sh" "<project_directory>" "<measurement.command>" "<measurement.working_directory>" <shared_files...>
 ```
 
@@ -320,7 +320,7 @@ Read the JSON output. Present any blockers to the user with suggested mitigation
 
 Count existing worktrees:
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 bash "$SKILL_DIR/scripts/experiment-worktree.sh" count
 ```
 
@@ -376,7 +376,7 @@ Read the code within `scope.mutable` to understand:
 Optionally read `references/agents/repo-research-analyst.md` and dispatch a generic subagent seeded with that local prompt for deeper codebase analysis if the scope is large or unfamiliar. Do not dispatch a standalone agent by type/name. When you do, resolve the question-agnostic project profile from the shared cache first (set `SKILL_DIR` to this skill's directory; protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -451,7 +451,7 @@ The Phase 3 blocks below each set `SKILL_DIR` inline as well (the loaded `ce-opt
 **Worktree backend:**
 1. Create experiment worktree:
    ```bash
-   SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+   SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
    WORKTREE_PATH=$(bash "$SKILL_DIR/scripts/experiment-worktree.sh" create "<spec_name>" <exp_index> "optimize/<spec_name>" <shared_files...>)  # creates optimize-exp/<spec_name>/exp-<NNN>
    ```
 2. Apply port parameterization if configured (set env vars for the measurement script)
@@ -486,7 +486,7 @@ For each completed experiment, **immediately**:
 
 1. **Run measurement** in the experiment's worktree:
    ```bash
-   SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+   SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
    bash "$SKILL_DIR/scripts/measure.sh" "<measurement.command>" <timeout_seconds> "<worktree_path>/<measurement.working_directory or .>" <env_vars...>
    ```
    - If stability mode is `repeat`, run the measurement harness `repeat_count` times in that working directory and aggregate the results exactly as in Phase 1 before evaluating gates or ranking the experiment.

--- a/skills/ce-optimize/references/repo-profile-cache.md
+++ b/skills/ce-optimize/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -294,7 +294,7 @@ Prepare a concise planning context summary (a paragraph or two) to pass as input
 **Resolve the project profile from the shared cache first.** The agnostic profile (stack, deps, conventions, structure) is identical at this commit, so reuse it instead of having `repo-research-analyst` re-derive `technology`/`architecture`/`conventions` every run. Set `SKILL_DIR` to this skill's directory and run the helper (protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 

--- a/skills/ce-plan/references/repo-profile-cache.md
+++ b/skills/ce-plan/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-polish/SKILL.md
+++ b/skills/ce-polish/SKILL.md
@@ -22,7 +22,7 @@ The scripts below ship in this skill's `scripts/` directory. The Bash tool's wor
 ### 1.1 Check for `.claude/launch.json`
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 bash "$SKILL_DIR/scripts/read-launch-json.sh"
 ```
 
@@ -33,7 +33,7 @@ If it finds a configuration, use it — the user already told us how to start th
 Identify the framework:
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 bash "$SKILL_DIR/scripts/detect-project-type.sh"
 ```
 
@@ -54,14 +54,14 @@ Route by type to the matching recipe reference for start command and port defaul
 For framework types that need a package manager, run the resolver and substitute the result into the start command:
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 bash "$SKILL_DIR/scripts/resolve-package-manager.sh"
 ```
 
 Resolve the port:
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 bash "$SKILL_DIR/scripts/resolve-port.sh" --type <type>
 ```
 

--- a/skills/ce-pov/SKILL.md
+++ b/skills/ce-pov/SKILL.md
@@ -60,7 +60,7 @@ Grounding searches code, git, the issue tracker, PRs, and docs — noisy work th
 **Resolve the project profile from the shared cache first.** The question-agnostic profile (stack, dependency surface + licenses, conventions, structure) is identical for every run at this commit, so reuse it instead of re-deriving. Set `SKILL_DIR` to this skill's directory and run the helper (full protocol in `references/repo-profile-cache.md`):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 

--- a/skills/ce-pov/references/repo-profile-cache.md
+++ b/skills/ce-pov/references/repo-profile-cache.md
@@ -38,7 +38,7 @@ Two checkouts at the same commit share the same entry. Lookup is git metadata on
 Invoke the helper via the `SKILL_DIR` anchor (set `SKILL_DIR` to the absolute path of the directory containing the SKILL.md you just read; the Bash tool's cwd is the user's project, not the skill dir):
 
 ```bash
-SKILL_DIR="<absolute path of this skill's directory>"
+SKILL_DIR="<absolute path of this skill's directory>";
 python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 ```
 
@@ -47,7 +47,7 @@ python3 "$SKILL_DIR/scripts/repo-profile-cache.py" get
 - `HIT` then the profile JSON on the following lines → load it as the agnostic profile; skip derivation.
 - `MISS` then a write-path on the next line → dispatch the `repo-profiler` persona to derive the profile, write its JSON output to a file, then persist it. This `put` runs after the profiler, so it is a **separate Bash-tool call** from the `get` above — shell variables do not persist between calls, so **re-set `SKILL_DIR` in the same command**:
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/repo-profile-cache.py" put <profile-json-file>
   ```
 - `NO-CACHE` → no git repo or no writable cache. Derive the profile fresh for this run and **skip** `put` (nothing to persist).

--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -17,7 +17,7 @@ Then fetch all feedback using the GraphQL script at [scripts/get-pr-comments](..
 # SKILL_DIR = the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from.
 # The Bash tool's CWD is the user's project, not the skill dir, and shell state does not
 # persist between Bash calls — set SKILL_DIR in each block below that runs a bundled script.
-SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 SCRIPT_DIR="$SKILL_DIR/scripts"
 if [ ! -f "$SCRIPT_DIR/get-pr-comments" ]; then
   echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use the fallback gh commands below." >&2
@@ -162,7 +162,7 @@ For `needs-human` verdicts, post the natural-sounding reply but do NOT resolve t
 
 0. **Verify the thread ID** before replying. GitHub Enterprise can return inconsistent node IDs for the same thread depending on the query path. Always confirm the ID from `get-pr-comments` resolves to the correct thread using [scripts/get-thread-for-comment](../scripts/get-thread-for-comment) with the comment's numeric URL ID:
 ```bash
-SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 SCRIPT_DIR="$SKILL_DIR/scripts"
 if [ ! -f "$SCRIPT_DIR/get-thread-for-comment" ]; then
   echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use gh api to inspect the review thread." >&2
@@ -177,7 +177,7 @@ The returned `id` is the authoritative thread ID to use for reply and resolve. I
 
 1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread):
 ```bash
-SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 SCRIPT_DIR="$SKILL_DIR/scripts"
 if [ ! -f "$SCRIPT_DIR/reply-to-pr-thread" ]; then
   echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; post the reply with gh api or gh pr comment as appropriate." >&2
@@ -190,7 +190,7 @@ Check that the returned comment URL contains the correct `OWNER/REPO` and PR num
 
 2. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread):
 ```bash
-SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 SCRIPT_DIR="$SKILL_DIR/scripts"
 if [ ! -f "$SCRIPT_DIR/resolve-pr-thread" ]; then
   echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; resolve the thread with gh api if supported." >&2
@@ -215,7 +215,7 @@ Include enough quoted context in the reply so the reader can follow which commen
 Re-fetch feedback to confirm resolution:
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 SCRIPT_DIR="$SKILL_DIR/scripts"
 if [ ! -f "$SCRIPT_DIR/get-pr-comments" ]; then
   echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use the fallback gh commands from Step 1." >&2

--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -11,20 +11,11 @@ If no PR number was provided, detect from the current branch:
 gh pr view --json number -q .number
 ```
 
-Then fetch all feedback using the GraphQL script at [scripts/get-pr-comments](../scripts/get-pr-comments):
+Then fetch all feedback using the GraphQL script at [scripts/get-pr-comments](../scripts/get-pr-comments). Set `SKILL_DIR` to the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from — the Bash tool's CWD is the user's project, not the skill dir, and shell state does not persist between Bash calls, so set it inline in each block below that runs a bundled script. If the bundled script is missing on disk the call fails plainly; fall back to the `gh` commands shown after this block.
 
 ```bash
-# SKILL_DIR = the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from.
-# The Bash tool's CWD is the user's project, not the skill dir, and shell state does not
-# persist between Bash calls — set SKILL_DIR in each block below that runs a bundled script.
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-SCRIPT_DIR="$SKILL_DIR/scripts"
-if [ ! -f "$SCRIPT_DIR/get-pr-comments" ]; then
-  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use the fallback gh commands below." >&2
-  exit 1
-fi
-
-bash "$SCRIPT_DIR/get-pr-comments" PR_NUMBER
+bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER
 ```
 
 Returns a JSON object with three keys:
@@ -160,44 +151,25 @@ For `needs-human` verdicts, post the natural-sounding reply but do NOT resolve t
 
 ### Review threads
 
-0. **Verify the thread ID** before replying. GitHub Enterprise can return inconsistent node IDs for the same thread depending on the query path. Always confirm the ID from `get-pr-comments` resolves to the correct thread using [scripts/get-thread-for-comment](../scripts/get-thread-for-comment) with the comment's numeric URL ID:
+0. **Verify the thread ID** before replying. GitHub Enterprise can return inconsistent node IDs for the same thread depending on the query path. Always confirm the ID from `get-pr-comments` resolves to the correct thread using [scripts/get-thread-for-comment](../scripts/get-thread-for-comment) with the comment's numeric URL ID. Extract the numeric comment ID from the comment URL (e.g. `discussion_r2589700` → `2589700`) for the `gh api` call; if the bundled script is missing, use `gh api` to inspect the review thread instead:
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-SCRIPT_DIR="$SKILL_DIR/scripts"
-if [ ! -f "$SCRIPT_DIR/get-thread-for-comment" ]; then
-  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use gh api to inspect the review thread." >&2
-  exit 1
-fi
-
-# Extract numeric comment ID from the comment URL (e.g. discussion_r2589700 → 2589700)
 GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/COMMENT_ID --jq .node_id
-bash "$SCRIPT_DIR/get-thread-for-comment" PR_NUMBER COMMENT_NODE_ID OWNER/REPO
+bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBER COMMENT_NODE_ID OWNER/REPO
 ```
 The returned `id` is the authoritative thread ID to use for reply and resolve. If it differs from what `get-pr-comments` returned, use the one from this script.
 
-1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread):
+1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread) (if the bundled script is missing, post the reply with `gh api` or `gh pr comment` as appropriate):
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-SCRIPT_DIR="$SKILL_DIR/scripts"
-if [ ! -f "$SCRIPT_DIR/reply-to-pr-thread" ]; then
-  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; post the reply with gh api or gh pr comment as appropriate." >&2
-  exit 1
-fi
-
-echo "REPLY_TEXT" | bash "$SCRIPT_DIR/reply-to-pr-thread" THREAD_ID
+echo "REPLY_TEXT" | bash "$SKILL_DIR/scripts/reply-to-pr-thread" THREAD_ID
 ```
 Check that the returned comment URL contains the correct `OWNER/REPO` and PR number before proceeding.
 
-2. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread):
+2. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread) (if the bundled script is missing, resolve the thread with `gh api` if supported):
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-SCRIPT_DIR="$SKILL_DIR/scripts"
-if [ ! -f "$SCRIPT_DIR/resolve-pr-thread" ]; then
-  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; resolve the thread with gh api if supported." >&2
-  exit 1
-fi
-
-bash "$SCRIPT_DIR/resolve-pr-thread" THREAD_ID
+bash "$SKILL_DIR/scripts/resolve-pr-thread" THREAD_ID
 ```
 
 ### PR comments and review bodies
@@ -216,13 +188,7 @@ Re-fetch feedback to confirm resolution:
 
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-SCRIPT_DIR="$SKILL_DIR/scripts"
-if [ ! -f "$SCRIPT_DIR/get-pr-comments" ]; then
-  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use the fallback gh commands from Step 1." >&2
-  exit 1
-fi
-
-bash "$SCRIPT_DIR/get-pr-comments" PR_NUMBER
+bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER
 ```
 
 The `review_threads` array should be empty (except `needs-human` items).

--- a/skills/ce-resolve-pr-feedback/references/targeted-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/targeted-mode.md
@@ -20,7 +20,7 @@ gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID \
 # SKILL_DIR = the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from
 # (the Bash tool's CWD is the user's project, not the skill dir; shell state does not
 #  persist between Bash calls, so always set it before calling a bundled script).
-SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 SCRIPT_DIR="$SKILL_DIR/scripts"
 if [ ! -f "$SCRIPT_DIR/get-thread-for-comment" ]; then
   echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use Full Mode's fallback gh commands to inspect the PR comments." >&2

--- a/skills/ce-resolve-pr-feedback/references/targeted-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/targeted-mode.md
@@ -15,19 +15,10 @@ gh api repos/OWNER/REPO/pulls/comments/COMMENT_ID \
   --jq '{node_id, path, line, body}'
 ```
 
-**Step 2** -- Map comment to its thread ID. Use [scripts/get-thread-for-comment](../scripts/get-thread-for-comment):
+**Step 2** -- Map comment to its thread ID. Use [scripts/get-thread-for-comment](../scripts/get-thread-for-comment). Set `SKILL_DIR` to the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from — the Bash tool's CWD is the user's project, not the skill dir, and shell state does not persist between Bash calls, so set it inline. If the bundled script is missing, use Full Mode's fallback `gh` commands to inspect the PR comments:
 ```bash
-# SKILL_DIR = the absolute directory you loaded the ce-resolve-pr-feedback SKILL.md from
-# (the Bash tool's CWD is the user's project, not the skill dir; shell state does not
-#  persist between Bash calls, so always set it before calling a bundled script).
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-SCRIPT_DIR="$SKILL_DIR/scripts"
-if [ ! -f "$SCRIPT_DIR/get-thread-for-comment" ]; then
-  echo "ce-resolve-pr-feedback bundled scripts not found under $SCRIPT_DIR; use Full Mode's fallback gh commands to inspect the PR comments." >&2
-  exit 1
-fi
-
-bash "$SCRIPT_DIR/get-thread-for-comment" PR_NUMBER COMMENT_NODE_ID [OWNER/REPO]
+bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBER COMMENT_NODE_ID [OWNER/REPO]
 ```
 
 This fetches thread IDs and their first comment IDs (minimal fields, no bodies) and returns the matching thread with full comment details.

--- a/skills/ce-riffrec-feedback-analysis/SKILL.md
+++ b/skills/ce-riffrec-feedback-analysis/SKILL.md
@@ -28,7 +28,7 @@ When the input is ambiguous (e.g., a zip arrived without context), inspect the r
 All non-setup paths share the same analyzer, which ships in this skill's `scripts/` directory. The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve. Invoke it by the skill's own absolute path: set `SKILL_DIR` to the directory you loaded this `ce-riffrec-feedback-analysis` SKILL.md from, in the same command (shell state does not persist between Bash calls):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 python "$SKILL_DIR/scripts/analyze_riffrec_zip.py" /path/to/input
 ```
 

--- a/skills/ce-riffrec-feedback-analysis/references/extensive-analysis.md
+++ b/skills/ce-riffrec-feedback-analysis/references/extensive-analysis.md
@@ -7,7 +7,7 @@ Use this path when the input is a longer recording (over ~60 seconds), contains 
 1. Run the analyzer (`SKILL_DIR` is the directory containing the `ce-riffrec-feedback-analysis` SKILL.md; set it in the same command — shell state does not persist between Bash calls):
 
    ```bash
-   SKILL_DIR="<absolute path of the directory containing the ce-riffrec-feedback-analysis SKILL.md>"
+   SKILL_DIR="<absolute path of the directory containing the ce-riffrec-feedback-analysis SKILL.md>";
    python "$SKILL_DIR/scripts/analyze_riffrec_zip.py" /path/to/input
    ```
 

--- a/skills/ce-riffrec-feedback-analysis/references/quick-bug-report.md
+++ b/skills/ce-riffrec-feedback-analysis/references/quick-bug-report.md
@@ -7,7 +7,7 @@ Use this path when the input is a short recording (under ~60 seconds), the user 
 1. Run the analyzer to a temp directory so nothing pollutes the repo (`SKILL_DIR` is the directory containing the `ce-riffrec-feedback-analysis` SKILL.md; set it in the same command — shell state does not persist between Bash calls):
 
    ```bash
-   SKILL_DIR="<absolute path of the directory containing the ce-riffrec-feedback-analysis SKILL.md>"
+   SKILL_DIR="<absolute path of the directory containing the ce-riffrec-feedback-analysis SKILL.md>";
    python "$SKILL_DIR/scripts/analyze_riffrec_zip.py" /path/to/input --output-dir "$(mktemp -d -t riffrec-quick-XXXXXX)"
    ```
 

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -31,7 +31,7 @@ Compound Engineering -- checking your environment...
 Run the bundled check script. Set `SKILL_DIR` to the absolute directory you loaded this `ce-setup` SKILL.md from — the Bash tool's CWD is the user's project, not the skill dir, so a bare `scripts/` path will not resolve:
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing this SKILL.md>"
+SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
 if [ -f "$SKILL_DIR/scripts/check-health" ]; then
   bash "$SKILL_DIR/scripts/check-health" --version VERSION
 else

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -32,11 +32,7 @@ Run the bundled check script. Set `SKILL_DIR` to the absolute directory you load
 
 ```bash
 SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
-if [ -f "$SKILL_DIR/scripts/check-health" ]; then
-  bash "$SKILL_DIR/scripts/check-health" --version VERSION
-else
-  echo "Bundled health script not found at $SKILL_DIR/scripts/check-health; run the inline checks from ce-setup instead."
-fi
+if [ -f "$SKILL_DIR/scripts/check-health" ]; then bash "$SKILL_DIR/scripts/check-health" --version VERSION; else echo "Bundled health script not found at $SKILL_DIR/scripts/check-health; run the inline checks from ce-setup instead."; fi
 ```
 
 Use the same command without `--version VERSION` if Step 1 could not determine a version.

--- a/skills/ce-sweep/SKILL.md
+++ b/skills/ce-sweep/SKILL.md
@@ -70,7 +70,7 @@ Resolve once and reuse for the entire run:
 **Every Bash call that runs the bundled engine sets `SKILL_DIR` inline** (shell state does not persist between calls):
 
 ```bash
-SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>"
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
 python3 "$SKILL_DIR/scripts/sweep-state.py" <subcommand> --state <state> ...
 ```
 

--- a/skills/ce-sweep/references/agents/media-analyzer.md
+++ b/skills/ce-sweep/references/agents/media-analyzer.md
@@ -15,7 +15,7 @@ You are a media-analysis specialist inside an already-running ce-sweep pass. You
 1. **Run the bundled analyzer on each media path.** The orchestrator gives you the absolute ce-sweep skill directory in the prompt's `<skill-dir>` block; set it inline in the same command (shell state does not persist between calls):
 
    ```
-   SKILL_DIR="<the absolute path from the <skill-dir> block>"
+   SKILL_DIR="<the absolute path from the <skill-dir> block>";
    python3 "$SKILL_DIR/scripts/analyze_riffrec_zip.py" <media_path> --output-dir <scratch_dir>
    ```
 

--- a/skills/ce-sweep/references/interview.md
+++ b/skills/ce-sweep/references/interview.md
@@ -126,7 +126,7 @@ Offer to seed state from an existing legacy feedback-tracking file so prior work
 - **Yes** -> ask for the file path. Then build a `--source-map`: for each legacy channel/source id in the file, pair it with the configured source id from section 1 (the short name the live connector reads by), as a JSON object like `{"C0AQLMQBGBD":"slack-alpha"}`. This is load-bearing — without it, an imported `C0AQLMQBGBD` cursor lands under `C0AQLMQBGBD` while the connector reads under `slack-alpha`, orphaning the cursor and re-ingesting everything on the first sweep. Run the import from **this skill's directory**; set `SKILL_DIR` inline to the absolute path of the directory containing the `SKILL.md` you loaded:
 
   ```bash
-  SKILL_DIR="<absolute path of this skill's directory>"
+  SKILL_DIR="<absolute path of this skill's directory>";
   python3 "$SKILL_DIR/scripts/sweep-state.py" import-legacy --state <sweep_state_path> --file <legacy-path> --source-map '{"<legacy-id>":"<config-source-id>"}'
   ```
 

--- a/tests/skills/ce-resolve-pr-feedback-script-dir.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-script-dir.test.ts
@@ -2,10 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { readFileSync } from "fs"
 import path from "path"
 
-const FULL_MODE = readFileSync(
-  path.join(import.meta.dir, "..", "..", "skills", "ce-resolve-pr-feedback", "references", "full-mode.md"),
-  "utf8",
-)
+const REFERENCES_DIR = path.join(import.meta.dir, "..", "..", "skills", "ce-resolve-pr-feedback", "references")
+const MODE_FILES = ["full-mode.md", "targeted-mode.md"] as const
 
 function fencedBashBlocks(markdown: string): string[] {
   const blocks: string[] = []
@@ -18,17 +16,27 @@ function fencedBashBlocks(markdown: string): string[] {
 }
 
 describe("ce-resolve-pr-feedback script directory handling", () => {
-  test("each SCRIPT_DIR command block resolves the skill script directory locally", () => {
-    const scriptDirBlocks = fencedBashBlocks(FULL_MODE).filter((block) => block.includes("$SCRIPT_DIR/"))
+  for (const file of MODE_FILES) {
+    const markdown = readFileSync(path.join(REFERENCES_DIR, file), "utf8")
+    const scriptBlocks = fencedBashBlocks(markdown).filter((block) => block.includes("$SKILL_DIR/scripts/"))
 
-    expect(scriptDirBlocks.length).toBeGreaterThan(0)
-    for (const block of scriptDirBlocks) {
-      // Each block must self-resolve the skill dir locally (shell state does not persist
-      // between Bash calls), via the portable model-filled SKILL_DIR anchor — not the
-      // Claude-only ${CLAUDE_SKILL_DIR} substitution.
-      expect(block).toContain('SKILL_DIR="')
-      expect(block).toContain('SCRIPT_DIR="$SKILL_DIR/scripts"')
-      expect(block).not.toContain("CLAUDE_SKILL_DIR")
-    }
-  })
+    test(`${file}: each bundled-script block resolves the skill dir via a flatten-safe SKILL_DIR anchor`, () => {
+      expect(scriptBlocks.length).toBeGreaterThan(0)
+      for (const block of scriptBlocks) {
+        // Blocks self-resolve the skill dir locally via the portable model-filled SKILL_DIR
+        // anchor (shell state does not persist between Bash calls) — not the Claude-only
+        // ${CLAUDE_SKILL_DIR} substitution.
+        expect(block).toContain('SKILL_DIR="')
+        expect(block).not.toContain("CLAUDE_SKILL_DIR")
+
+        // Flatten-safety: the SKILL_DIR assignment must terminate with `;`. Some hosts flatten
+        // a fenced block to one line (newline -> space); without the `;` this becomes the
+        // env-var-prefix form `SKILL_DIR="..." bash "$SKILL_DIR/..."`, where the shell expands
+        // $SKILL_DIR before the assignment applies and the script path collapses to `/scripts/...`.
+        const assignment = block.split("\n").find((line) => line.trimStart().startsWith('SKILL_DIR="'))
+        expect(assignment).toBeDefined()
+        expect(assignment!.trimEnd().endsWith(";")).toBe(true)
+      }
+    })
+  }
 })


### PR DESCRIPTION
## Summary

Running a skill on Codex could fail with `python3: can't open file '/scripts/repo-profile-cache.py'` — the skill's own bundled-script path collapsed to an absolute `/scripts/...`. Skills now invoke their bundled scripts reliably regardless of how the host executes the block.

The blocks set `SKILL_DIR` on one line and ran the script on the next. Hosts that flatten a fenced block to a single line (observed on Codex) replace the newline with a space, turning a two-line block into the env-var-prefix form `SKILL_DIR="..." python3 "$SKILL_DIR/..."` — where the shell expands `$SKILL_DIR` *before* the assignment prefix takes effect, so it expands to empty.

Two block shapes needed different fixes:

- **Simple two-line blocks** (assignment + one command): a trailing `;` on the `SKILL_DIR` assignment makes it a complete statement that survives flattening. Applied across 13 skills and their references, all 9 byte-duplicated `repo-profile-cache.md` copies, and the AGENTS.md tier-3 canonical example that seeds the pattern.
- **Multi-statement guarded blocks**: a trailing `;` alone is not enough — a flattened `SCRIPT_DIR="$SKILL_DIR/scripts" if [...]` is a bash syntax error (assignment prefix before the `if` reserved word), and `fi bash` is invalid. The six `ce-resolve-pr-feedback` blocks dropped the `SCRIPT_DIR` intermediate and the redundant `[ -f ]` existence guard for the flatten-safe two-line form (the missing-script case is already covered by the prose `gh` fallback beside each block); the graceful-degradation `if/else` guards in `ce-compound` and `ce-setup` were collapsed onto a single physical line so there are no interior newlines to flatten.

## New concepts

**Shell assignment-prefix expansion timing.** In `VAR=value command "$VAR/..."`, bash expands `$VAR` in the argument list *before* applying the `VAR=value` prefix — the prefix only sets `VAR` in the invoked command's environment, not in the current shell doing the expansion. So `$VAR` reads its old (here, unset → empty) value on the same line that sets it.

```bash
# BROKEN: $SKILL_DIR expands to empty -> arg becomes /scripts/x.py
SKILL_DIR="/some/dir" python3 script.py "$SKILL_DIR/scripts/x.py"

# CORRECT: the ; ends the assignment as its own statement, so
# $SKILL_DIR is set in the shell before the next command expands it
SKILL_DIR="/some/dir"; python3 script.py "$SKILL_DIR/scripts/x.py"
```

A two-line block (`VAR=...` newline `command`) behaves like the correct form — *until* a host flattens the newline to a space, at which point it silently becomes the broken form. The trailing `;` makes the two forms equivalent. **When not to rely on this:** anything past the assignment→first-command boundary. A fully flattened multi-command block still needs a real separator at *every* boundary — which is why the guarded blocks above were restructured rather than just `;`-terminated: `SCRIPT_DIR="..." if` and `fi bash` stay broken no matter how many assignment lines end in `;`.

## Validation

Skill-content change plus one test update, no runtime code. Each edited guarded block, flattened (newline→space), passes `bash -n`; the `ce-resolve-pr-feedback` script-dir test now asserts the `;`-termination invariant across both mode files. `bun test` (1927 pass / 0 fail) including the `repo-profile-cache.md` byte-parity test that guards the 9 duplicated copies staying identical; `bun run release:validate` reports metadata in sync. Root cause reproduced directly: the env-prefix form yields `argv1 = /scripts/x.py`, the `;` form yields the full path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
