### PR TITLE
fix(skills): remove Claude-only $ARGUMENTS from skill bodies

### DIFF
--- a/docs/skills/ce-compound.md
+++ b/docs/skills/ce-compound.md
@@ -171,9 +171,9 @@ Put it in the repo's `AGENTS.md`/`CLAUDE.md`, or in your global instruction file
 
 **Run it automatically** — no prompt, because not being interrupted is the whole point of automating it:
 
-> After a solved, verified problem produces a non-trivial, reusable learning, automatically invoke the `ce-compound` skill in `mode:headless`. Only in repositories that accept `docs/solutions/` as a tracked knowledge store.
+> After a solved, verified problem produces a non-trivial, reusable learning, automatically invoke the `ce-compound` skill, passing `mode:headless` as the skill argument. Only in repositories that accept `docs/solutions/` as a tracked knowledge store.
 
-Auto-run writes to `docs/solutions/` (and may touch `CONCEPTS.md` or, in headless, the instruction file) without asking — but that's the point, and it's no scarier than the other edits you're already making on the branch and reviewing before you commit. Use `mode:headless` explicitly: a plain "automatically invoke" still runs interactively and can stop for the one-time discoverability-consent prompt, so it isn't truly silent.
+Auto-run writes to `docs/solutions/` (and may touch `CONCEPTS.md` or, in headless, the instruction file) without asking — but that's the point, and it's no scarier than the other edits you're already making on the branch and reviewing before you commit. Pass `mode:headless` as an actual argument, not just as a description: the skill only goes non-interactive when that token is present in the invocation, so a plain "automatically invoke" still runs interactively and can stop for the one-time discoverability-consent prompt — not truly silent.
 
 Every other phrase in those lines is deliberate too:
 

--- a/docs/skills/ce-compound.md
+++ b/docs/skills/ce-compound.md
@@ -159,6 +159,31 @@ The auto-invoke triggers happen mid-conversation; you don't need to remember the
 
 ---
 
+## Make Capture Automatic
+
+The auto-invoke trigger phrases ("that worked", "it's fixed") only fire when you happen to say one of them. If you keep forgetting to capture, add a standing instruction to your agent's instruction file so the agent proposes capture on its own once a fix is verified — before it hands the session back to you.
+
+Put it in the repo's `AGENTS.md`/`CLAUDE.md`, or in your global instruction file (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`) to make it apply in every repo. Pick the variant that matches how much of a checkpoint you want:
+
+**Offer first** — the agent asks before capturing, so you get a beat to say "not this one":
+
+> After a solved, verified problem produces a non-trivial, reusable learning, offer once — before the final handoff — to invoke the `ce-compound` skill. Only in repositories that accept `docs/solutions/` as a tracked knowledge store.
+
+**Run it automatically** — no prompt, because not being interrupted is the whole point of automating it:
+
+> After a solved, verified problem produces a non-trivial, reusable learning, automatically invoke the `ce-compound` skill in `mode:headless`. Only in repositories that accept `docs/solutions/` as a tracked knowledge store.
+
+Auto-run writes to `docs/solutions/` (and may touch `CONCEPTS.md` or, in headless, the instruction file) without asking — but that's the point, and it's no scarier than the other edits you're already making on the branch and reviewing before you commit. Use `mode:headless` explicitly: a plain "automatically invoke" still runs interactively and can stop for the one-time discoverability-consent prompt, so it isn't truly silent.
+
+Every other phrase in those lines is deliberate too:
+
+- **"invoke the `ce-compound` skill"**, not "run `/ce-compound`" — instruction files are read by whatever agent you're using (Codex, Gemini, Cursor, Claude Code), and the slash-command form isn't reliably agent-callable across all of them. Reference the capability, not the keystroke.
+- **"before the final handoff"**, not "at the end of the session" — an agent can't reliably tell when a session has *ended*, but it does know when it's about to hand a verified result back to you.
+- **"non-trivial, reusable learning"** — the bar is a generalizable insight worth re-reading, not merely an expensive one-off incident.
+- **"repositories that accept `docs/solutions/`"** — the real question is whether the repo welcomes generated learning docs, which is usually broader than "do I own it." Forks and open-source projects you contribute to often don't; some repos you don't own still do.
+
+---
+
 ## Output Artifact
 
 ```text

--- a/docs/skills/ce-compound.md
+++ b/docs/skills/ce-compound.md
@@ -173,7 +173,7 @@ Put it in the repo's `AGENTS.md`/`CLAUDE.md`, or in your global instruction file
 
 > After a solved, verified problem produces a non-trivial, reusable learning, automatically invoke the `ce-compound` skill, passing `mode:headless` as the skill argument. Only in repositories that accept `docs/solutions/` as a tracked knowledge store.
 
-Auto-run writes to `docs/solutions/` (and may touch `CONCEPTS.md` or, in headless, the instruction file) without asking — but that's the point, and it's no scarier than the other edits you're already making on the branch and reviewing before you commit. Pass `mode:headless` as an actual argument, not just as a description: the skill only goes non-interactive when that token is present in the invocation, so a plain "automatically invoke" still runs interactively and can stop for the one-time discoverability-consent prompt — not truly silent.
+Auto-run writes to `docs/solutions/` (and may touch `CONCEPTS.md` or, in headless, the instruction file) without asking — but that's the point, and it's no scarier than the other edits you're already making on the branch and reviewing before you commit. Passing `mode:headless` as an argument is the explicit, unambiguous form: the skill also honors a clear "run headless / without prompts" request, but the token removes all doubt — without a headless signal the run stays interactive and can stop for the one-time discoverability-consent prompt.
 
 Every other phrase in those lines is deliberate too:
 

--- a/docs/solutions/skill-design/arguments-token-is-claude-only-in-skill-bodies.md
+++ b/docs/solutions/skill-design/arguments-token-is-claude-only-in-skill-bodies.md
@@ -1,6 +1,7 @@
 ---
 title: "$ARGUMENTS is reliably substituted inside SKILL.md only on Claude Code — reason over the user's prompt instead"
 date: 2026-06-26
+last_updated: 2026-07-12
 category: skill-design
 module: "skills (argument handling across harnesses)"
 problem_type: convention
@@ -39,7 +40,9 @@ It is a sibling of the bundled-script path problem (see `bundled-script-path-res
 Separate the two uses — they take different fixes:
 
 - **Reasoning / flag detection** ("scan `$ARGUMENTS` for `output:`/`mode:`"). The agent does not need the token here — the user's request is already in its context on every harness. Phrase it harness-neutrally: **reason over the user's prompt** for the intent, honoring both the shorthand token (`output:html`) and plain language ("make this a webpage"). Add the discriminating guard: a format/flag named as **subject matter** ("add an HTML export feature", "plan the CSV importer") is the work, not a flag — do not act on it.
