### PR TITLE
fix(skills): guard bash blocks against newline-flatten breakage

### DIFF
--- a/skills/ce-brainstorm/references/reasoning-elevation.md
+++ b/skills/ce-brainstorm/references/reasoning-elevation.md
@@ -9,10 +9,10 @@ Elevation dispatches the reasoning-heavy authoring/interpretation step to a high
 Before reading any Fable config key, parsing Fable intent, or emitting any Fable string, self-identify the host with the same env-var union `ce-code-review` uses:
 
 ```bash
-if [ -n "${CURSOR_AGENT:-}${CURSOR_CONVERSATION_ID:-}" ]; then HOST=cursor
-elif [ "${CLAUDECODE:-}" = "1" ]; then HOST=claude
-elif [ -n "${CODEX_SANDBOX:-}${CODEX_SESSION_ID:-}${CODEX_THREAD_ID:-}${CODEX_CI:-}" ]; then HOST=codex
-else HOST=unknown; fi
+if [ -n "${CURSOR_AGENT:-}${CURSOR_CONVERSATION_ID:-}" ]; then HOST=cursor;
+elif [ "${CLAUDECODE:-}" = "1" ]; then HOST=claude;
+elif [ -n "${CODEX_SANDBOX:-}${CODEX_SESSION_ID:-}${CODEX_THREAD_ID:-}${CODEX_CI:-}" ]; then HOST=codex;
+else HOST=unknown; fi;
 echo "HOST: $HOST"
 ```
 

