### PR TITLE
fix(cli): strip legacy Codex tool map instead of upserting it

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,28 @@ CODEX_HOME="$HOME/.codex/profiles/work" codex plugin add compound-engineering@co
 
 The marketplace step only makes the plugin available; the plugin install is what activates the native CE skills for that profile.
 
+#### Remove the legacy Codex tool map (pre-native installs)
+
+If you previously installed Compound Engineering with the Bun `convert` / `install --to codex` CLI (before native Codex plugin support), that path may have inserted a managed block into your **global** Codex instructions file:
+
+`<!-- BEGIN COMPOUND CODEX TOOL MAP -->` … `<!-- END COMPOUND CODEX TOOL MAP -->`
+
+in `$CODEX_HOME/AGENTS.md` (default `~/.codex/AGENTS.md`). That Claude-compat tool map is obsolete — CE skills name Codex tools inline — and one of its lines incorrectly told Codex to collapse subagent dispatch onto the main thread. Native plugin install does **not** add this block.
+
+Paste this into Codex (or any agent with access to your home directory) to remove it:
+
+```text
+Remove the obsolete Compound Engineering Codex tool-map block from my Codex home AGENTS.md.
+
+1. Check `$CODEX_HOME/AGENTS.md` if CODEX_HOME is set, otherwise `~/.codex/AGENTS.md`. If I use Codex profiles, also check `~/.codex/profiles/*/AGENTS.md`.
+2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` and `<!-- END COMPOUND CODEX TOOL MAP -->`.
+3. If both are present, delete only the span from the BEGIN line through the END line (inclusive), leaving any other user content untouched. Do not edit project/repo AGENTS.md unless those exact sentinels are present there.
+4. If the file is empty after the removal, delete the file.
+5. Show a short before/after summary of what you changed (or say the block was already absent). Do not add a replacement tool map.
+```
+
+Re-running the Bun convert/install CLI for Codex also strips the block if it is still present; it no longer inserts it.
+
 ### Kimi Code CLI
 
 Kimi Code CLI can install Compound Engineering directly from this repository because the repo ships a native `.kimi-plugin/plugin.json` manifest:

--- a/src/commands/convert.ts
+++ b/src/commands/convert.ts
@@ -4,7 +4,7 @@ import path from "path"
 import { loadClaudePlugin } from "../parsers/claude"
 import { targets, validateScope } from "../targets"
 import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
-import { ensureCodexAgentsFile } from "../utils/codex-agents"
+import { stripCodexAgentsToolMap } from "../utils/codex-agents"
 import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../utils/resolve-output"
 import { detectInstalledTools } from "../utils/detect-tools"
@@ -137,7 +137,7 @@ export default defineCommand({
       }
 
       if (activeTargets.some((t) => t.name === "codex")) {
-        await ensureCodexAgentsFile(codexHome)
+        await stripCodexAgentsToolMap(codexHome)
       }
       return
     }
@@ -207,7 +207,7 @@ export default defineCommand({
     }
 
     if (allTargets.includes("codex")) {
-      await ensureCodexAgentsFile(codexHome)
+      await stripCodexAgentsToolMap(codexHome)
     }
   },
 })

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -7,7 +7,7 @@ import { loadClaudePlugin } from "../parsers/claude"
 import { targets, validateScope } from "../targets"
 import { pathExists } from "../utils/files"
 import type { ClaudeToOpenCodeOptions, PermissionMode } from "../converters/claude-to-opencode"
-import { ensureCodexAgentsFile } from "../utils/codex-agents"
+import { stripCodexAgentsToolMap } from "../utils/codex-agents"
 import { expandHome, resolveCodexHome, resolveTargetHome } from "../utils/resolve-home"
 import { resolveOpenCodeWriteScope, resolveTargetOutputRoot } from "../utils/resolve-output"
 import { detectInstalledTools } from "../utils/detect-tools"
@@ -148,7 +148,7 @@ export default defineCommand({
         }
 
         if (activeTargets.some((t) => t.name === "codex")) {
-          await ensureCodexAgentsFile(codexHome)
+          await stripCodexAgentsToolMap(codexHome)
         }
         return
       }
@@ -216,7 +216,7 @@ export default defineCommand({
       }
 
       if (allTargets.includes("codex")) {
-        await ensureCodexAgentsFile(codexHome)
+        await stripCodexAgentsToolMap(codexHome)
       }
     } finally {
       if (resolvedPlugin.cleanup) {

--- a/src/utils/codex-agents.ts
+++ b/src/utils/codex-agents.ts
@@ -1,65 +1,57 @@
+import { promises as fs } from "fs"
 import path from "path"
-import { ensureDir, pathExists, readText, writeText } from "./files"
+import { pathExists, readText, writeText } from "./files"
 
 export const CODEX_AGENTS_BLOCK_START = "<!-- BEGIN COMPOUND CODEX TOOL MAP -->"
 export const CODEX_AGENTS_BLOCK_END = "<!-- END COMPOUND CODEX TOOL MAP -->"
 
-const CODEX_AGENTS_BLOCK_BODY = `## Compound Codex Tool Mapping (Claude Compatibility)
-
-This section maps Claude Code plugin tool references to Codex behavior.
-Only this block is managed automatically.
-
-Tool mapping:
-- Read: use shell reads (cat/sed) or rg
-- Write: create files via shell redirection or apply_patch
-- Edit/MultiEdit: use apply_patch
-- Bash: use shell_command
-- Grep: use rg (fallback: grep)
-- Glob: use rg --files or find
-- LS: use ls via shell_command
-- WebFetch/WebSearch: use curl or Context7 for library docs
-- AskUserQuestion/Question: present choices as a numbered list in chat and wait for a reply number. For multi-select (multiSelect: true), accept comma-separated numbers. Never skip or auto-configure — always wait for the user's response before proceeding.
-- Task (subagent dispatch) / Subagent / Parallel: run sequentially in main thread; use multi_tool_use.parallel for tool calls
-- TaskCreate/TaskUpdate/TaskList/TaskGet/TaskStop/TaskOutput (Claude Code task-tracking, current): use update_plan (Codex's task-tracking primitive)
-- TodoWrite/TodoRead (Claude Code task-tracking, legacy — deprecated, replaced by Task* tools): use update_plan
-- Skill: open the referenced SKILL.md and follow it
-- ExitPlanMode: ignore
-`
-
-export async function ensureCodexAgentsFile(codexHome: string): Promise<void> {
-  await ensureDir(codexHome)
+/**
+ * Remove the legacy Compound Codex tool-map block from `$CODEX_HOME/AGENTS.md`.
+ *
+ * Native Codex plugin install no longer needs this Claude-compat shim; skills
+ * name Codex tools inline. Older Bun convert/install runs used to upsert the
+ * block — this strips it on any future Codex-targeting convert/install so the
+ * bad mapping cannot recur, without creating AGENTS.md when absent.
+ */
+export async function stripCodexAgentsToolMap(codexHome: string): Promise<void> {
   const filePath = path.join(codexHome, "AGENTS.md")
-  const block = buildCodexAgentsBlock()
-
   if (!(await pathExists(filePath))) {
-    await writeText(filePath, block + "\n")
     return
   }
 
   const existing = await readText(filePath)
-  const updated = upsertBlock(existing, block)
-  if (updated !== existing) {
-    await writeText(filePath, updated)
+  const updated = removeCodexAgentsToolMapBlock(existing)
+  if (updated === existing) {
+    return
   }
+
+  if (updated.trim().length === 0) {
+    await fs.unlink(filePath)
+    return
+  }
+
+  await writeText(filePath, updated)
 }
 
-function buildCodexAgentsBlock(): string {
-  return [CODEX_AGENTS_BLOCK_START, CODEX_AGENTS_BLOCK_BODY.trim(), CODEX_AGENTS_BLOCK_END].join("\n")
-}
-
-function upsertBlock(existing: string, block: string): string {
+/** Pure strip helper — exported for tests. */
+export function removeCodexAgentsToolMapBlock(existing: string): string {
   const startIndex = existing.indexOf(CODEX_AGENTS_BLOCK_START)
   const endIndex = existing.indexOf(CODEX_AGENTS_BLOCK_END)
 
-  if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
-    const before = existing.slice(0, startIndex).trimEnd()
-    const after = existing.slice(endIndex + CODEX_AGENTS_BLOCK_END.length).trimStart()
-    return [before, block, after].filter(Boolean).join("\n\n") + "\n"
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    return existing
   }
 
-  if (existing.trim().length === 0) {
-    return block + "\n"
+  const before = existing.slice(0, startIndex).trimEnd()
+  const after = existing.slice(endIndex + CODEX_AGENTS_BLOCK_END.length).trimStart()
+  if (!before && !after) {
+    return ""
   }
-
-  return existing.trimEnd() + "\n\n" + block + "\n"
+  if (!before) {
+    return after.endsWith("\n") ? after : after + "\n"
+  }
+  if (!after) {
+    return before + "\n"
+  }
+  return before + "\n\n" + after + (after.endsWith("\n") ? "" : "\n")
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1141,7 +1141,8 @@ describe("CLI", () => {
     expect(stdout).toContain(codexRoot)
     expect(await exists(path.join(codexRoot, "skills", "compound-engineering", "ce-plan", "SKILL.md"))).toBe(true)
     expect(await exists(path.join(tempRoot, ".agents", "skills", "ce-plan"))).toBe(false)
-    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(true)
+    // Native Codex no longer needs a managed Claude-compat tool map in AGENTS.md.
+    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(false)
   })
 
   test("install --to codex default omits skills and agents for native plugin install", async () => {
@@ -1185,9 +1186,60 @@ describe("CLI", () => {
     // Compound Engineering no longer ships standalone agents, so the default
     // Codex converter followup has no CE payload to emit.
     expect(await exists(path.join(codexRoot, "agents", "compound-engineering"))).toBe(false)
-    // AGENTS.md is emitted because --to codex always ensures a root AGENTS.md
-    // exists for Codex's discovery chain.
-    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(true)
+    // Convert/install no longer creates AGENTS.md; it only strips a legacy tool map if present.
+    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(false)
+  })
+
+  test("install --to codex strips a legacy Compound Codex tool map from AGENTS.md", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-codex-strip-map-"))
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cli-codex-strip-map-ws-"))
+    const projectRoot = path.join(import.meta.dir, "..")
+    const fixtureRoot = path.join(import.meta.dir, "fixtures", "sample-plugin")
+    const codexRoot = path.join(tempRoot, ".codex")
+    await fs.mkdir(codexRoot, { recursive: true })
+    await fs.writeFile(
+      path.join(codexRoot, "AGENTS.md"),
+      [
+        "# Keep me",
+        "",
+        "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+        "legacy map",
+        "<!-- END COMPOUND CODEX TOOL MAP -->",
+        "",
+      ].join("\n"),
+    )
+
+    const proc = Bun.spawn([
+      "bun",
+      "run",
+      path.join(projectRoot, "src", "index.ts"),
+      "install",
+      fixtureRoot,
+      "--to",
+      "codex",
+    ], {
+      cwd: workspaceRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: tempRoot,
+        CODEX_HOME: codexRoot,
+      },
+    })
+
+    const exitCode = await proc.exited
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+
+    if (exitCode !== 0) {
+      throw new Error(`CLI failed (exit ${exitCode}).\nstdout: ${stdout}\nstderr: ${stderr}`)
+    }
+
+    const agentsMd = await fs.readFile(path.join(codexRoot, "AGENTS.md"), "utf8")
+    expect(agentsMd).toContain("# Keep me")
+    expect(agentsMd).not.toContain("<!-- BEGIN COMPOUND CODEX TOOL MAP -->")
+    expect(agentsMd).not.toContain("legacy map")
   })
 
   test("install --to codex respects CODEX_HOME when --codex-home is omitted", async () => {
@@ -1457,7 +1509,7 @@ describe("CLI", () => {
     expect(await exists(path.join(codexRoot, "prompts", "workflows-review.md"))).toBe(true)
     expect(await exists(path.join(codexRoot, "skills", "compound-engineering", "workflows-review", "SKILL.md"))).toBe(true)
     expect(await exists(path.join(tempRoot, ".agents", "skills", "workflows-review"))).toBe(false)
-    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(true)
+    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(false)
   })
 
   test("install supports --also with codex output", async () => {
@@ -1501,7 +1553,7 @@ describe("CLI", () => {
     expect(await exists(path.join(codexRoot, "skills", "compound-engineering", "skill-one", "SKILL.md"))).toBe(true)
     expect(await exists(path.join(tempRoot, ".agents", "skills", "workflows-review"))).toBe(false)
     expect(await exists(path.join(tempRoot, ".agents", "skills", "skill-one"))).toBe(false)
-    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(true)
+    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(false)
   })
 
   test("install --to codex --also opencode without --output writes opencode to global root, not nested", async () => {
@@ -1555,8 +1607,8 @@ describe("CLI", () => {
     expect(await exists(path.join(opencodeGlobalRoot, "opencode.json"))).toBe(true)
     expect(await exists(path.join(opencodeGlobalRoot, "agents", "repo-research-analyst.md"))).toBe(true)
     expect(await exists(path.join(opencodeGlobalRoot, "opencode", "opencode.json"))).toBe(false)
-    // Codex still landed at the explicit --codex-home.
-    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(true)
+    // Codex still landed at the explicit --codex-home without creating AGENTS.md.
+    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(false)
   })
 
   test("install --to opencode --also codex without --output keeps opencode at global root", async () => {
@@ -1603,7 +1655,7 @@ describe("CLI", () => {
     const opencodeGlobalRoot = path.join(tempRoot, ".config", "opencode")
     expect(await exists(path.join(opencodeGlobalRoot, "opencode.json"))).toBe(true)
     expect(await exists(path.join(opencodeGlobalRoot, "agents", "repo-research-analyst.md"))).toBe(true)
-    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(true)
+    expect(await exists(path.join(codexRoot, "AGENTS.md"))).toBe(false)
   })
 
   test("install --to opencode without --output respects OPENCODE_CONFIG_DIR", async () => {

--- a/tests/codex-agents.test.ts
+++ b/tests/codex-agents.test.ts
@@ -5,60 +5,99 @@ import os from "os"
 import {
   CODEX_AGENTS_BLOCK_END,
   CODEX_AGENTS_BLOCK_START,
-  ensureCodexAgentsFile,
+  removeCodexAgentsToolMapBlock,
+  stripCodexAgentsToolMap,
 } from "../src/utils/codex-agents"
 
 async function readFile(filePath: string): Promise<string> {
   return fs.readFile(filePath, "utf8")
 }
 
-describe("ensureCodexAgentsFile", () => {
-  test("creates AGENTS.md with managed block when missing", async () => {
-    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agents-"))
-    await ensureCodexAgentsFile(tempRoot)
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
 
-    const agentsPath = path.join(tempRoot, "AGENTS.md")
-    const content = await readFile(agentsPath)
-    expect(content).toContain(CODEX_AGENTS_BLOCK_START)
-    expect(content).toContain("Tool mapping")
-    expect(content).toContain("TaskCreate/TaskUpdate/TaskList/TaskGet/TaskStop/TaskOutput")
-    expect(content).toContain("use update_plan")
-    expect(content).toContain(CODEX_AGENTS_BLOCK_END)
+describe("removeCodexAgentsToolMapBlock", () => {
+  test("returns content unchanged when sentinels are absent", () => {
+    const input = "# My Rules\n\nKeep this.\n"
+    expect(removeCodexAgentsToolMapBlock(input)).toBe(input)
   })
 
-  test("appends block without touching existing content", async () => {
-    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agents-existing-"))
-    const agentsPath = path.join(tempRoot, "AGENTS.md")
-    await fs.writeFile(agentsPath, "# My Rules\n\nKeep this.")
+  test("strips only the managed sentinel block", () => {
+    const input = [
+      "Intro text",
+      "",
+      CODEX_AGENTS_BLOCK_START,
+      "old managed content",
+      CODEX_AGENTS_BLOCK_END,
+      "",
+      "Footer text",
+      "",
+    ].join("\n")
 
-    await ensureCodexAgentsFile(tempRoot)
+    const result = removeCodexAgentsToolMapBlock(input)
+    expect(result).toContain("Intro text")
+    expect(result).toContain("Footer text")
+    expect(result).not.toContain(CODEX_AGENTS_BLOCK_START)
+    expect(result).not.toContain(CODEX_AGENTS_BLOCK_END)
+    expect(result).not.toContain("old managed content")
+  })
+
+  test("returns empty string when the file is only the managed block", () => {
+    const input = [CODEX_AGENTS_BLOCK_START, "only this", CODEX_AGENTS_BLOCK_END].join("\n")
+    expect(removeCodexAgentsToolMapBlock(input)).toBe("")
+  })
+})
+
+describe("stripCodexAgentsToolMap", () => {
+  test("no-ops when AGENTS.md is missing", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agents-missing-"))
+    await stripCodexAgentsToolMap(tempRoot)
+    expect(await exists(path.join(tempRoot, "AGENTS.md"))).toBe(false)
+  })
+
+  test("preserves user content and removes the managed block", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agents-strip-"))
+    const agentsPath = path.join(tempRoot, "AGENTS.md")
+    await fs.writeFile(
+      agentsPath,
+      ["# My Rules", "", "Keep this.", "", CODEX_AGENTS_BLOCK_START, "legacy map", CODEX_AGENTS_BLOCK_END, ""].join("\n"),
+    )
+
+    await stripCodexAgentsToolMap(tempRoot)
 
     const content = await readFile(agentsPath)
     expect(content).toContain("# My Rules")
     expect(content).toContain("Keep this.")
-    expect(content).toContain(CODEX_AGENTS_BLOCK_START)
-    expect(content).toContain(CODEX_AGENTS_BLOCK_END)
+    expect(content).not.toContain(CODEX_AGENTS_BLOCK_START)
+    expect(content).not.toContain("legacy map")
   })
 
-  test("replaces only the managed block when present", async () => {
-    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agents-update-"))
+  test("deletes AGENTS.md when it only contained the managed block", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agents-delete-"))
     const agentsPath = path.join(tempRoot, "AGENTS.md")
-    const seed = [
-      "Intro text",
-      CODEX_AGENTS_BLOCK_START,
-      "old content",
-      CODEX_AGENTS_BLOCK_END,
-      "Footer text",
-    ].join("\n")
-    await fs.writeFile(agentsPath, seed)
+    await fs.writeFile(
+      agentsPath,
+      [CODEX_AGENTS_BLOCK_START, "legacy map", CODEX_AGENTS_BLOCK_END, ""].join("\n"),
+    )
 
-    await ensureCodexAgentsFile(tempRoot)
+    await stripCodexAgentsToolMap(tempRoot)
 
-    const content = await readFile(agentsPath)
-    expect(content).toContain("Intro text")
-    expect(content).toContain("Footer text")
-    expect(content).not.toContain("old content")
-    expect(content).toContain(CODEX_AGENTS_BLOCK_START)
-    expect(content).toContain(CODEX_AGENTS_BLOCK_END)
+    expect(await exists(agentsPath)).toBe(false)
+  })
+
+  test("leaves AGENTS.md alone when the managed block is already gone", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "codex-agents-clean-"))
+    const agentsPath = path.join(tempRoot, "AGENTS.md")
+    await fs.writeFile(agentsPath, "# My Rules\n\nKeep this.\n")
+
+    await stripCodexAgentsToolMap(tempRoot)
+
+    expect(await readFile(agentsPath)).toBe("# My Rules\n\nKeep this.\n")
   })
 })

--- a/tests/real-plugin-conversion.test.ts
+++ b/tests/real-plugin-conversion.test.ts
@@ -313,10 +313,12 @@ for (const pluginName of PLUGIN_NAMES) {
       // the skills dir is the platform-filtered skills plus the commands.
       const expectedSkills = [...new Set([...skillsForPlatform(inventory, "codex"), ...inventory.commands])].sort()
 
-      const agentsMd = readFileSync(path.join(root, "AGENTS.md"), "utf8")
-      expect(agentsMd).toContain("<!-- BEGIN COMPOUND CODEX TOOL MAP -->")
-      expect(agentsMd).toContain("<!-- END COMPOUND CODEX TOOL MAP -->")
-
+      const agentsMdPath = path.join(root, "AGENTS.md")
+      if (existsSync(agentsMdPath)) {
+        const agentsMd = readFileSync(agentsMdPath, "utf8")
+        expect(agentsMd).not.toContain("<!-- BEGIN COMPOUND CODEX TOOL MAP -->")
+        expect(agentsMd).not.toContain("<!-- END COMPOUND CODEX TOOL MAP -->")
+      }
       const tomlNames = listFileBasenames(path.join(root, "agents", pluginName), ".toml")
       expect(tomlNames).toEqual(inventory.agents)
       for (const name of tomlNames) {


### PR DESCRIPTION
## Summary

Before native Codex plugin support, Bun `convert` / `install --to codex` wrote a managed Claude-compat tool map into `$CODEX_HOME/AGENTS.md`. That map is obsolete (skills name Codex tools inline) and actively harmful: it told Codex to collapse subagent dispatch onto the main thread, contradicting skills that need `spawn_agent`.

This PR stops inserting the block. Any future Bun Codex convert/install strips the sentinel span if it is still present, and the README adds a copy-paste cleanup prompt for people who will never re-run that CLI.

Fixes #1099.

## Test plan

- [x] `bun test tests/codex-agents.test.ts tests/cli.test.ts tests/real-plugin-conversion.test.ts`
- [ ] Confirm README cleanup prompt is under the Codex CLI install section and names `$CODEX_HOME` / profiles correctly
