### PR TITLE
fix(lfg): allow agent invocation for the autonomous brainstorm handoff

### DIFF
--- a/.cline/INSTALL.md
+++ b/.cline/INSTALL.md
@@ -23,13 +23,13 @@ From a clone of this repository:
 
 The script creates symlinks so Cline reads the live skill directories from your checkout. Re-run it after `git pull` to refresh links when skill folder names change. It only ever creates or replaces CE-owned symlinks (links whose target resolves under this checkout's `skills/` tree); an existing `~/.cline/skills/<name>` pointing at your own skill, a fork, or another checkout is left untouched. Default installs also remove only manual-only symlinks that are CE-owned.
 
-Skills marked `disable-model-invocation: true` (for example `lfg`, `ce-dogfood`, `ce-polish`) are **not** linked by default — Cline auto-activates from description matching and has no manual-only gate, so linking them would let them fire unintentionally. Those slash commands are unavailable until you opt in:
+Skills marked `disable-model-invocation: true` (for example `ce-dogfood`, `ce-polish`, `ce-setup`) are **not** linked by default — Cline auto-activates from description matching and has no manual-only gate, so linking them would let them fire unintentionally. Those slash commands are unavailable until you opt in:
 
 ```bash
 ./compound-engineering-plugin/.cline/scripts/install-skills.sh --global --include-manual
 ```
 
-`--include-manual` links manual-only skills so `/lfg` and similar commands work, with a warning that Cline may still auto-activate them when descriptions match. Omit the flag if you do not need those workflows on Cline.
+`--include-manual` links manual-only skills so `/ce-polish` and similar commands work, with a warning that Cline may still auto-activate them when descriptions match. Omit the flag if you do not need those workflows on Cline.
 
 ## Pin a release
 

--- a/docs/specs/cline.md
+++ b/docs/specs/cline.md
@@ -59,7 +59,7 @@ Project-scoped skills from a checkout:
 /path/to/compound-engineering-plugin/.cline/scripts/install-skills.sh --project
 ```
 
-Manual-only skills (for example `lfg`, `ce-polish`) require the opt-in flag:
+Manual-only skills (for example `ce-polish`, `ce-setup`) require the opt-in flag:
 
 ```bash
 /path/to/compound-engineering-plugin/.cline/scripts/install-skills.sh --global --include-manual

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: lfg
-description: Run the full hands-off engineering pipeline from planning through a green PR.
-disable-model-invocation: true
+description: "Run the full autonomous shipping pipeline end-to-end, hands-off with no check-ins: plan, implement, review and fix, commit, push a branch, open a PR, and watch CI to green. Use only when the user explicitly asks to build or ship something autonomously all the way to an open PR, or invokes lfg directly — it pushes and opens a PR without stopping. Not for in-the-loop work where the user reviews each step: use ce-plan to plan, ce-work to implement a plan, ce-debug to fix a bug, or ce-commit-push-pr to commit and open a PR for existing changes."
 argument-hint: "[feature description]"
 ---
 

--- a/tests/cline-install-skills.test.ts
+++ b/tests/cline-install-skills.test.ts
@@ -25,7 +25,7 @@ const installScript = path.join(
   "install-skills.sh",
 )
 
-const manualSkill = "lfg"
+const manualSkill = "ce-setup"
 const invocableSkill = "ce-plan"
 
 type RunResult = {
@@ -66,8 +66,8 @@ async function pathExists(filePath: string): Promise<boolean> {
 describe("cline install-skills.sh", () => {
   test("does not remove unrelated manual-only skill symlinks", async () => {
     const dest = await makeTempDir("cline-skills-dest-")
-    const userSkill = await makeTempDir("cline-user-lfg-")
-    await fs.writeFile(path.join(userSkill, "SKILL.md"), "# user lfg\n")
+    const userSkill = await makeTempDir(`cline-user-${manualSkill}-`)
+    await fs.writeFile(path.join(userSkill, "SKILL.md"), `# user ${manualSkill}\n`)
 
     await fs.symlink(userSkill, path.join(dest, manualSkill))
 
@@ -77,7 +77,7 @@ describe("cline install-skills.sh", () => {
 
     expect(result.exitCode).toBe(0)
     expect(await pathExists(path.join(dest, manualSkill))).toBe(true)
-    expect(result.stderr).not.toContain("removed lfg")
+    expect(result.stderr).not.toContain(`removed ${manualSkill}`)
   })
 
   test("does not overwrite an existing user-managed symlink for an invocable skill", async () => {
@@ -112,6 +112,6 @@ describe("cline install-skills.sh", () => {
 
     expect(result.exitCode).toBe(0)
     expect(await pathExists(path.join(dest, manualSkill))).toBe(false)
-    expect(result.stderr).toContain("removed lfg: stale CE manual-only symlink")
+    expect(result.stderr).toContain(`removed ${manualSkill}: stale CE manual-only symlink`)
   })
 })

--- a/tests/skill-conventions.test.ts
+++ b/tests/skill-conventions.test.ts
@@ -150,7 +150,6 @@ const EXPECTED_USER_INVOKED_SKILLS = new Set([
   "ce-setup",
   "ce-sweep",
   "ce-test-xcode",
-  "lfg",
 ])
 
 const REQUIRED_MODEL_INVOKED_CALLEES = new Set([
@@ -173,6 +172,7 @@ const REQUIRED_MODEL_INVOKED_CALLEES = new Set([
   "ce-test-browser",
   "ce-work",
   "ce-worktree",
+  "lfg",
 ])
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Picking "Ship it autonomously with `lfg`" in the `ce-brainstorm` handoff used to dead-end: the handoff invokes `lfg` through the skill tool, but `lfg` carried `disable-model-invocation: true`, so the call was blocked and the user had to drop out and run `/lfg` by hand. Removing the flag lets the handoff invoke `lfg` in-session as it always intended — and moves `lfg` into the model-invoked-callee test set, where a sibling-called skill belongs.

The flag was guarding against spurious auto-selection of a pipeline that pushes a branch and opens a PR. Claude Code has no "callable-by-a-sibling-but-never-auto-selected" mode, so the control is the description itself: it is rewritten as a narrow activation contract that fires only on explicit autonomous-shipping intent or a direct `/lfg`, and routes ordinary build/plan/debug/commit requests to the focused skills (`ce-plan`, `ce-work`, `ce-debug`, `ce-commit-push-pr`). A stray auto-select stays interruptible — `lfg` plans and edits locally for a while before it ever pushes.

The cline install test and two docs used `lfg` as their example of a manual-only skill; those now point at a skill that is still manual-only.

Validation: `bun test` (1931 pass / 0 fail) and `bun run release:validate` (metadata in sync).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