--- a/skills/ce-code-review/references/cross-model-review.md
+++ b/skills/ce-code-review/references/cross-model-review.md
@@ -12,10 +12,10 @@ All the invocation detail (composing the prompt from the persona, read-only flag
 ## Step 1 — Identify host and peer (runtime self-id, no build-time)
 
 ```bash
-if [ -n "${CURSOR_AGENT:-}${CURSOR_CONVERSATION_ID:-}" ]; then XHOST=cursor; XPEER=codex
-elif [ "${CLAUDECODE:-}" = "1" ]; then XHOST=claude; XPEER=codex
-elif [ -n "${CODEX_SANDBOX:-}${CODEX_SANDBOX_NETWORK_DISABLED:-}${CODEX_SESSION_ID:-}${CODEX_THREAD_ID:-}${CODEX_CI:-}" ]; then XHOST=codex; XPEER=claude
-else XHOST=unknown; XPEER=""; fi
+if [ -n "${CURSOR_AGENT:-}${CURSOR_CONVERSATION_ID:-}" ]; then XHOST=cursor; XPEER=codex;
+elif [ "${CLAUDECODE:-}" = "1" ]; then XHOST=claude; XPEER=codex;
+elif [ -n "${CODEX_SANDBOX:-}${CODEX_SANDBOX_NETWORK_DISABLED:-}${CODEX_SESSION_ID:-}${CODEX_THREAD_ID:-}${CODEX_CI:-}" ]; then XHOST=codex; XPEER=claude;
+else XHOST=unknown; XPEER=""; fi;
 echo "XMODEL_HOST: $XHOST  PEER: ${XPEER:-none}"
 ```
 

--- a/skills/ce-compound-refresh/references/per-action-flows.md
+++ b/skills/ce-compound-refresh/references/per-action-flows.md
@@ -68,9 +68,9 @@ Do not let replacement subagents invent frontmatter fields, enum values, or sect
 
    ```bash
    if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/validate-frontmatter.py" ]; then
-     python3 "${CLAUDE_SKILL_DIR}/scripts/validate-frontmatter.py" <new-learning-path>
+     python3 "${CLAUDE_SKILL_DIR}/scripts/validate-frontmatter.py" <new-learning-path>;
    else
-     echo "Bundled validate-frontmatter.py not resolvable on this platform; applying the parser-safety checklist manually."
+     echo "Bundled validate-frontmatter.py not resolvable on this platform; applying the parser-safety checklist manually.";
    fi
    ```
 

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -319,9 +319,9 @@ The orchestrating agent (main conversation) performs these steps:
 
    ```bash
    if [ -n "${CLAUDE_SKILL_DIR}" ] && [ -f "${CLAUDE_SKILL_DIR}/scripts/validate-frontmatter.py" ]; then
-     python3 "${CLAUDE_SKILL_DIR}/scripts/validate-frontmatter.py" <output-path>
+     python3 "${CLAUDE_SKILL_DIR}/scripts/validate-frontmatter.py" <output-path>;
    else
-     echo "Bundled validate-frontmatter.py not resolvable on this platform; applying the parser-safety checklist manually."
+     echo "Bundled validate-frontmatter.py not resolvable on this platform; applying the parser-safety checklist manually.";
    fi
    ```
 

--- a/skills/ce-plan/references/reasoning-elevation.md
+++ b/skills/ce-plan/references/reasoning-elevation.md
@@ -9,10 +9,10 @@ Elevation dispatches the reasoning-heavy authoring/interpretation step to a high
 Before reading any Fable config key, parsing Fable intent, or emitting any Fable string, self-identify the host with the same env-var union `ce-code-review` uses:
 
 ```bash
-if [ -n "${CURSOR_AGENT:-}${CURSOR_CONVERSATION_ID:-}" ]; then HOST=cursor
-elif [ "${CLAUDECODE:-}" = "1" ]; then HOST=claude
-elif [ -n "${CODEX_SANDBOX:-}${CODEX_SESSION_ID:-}${CODEX_THREAD_ID:-}${CODEX_CI:-}" ]; then HOST=codex
-else HOST=unknown; fi
+if [ -n "${CURSOR_AGENT:-}${CURSOR_CONVERSATION_ID:-}" ]; then HOST=cursor;
+elif [ "${CLAUDECODE:-}" = "1" ]; then HOST=claude;
+elif [ -n "${CODEX_SANDBOX:-}${CODEX_SESSION_ID:-}${CODEX_THREAD_ID:-}${CODEX_CI:-}" ]; then HOST=codex;
+else HOST=unknown; fi;
 echo "HOST: $HOST"
 ```
 

--- a/skills/ce-test-browser/SKILL.md
+++ b/skills/ce-test-browser/SKILL.md
@@ -96,14 +96,14 @@ Confirm the server is up before asking the headed/headless question — a manual
 
 ```bash
 if lsof -i ":${PORT}" -sTCP:LISTEN -t >/dev/null 2>&1; then
-  echo "Server running on port ${PORT}"
+  echo "Server running on port ${PORT}";
 else
-  echo "Server not running on port ${PORT}"
-  echo "Start your dev server, then re-run:"
-  echo "  Rails: bin/dev  or  rails server -p ${PORT}"
-  echo "  Node/Next.js: npm run dev"
-  echo "  Custom port: run this skill again with --port <your-port>"
-  exit 0
+  echo "Server not running on port ${PORT}";
+  echo "Start your dev server, then re-run:";
+  echo "  Rails: bin/dev  or  rails server -p ${PORT}";
+  echo "  Node/Next.js: npm run dev";
+  echo "  Custom port: run this skill again with --port <your-port>";
+  exit 0;
 fi
 ```
 

--- a/tests/skills/ce-resolve-pr-feedback-script-dir.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-script-dir.test.ts
@@ -1,24 +1,17 @@
 import { describe, expect, test } from "bun:test"
 import { readFileSync } from "fs"
 import path from "path"
+import { extractBashBlocks } from "./fenced-blocks"
 
 const REFERENCES_DIR = path.join(import.meta.dir, "..", "..", "skills", "ce-resolve-pr-feedback", "references")
 const MODE_FILES = ["full-mode.md", "targeted-mode.md"] as const
 
-function fencedBashBlocks(markdown: string): string[] {
-  const blocks: string[] = []
-  const pattern = /```bash\n([\s\S]*?)\n```/g
-  let match: RegExpExecArray | null
-  while ((match = pattern.exec(markdown)) !== null) {
-    blocks.push(match[1] ?? "")
-  }
-  return blocks
-}
-
 describe("ce-resolve-pr-feedback script directory handling", () => {
   for (const file of MODE_FILES) {
     const markdown = readFileSync(path.join(REFERENCES_DIR, file), "utf8")
-    const scriptBlocks = fencedBashBlocks(markdown).filter((block) => block.includes("$SKILL_DIR/scripts/"))
+    const scriptBlocks = extractBashBlocks(markdown)
+      .map((b) => b.body)
+      .filter((block) => block.includes("$SKILL_DIR/scripts/"))
 
     test(`${file}: each bundled-script block resolves the skill dir via a flatten-safe SKILL_DIR anchor`, () => {
       expect(scriptBlocks.length).toBeGreaterThan(0)

--- a/tests/skills/fenced-blocks.ts
+++ b/tests/skills/fenced-blocks.ts
@@ -1,0 +1,27 @@
+export type FencedBashBlock = { line: number; body: string }
+
+/**
+ * Extract ```bash fenced blocks from markdown, handling fences indented inside markdown
+ * lists (the opening indent is stripped from each body line and the closing fence must
+ * match that same indent). `line` is the 1-based line of the opening fence.
+ */
+export function extractBashBlocks(markdown: string): FencedBashBlock[] {
+  const blocks: FencedBashBlock[] = []
+  const lines = markdown.split("\n")
+  for (let i = 0; i < lines.length; i++) {
+    const open = /^(\s*)```bash\s*$/.exec(lines[i]!)
+    if (!open) continue
+    const indent = open[1]!
+    const close = new RegExp(`^${indent}\`\`\`\\s*$`)
+    const start = i
+    const body: string[] = []
+    i++
+    while (i < lines.length && !close.test(lines[i]!)) {
+      const ln = lines[i]!
+      body.push(ln.startsWith(indent) ? ln.slice(indent.length) : ln)
+      i++
+    }
+    blocks.push({ line: start + 1, body: body.join("\n") })
+  }
+  return blocks
+}

--- a/tests/skills/flatten-safety.test.ts
+++ b/tests/skills/flatten-safety.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test"
+import { execFileSync } from "child_process"
+import { readFileSync } from "fs"
+import { Glob } from "bun"
+import path from "path"
+import { extractBashBlocks } from "./fenced-blocks"
+
+// Some hosts (observed on Codex) execute a fenced code block by flattening it to a single
+// line — every newline becomes a space — before handing it to the shell. A block that is
+// valid multi-line can then become a syntax error: `SCRIPT_DIR="..." if [...]` (assignment
+// prefix before a reserved word), `fi bash`, or `then X elif` all break. This lint replays
+// that transformation on every ```bash block under skills/ and asserts it still parses
+// (`bash -n`). Keep blocks flatten-safe by ending each physical line in a separator that
+// survives the newline->space swap (`;`, `then`, `else`, `&&`, `|`, ...).
+//
+// See docs/solutions for the origin (PR #1105). Two block kinds are exempt:
+//   - heredocs (`<<EOF`), which are inherently multi-line and never pasted as one line, and
+//   - blocks carrying a `# flatten-lint: skip` marker, for the rare intentionally-multi-line
+//     case (e.g. an illustrative broken/correct example). Prefer fixing over skipping.
+//
+// Scope: this catches the syntax-error class only. A flattened `#` comment that swallows a
+// following command is a silent no-op, not a parse error, so `bash -n` cannot see it — keep
+// executable comments out of runnable blocks (put them in surrounding prose) rather than
+// relying on this lint to flag them.
+
+const SKILLS_DIR = path.join(import.meta.dir, "..", "..", "skills")
+
+type Block = { file: string; line: number; body: string }
+
+function isExempt(body: string): boolean {
+  if (/<<-?\s*['"]?\w+/.test(body)) return true // heredoc: inherently multi-line
+  if (/#\s*flatten-lint:\s*skip/.test(body)) return true
+  return false
+}
+
+/** Replace <angle-bracket placeholders> with a path-like token so `bash -n` sees valid words. */
+function withPlaceholders(body: string): string {
+  return body.replace(/<[^>\n]*>/g, "/tmp/ph")
+}
+
+function parsesWhenFlattened(body: string): { ok: true } | { ok: false; error: string } {
+  const flattened = withPlaceholders(body).replace(/\n/g, " ")
+  try {
+    execFileSync("bash", ["-n"], { input: flattened, stdio: ["pipe", "pipe", "pipe"] })
+    return { ok: true }
+  } catch (e) {
+    const stderr = (e as { stderr?: Buffer }).stderr?.toString().trim() ?? String(e)
+    return { ok: false, error: stderr.split("\n").pop() ?? stderr }
+  }
+}
+
+const allBlocks: Block[] = [...new Glob("**/*.md").scanSync({ cwd: SKILLS_DIR })]
+  .sort()
+  .flatMap((rel) =>
+    extractBashBlocks(readFileSync(path.join(SKILLS_DIR, rel), "utf8")).map((b) => ({ file: rel, ...b })),
+  )
+
+describe("skills bash blocks are flatten-safe", () => {
+  test("every ```bash block still parses when flattened to a single line", () => {
+    expect(allBlocks.length).toBeGreaterThan(0)
+
+    const failures = allBlocks
+      .filter((b) => !isExempt(b.body))
+      .map((b) => ({ b, result: parsesWhenFlattened(b.body) }))
+      .filter((r) => !r.result.ok)
+      .map((r) => `  ${r.b.file}:${r.b.line} — ${(r.result as { error: string }).error}`)
+
+    expect(
+      failures,
+      failures.length
+        ? `These ${failures.length} bash block(s) break when a host flattens them to one line ` +
+            `(newline->space). End each physical line in a separator (';', 'then', 'else', ...) ` +
+            `or add a '# flatten-lint: skip' marker if it is legitimately multi-line:\n${failures.join("\n")}`
+        : undefined,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #1105. That PR fixed the flatten-unsafe bundled-script blocks by hand; this one makes the whole class impossible to reintroduce silently. A new test replays the exact transform a flattening host (observed on Codex) applies — every newline in a ```bash block becomes a space — across all skill markdown, and fails if the result no longer parses (`bash -n`).

Running it surfaced 6 blocks #1105 didn't touch, all multi-line `if/elif/else/fi` guards that become bash syntax errors when flattened:

- host detection in `ce-brainstorm` / `ce-plan` `reasoning-elevation.md` and `ce-code-review` `cross-model-review.md`
- the `${CLAUDE_SKILL_DIR}` validate-frontmatter guards in `ce-compound` and `ce-compound-refresh`
- the `lsof` server check in `ce-test-browser`

Each is fixed by ending its interior lines with `;`, which keeps the readable multi-line form but survives the newline→space collapse. The shared ```bash-fence parser is extracted into `tests/skills/fenced-blocks.ts` (indent-aware, so it also handles fences nested inside markdown lists) and now backs both the new lint and the existing `ce-resolve-pr-feedback` script-dir test.

**Scope and limits:** heredocs (inherently multi-line) and blocks carrying a `# flatten-lint: skip` marker are exempt. `bash -n` catches the syntax-error class only — a flattened `#` comment that swallows the command after it is a silent no-op, not a parse error, so the lint cannot see it (keep executable comments in prose, out of runnable blocks).

## Validation

`bun test` 1928 pass / 0 fail; `tsc --noEmit` clean; `bun run release:validate` in sync. The lint was confirmed by reverting each fix: it goes red with a `file:line` list naming the offending block, and green once fixed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