-- **Input injection** (`<feature_description> #$ARGUMENTS </feature_description>`). This is load-bearing on Claude — it is *how* the description reaches the agent inline. Keep the token, but pair it with a fallback so non-Claude harnesses degrade gracefully: *"if this shows a literal `$ARGUMENTS`, the harness did not substitute it — use the user's actual request from the conversation."* This mirrors the pre-resolution-with-fallback pattern AGENTS.md already prescribes for `${CLAUDE_PLUGIN_ROOT}`.
+- **Input injection** (`<feature_description> #$ARGUMENTS </feature_description>`). On Claude this is *how* the description reaches the agent inline, but the token is not actually necessary — the user's request is redundantly present in the agent's context on every harness (Claude Code invokes a skill via the Skill tool, so the user's turn stays in the transcript; the OpenCode converter injects args through its own command stub; Codex/Gemini/Cursor load the skill mid-conversation). Two tiers of fix, in increasing cleanliness:
+  - *Minimal (graceful degradation):* keep the token but pair it with a fallback — *"if this shows a literal `$ARGUMENTS`, the harness did not substitute it — use the user's actual request from the conversation."* Mirrors the pre-resolution-with-fallback pattern AGENTS.md prescribes for `${CLAUDE_PLUGIN_ROOT}`. Fixes the failure but leaves the Claude-only token in place with prose wrapped around it.
+  - *Preferred (remove the token entirely):* replace the slot with a prose binding that reads the input from the conversation — e.g. "the **feature description** is whatever the user asked to plan when invoking this skill; read it from their request in the current conversation." This removes the "was it substituted?" question by construction instead of papering over it. Two things must be preserved when you do this: (1) any **named reference** downstream logic depends on — several skills use the injection tag as a *variable* elsewhere (`<input_document>`, `<bug_description>`, `{focus_hint}`), so define the name in the prose ("the rest of this skill refers to it as `<input_document>`") rather than orphaning those references; and (2) each skill's existing **empty/clarify handling** — route a missing input into the skill's own "ask the user" / "proceed open-ended" path rather than adding a competing one. This was applied to every injection-slot skill in #1110 (open as of this writing).
 
 ## Why This Matters
 
@@ -74,7 +77,7 @@ Flag detection — before (Claude-only) vs after (harness-neutral), from the out
    doc-format request — do not switch on it.
 ```
 
-Injection point — keep the token, add the fallback:
+Injection point — two fixes. Minimal (keep the token, add a fallback):
 
 ```text
 <feature_description> #$ARGUMENTS </feature_description>
@@ -83,4 +86,19 @@ Injection point — keep the token, add the fallback:
 substitute it — use the user's actual request from the conversation.)
 ```
 
-**Status / scope note:** at capture time the harness-neutral fix was applied only to the output-format resolution tier in `ce-plan`/`ce-brainstorm`/`ce-ideate`. The broader sweep — adding the injection-point fallback across all ~13 skills that use `$ARGUMENTS`, plus a portability note in AGENTS.md's "Platform-Specific Variables in Skills" section (it is not documented there today) — was deliberately deferred as low-risk. The empirical question (does Codex/Cursor substitute `$ARGUMENTS` inside a *skill body*) was reasoned from specs, not probed; a 2-harness orchestration probe would settle it definitively. See `bundled-script-path-resolution-across-harnesses.md` and `codex-skill-prompt-entrypoints.md` for adjacent cross-harness skill-portability findings.
+Preferred (remove the token; bind the input in prose, preserving the named
+reference downstream logic uses):
+
+```text
+The input document for this run is whatever the user provided when invoking
+this skill — read it from their request in the current conversation. The rest
+of this skill refers to it as <input_document>; if the user provided nothing,
+treat <input_document> as blank.
+```
+
+**Status / scope note (updated 2026-07-12):** both items the original capture deferred are now done, and the fix landed cleaner than the deferred plan.
+
+- **The broad sweep is complete, via removal rather than fallback.** Every `$ARGUMENTS` reference was removed from all skill *bodies* — five prose-logic references reworded to "the arguments you were invoked with," and ten input-injection slots converted to conversation-sourced prose bindings (preserving named references and each skill's empty/clarify handling). Done in #1110 (open as of this writing). The OpenCode command-stub converter still emits its own `$ARGUMENTS` (`src/converters/claude-to-opencode.ts`) and is untouched — removal applies to skill bodies, not the converter's generated command entry.
+- **The empirical question is settled by the 2-harness probe the original note called for.** The *current* skill bodies (no `$ARGUMENTS`) were injected into fresh Claude and Codex subagents across five input-ingestion cases — explicit request, empty/bare invocation, `mode:` token stripping, blank-input discovery, and subject identification — covering `ce-plan`, `ce-work`, and `ce-pov`. Result: **5/5 on both hosts**, every run confirming no `$ARGUMENTS` reliance. Codex derived the input from the conversation, stripped mode tokens, and hit the ask/discovery paths identically to Claude. So "reason over the prompt / read from the conversation" is verified cross-host, not just reasoned from specs.
+
+Still open (low-priority): a portability note in AGENTS.md's "Platform-Specific Variables in Skills" section — `$ARGUMENTS` is still not called out there by name. See `bundled-script-path-resolution-across-harnesses.md` and `codex-skill-prompt-entrypoints.md` for adjacent cross-harness skill-portability findings.

--- a/docs/solutions/skill-design/arguments-token-is-claude-only-in-skill-bodies.md
+++ b/docs/solutions/skill-design/arguments-token-is-claude-only-in-skill-bodies.md
@@ -42,7 +42,12 @@ Separate the two uses — they take different fixes:
 - **Reasoning / flag detection** ("scan `$ARGUMENTS` for `output:`/`mode:`"). The agent does not need the token here — the user's request is already in its context on every harness. Phrase it harness-neutrally: **reason over the user's prompt** for the intent, honoring both the shorthand token (`output:html`) and plain language ("make this a webpage"). Add the discriminating guard: a format/flag named as **subject matter** ("add an HTML export feature", "plan the CSV importer") is the work, not a flag — do not act on it.
 - **Input injection** (`<feature_description> #$ARGUMENTS </feature_description>`). On Claude this is *how* the description reaches the agent inline, but the token is not actually necessary — the user's request is redundantly present in the agent's context on every harness (Claude Code invokes a skill via the Skill tool, so the user's turn stays in the transcript; the OpenCode converter injects args through its own command stub; Codex/Gemini/Cursor load the skill mid-conversation). Two tiers of fix, in increasing cleanliness:
   - *Minimal (graceful degradation):* keep the token but pair it with a fallback — *"if this shows a literal `$ARGUMENTS`, the harness did not substitute it — use the user's actual request from the conversation."* Mirrors the pre-resolution-with-fallback pattern AGENTS.md prescribes for `${CLAUDE_PLUGIN_ROOT}`. Fixes the failure but leaves the Claude-only token in place with prose wrapped around it.
-  - *Preferred (remove the token entirely):* replace the slot with a prose binding that reads the input from the conversation — e.g. "the **feature description** is whatever the user asked to plan when invoking this skill; read it from their request in the current conversation." This removes the "was it substituted?" question by construction instead of papering over it. Two things must be preserved when you do this: (1) any **named reference** downstream logic depends on — several skills use the injection tag as a *variable* elsewhere (`<input_document>`, `<bug_description>`, `{focus_hint}`), so define the name in the prose ("the rest of this skill refers to it as `<input_document>`") rather than orphaning those references; and (2) each skill's existing **empty/clarify handling** — route a missing input into the skill's own "ask the user" / "proceed open-ended" path rather than adding a competing one. This was applied to every injection-slot skill in #1110 (open as of this writing).
+  - *Preferred (remove the token entirely):* replace the slot with a prose binding that reads the input from the invocation — e.g. "the **feature description** is the input this skill was invoked with, present in the current prompt or conversation." This removes the "was it substituted?" question by construction instead of papering over it. Three things must be preserved when you do this:
+    1. **Named references.** Several skills use the injection tag as a *variable* elsewhere (`<input_document>`, `<bug_description>`, `{focus_hint}`), so define the name in the prose ("the rest of this skill refers to it as `<input_document>`") rather than orphaning those references.
+    2. **Empty/clarify handling.** Route a missing input into the skill's own "ask the user" / "proceed open-ended" path rather than adding a competing one.
+    3. **Caller-neutral semantics — the subtle one.** `$ARGUMENTS` is *whatever the skill was invoked with*, by **any** caller. Bind the input to "the input this skill was invoked with," **not** "the user's request" — because a skill is often invoked by *another skill* in `mode:pipeline` (e.g. `ce-babysit-pr` calls `ce-debug` passing failing jobs and log tails as the argument; `lfg` calls `ce-plan`/`ce-work` with a payload). A binding that says "read the user's request" makes a pipeline-delegated skill ignore the caller's payload and parse an empty input, silently breaking the autonomous path. This was caught in review on `ce-debug`'s binding: the first-pass rewrite narrowed the input to "the user," and the fix was to phrase it as the invocation input from the user *or* a calling skill. The prose-logic phrasing "the arguments you were invoked with" was already caller-neutral; only the injection-slot bindings needed this widening.
+
+  This was applied to every injection-slot skill in #1110 (open as of this writing).
 
 ## Why This Matters
 
@@ -90,10 +95,11 @@ Preferred (remove the token; bind the input in prose, preserving the named
 reference downstream logic uses):
 
 ```text
-The input document for this run is whatever the user provided when invoking
-this skill — read it from their request in the current conversation. The rest
-of this skill refers to it as <input_document>; if the user provided nothing,
-treat <input_document> as blank.
+The input document for this run is the input this skill was invoked with —
+present in the current prompt or conversation, whether the user provided it
+directly or a calling skill passed it (e.g. in mode:pipeline). The rest of this
+skill refers to it as <input_document>; if nothing was provided, treat
+<input_document> as blank.
 ```
 
 **Status / scope note (updated 2026-07-12):** both items the original capture deferred are now done, and the fix landed cleaner than the deferred plan.

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -44,9 +44,9 @@ Sub-agent dispatch is tiered by task shape, never hardcoded to a model name. Whe
 
 ## Feature Description
 
-The **feature description** is whatever the user asked to explore when invoking this skill — read it from their request in the current conversation.
+The **feature description** is the input this skill was invoked with — what to explore, present in the current prompt or conversation, whether the user provided it directly or a calling skill passed it.
 
-**If the user gave no feature description, ask the user:** "What would you like to explore? Please describe the feature, problem, or improvement you're thinking about."
+**If no feature description was provided, ask the user:** "What would you like to explore? Please describe the feature, problem, or improvement you're thinking about."
 
 Do not proceed until you have a feature description from the user.
 

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -44,9 +44,9 @@ Sub-agent dispatch is tiered by task shape, never hardcoded to a model name. Whe
 
 ## Feature Description
 
-<feature_description> #$ARGUMENTS </feature_description>
+The **feature description** is whatever the user asked to explore when invoking this skill — read it from their request in the current conversation.
 
-**If the feature description above is empty, ask the user:** "What would you like to explore? Please describe the feature, problem, or improvement you're thinking about."
+**If the user gave no feature description, ask the user:** "What would you like to explore? Please describe the feature, problem, or improvement you're thinking about."
 
 Do not proceed until you have a feature description from the user.
 

--- a/skills/ce-code-review/SKILL.md
+++ b/skills/ce-code-review/SKILL.md
@@ -18,7 +18,7 @@ Reviews code changes using dynamically selected reviewer personas. Spawns parall
 
 ## Argument Parsing
 
-Parse `$ARGUMENTS` for optional tokens. Strip each recognized token before interpreting the remainder as a PR number, GitHub URL, or branch name.
+Parse the arguments you were invoked with for optional tokens. Strip each recognized token before interpreting the remainder as a PR number, GitHub URL, or branch name.
 
 | Token | Example | Effect |
 |-------|---------|--------|
@@ -67,7 +67,7 @@ Same pipeline for default and `mode:agent`:
 
 ## Quick Review Short-Circuit
 
-If `$ARGUMENTS` indicates the user wants a quick, fast, or light code review — and **`mode:agent` is not active** — do not dispatch the multi-agent flow.
+If the invocation arguments indicate the user wants a quick, fast, or light code review — and **`mode:agent` is not active** — do not dispatch the multi-agent flow.
 
 **Announce the chosen path** before any other work (Quick review vs Multi-agent review). Skip this announcement when `mode:agent` is active.
 

--- a/skills/ce-compound-refresh/SKILL.md
+++ b/skills/ce-compound-refresh/SKILL.md
@@ -10,7 +10,7 @@ Maintain the quality of `docs/solutions/` over time. This workflow reviews exist
 
 ## Mode Detection
 
-Check if `$ARGUMENTS` contains `mode:headless`. If present, strip it from arguments (use the remainder as a scope hint) and run in **headless mode**.
+Check whether the arguments you were invoked with contain `mode:headless`. If present, strip it from the arguments (use the remainder as a scope hint) and run in **headless mode**.
 
 | Mode | When | Behavior |
 |------|------|----------|
@@ -105,7 +105,7 @@ Exclude:
 
 Find all `.md` files under `docs/solutions/`, excluding `README.md` files and anything under `_archived/`. If an `_archived/` directory exists, note it in the report as a legacy artifact that should be cleaned up (files either restored or deleted).
 
-If `$ARGUMENTS` is provided, use it to narrow scope before proceeding. Try these matching strategies in order, stopping at the first that produces results:
+If a scope argument was provided, use it to narrow scope before proceeding. Try these matching strategies in order, stopping at the first that produces results:
 
 1. **Directory match** — check if the argument matches a subdirectory name under `docs/solutions/` (e.g., `performance-issues`, `database-issues`)
 2. **Frontmatter match** — search `module`, `component`, or `tags` fields in learning frontmatter for the argument

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -31,12 +31,12 @@ If invoked specifically to create or bootstrap `CONCEPTS.md` from scratch rather
 
 ## Mode Detection
 
-Check `$ARGUMENTS` for a `mode:headless` token. Tokens starting with `mode:` are flags, not context — strip `mode:headless` from arguments before treating the remainder as the brief context hint.
+Enter headless mode when **either** holds: `$ARGUMENTS` contains the `mode:headless` token, **or** the invocation makes non-interactive intent unmistakable — a caller or standing instruction asking to run `ce-compound` "headless", "non-interactively", "unattended", or "without prompts/questions". The token is the explicit form; a clear natural-language request for a non-interactive run is equivalent. Bare "automatically" or "auto-run" is **not** on its own a headless signal — it speaks to *invoking* the skill, not to suppressing its prompts — so an ambiguous or absent signal defaults to interactive. Tokens starting with `mode:` are flags, not context — strip `mode:headless` from arguments before treating the remainder as the brief context hint.
 
 | Mode | When | Behavior |
 |------|------|----------|
-| **Interactive** (default) | No mode token present | Auto-pick Full vs Lightweight and report the choice; run session history as an automatic probe (Full only); prompt for Discoverability Check consent; end with a plain summary (no "What's next?" menu) |
-| **Headless** | `mode:headless` in arguments | No blocking questions. Run **Full mode without session history**. Apply the Discoverability Check edit silently if a gap exists. Skip Phase 3 specialized reviews. End with a structured terminal report — no "What's next?" menu. |
+| **Interactive** (default) | No headless token or clear non-interactive intent | Auto-pick Full vs Lightweight and report the choice; run session history as an automatic probe (Full only); prompt for Discoverability Check consent; end with a plain summary (no "What's next?" menu) |
+| **Headless** | `mode:headless` token present, or the invocation makes non-interactive intent unmistakable | No blocking questions. Run **Full mode without session history**. Apply the Discoverability Check edit silently if a gap exists. Skip Phase 3 specialized reviews. End with a structured terminal report — no "What's next?" menu. |
 
 Headless mode is intended for automations and skill-to-skill invocation where no human is present to answer questions. The doc itself is identical to what an interactive Full run would produce — classification work (track, category, overlap) follows the same rules and writes nothing extra into the artifact. Once detected, headless mode applies for the entire run.
 

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -31,7 +31,7 @@ If invoked specifically to create or bootstrap `CONCEPTS.md` from scratch rather
 
 ## Mode Detection
 
-Enter headless mode when **either** holds: `$ARGUMENTS` contains the `mode:headless` token, **or** the invocation makes non-interactive intent unmistakable — a caller or standing instruction asking to run `ce-compound` "headless", "non-interactively", "unattended", or "without prompts/questions". The token is the explicit form; a clear natural-language request for a non-interactive run is equivalent. Bare "automatically" or "auto-run" is **not** on its own a headless signal — it speaks to *invoking* the skill, not to suppressing its prompts — so an ambiguous or absent signal defaults to interactive. Tokens starting with `mode:` are flags, not context — strip `mode:headless` from arguments before treating the remainder as the brief context hint.
+Enter headless mode when **either** holds: the arguments you were invoked with contain the `mode:headless` token, **or** the invocation makes non-interactive intent unmistakable — a caller or standing instruction asking to run `ce-compound` "headless", "non-interactively", "unattended", or "without prompts/questions". The token is the explicit form; a clear natural-language request for a non-interactive run is equivalent. Bare "automatically" or "auto-run" is **not** on its own a headless signal — it speaks to *invoking* the skill, not to suppressing its prompts — so an ambiguous or absent signal defaults to interactive. Tokens starting with `mode:` are flags, not context — strip `mode:headless` from arguments before treating the remainder as the brief context hint.
 
 | Mode | When | Behavior |
 |------|------|----------|

--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[issue reference, error message, test path, or description of br
 
 Find root causes, then fix them. This skill investigates bugs systematically — tracing the full causal chain before proposing a fix — and optionally implements the fix with test-first discipline.
 
-The **bug description** is whatever the user provided when invoking this skill — read it from their request in the current conversation: a description of the failure, a `mode:` token, or an issue reference (`#123`, `org/repo#123`, or an issue URL). The rest of this skill refers to it as `<bug_description>`; if the user provided nothing, treat `<bug_description>` as blank.
+The **bug description** is the input this skill was invoked with — the failure to diagnose, present in the current prompt or conversation, whether the user provided it directly or a calling skill passed it (e.g. `ce-babysit-pr` / `lfg` in `mode:pipeline`, which pass the failing jobs and log tails as the argument). It may be a description of the failure, a `mode:` token, or an issue reference (`#123`, `org/repo#123`, or an issue URL). The rest of this skill refers to it as `<bug_description>`; if nothing was provided, treat `<bug_description>` as blank.
 
 ## Mode
 

--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[issue reference, error message, test path, or description of br
 
 Find root causes, then fix them. This skill investigates bugs systematically — tracing the full causal chain before proposing a fix — and optionally implements the fix with test-first discipline.
 
-<bug_description> #$ARGUMENTS </bug_description>
+The **bug description** is whatever the user provided when invoking this skill — read it from their request in the current conversation: a description of the failure, a `mode:` token, or an issue reference (`#123`, `org/repo#123`, or an issue URL). The rest of this skill refers to it as `<bug_description>`; if the user provided nothing, treat `<bug_description>` as blank.
 
 ## Mode
 

--- a/skills/ce-dogfood/SKILL.md
+++ b/skills/ce-dogfood/SKILL.md
@@ -51,7 +51,7 @@ This workflow drives the browser exclusively through the `agent-browser` CLI. Do
 
 ### Phase 0: Scope and Get on the Right Branch
 
-Parse `$ARGUMENTS`: a PR number, a branch name, or blank (use current branch). Strip `--port PORT` if present.
+Parse the arguments you were invoked with: a PR number, a branch name, or blank (use current branch). Strip `--port PORT` if present.
 
 1. **Identify the target — keep PR identity; do not switch the working tree yet.**
    - **PR number:** the target *is the PR* — carry the number through every later step (trunk check, isolation, checkout). Read its head only for display (`gh pr view <number> --json headRefName,isCrossRepository`), but do **not** reduce it to a bare branch name: a fork PR's head can even be named `main`/`master`. Do not check out yet.

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[a concept, a diff ref, an idea, or 'what happened this week?'] 
 
 Teach the user one thing well: a concept, a change, an idea, or a window of their own recent work. Agent-driven development removed the learning that writing code by hand used to provide; this skill is the replacement — the human keeps learning while agents do the writing.
 
-What to explain is whatever the user asked about when invoking this skill; read it from their request in the current conversation.
+What to explain is the input this skill was invoked with, present in the current prompt or conversation (whether the user asked directly or a calling skill passed it).
 
 **Note: The current year is 2026.** Use this when weighting external sources and dating artifacts.
 

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -8,9 +8,7 @@ argument-hint: "[a concept, a diff ref, an idea, or 'what happened this week?'] 
 
 Teach the user one thing well: a concept, a change, an idea, or a window of their own recent work. Agent-driven development removed the learning that writing code by hand used to provide; this skill is the replacement — the human keeps learning while agents do the writing.
 
-<explain_request> #$ARGUMENTS </explain_request>
-
-*(If `$ARGUMENTS` above appears as a literal token rather than the user's words — it was not substituted on this host — use the user's actual request from the conversation as the input.)*
+What to explain is whatever the user asked about when invoking this skill; read it from their request in the current conversation.
 
 **Note: The current year is 2026.** Use this when weighting external sources and dating artifacts.
 

--- a/skills/ce-ideate/SKILL.md
+++ b/skills/ce-ideate/SKILL.md
@@ -25,7 +25,7 @@ Ask one question at a time. Prefer concise single-select choices when natural op
 
 ## Focus Hint
 
-The **focus hint** is any optional context the user gave when invoking this skill — read it from their request in the current conversation. The rest of this skill refers to it as `{focus_hint}` (empty if they gave none).
+The **focus hint** is any optional context this skill was invoked with — present in the current prompt or conversation, whether the user gave it directly or a calling skill passed it. The rest of this skill refers to it as `{focus_hint}` (empty if none was given).
 
 Interpret any provided argument as optional context. It may be:
 

--- a/skills/ce-ideate/SKILL.md
+++ b/skills/ce-ideate/SKILL.md
@@ -25,7 +25,7 @@ Ask one question at a time. Prefer concise single-select choices when natural op
 
 ## Focus Hint
 
-<focus_hint> #$ARGUMENTS </focus_hint>
+The **focus hint** is any optional context the user gave when invoking this skill — read it from their request in the current conversation. The rest of this skill refers to it as `{focus_hint}` (empty if they gave none).
 
 Interpret any provided argument as optional context. It may be:
 

--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -14,9 +14,9 @@ Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (cal
 
 ## Input
 
-The **optimization input** is whatever the user provided when invoking this skill — read it from their request in the current conversation: a goal to optimize, or a path to an optimization spec YAML file.
+The **optimization input** is the input this skill was invoked with — present in the current prompt or conversation, whether the user provided it directly or a calling skill passed it: a goal to optimize, or a path to an optimization spec YAML file.
 
-If the user provided no optimization input, ask: "What would you like to optimize? Describe the goal, or provide a path to an optimization spec YAML file."
+If no optimization input was provided, ask: "What would you like to optimize? Describe the goal, or provide a path to an optimization spec YAML file."
 
 ## Optimization Spec Schema
 

--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -14,9 +14,9 @@ Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (cal
 
 ## Input
 
-<optimization_input> #$ARGUMENTS </optimization_input>
+The **optimization input** is whatever the user provided when invoking this skill — read it from their request in the current conversation: a goal to optimize, or a path to an optimization spec YAML file.
 
-If the input above is empty, ask: "What would you like to optimize? Describe the goal, or provide a path to an optimization spec YAML file."
+If the user provided no optimization input, ask: "What would you like to optimize? Describe the goal, or provide a path to an optimization spec YAML file."
 
 ## Optimization Spec Schema
 

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -30,9 +30,9 @@ Ask one question at a time. Prefer a concise single-select choice when natural o
 
 ## Feature Description
 
-The **feature description** is whatever the user asked to plan when invoking this skill — read it from their request in the current conversation.
+The **feature description** is the input this skill was invoked with — what to plan, present in the current prompt or conversation, whether the user provided it directly or a calling skill passed it (e.g. `lfg` in `mode:pipeline`).
 
-**If the user gave no feature description, ask the user:** "What would you like to plan? Describe the task, goal, or project you have in mind." Then wait for their response before continuing.
+**If no feature description was provided, ask the user:** "What would you like to plan? Describe the task, goal, or project you have in mind." Then wait for their response before continuing.
 
 If the input is present but unclear or underspecified, do not abandon — ask one or two clarifying questions, or proceed to Phase 0.4's planning bootstrap to establish enough context. The goal is always to help the user plan, never to exit the workflow.
 

--- a/skills/ce-plan/SKILL.md
+++ b/skills/ce-plan/SKILL.md
@@ -30,9 +30,9 @@ Ask one question at a time. Prefer a concise single-select choice when natural o
 
 ## Feature Description
 
-<feature_description> #$ARGUMENTS </feature_description>
+The **feature description** is whatever the user asked to plan when invoking this skill — read it from their request in the current conversation.
 
-**If the feature description above is empty, ask the user:** "What would you like to plan? Describe the task, goal, or project you have in mind." Then wait for their response before continuing.
+**If the user gave no feature description, ask the user:** "What would you like to plan? Describe the task, goal, or project you have in mind." Then wait for their response before continuing.
 
 If the input is present but unclear or underspecified, do not abandon — ask one or two clarifying questions, or proceed to Phase 0.4's planning bootstrap to establish enough context. The goal is always to help the user plan, never to exit the workflow.
 

--- a/skills/ce-pov/SKILL.md
+++ b/skills/ce-pov/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[the external thing to judge, plus any links] — or invoke bare
 
 Return a decisive, **graded verdict** on something from the outside world — judged against *this project*, not in the abstract.
 
-The subject of this point of view — the thing to judge — is whatever the user asked about when invoking this skill; read it from their request in the current conversation.
+The subject of this point of view — the thing to judge — is the input this skill was invoked with, present in the current prompt or conversation (whether the user asked directly or a calling skill passed it).
 
 **Note: The current year is 2026.** Use this when weighting source recency and dating any captured record.
 

--- a/skills/ce-pov/SKILL.md
+++ b/skills/ce-pov/SKILL.md
@@ -8,9 +8,7 @@ argument-hint: "[the external thing to judge, plus any links] — or invoke bare
 
 Return a decisive, **graded verdict** on something from the outside world — judged against *this project*, not in the abstract.
 
-<pov_request> #$ARGUMENTS </pov_request>
-
-*(If `$ARGUMENTS` above appears as a literal token rather than the user's words — it was not substituted on this host — use the user's actual request from the conversation as the input.)*
+The subject of this point of view — the thing to judge — is whatever the user asked about when invoking this skill; read it from their request in the current conversation.
 
 **Note: The current year is 2026.** Use this when weighting source recency and dating any captured record.
 

--- a/skills/ce-product-pulse/SKILL.md
+++ b/skills/ce-product-pulse/SKILL.md
@@ -26,7 +26,7 @@ Ask one question at a time. Reserve multi-select for first-run configuration onl
 
 ## Lookback Window
 
-The **lookback window** is the time range the user gave when invoking this skill (e.g. `24h`, `7d`) — read it from their request in the current conversation.
+The **lookback window** is the time range this skill was invoked with (e.g. `24h`, `7d`) — present in the current prompt or conversation, whether the user gave it directly or a calling skill passed it.
 
 Interpret the argument as a time window. Common forms:
 

--- a/skills/ce-product-pulse/SKILL.md
+++ b/skills/ce-product-pulse/SKILL.md
@@ -26,7 +26,7 @@ Ask one question at a time. Reserve multi-select for first-run configuration onl
 
 ## Lookback Window
 
-<lookback> #$ARGUMENTS </lookback>
+The **lookback window** is the time range the user gave when invoking this skill (e.g. `24h`, `7d`) — read it from their request in the current conversation.
 
 Interpret the argument as a time window. Common forms:
 

--- a/skills/ce-strategy/SKILL.md
+++ b/skills/ce-strategy/SKILL.md
@@ -20,7 +20,7 @@ Ask one question at a time. Prefer free-form responses for the substantive secti
 
 ## Focus Hint
 
-The **focus hint** is any optional argument the user gave when invoking this skill — read it from their request in the current conversation (empty if they gave none).
+The **focus hint** is any optional argument this skill was invoked with — present in the current prompt or conversation, whether the user gave it directly or a calling skill passed it (empty if none was given).
 
 Interpret any argument as an optional focus: a section name to revisit (`metrics`, `approach`, `tracks`) or a scope hint. With no argument, proceed open-ended and let the file state decide the path.
 

--- a/skills/ce-strategy/SKILL.md
+++ b/skills/ce-strategy/SKILL.md
@@ -20,7 +20,7 @@ Ask one question at a time. Prefer free-form responses for the substantive secti
 
 ## Focus Hint
 
-<focus_hint> #$ARGUMENTS </focus_hint>
+The **focus hint** is any optional argument the user gave when invoking this skill — read it from their request in the current conversation (empty if they gave none).
 
 Interpret any argument as an optional focus: a section name to revisit (`metrics`, `approach`, `tracks`) or a scope hint. With no argument, proceed open-ended and let the file state decide the path.
 

--- a/skills/ce-work/SKILL.md
+++ b/skills/ce-work/SKILL.md
@@ -14,7 +14,7 @@ This command takes a work document (plan or specification) or a bare prompt desc
 
 ## Input Document
 
-The **input document** for this run is whatever the user provided when invoking this skill — read it from their request in the current conversation: a plan or spec path, a `mode:` token followed by a path, or a bare work prompt. The rest of this skill refers to it as `<input_document>`; if the user provided nothing, treat `<input_document>` as blank.
+The **input document** for this run is the input this skill was invoked with — present in the current prompt or conversation, whether the user provided it directly or a calling skill passed it (e.g. `lfg` in `mode:pipeline`, which passes a plan path). It may be a plan or spec path, a `mode:` token followed by a path, or a bare work prompt. The rest of this skill refers to it as `<input_document>`; if nothing was provided, treat `<input_document>` as blank.
 
 ## Execution Workflow
 

--- a/skills/ce-work/SKILL.md
+++ b/skills/ce-work/SKILL.md
@@ -14,7 +14,7 @@ This command takes a work document (plan or specification) or a bare prompt desc
 
 ## Input Document
 
-<input_document> #$ARGUMENTS </input_document>
+The **input document** for this run is whatever the user provided when invoking this skill — read it from their request in the current conversation: a plan or spec path, a `mode:` token followed by a path, or a bare work prompt. The rest of this skill refers to it as `<input_document>`; if the user provided nothing, treat `<input_document>` as blank.
 
 ## Execution Workflow
 

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -9,9 +9,9 @@ CRITICAL: You MUST execute every step below IN ORDER. Do NOT skip any required s
 
 When invoking any skill referenced below, resolve its name against the available-skills list the host platform provides and use that exact entry. Some platforms list skills under a plugin namespace (e.g., `compound-engineering:ce-plan`); others list the bare name. Invoking a short-form guess that isn't in the list will fail — always match a listed entry verbatim before calling the Skill/Task tool.
 
-1. Invoke the `ce-plan` skill with `$ARGUMENTS`.
+1. Invoke the `ce-plan` skill with the arguments you were invoked with.
 
-   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, invoke `ce-plan` again with `$ARGUMENTS`. Do NOT proceed to step 2 until a written plan exists. **Record the plan file path** — it will be passed to ce-work in step 2 and ce-code-review in step 4.
+   GATE: STOP. If ce-plan reported the task is non-software and cannot be processed in pipeline mode, stop the pipeline and inform the user that LFG requires software tasks. Otherwise, verify that the `ce-plan` workflow produced a plan file in `docs/plans/`. If no plan file was created, invoke `ce-plan` again with those same arguments. Do NOT proceed to step 2 until a written plan exists. **Record the plan file path** — it will be passed to ce-work in step 2 and ce-code-review in step 4.
 
    Read the plan metadata before continuing. If the plan has `artifact_contract: ce-unified-plan/v1`, proceed only when it has `artifact_readiness: implementation-ready` and `execution: code`. Stop the pipeline for `artifact_readiness: requirements-only`, any unrecognized readiness value, `execution: knowledge-work`, approach-plan outputs, answer-seeking/universal outputs, or invalid progress-like readiness values. LFG never launches `/goal` directly; when goal-mode or dynamic workflows are appropriate, `ce-work` owns that implementation engine choice and must return control to LFG afterward.
 


### PR DESCRIPTION
## Summary

Three related changes, unified by making Compound Engineering skills behave correctly across every agent harness this plugin targets (Claude Code, Codex, Gemini, Cursor). The PR grew from a small docs addition into a cross-harness portability fix once the underlying `$ARGUMENTS` gap surfaced during review.

### Cross-harness input handling (the bulk)

`$ARGUMENTS` is a Claude Code / OpenCode command-template substitution that is **inert inside SKILL.md bodies** on Codex, Gemini, and Cursor — so any skill reading its input or a mode token from `$ARGUMENTS` silently misbehaved off-Claude. Every `$ARGUMENTS` reference in skill content is now gone, replaced by harness-neutral phrasing that reads the input from the user's request in the conversation (always present in the agent's context on every harness):

- **Prose-logic references** (`ce-compound-refresh`, `ce-code-review`, `ce-dogfood`, `lfg`) now say "the arguments you were invoked with."
- **Ten input-injection slots** (`ce-work`, `ce-strategy`, `ce-brainstorm`, `ce-product-pulse`, `ce-debug`, `ce-ideate`, `ce-optimize`, `ce-plan`, `ce-pov`, `ce-explain`) became a prose binding sourced from the conversation — preserving the named references (`<input_document>`, `<bug_description>`, `{focus_hint}`) their downstream logic depends on, and each skill's existing empty/clarify handling.

The OpenCode command-stub converter still emits its own `$ARGUMENTS` and is untouched.

### `ce-compound` recognizes headless intent

Mode Detection previously entered headless mode only on the literal `mode:headless` token, so a cross-agent standing instruction phrased in natural language ("run without prompts") fell through to an interactive run with a consent prompt. It now also enters headless when the invocation makes non-interactive intent unmistakable — while a bare "automatically"/"auto-run" correctly stays interactive, since that speaks to *invoking* the skill, not suppressing its prompts.

### Docs: make capture automatic

New "Make Capture Automatic" section on the `ce-compound` docs page showing how to add a standing instruction to a repo or global `AGENTS.md`/`CLAUDE.md` so an agent proposes (or auto-runs) capture on its own. Offer-first and auto-run (`mode:headless`) are presented as peer variants, gated on whether the repo accepts `docs/solutions/` as a tracked knowledge store.

## Validation

`bun test` — 1930 pass, 0 fail. `bun run release:validate` — metadata in sync (30 skills). All changes are prose within skill/doc bodies; no converter, parser, or output-path code touched. A cross-host behavioral eval of the input-handling change (Claude + Codex) is the recommended pre-merge follow-up, since it alters how ten skills ingest their input.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
