### PR TITLE
fix(ce-proof): migrate to Proof v3 and owner credential lifecycle

### DIFF
--- a/docs/plans/2026-07-13-001-fix-ce-proof-v3-owner-lifecycle-plan.md
+++ b/docs/plans/2026-07-13-001-fix-ce-proof-v3-owner-lifecycle-plan.md
@@ -1,0 +1,251 @@
+---
+title: "fix: Migrate ce-proof to Proof v3 and owner credential lifecycle"
+type: fix
+status: active
+date: 2026-07-13
+origin: "GitHub #876 + session diagnosis; Proof docs at EveryInc/proof (docs/proof.SKILL.md, docs/agent-docs.md, AGENT_CONTRACT.md)"
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# fix: Migrate ce-proof to Proof v3 and owner credential lifecycle
+
+## Goal Capsule
+
+- **Objective:** Make `ce-proof` teach only Proof’s current web agent HTTP surface (`/v3/document`, `/v3/edit`) and the official `accessToken` / `ownerSecret` ownership model, while keeping compound-engineering’s publish-primary product shell (identity, one-way local-file publish, pull-to-local, upstream handoffs).
+- **Authority:** Confirmed scope from this planning session; Proof’s hosted-agent docs in the local `EveryInc/proof` checkout as the API source of truth (not `proof-sdk`, which lags production). Issue [#876](https://github.com/EveryInc/compound-engineering-plugin/issues/876) supplies the ownerSecret orphan-doc symptom and cleanup gap.
+- **Done when:** `skills/ce-proof/SKILL.md` and `docs/skills/ce-proof.md` contain no Local Bridge, `/ops`, `/edit/v2`, `/state`, `/snapshot`, or `baseToken` teaching; create workflow persists both credentials with distinct roles; delete/claim/revocation and “no comment delete” are documented; content-contract tests pin the new surface; unified-plan publish phrases still pass; `bun test` green; PR can close #876.
+
+## Product Contract
+
+### Summary
+
+`ce-proof` currently documents an obsolete Proof agent API (state/ops/edit-v2 + `baseToken`) and an equal Local Bridge layer, while showing `ownerSecret` in a sample JSON without extracting or using it. Agents copy the create example, drop the only delete credential, and leave undeletable orphan docs (marks can survive emptied content). Proof’s official agent skill already documents v3 + credential roles. This plan rewrites the CE skill to that substrate under CE’s publish-primary shell, with no legacy appendix and no Bridge.
+
+### Requirements
+
+- R1. Document only the Proof web agent HTTP surface: create via `POST /share/markdown`, read via `GET /api/agent/<slug>/v3/document`, mutate via `POST /api/agent/<slug>/v3/edit` (optional `baseRevision`; no `baseToken`).
+- R2. Remove Local Bridge (`localhost:9847` and all bridge endpoint tables) from the skill and catalog page; the skill is web-first only.
+- R3. Remove teaching of `/api/agent/{slug}/state`, `/snapshot`, `/ops`, `/edit/v2`, `baseToken` / `mutationBase`, `STALE_BASE` / `BASE_TOKEN_REQUIRED`, and `rewrite.apply` + `LIVE_CLIENTS_PRESENT` as the whole-doc path.
+- R4. Preserve CE product shell: identity `ai:compound-engineering` / display name `Compound Engineering`; Publish Mode (one-way from local markdown via `jq --rawfile`); HTML unified plans stay local; readiness-aware plan titles; direct + upstream entry points; Pull to Local as an explicit atomic sync.
+- R5. On create, extract and retain for the session: `slug`, `accessToken`, `ownerSecret`, `shareUrl`/`tokenUrl`, and useful `_links`. Teach `accessToken` as everyday bearer and `ownerSecret` as owner-only (delete / owner ops) — never as the everyday bearer; store them separately.
+- R6. Always hand humans the tokenized link (`tokenUrl`), never a bare `/d/<slug>` alone, so editor capability and claim capability remain available.
+- R7. Document delete: `DELETE /api/documents/<slug>` authorized by `ownerSecret` (or Every owner session). Viewer/commenter/editor tokens cannot delete. Document `DOCUMENT_DELETE_FORBIDDEN` reasons and post-delete `shareState: "DELETED"` / later `410`.
+- R8. Document ownership claim: public creates are ownerless until a signed-in Every user claims in the browser; claim permanently revokes `ownerSecret` while `accessToken` keeps working; after claim, owner-level ops belong to the owner (ask them / use their session) — do not retry delete with the revoked secret.
+- R9. Do not auto-DELETE after every publish handoff (review docs must linger). Delete when the user asks to remove/clean up, or when finishing an explicitly ephemeral scratch doc the user is done with. Persist `ownerSecret` for the session so cleanup remains possible while unclaimed.
+- R10. Warn that emptying markdown / `set_document` does not scrub comment marks; v3 supports resolve/unresolve but not comment delete; without owner delete authority, content wipe is not a privacy cleanup.
+- R11. Re-teach edit ladder and retries in v3 terms: prefer narrow `replace`/`insert`/`delete`; use `suggest` when track-changes matter; `set_document` last (collab-safe per Proof). Retry against `error.current` / re-read on `202`/`PENDING`; never silent first-match on ambiguous targets.
+- R12. Keep frontmatter discoverability (negative triggers for proofread/math/PoC) and model-invoked callee status. Omit MCP Mode as a first-class section (optional one-liner only if needed).
+- R13. Update `docs/skills/ce-proof.md` and the Collaboration catalog row in lockstep; preserve unified-plan contract phrases agents and tests rely on (`Only publish markdown`, `requirements-only` title labeling).
+- R14. Add regression tests so create/ownership/v3 guidance cannot regress to the old copy-paste gap.
+
+### Scope Boundaries
+
+**In scope**
+
+- `skills/ce-proof/SKILL.md` full rewrite of the HTTP protocol chapters
+- `docs/skills/ce-proof.md` + `docs/skills/README.md` Collaboration row wording
+- Content-contract tests under `tests/` pinning v3 + owner lifecycle + absence of Bridge/legacy paths
+- Closing #876 via the ownership sections of this rewrite
+
+**Out of scope**
+
+- Changing Proof product code or `proof-sdk`
+- Adopting Proof’s `collaborative_docs` / `all_new_markdown` auto-create defaults
+- Dual-documenting legacy HTTP or keeping a “legacy appendix”
+- Local Bridge retention or demotion (full removal)
+- MCP/OAuth as the primary CE install path
+- Caller skill rewrites (`ce-plan` / `ce-brainstorm` / `ce-ideate` handoffs) unless a named CE workflow phrase disappears
+- Stale-skill registry edits (name stays `ce-proof`)
+- Skill-count bump in `tests/release-metadata.test.ts`
+
+### Deferred to Follow-Up Work
+
+- Optional skill-creator behavioral evals against live Proof (recommended after merge if manual smoke is thin)
+- Refreshing Codex writer fixture URLs from `/state` to `/v3/document` for realism (not blocking; fixtures are URL-preservation tests, not skill SoT)
+
+## Planning Contract
+
+### Assumptions
+
+- Hosted `proofeditor.ai` matches the local `EveryInc/proof` docs (`docs/proof.SKILL.md`, `docs/agent-docs.md`, `AGENT_CONTRACT.md`) more closely than `proof-sdk`.
+- Upstream handoffs only need `ce-proof` to keep Publish Mode + identity + return-control; they do not embed legacy HTTP shapes.
+- `.agy/skills/ce-proof` is not a second SoT (symlink/install entry); edit `skills/ce-proof/` only.
+
+### Key Technical Decisions
+
+- KTD1. **CE shell + Proof v3 core.** Rewrite protocol chapters from Proof’s official skill; do not paste `proof.SKILL.md` wholesale (would wipe CE identity, publish-primary defaults, pull-to-local, and frontmatter shape).
+- KTD2. **Hard cutover.** No legacy appendix; grepping the skill for `/edit/v2`, `baseToken`, `Local Bridge`, `/ops` (agent ops path), and `/state` (agent state path) must find zero teaching hits after the rewrite.
+- KTD3. **Ownership model from Proof, not #876’s “user creates first” default.** Agent create remains valid; capture both secrets; hand `tokenUrl`; teach claim/revocation; delete with `ownerSecret` while unclaimed.
+- KTD4. **Lifecycle policy.** Persist `ownerSecret` for the session; delete on user request / ephemeral end — never as an automatic post-publish step that would destroy review URLs from chain handoffs.
+- KTD5. **Pull-to-local reads v3.** Replace `/state` markdown extraction with `v3/document` (or content-negotiated markdown) while keeping atomic `jq -jr` + `mv` and confirm-before-side-effect-write.
+- KTD6. **MCP omitted as a section.** At most one optional preference line if typed `proof_*` tools exist; HTTP/`Bash` remains the portable path.
+- KTD7. **Catalog + skill + tests move together.** Treat docs-page drift as a ship blocker for this PR.
+- KTD8. **Test strategy.** Mechanical content-contract assertions in `bun test`; live Proof smoke / skill-creator is recommended verification, not a substitute for the contract tests.
+
+### High-Level Technical Design
+
+Target skill shape (ordered chapters):
+
+```mermaid
+flowchart TD
+  A[Identity CE defaults] --> B[Publish Mode + entry points]
+  B --> C[Create share/markdown + save both credentials]
+  C --> D[Join: presence + v3/document]
+  D --> E[Edit: v3/edit ladder + error table]
+  E --> F[Pull to Local]
+  F --> G[Ownership: claim / delete / marks warning]
+  G --> H[Bug report + discovery links]
+```
+
+Credential lifecycle (must be taught explicitly):
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant Proof
+  participant Human
+  Agent->>Proof: POST /share/markdown
+  Proof-->>Agent: accessToken + ownerSecret + tokenUrl
+  Agent->>Human: hand tokenUrl only
+  Note over Agent: use accessToken for read/edit/presence
+  alt Human claims ownership
+    Human->>Proof: Claim in UI
+    Proof-->>Agent: ownerSecret revoked; accessToken still works
+    Note over Agent: delete only via owner / ask human
+  else Still ownerless
+    Agent->>Proof: DELETE with ownerSecret when user wants cleanup
+  end
+```
+
+### Product Contract preservation
+
+Product Contract written in this bootstrap (no upstream brainstorm). Confirmed user scope: v3-only HTTP, Proof ownership model, Bridge removed.
+
+## Implementation Units
+
+### U1. Rewrite `skills/ce-proof/SKILL.md` to v3 + ownership
+
+**Goal:** Replace the obsolete HTTP + Bridge body with CE shell + Proof v3 protocol and ownership lifecycle.
+
+**Requirements:** R1–R12
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/ce-proof/SKILL.md`
+
+**Approach:**
+- Keep frontmatter name/`description` intent (negative triggers) and `allowed-tools`.
+- Keep Identity, Publish Mode, Create-from-file (`jq --rawfile`), entry points, HTML/plan title rules.
+- Replace all Web API edit/read/retry chapters with condensed v3 from Proof docs (visible-text ops, `comments[]`/`suggestions[]`, error envelope, optional `baseRevision`, Idempotency-Key for important writes).
+- Expand create workflow extraction to include `OWNER_SECRET` with an inline “required for owner delete; not everyday bearer” note; always echo `tokenUrl`.
+- Add Ownership section: roles, claim/revocation, DELETE examples, marks/privacy warning, when to delete vs leave for review.
+- Rewrite Review / Create / Pull workflows’ curl samples to v3 only.
+- Delete Local Bridge section entirely.
+- Apply portable-authoring admission: falsifiable protocol over motivational prose; no dual-path insurance.
+
+**Patterns to follow:**
+- Proof `docs/proof.SKILL.md` + `docs/agent-docs.md` for API truth
+- Existing CE Publish Mode / identity / pull-to-local patterns in current `skills/ce-proof/SKILL.md`
+- `docs/solutions/skill-design/portable-agent-skill-authoring.md` and frontier-modernization (PROTOCOL fully prescribed; JUDGMENT compressed)
+
+**Test scenarios:**
+- Covered by U3 content contracts + Verification Contract smoke.
+- Preserve strings required by `tests/skills/unified-plan-artifact-contract.test.ts`: `Only publish markdown` and `requirements-only`.
+
+**Verification:** Skill grep-clean of legacy tokens; create sample extracts `ownerSecret`; delete + claim language present; Bridge absent; unified-plan test still passes after U3.
+
+---
+
+### U2. Rewrite catalog docs for web-first v3
+
+**Goal:** Align human-facing skill docs with the rewritten skill; remove Bridge and legacy API teaching.
+
+**Requirements:** R13
+
+**Dependencies:** U1 (or write in the same PR after U1 content is settled)
+
+**Files:**
+- Modify: `docs/skills/ce-proof.md`
+- Modify: `docs/skills/README.md` (Collaboration row)
+- Optionally touch: `README.md` inventory blurb if purpose text should mention ownership/v3 (only if wording is now wrong)
+
+**Approach:**
+- Retell TL;DR / Novel / Reference / FAQ around one-read/one-write v3, credential roles, delete/claim, pull-to-local, publish-primary.
+- Remove Local Bridge peer-layer language and `/ops` vs `/edit/v2` FAQ answers.
+- Keep chain-position and standalone usage sections; update “when to skip” so network-only (no Bridge fallback).
+
+**Patterns to follow:** Existing `docs/skills/ce-proof.md` structure; AGENTS.md plugin-doc sync convention.
+
+**Test expectation:** none — prose catalog; U3 may optionally assert catalog row no longer says “Local Bridge”.
+
+**Verification:** Catalog no longer advertises Bridge or `baseToken`; examples match skill curl shapes.
+
+---
+
+### U3. Content-contract regression tests
+
+**Goal:** Prevent the create-example ownerSecret drop and legacy-surface regression.
+
+**Requirements:** R14, R1–R3, R5–R8, R13 (testable slices)
+
+**Dependencies:** U1 (and U2 if asserting catalog strings)
+
+**Files:**
+- Create or modify: a focused test under `tests/` (prefer extending an existing skill content test file if one fits; otherwise add e.g. `tests/skills/ce-proof-contract.test.ts`)
+- Modify if needed: `tests/skills/unified-plan-artifact-contract.test.ts` (only if publish phrases move)
+
+**Approach:**
+- Assert `skills/ce-proof/SKILL.md` contains: `v3/document`, `v3/edit`, `ownerSecret` extraction guidance (e.g. `OWNER_SECRET` or explicit persist language), `DELETE` `/api/documents`, claim/revocation or “permanently revoked”, and `tokenUrl`.
+- Assert absence of: `Local Bridge`, `localhost:9847`, `/edit/v2`, `baseToken`, agent `/ops` teaching path, agent `/state` teaching path, `rewrite.apply` as documented op.
+- Keep unified-plan expectations green.
+- Do not bump `skills: 30` in release-metadata.
+
+**Patterns to follow:** `tests/skills/unified-plan-artifact-contract.test.ts` style of reading skill files as strings; skill-conventions listing for `ce-proof`.
+
+**Test scenarios:**
+- Happy path: skill file includes v3 endpoints and ownerSecret persist + DELETE guidance.
+- Negative: skill file does not include Local Bridge / edit-v2 / baseToken teaching strings.
+- Integration: unified-plan artifact contract still finds markdown-only + requirements-only labeling.
+- Edge: description length and model-invoked callee conventions still pass via existing `skill-conventions` suite.
+
+**Verification:** `bun test` for the new/updated files plus full suite before PR.
+
+**Execution note:** Write the failing content assertions first, then land U1/U2 until green.
+
+## Verification Contract
+
+- `bun test` (full suite) after U1–U3
+- Targeted: new `ce-proof` content-contract tests + `tests/skills/unified-plan-artifact-contract.test.ts` + `tests/skill-conventions.test.ts`
+- Manual smoke (recommended): create a throwaway doc on `proofeditor.ai`, confirm response includes `ownerSecret`, read/edit via v3 with `accessToken`, DELETE with `ownerSecret`, confirm editor token cannot DELETE
+- `bun run release:validate` if description inventory wording changes in ways that affect release metadata (skill count unchanged expected)
+
+## Definition of Done
+
+- U1–U3 complete and verification green
+- No legacy HTTP or Local Bridge teaching remains in skill or catalog page
+- #876 addressable by this change set (`Fixes #876` in the PR)
+- Callers unchanged unless a broken named workflow phrase forces a minimal text tweak
+- No hand-bumped plugin versions or changelog entries
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Proof docs drift from hosted production | Prefer local Proof repo docs; smoke against `proofeditor.ai`; note proof-sdk lag if consulted |
+| Agents still invent `/ops` from memory | Hard cutover + negative tests; short explicit “use v3 only” line near edit section |
+| Auto-delete destroys review handoffs | KTD4 / R9: delete is user-driven, not post-publish automatic |
+| Claim revokes secret mid-session | Teach revocation; after claim, stop using `ownerSecret` for delete |
+| Catalog/skill drift | U2 mandatory in same PR; optional catalog string assert in U3 |
+| Naive paste of Proof skill | KTD1; preserve CE shell checklist in U1 verification |
+
+## Sources & Research
+
+- Issue [#876](https://github.com/EveryInc/compound-engineering-plugin/issues/876)
+- Local Proof: `docs/proof.SKILL.md`, `docs/agent-docs.md`, `AGENT_CONTRACT.md` (create/delete/claim/v3)
+- Current CE: `skills/ce-proof/SKILL.md`, `docs/skills/ce-proof.md`
+- Learnings: `docs/solutions/skill-design/portable-agent-skill-authoring.md`, `frontier-model-skill-modernization-methodology.md`, `bundled-script-path-resolution-across-harnesses.md` (agents copy fenced examples), `integrations/opencode-temperature-rejected-by-sonnet5-opus48.md` (API bumps need full consumer audit)
+- Confirmed scoping: v3-only HTTP; Proof ownership model; Bridge removed; no legacy appendix

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -110,7 +110,7 @@ Invoked when a specific need arises — not part of any chain.
 
 | Skill | Description |
 |-------|-------------|
-| [`/ce-proof`](./ce-proof.md) | Publish, view, comment on, and edit markdown via [Proof](https://www.proofeditor.ai), Every's collaborative editor — Web API and Local Bridge surfaces |
+| [`/ce-proof`](./ce-proof.md) | Publish, view, comment on, and edit markdown via [Proof](https://www.proofeditor.ai), Every's collaborative editor — hosted v3 web API with owner credential lifecycle |
 
 ---
 

--- a/docs/skills/ce-proof.md
+++ b/docs/skills/ce-proof.md
@@ -2,7 +2,7 @@
 
 > Publish, share, view, comment on, and edit markdown documents via [Proof](https://www.proofeditor.ai), Every's collaborative markdown editor.
 
-`ce-proof` is the **collaborative-doc** skill. Proof is a real-time markdown editor where humans and agents can both work on the same document. The skill's primary use is **one-way publishing**: take a local markdown file (a brainstorm, a plan, a learning, a draft), create a shared Proof doc from it, and hand the user a shareable URL. The local file stays canonical — publishing does not sync anything back to disk. The skill also reads shared Proof docs and makes comment/suggestion/block edits over Proof's API when the agent is handed a URL to participate in. It exposes both Proof's web API (no install; create, read, edit shared docs via HTTP) and the local bridge (drives the macOS Proof app at `localhost:9847`).
+`ce-proof` is the **collaborative-doc** skill. Proof is a real-time markdown editor where humans and agents can both work on the same document. The skill's primary use is **one-way publishing**: take a local markdown file (a brainstorm, a plan, a learning, a draft), create a shared Proof doc from it, and hand the user a shareable URL. The local file stays canonical — publishing does not sync anything back to disk. The skill also reads shared Proof docs and makes comment/suggestion/content edits over Proof's **v3 web API** when the agent is handed a URL to participate.
 
 ---
 
@@ -10,11 +10,12 @@
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Publishes local markdown to a shareable Proof doc, reads shared docs, and makes comment / suggestion / block edits over the API |
+| What does it do? | Publishes local markdown to a shareable Proof doc, reads shared docs, and edits via Proof's v3 HTTP API |
 | When to use it | "Share to Proof", "publish to Proof", "view this in Proof"; auto-invoked on `ce-brainstorm` / `ce-plan` / `ce-ideate` publish handoffs |
 | What it produces | A shareable Proof URL (publish), or edits/comments on a shared doc you point it at |
-| Two layers | Web API (HTTP, no install) and Local Bridge (drives macOS Proof app) |
+| API surface | Hosted web API at `proofeditor.ai` — `v3/document` (read) and `v3/edit` (write) |
 | Sync direction | One-way publish by default — the local file stays canonical. Pulling a Proof doc back to local is a separate, explicit action |
+| Ownership | Capture `accessToken` (everyday) and `ownerSecret` (delete); claim in the UI revokes `ownerSecret` |
 
 ---
 
@@ -26,35 +27,28 @@ Sharing markdown drafts for review is harder than it looks:
 - **Pasting comments is lossy** — "see the bullet on line 47" doesn't anchor; a week later nobody remembers what bullet
 - **Tracked changes need infrastructure** — "suggest this edit" is meaningful only when there's a real accept/reject affordance
 - **Identity drifts** — when an agent edits, who edited? Without consistent attribution, comment authorship in the rendered doc is wrong
-- **State management is fragile** — concurrent edits collide; mutations need base tokens; retry logic is full of footguns
+- **Credentials are easy to drop** — create returns an `ownerSecret` that is the only delete credential for ownerless docs; agents that copy incomplete examples leave undeletable orphans
 - **PII / secrets in transit** — uploading content to a third-party editor is a real concern; the user needs to know what's leaving local
 
 ## The Solution
 
-`ce-proof` runs publishing and collaboration through Proof's structured API:
+`ce-proof` runs publishing and collaboration through Proof's structured v3 API:
 
 - **One-way publish** — create a shared doc from a local markdown file and return a shareable URL; the local file stays canonical
-- **Web API** for shared docs — no install needed; create, read, edit via HTTP; user gets a shareable URL with an access token
-- **Direct shared-link reads** — agents can fetch Proof URLs with `Accept: application/json` or `Accept: text/markdown`, no browser automation needed
-- **Local Bridge** when the macOS Proof app is running — drives the open document directly via `localhost:9847`
+- **Web API** — no install needed; create, read, edit via HTTP; user gets a shareable URL with an access token
+- **v3 one-read / one-write** — `GET /api/agent/<slug>/v3/document` and `POST /api/agent/<slug>/v3/edit`; visible-text targets; optional `baseRevision`; no base tokens
+- **Credential roles** — `accessToken` for everyday calls; `ownerSecret` for owner delete; always hand `tokenUrl`
 - **Consistent identity** — `by: "ai:compound-engineering"` on every op; `name: "Compound Engineering"` bound once via `/presence`
-- **Efficient edit passes** — filtered comment reads, one block-edit batch for content changes, one comment batch for replies/resolutions
-- **Rewrite-last edit strategy** — exact replacements and block edits first; whole-doc replacement only when truly unavoidable
-- **`baseToken` discipline** — seed from a read, chain the next token from mutation responses; on `STALE_BASE` re-read and retry once; verify before retry on potentially-applied mutations
-- **Idempotency keys** for safe exact-request retries without duplicate writes
+- **Narrow-first edit ladder** — `replace` / `insert` / `delete` → `suggest` when track-changes matter → `set_document` last (collab-safe)
+- **Retry against `error.current`** — closed error envelope with `retryable`; re-read on `202` / `PENDING`
 
 ---
 
 ## What Makes It Novel
 
-### 1. Web API + Local Bridge — both supported, same identity model
+### 1. CE publish shell on Proof's current agent contract
 
-Proof exposes two surfaces:
-
-- **Web API** at `proofeditor.ai` — anyone with the share URL can read/edit; great for shared review
-- **Local Bridge** at `localhost:9847` — drives the open Proof.app on macOS directly; great for one-machine workflows
-
-The skill documents both. Identity stays consistent: `ai:compound-engineering` machine ID, `Compound Engineering` display name. A caller can override the identity pair if a distinct sub-agent should own the doc.
+Proof's official agent docs define v3 + ownership. `ce-proof` keeps compound-engineering's product shell (publish-primary, fixed identity, pull-to-local, upstream handoffs) while teaching that current HTTP contract — not a stale dual-endpoint agent surface.
 
 ### 2. One-way publish as the primary mode
 
@@ -62,86 +56,28 @@ Publishing is the chain's primary use case:
 
 - Create a shared Proof doc from a local markdown file via `POST /share/markdown`; user gets a URL
 - Bind the display name via `POST /presence`
-- Surface the URL — the user opens it to read, comment, and share with others
+- Surface the `tokenUrl` — the user opens it to read, comment, and share with others
 
 The local file remains the canonical record; nothing syncs back to disk as a side effect of publishing. Two entry points, identical mechanics:
 
 - **Direct user request** — bare phrase like "share this to proof" or "publish this to proof"
 - **Upstream skill handoff** — `ce-brainstorm` / `ce-ideate` / `ce-plan` finishes a draft and hands it to publish
 
-### 3. Mutation discipline — token chaining + verify-before-retry
+### 3. Owner credential lifecycle
 
-Every Proof mutation requires a `baseToken`. The skill teaches the right pattern:
+Create returns both `accessToken` and `ownerSecret`. The skill requires extracting both, keeping `ownerSecret` in session memory only (never in the repo tree), and using it for `DELETE /api/documents/<slug>` when the user wants cleanup of an unclaimed doc. Publish handoffs do **not** auto-delete — review URLs must linger. If a human claims the doc, `ownerSecret` is permanently revoked; `accessToken` keeps working and delete moves to the owner.
 
-- **Read once, chain tokens** — seed from `/state` or `/snapshot`, then reuse the next `mutationBase.token` returned by successful mutations
-- **On `STALE_BASE` / `BASE_TOKEN_REQUIRED` / `MISSING_BASE` / `INVALID_BASE_TOKEN`** — re-read `/state`, rebuild the body with a fresh token, retry once with a new idempotency key
-- **On `INVALID_OPERATIONS` / `INVALID_REQUEST` / 422 errors** — fix the payload first, don't retry blindly
-- **On `COLLAB_SYNC_FAILED` / 5xx / network timeout / `202 with collab.status: "pending"`** — the canonical doc *may* have been written; re-read `/state` and check whether the intended mark/edit is already present **before retrying**
-- **`Idempotency-Key`** is recommended on every mutation; required when contract demands it. Reuse the same key only for an exact same-body resend; if the body changes (including a fresh `baseToken`), mint a new key
+### 4. v3 mutation discipline
 
-> Duplicate-mark incidents usually come from retrying a `comment.add` or `suggestion.add` after a timeout without verifying. When in doubt: re-read, diff, then decide.
+Every edit goes through `v3/edit` with an `operations` array. Targets are visible text. Ambiguous matches fail closed with `TARGET_AMBIGUOUS` + candidates. Content ops are atomic; review ops follow. Retryable failures carry `error.current` so the agent re-resolves instead of blind-retrying.
 
-### 4. Two endpoint shapes — `/ops` and `/edit/v2`
+### 5. Atomic pull-to-local (separate, explicit action)
 
-Proof has two write surfaces with **load-bearing differences** the skill teaches:
+Publishing is one-way, but a user can still pull a Proof doc's current state down to a local markdown file as a deliberate step. The skill reads `v3/document`, streams `.markdown` with `jq -jr`, and renames atomically. It asks for confirmation when the pull is a side-effect.
 
-- **`/api/agent/{slug}/ops`** — top-level `type` for one mark op, or top-level `operations` for batched comment thread mutations. Best for comments, suggestions, replies, and resolves.
-- **`/api/agent/{slug}/edit/v2`** — `operations` array where each entry has `op`. Atomic batch — every op lands or none. Best for block-level edits and bulk sweeps (`replace_block`, `insert_after`, `find_replace_in_doc`, etc.)
+### 6. Consistent agent identity
 
-Sending an `op`-shaped operation to `/ops` returns 422; the wire format isn't interchangeable. The skill documents both.
-
-### 5. Efficient comment passes — edit batch, then comment batch
-
-When the agent participates in a shared doc's comment threads, the efficient pass shape is:
-
-- Read `GET /state?kinds=comment` so provenance/authorship marks never pollute the needs-reply list
-- Apply agreed content edits with one `/edit/v2` batch where possible
-- Use `find_replace_in_doc` for literal doc-wide replacements such as terminology or punctuation sweeps
-- Reply to and resolve handled threads in one `/ops` batch using `comment.reply` with `resolve: true`
-
-This turns an 8-comment review from dozens of sequential reply/resolve/state-read requests into a small number of authoritative mutations.
-
-### 6. Rewrite Is The Last Resort
-
-Agents should not start by replacing the full document. The preferred edit ladder is:
-
-- `find_replace_in_doc` for exact repeated substitutions
-- `/edit/v2` block operations for known paragraphs, list items, sections, insertions, and deletions
-- `suggestion.add` when visible track changes are the desired review surface
-- `rewrite.apply` only when the user explicitly wants a whole-doc replacement or the change cannot be expressed safely with narrower operations
-
-That keeps human comments stable, avoids clobbering live collaborators, and makes retries easier to reason about.
-
-### 7. Tracked suggestion with `status: "accepted"`
-
-`suggestion.add` defaults to creating a pending suggestion the user must accept/reject. The skill also exposes `status: "accepted"` — creates the suggestion mark **and** commits the change in one call. The mark persists as audit trail with per-edit attribution; the user can still reject to revert. Useful when the agent is confident and the user wants to see what landed without an explicit accept step.
-
-### 8. `LIVE_CLIENTS_PRESENT` awareness
-
-While a client is connected to a Proof doc, the skill knows what's safe:
-
-- **`/edit/v2`** — works during active collab
-- **`suggestion.add`** (including `status: "accepted"`) — works during active collab
-- **All comment ops** — work during active collab
-- **`rewrite.apply`** — blocked by `LIVE_CLIENTS_PRESENT`; would clobber in-flight Yjs edits
-
-The skill tells callers to reserve `rewrite.apply` for no-client scenarios and use the granular ops or `/edit/v2` during active sessions.
-
-### 9. Atomic pull-to-local (separate, explicit action)
-
-Publishing is one-way, but a user can still pull a Proof doc's current state down to a local markdown file as a deliberate, separate step (e.g., after others edited the shared doc). When they do, the write is **atomic**:
-
-```bash
-# Stream .markdown bytes directly to a temp sibling, then rename.
-TMP="${LOCAL}.proof-sync.$$"
-jq -jr '.markdown' "$STATE_TMP" > "$TMP" && mv "$TMP" "$LOCAL"
-```
-
-`jq -jr` (no trailing newline, raw string) preserves byte-for-byte content including trailing newlines. `mv` within the same filesystem is atomic — a crashed write leaves the original untouched, never half-written. The skill asks the user to confirm before writing when the pull isn't directly asked for — silent overwrites are surprising.
-
-### 10. Consistent agent identity
-
-The skill enforces `by: "ai:compound-engineering"` on every op and `X-Agent-Id: ai:compound-engineering` in headers. Display name `Compound Engineering` is bound once per session via `/presence`. **Don't use `ai:compound` or other ad-hoc variants** — identity stays uniform unless a caller explicitly overrides for a sub-agent context.
+The skill enforces `by: "ai:compound-engineering"` on every op and `X-Agent-Id: ai:compound-engineering` in headers. Display name `Compound Engineering` is bound once per session via `/presence`. **Don't use `ai:compound` or other ad-hoc variants** — identity stays uniform unless a caller explicitly overrides.
 
 ---
 
@@ -149,7 +85,7 @@ The skill enforces `by: "ai:compound-engineering"` on every op and `X-Agent-Id: 
 
 `/ce-plan` finishes a notification-mute plan and the user picks "Publish to Proof" at the Phase 5.4 menu. Plan invokes `ce-proof` with the plan path and title.
 
-The skill creates a Proof doc via `POST /share/markdown` with the plan content, returns a URL with token, and binds the display name via `POST /presence`. It surfaces the URL to the user and returns control to `ce-plan` Phase 5.4 — the local plan file at `docs/plans/2026-05-04-001-feat-notification-mute-plan.md` is untouched and remains canonical.
+The skill creates a Proof doc via `POST /share/markdown` with the plan content, retains `accessToken` + `ownerSecret`, returns the `tokenUrl`, and binds the display name via `POST /presence`. It surfaces the URL to the user and returns control to `ce-plan` Phase 5.4 — the local plan file remains canonical and untouched.
 
 The user opens the URL in their browser, reads the plan, adds inline comments, and shares the link with a teammate. Nothing syncs back to disk; the menu re-renders so the user can start `/ce-work`, create an issue, or pause.
 
@@ -167,7 +103,7 @@ Reach for `ce-proof` when:
 Skip `ce-proof` when:
 
 - The doc is small enough that chat-paste-and-discuss works fine
-- You don't have network access (web API needs `proofeditor.ai`); the local bridge is macOS-only
+- You don't have network access (web API needs `proofeditor.ai`)
 - The content is too sensitive to upload to a third-party editor — keep it local
 
 ---
@@ -193,6 +129,7 @@ Direct invocation for ad-hoc Proof work:
 - **From a Proof URL** — `/ce-proof https://www.proofeditor.ai/d/abc123?token=xxx` (read state, add comments, suggest edits)
 - **Publish the just-edited file** — "share this to proof" picks up whichever markdown was just touched
 - **Pull a Proof doc to local** — sync current Proof state to a markdown file (atomic write; explicit, confirmed)
+- **Cleanup** — when the user asks to remove an unclaimed doc you created, `DELETE` with the session `ownerSecret`
 
 ---
 
@@ -200,24 +137,22 @@ Direct invocation for ad-hoc Proof work:
 
 | API surface | When |
 |-------------|------|
-| Web API at `proofeditor.ai` | Default; no install; shareable URLs |
-| Local Bridge at `localhost:9847` | macOS Proof.app running; one-machine workflow |
+| `POST /share/markdown` | Create / publish |
+| `GET /api/agent/{slug}/v3/document` | Read markdown + comments + suggestions |
+| `POST /api/agent/{slug}/v3/edit` | Content and review mutations |
+| `DELETE /api/documents/{slug}` | Owner delete (`ownerSecret` or Every owner session) |
 
-| Op (Web API `/ops`) | Purpose |
-|---------------------|---------|
-| `comment.add` | Comment on a quote |
-| `comment.reply` | Reply within a thread; `resolve: true` replies and closes in one mutation |
-| `comment.resolve` / `comment.unresolve` | Toggle thread resolution |
-| `suggestion.add` | Tracked edit (pending or `status: "accepted"`) |
-| `suggestion.accept` / `suggestion.reject` | Resolve a suggestion |
-| `rewrite.apply` | Last-resort whole-doc replacement (blocked by `LIVE_CLIENTS_PRESENT`) |
+| v3 content op | Purpose |
+|---------------|---------|
+| `replace` / `insert` / `delete` | Narrow prose edits (visible-text targets) |
+| `set_document` | Whole-doc replacement (last resort; collab-safe) |
 
-| Endpoint | Wire format | Best for |
-|----------|-------------|----------|
-| `/api/agent/{slug}/ops` | Top-level `type` or comment `operations` batch | Marks, batched replies/resolves |
-| `/api/agent/{slug}/edit/v2` | `operations: [{op, ...}, ...]` | Atomic block batches and `find_replace_in_doc` sweeps |
+| v3 review op | Purpose |
+|--------------|---------|
+| `comment` / `reply` / `resolve` / `unresolve` | Comment threads (no comment delete) |
+| `suggest` / `accept` / `reject` | Tracked suggestions |
 
-Identity defaults: `by: "ai:compound-engineering"`, `X-Agent-Id: ai:compound-engineering`, `name: "Compound Engineering"`. `Idempotency-Key` recommended on every mutation and required when the contract says so.
+Identity defaults: `by: "ai:compound-engineering"`, `X-Agent-Id: ai:compound-engineering`, `name: "Compound Engineering"`.
 
 ---
 
@@ -226,20 +161,23 @@ Identity defaults: `by: "ai:compound-engineering"`, `X-Agent-Id: ai:compound-eng
 **Does publishing sync edits back to my local file?**
 No. Publishing is one-way — it creates a shared Proof doc and returns a URL; the local file stays canonical. If you want the current Proof state on disk, pull it down explicitly (a separate, confirmed action that writes atomically).
 
-**Why two endpoint shapes?**
-Different concerns. `/ops` handles mark mutations, including batched existing-thread comment replies/resolves. `/edit/v2` handles atomic batches of block-level edits and document-wide literal replacement. The wire formats differ — sending `op` shape to `/ops` returns 422.
+**Why two tokens on create?**
+`accessToken` is the everyday bearer for read/edit/presence. `ownerSecret` is the only credential that can delete an ownerless agent-created doc. Dropping `ownerSecret` leaves an undeletable orphan.
 
 **Should I rewrite the whole doc?**
-Almost never as a first move. Use `find_replace_in_doc` for literal sweeps and block-level `/edit/v2` for scoped edits. Use `rewrite.apply` only when the user asked for full replacement or the change cannot be represented with narrower operations.
+Almost never as a first move. Prefer `replace` / `insert` / `delete`. Use `suggest` when visible track changes matter. Use `set_document` only when the user asked for full replacement or the change cannot be represented narrowly.
 
 **What's the right mutation pattern?**
-Read `/state?kinds=comment` for comment work or `/snapshot` for block refs, capture `mutationBase.token`, then update your cached token from successful mutation responses. On `STALE_BASE`, re-read and retry once with fresh token. On potentially-applied errors (5xx, timeout, `202 pending`), re-read and check whether the change is already present before retrying — duplicate marks come from retrying without verifying.
+Read `v3/document` once, send one `v3/edit` with the operations you need, then inspect the settled response (or re-read on `202`). On retryable errors, re-resolve against `error.current`.
 
 **Why the `ai:compound-engineering` identity?**
 For consistent attribution. Mark authorship in the rendered doc shows who edited; if the agent uses `ai:compound` one day and `ai:compound-engineering` the next, the audit trail looks fragmented. The skill enforces one identity unless a caller explicitly overrides.
 
 **Can I edit a doc while a user is connected?**
-Yes for `/edit/v2`, `suggestion.add` (including `status: "accepted"`), and all comment ops. No for `rewrite.apply` — it's blocked by `LIVE_CLIENTS_PRESENT` because it would clobber in-flight Yjs edits.
+Yes. v3 content and review ops work during active collab. `set_document` is applied as a minimal diff and is documented as safe with live collaborators.
+
+**Does emptying a doc remove comments?**
+No. Emptying markdown does not scrub comment marks. Delete the document with `ownerSecret` (while unclaimed) or ask the owner after claim.
 
 **What if the upload fails?**
 The skill retries once. If it still fails, callers get a clear error and can decide what to do (often: stay in the chain skill's menu without the Proof handoff, or fall back to local-only). Persistent failures get reported to Proof via `POST /api/bridge/report_bug` for diagnosis.
@@ -252,3 +190,4 @@ The skill retries once. If it still fails, callers get a clear error and can dec
 - [`/ce-plan`](./ce-plan.md) — Phase 5.4 "Publish to Proof" handoff
 - [`/ce-ideate`](./ce-ideate.md) — Phase 5 "Publish to Proof" option
 - [Proof](https://www.proofeditor.ai) — the editor itself; this skill is the agent client
+- [Proof agent docs](https://www.proofeditor.ai/agent-docs) — hosted agent contract

--- a/skills/ce-proof/SKILL.md
+++ b/skills/ce-proof/SKILL.md
@@ -10,10 +10,7 @@ allowed-tools:
 
 # Proof - Collaborative Markdown Editor
 
-Proof is a collaborative document editor for humans and agents. It supports two modes:
-
-1. **Web API** - Create and edit shared documents via HTTP (no install needed)
-2. **Local Bridge** - Drive the macOS Proof app via localhost:9847
+Proof is a collaborative document editor for humans and agents. This skill uses the **hosted web API** at `https://www.proofeditor.ai` (HTTP/`Bash`). If typed `proof_*` MCP tools are already available in the harness, prefer them; otherwise use the HTTP recipes below.
 
 ## Identity and Attribution
 
@@ -36,381 +33,314 @@ to Proof; return the local browser/open path instead. When publishing a unified
 plan, label the title by readiness when available, e.g. `Plan: <title>
 (requirements-only)` or `Plan: <title> (implementation-ready)`.
 
-## Web API (Primary for Sharing)
+Do not silently replace repo-tracked project docs with Proof links. Do not put secrets, credentials, API keys, private tokens, or sensitive personal data in Proof unless the user explicitly approves.
+
+## Credentials
+
+Document creation returns two credentials with different jobs:
+
+- `accessToken` — everyday bearer for read, edit, presence, and events. Use this for all non-owner agent API calls.
+- `ownerSecret` — owner authority only (delete and other owner-level ops). Never use it as the everyday bearer.
+
+Store them separately for the session (shell vars or equivalent non-repo memory). Never write `ownerSecret` or `accessToken` into repo-tracked files, commits, or durable project logs. Never expose `ownerSecret` in user-facing UI copy.
+
+Always hand humans the tokenized link (`tokenUrl`), never a bare `/d/<slug>` alone — the editor token doubles as claim capability for ownerless docs.
+
+Public creates are ownerless until a signed-in Every user claims the doc in the browser (account menu → Claim ownership). Claiming permanently revokes `ownerSecret`; `accessToken` keeps working. After claim, delete and other owner ops belong to the owner's Every account — ask the owner, or use their Every session token. Do not retry delete with a revoked `ownerSecret`.
+
+Treat a `403` with `code: "DOCUMENT_DELETE_FORBIDDEN"` and `reason: "CREDENTIAL_NOT_OWNER"`, or a `401` when presenting the creation `ownerSecret`, as evidence the secret was revoked (commonly after claim). Stop using that `ownerSecret`; ask the owner to delete or supply an Every owner session.
+
+## Web API
+
+Auth on document surfaces (preferred first):
+
+- `Authorization: Bearer <accessToken>`
+- `x-share-token: <accessToken>`
+- `?token=<accessToken>` on the request URL
+
+Canonical agent read/write (v3 only — do not invent other agent mutation paths):
+
+- Read: `GET /api/agent/<slug>/v3/document`
+- Write: `POST /api/agent/<slug>/v3/edit`
 
 ### Create a Shared Document
 
-No authentication required. Returns a shareable URL with access token.
+No authentication required on the public create route. Returns a shareable URL with tokens.
 
 ```bash
-curl -X POST https://www.proofeditor.ai/share/markdown \
+curl -sS -X POST https://www.proofeditor.ai/share/markdown \
   -H "Content-Type: application/json" \
   -d '{"title":"My Doc","markdown":"# Hello\n\nContent here."}'
 ```
 
-**Response format:**
+**Response fields to keep:**
+
 ```json
 {
   "slug": "abc123",
   "tokenUrl": "https://www.proofeditor.ai/d/abc123?token=xxx",
   "accessToken": "xxx",
   "ownerSecret": "yyy",
+  "shareUrl": "https://www.proofeditor.ai/d/abc123",
   "_links": {
-    "state": "https://www.proofeditor.ai/api/agent/abc123/state",
-    "ops": "https://www.proofeditor.ai/api/agent/abc123/ops"
+    "read": "https://www.proofeditor.ai/api/agent/abc123/v3/document",
+    "edit": { "method": "POST", "href": "/api/agent/abc123/v3/edit" },
+    "delete": { "method": "DELETE", "href": "/api/documents/abc123" }
   }
 }
 ```
 
-Use the `tokenUrl` as the shareable link. The `_links` give you the exact API paths.
+Use `tokenUrl` as the shareable link. Extract `slug`, `accessToken`, and `ownerSecret` immediately — `ownerSecret` is required for cleanup while the doc is still unclaimed.
 
 ### Read a Shared Document
 
-If you already have a shared Proof URL, no browser automation is needed. Fetch the URL directly with content negotiation:
+If you already have a shared Proof URL, fetch with content negotiation or v3:
 
 ```bash
-curl -s -H "Accept: application/json" "https://www.proofeditor.ai/d/{slug}?token=<token>"
-curl -s -H "Accept: text/markdown" "https://www.proofeditor.ai/d/{slug}?token=<token>"
+curl -sS -H "Accept: application/json" "https://www.proofeditor.ai/d/{slug}?token=<token>"
+curl -sS -H "Accept: text/markdown" "https://www.proofeditor.ai/d/{slug}?token=<token>"
+
+curl -sS "https://www.proofeditor.ai/api/agent/{slug}/v3/document" \
+  -H "Authorization: Bearer <token>" \
+  -H "X-Agent-Id: ai:compound-engineering"
+# -> { ok, revision, title, markdown, comments[], suggestions[], mutationReady? }
 ```
 
-The JSON response includes the markdown, API links, and agent auth hints. Use `/state` when you need mutation metadata, marks, or presence:
+ACTIVE docs can be read tokenlessly via `v3/document`. Mutations, presence, and events need a tokenized credential. Tokenless `GET /d/<slug>` JSON reports `role: null` and no mutation links — that is truthful capability reporting, not a browser lock.
 
-```bash
-curl -s "https://www.proofeditor.ai/api/agent/{slug}/state" \
-  -H "x-share-token: <token>"
-```
+`comments[]` and `suggestions[]` on the v3 read are the source of review state. Use a comment's `id` for `reply` / `resolve` / `unresolve`. Use a suggestion's `id` for `accept` / `reject`. v3 supports resolving and unresolving comments; it does **not** support deleting comments.
 
-For comment-ingest workflows, prefer the server-side filter:
-
-```bash
-curl -s "https://www.proofeditor.ai/api/agent/{slug}/state?kinds=comment" \
-  -H "x-share-token: <token>"
-```
-
-`state.marks` is a union of comments, suggestions, and provenance/authorship marks. The `?kinds=comment` filter avoids treating human-authored provenance marks as review comments.
+When `mutationReady` is `false`, `revision` may be `null` — omit `baseRevision` and re-read shortly.
 
 ### Edit a Shared Document
 
-Comment, suggestion, and rewrite operations go to `POST https://www.proofeditor.ai/api/agent/{slug}/ops`. Block edits use `/api/agent/{slug}/edit/v2`.
+Send `{ by, baseRevision?, operations: [...] }` to `POST /api/agent/{slug}/v3/edit`. Targets are **visible text** in `markdown` (not raw markdown syntax, not block refs). There is no base token. `baseRevision` (integer from the last read) is an optional conflict guard — omit it to apply at head. `Idempotency-Key` is optional; use one for important writes and retries.
 
-**Note:** Use the `/api/agent/{slug}/ops` path (from `_links` in create response), NOT `/api/documents/{slug}/ops`.
-
-**Authentication for protected docs:**
-- Header: `x-share-token: <token>` or `Authorization: Bearer <token>`
-- Token comes from the URL parameter: `?token=xxx` or the `accessToken` from create response
-- Header: `X-Agent-Id: ai:compound-engineering` (required for presence; include on ops for consistent attribution)
-
-**Wire-format reminder.** `/api/agent/{slug}/ops` uses a top-level `type` field; `/api/agent/{slug}/edit/v2` uses an `operations` array where each entry has `op`. Do not mix — sending `op` to `/ops` returns 422.
-
-**Every mutation requires a `baseToken`.** Reuse the `mutationBase.token` from the most recent `/state` or `/snapshot` read, then update it from successful mutation responses (`.mutationBase.token`). On `BASE_TOKEN_REQUIRED` or `STALE_BASE`, re-read and retry once. Only do a pre-mutation read if no prior read has happened in this session or you need fresh document/comment/snapshot content.
-
-`/edit/v2` block refs are a separate concern: they can drift across revisions, so re-fetch `/snapshot` for fresh refs before a block edit if any writes have landed since your last snapshot.
-
-### Edit Strategy: Avoid Whole-Doc Rewrite
-
-Do not default to full-document replacement. Pick the narrowest edit primitive that matches the requested change:
-
-1. **Literal repeated change:** use `/edit/v2` with `find_replace_in_doc` (optionally constrained by `fromRef`, `toRef`, or `block_filter`). This is the fastest and least error-prone path for terminology renames, punctuation/style sweeps, and other exact text substitutions.
-2. **Known block or section change:** use `/edit/v2` block operations from a fresh `/snapshot`: `replace_block`, `insert_before`, `insert_after`, `delete_block`, `replace_range`, or `find_replace_in_block`.
-3. **Visible track-changes desired:** use `/ops` `suggestion.add` (pending or `status: "accepted"`) when the user should see a suggestion mark and reject/revert affordance for that specific edit.
-4. **Whole-doc replacement:** use `rewrite.apply` only as a last resort when the user explicitly asks to replace the entire document, when the intended change is genuinely global and cannot be expressed as block/range/find-replace operations, and when no live clients are present. Before rewriting, read current state, preserve comments/marks expectations, and mention that the rewrite is broad.
-
-When in doubt, start with `/snapshot` and build a small `/edit/v2` batch. A narrow failed edit is easier to inspect and retry than a broad rewrite, and it avoids clobbering concurrent human work.
-
-**Retry discipline after mutation errors — verify before retrying.** An error response is not proof that nothing was written.
-
-- `STALE_BASE`, `BASE_TOKEN_REQUIRED`, `MISSING_BASE`, `INVALID_BASE_TOKEN` — pre-commit, token-related. Re-read `/state`, rebuild the request body with a fresh `baseToken`, and retry once with a new `Idempotency-Key`.
-- `ANCHOR_NOT_FOUND`, `ANCHOR_AMBIGUOUS` — pre-commit, but the `quote` no longer uniquely matches content. Re-reading does not help by itself; the caller must tighten or regenerate the anchor before retrying. Do not auto-retry blindly.
-- `INVALID_OPERATIONS`, `INVALID_REQUEST`, `INVALID_REF`, `INVALID_BLOCK_MARKDOWN`, `INVALID_RANGE`, `INVALID_MARKDOWN`, 422 — pre-commit, but the payload is wrong. Do not retry blindly; fix the payload first.
-- `COLLAB_SYNC_FAILED`, `REWRITE_BARRIER_FAILED`, `PROJECTION_STALE`, `INTERNAL_ERROR`, 5xx, network timeout, and any **202 with `collab.status: "pending"`** — the canonical doc may have been written even though the call looks like a failure. Before any retry, re-read `/state` and check whether the intended mark/edit is already present; only retry if it isn't.
-- `Idempotency-Key` (see below) protects against double-apply *on the same request* (e.g., TCP-level retry). It does not help if you build a new request body and send a second call — that is a new logical write with a new key.
-
-Duplicate-mark incidents usually come from retrying a `comment.add` or `suggestion.add` after a timeout without verifying. When in doubt: re-read, diff, then decide.
-
-**`Idempotency-Key` header** is recommended on every mutation for safe automation retries; required when `/state.contract.idempotencyRequired` is true. Use the same key only when resending the exact same serialized request body. If the body changes — including because you replaced `baseToken` after `STALE_BASE` — mint a new key or Proof will reject it as key reuse with a different payload.
-
-**Comment on text:**
-```json
-{"type": "comment.add", "quote": "text to comment on", "by": "ai:compound-engineering", "text": "Your comment here", "baseToken": "<token>"}
-```
-
-**Reply to a comment:**
-```json
-{"type": "comment.reply", "markId": "<id>", "by": "ai:compound-engineering", "text": "Reply text", "baseToken": "<token>"}
-```
-
-**Reply and resolve in one mutation:**
-```json
-{"type": "comment.reply", "markId": "<id>", "by": "ai:compound-engineering", "text": "Fixed.", "resolve": true, "baseToken": "<token>"}
-```
-
-**Batch existing-thread comment mutations:**
-```json
-{"by": "ai:compound-engineering", "baseToken": "<token>", "operations": [
-  {"type": "comment.reply", "markId": "<id-1>", "text": "Fixed.", "resolve": true},
-  {"type": "comment.reply", "markId": "<id-2>", "text": "Leaving this open because X."}
-]}
-```
-
-Batch `/ops` supports `comment.reply`, `comment.resolve`, and `comment.unresolve` for existing threads. Use it to reply to and resolve multiple threads in one call instead of issuing separate reply and resolve requests per thread.
-
-**Resolve / unresolve a comment:**
-```json
-{"type": "comment.resolve", "markId": "<id>", "by": "ai:compound-engineering", "baseToken": "<token>"}
-{"type": "comment.unresolve", "markId": "<id>", "by": "ai:compound-engineering", "baseToken": "<token>"}
-```
-
-**Suggest a replacement (pending — user must accept/reject):**
-```json
-{"type": "suggestion.add", "kind": "replace", "quote": "original text", "by": "ai:compound-engineering", "content": "replacement text", "baseToken": "<token>"}
-```
-
-**Suggest and immediately apply (tracked but committed — user can reject to revert):**
-```json
-{"type": "suggestion.add", "kind": "replace", "quote": "original text", "by": "ai:compound-engineering", "content": "replacement text", "status": "accepted", "baseToken": "<token>"}
-```
-
-`status: "accepted"` creates the suggestion mark and commits the change in one call. The mark persists as an audit trail with per-edit attribution and a reject-to-revert affordance. Works with `kind: "insert" | "delete" | "replace"`.
-
-**Accept or reject an existing suggestion:**
-```json
-{"type": "suggestion.accept", "markId": "<id>", "by": "ai:compound-engineering", "baseToken": "<token>"}
-{"type": "suggestion.reject", "markId": "<id>", "by": "ai:compound-engineering", "baseToken": "<token>"}
-```
-
-`suggestion.resolve` is not supported — use accept or reject instead.
-
-**Whole-doc rewrite (last resort):**
-```json
-{"type": "rewrite.apply", "content": "full new markdown", "by": "ai:compound-engineering", "baseToken": "<token>"}
-```
-
-Prefer `find_replace_in_doc` or block-level `/edit/v2` operations first. `rewrite.apply` is broad, disruptive, and blocked while live clients are connected.
-
-**Block-level edits via `/edit/v2`** (separate endpoint, separate shape):
 ```bash
-curl -X POST "https://www.proofeditor.ai/api/agent/{slug}/edit/v2" \
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/{slug}/v3/edit" \
   -H "Content-Type: application/json" \
-  -H "x-share-token: <token>" \
+  -H "Authorization: Bearer <token>" \
   -H "X-Agent-Id: ai:compound-engineering" \
-  -H "Idempotency-Key: <uuid>" \
+  -H "Idempotency-Key: $(uuidgen)" \
   -d '{
-    "by": "ai:compound-engineering",
-    "baseToken": "mt1:<token>",
-    "operations": [
-      {"op": "replace_block", "ref": "b3", "block": {"markdown": "Updated paragraph."}},
-      {"op": "insert_after", "ref": "b3", "blocks": [{"markdown": "## New section"}]}
+    "by":"ai:compound-engineering",
+    "operations":[
+      {"op":"replace","find":"old visible text","with":"new text"},
+      {"op":"comment","on":"text to anchor on","body":"Is this still accurate?"}
     ]
   }'
 ```
 
-Per-op body shape (singular `block` vs plural `blocks` is load-bearing — sending the wrong one returns 422):
+**Content operations:**
 
-| op | body fields |
+| op | body |
 |---|---|
-| `replace_block` | `ref`, `block: {markdown}` |
-| `insert_after` | `ref`, `blocks: [{markdown}, ...]` |
-| `insert_before` | `ref`, `blocks: [{markdown}, ...]` |
-| `delete_block` | `ref` |
-| `replace_range` | `fromRef`, `toRef`, `blocks: [{markdown}, ...]` |
-| `find_replace_in_block` | `ref`, `find`, `replace`, `occurrence: "first" \| "all"` |
-| `find_replace_in_doc` | `find`, `replace`, `occurrence: "first" \| "all"`, optional `fromRef`, `toRef`, `block_filter` |
+| `replace` | `find`, `with` (optional `occurrence` / `before` / `after`) |
+| `insert` | `after` or `before` + `markdown` (anchor: quote, `heading:Title`, `section:Title`, `"start"`, or `"end"`) |
+| `delete` | `find` |
+| `set_document` | `markdown` (whole-doc replace as a minimal diff; safe with live collaborators) |
 
-Read `/snapshot` to get block `ref` IDs and `mutationBase.token`. `ref` values are opaque request tokens tied to the snapshot/baseToken; re-read `/snapshot` before follow-up block edits if writes have landed. `operations` commits atomically — either every op lands or none do — so one `/edit/v2` call can batch dozens of block edits safely and efficiently. Successful full responses include the next `mutationBase.token` and fresh `snapshot.blocks[].ref` values for chaining.
+**Review operations:**
 
-For literal doc-wide sweeps, prefer `find_replace_in_doc` over many block replacements or a whole-doc rewrite. Validate large batches with `?dryRun=1` or `?validate=1`; use `?return=minimal` when you only need `ok`, `revision`, `appliedCount`, and the next `mutationBase`.
+| op | body |
+|---|---|
+| `comment` | `on`, `body` (optional `occurrence`) |
+| `reply` | `comment` (id), `body`, optional `resolve: true` |
+| `resolve` / `unresolve` | `comment` (id) |
+| `suggest` | `kind: "insert"\|"delete"\|"replace"`, `find`, `with?` (`with` required for insert/replace) |
+| `accept` / `reject` | `suggestion` (id) |
 
-**Editing while a client is connected is fine.** `/edit/v2`, `suggestion.add` (including `status: "accepted"`), and all comment ops work during active collab. Only `rewrite.apply` is blocked by `LIVE_CLIENTS_PRESENT` — it would clobber in-flight Yjs edits.
+### Edit Strategy
 
-**When the loop breaks.** If a mutation keeps failing after a fresh read and one retry, or state across reads looks inconsistent, call `POST https://www.proofeditor.ai/api/bridge/report_bug` with the failing request ID, slug, and raw response. The server enriches and files an issue.
+Prefer the narrowest op:
 
-### Known Limitations (Web API)
+1. Literal or scoped prose change → `replace` / `insert` / `delete`
+2. Visible track-changes desired → `suggest` (then `accept`/`reject` as needed)
+3. Whole-doc replacement → `set_document` only when the user asks for full replacement or the change cannot be expressed narrowly
 
-- Bridge-style endpoints (`/d/{slug}/bridge/*`) require client version headers (`x-proof-client-version`, `x-proof-client-build`, `x-proof-client-protocol`) and return 426 CLIENT_UPGRADE_REQUIRED without them. Use `/api/agent/{slug}/ops` instead.
+If a `find`/anchor matches more than once, the server rejects with `TARGET_AMBIGUOUS` and `error.candidates` — nothing is changed. Disambiguate with `occurrence` (`"first"`, `"last"`, or 0-based index) or `before`/`after`. Never assume silent first-match.
 
-## Local Bridge (macOS App)
+Content ops in one request apply atomically; review ops then apply in order. If a review op fails after content committed, the response is `ok: false` with `partial: true` — re-read and retry only the failed op (same `Idempotency-Key` safely replays).
 
-Requires Proof.app running. Bridge at `http://localhost:9847`.
+**Errors** use `{ ok:false, error:{ code, message, retryable, opIndex?, target?, candidates?, current? } }`. Codes: `AUTH`, `NOT_FOUND`, `INVALID_REQUEST`, `TARGET_NOT_FOUND`, `TARGET_AMBIGUOUS`, `CONFLICT`, `TOO_LARGE`, `BUSY`, `PENDING`, `INTERNAL`.
 
-**Required headers:**
-- `X-Agent-Id: ai:compound-engineering` (identity for presence; keep aligned with `by`)
-- `Content-Type: application/json`
-- `X-Window-Id: <uuid>` (when multiple docs open)
+- `retryable: false` — fix the request; do not blind-retry
+- `retryable: true` with `error.current` — re-resolve targets against `current` and retry once
+- `TARGET_AMBIGUOUS` — add `occurrence` / `before` / `after` from `candidates`
+- `BUSY` — brief backoff and retry
+- Settled `200` with `ok:true` — inspect returned `revision` / document; chain without an extra read when the body is complete
+- `202` / `PENDING` — write may have committed; re-read `v3/document` before chaining or reporting success
 
-### Key Endpoints
+After every successful edit: confirm `ok:true`, confirm the intended text/comment/suggestion, then report the Proof link with a short summary.
 
-| Method | Endpoint | Purpose |
-|--------|----------|---------|
-| GET | `/windows` | List open documents |
-| GET | `/state` | Read markdown, cursor, word count |
-| GET | `/marks` | List all suggestions and comments |
-| POST | `/marks/suggest-replace` | `{"quote":"old","by":"ai:compound-engineering","content":"new"}` |
-| POST | `/marks/suggest-insert` | `{"quote":"after this","by":"ai:compound-engineering","content":"insert"}` |
-| POST | `/marks/suggest-delete` | `{"quote":"delete this","by":"ai:compound-engineering"}` |
-| POST | `/marks/comment` | `{"quote":"text","by":"ai:compound-engineering","text":"comment"}` |
-| POST | `/marks/reply` | `{"markId":"<id>","by":"ai:compound-engineering","text":"reply"}` |
-| POST | `/marks/resolve` | `{"markId":"<id>","by":"ai:compound-engineering"}` |
-| POST | `/marks/accept` | `{"markId":"<id>"}` |
-| POST | `/marks/reject` | `{"markId":"<id>"}` |
-| POST | `/rewrite` | Last-resort whole-doc replacement: `{"content":"full markdown","by":"ai:compound-engineering"}` |
-| POST | `/presence` | `{"status":"reading","summary":"..."}` |
-| GET | `/events/pending` | Poll for user actions |
+### Presence
 
-### Presence Statuses
+```bash
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/{slug}/presence" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -H "X-Agent-Id: ai:compound-engineering" \
+  -d '{"name":"Compound Engineering","status":"reading","summary":"Joining the doc"}'
+```
 
-`thinking`, `reading`, `idle`, `acting`, `waiting`, `completed`
+Common statuses: `reading`, `thinking`, `acting`, `waiting`, `completed`, `error`.
+
+### Title
+
+```bash
+curl -sS -X PUT "https://www.proofeditor.ai/api/documents/{slug}/title" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"title":"Updated document title"}'
+```
+
+### Delete
+
+Only owner credentials can delete:
+
+```bash
+curl -sS -X DELETE "https://www.proofeditor.ai/api/documents/{slug}" \
+  -H "Authorization: Bearer <ownerSecret>"
+```
+
+Viewer, commenter, and editor `accessToken` values cannot delete. Success returns `shareState: "DELETED"`; later reads return deleted-document responses (`410` on many routes).
+
+**Lifecycle:** Do **not** auto-delete after every publish handoff — review docs must linger. Persist `ownerSecret` for the session. Delete when the user asks to remove/clean up, or when finishing an explicitly ephemeral scratch doc the user is done with.
+
+### Marks and privacy
+
+Emptying the markdown (including `set_document` to blank/minimal content) does **not** scrub comment marks. Quote and commentary fields can remain readable via `v3/document` to anyone with the share credential. Without owner delete authority, content wipe is not a privacy cleanup — delete the document with `ownerSecret` (while unclaimed) or ask the owner after claim.
+
+### When the loop breaks
+
+If a mutation keeps failing after a fresh read and one safe retry, call `POST https://www.proofeditor.ai/api/bridge/report_bug` with the failing request ID, slug, and raw response. The server enriches and files an issue. Ask before including the user's name/email.
 
 ## Workflow: Review a Shared Document
 
 When given a Proof URL like `https://www.proofeditor.ai/d/abc123?token=xxx`:
 
-1. Extract the slug (`abc123`) and token from the URL
-2. Read the document via content negotiation on the shared URL or via `/api/agent/{slug}/state` when you need marks/mutation metadata
-3. For content edits, prefer `/edit/v2` `find_replace_in_doc` or block operations; use `/ops` for comments, suggestions, and comment replies/resolution
-4. The author sees changes in real-time
+1. Extract the slug and token
+2. Bind presence with the CE identity defaults
+3. Read via `v3/document`
+4. Edit with `v3/edit` (narrow content ops; review ops for comments/suggestions)
 
 ```bash
-SHARE_URL="https://www.proofeditor.ai/d/abc123?token=xxx"
-curl -s -H "Accept: application/json" "$SHARE_URL"
-curl -s -H "Accept: text/markdown" "$SHARE_URL"
+TOKEN="xxx"
+SLUG="abc123"
+AGENT="ai:compound-engineering"
 
-# Read once for content + the initial baseToken.
-# After each successful mutation, update BASE from the response's mutationBase.token.
-STATE=$(curl -s "https://www.proofeditor.ai/api/agent/abc123/state" \
-  -H "x-share-token: xxx")
-BASE=$(printf '%s' "$STATE" | jq -r '.mutationBase.token')
-# Inspect doc fields as needed: printf '%s' "$STATE" | jq '.markdown, .revision'
-
-# Comment
-OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
   -H "Content-Type: application/json" \
-  -H "x-share-token: xxx" \
-  -H "X-Agent-Id: ai:compound-engineering" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d "$(jq -n --arg base "$BASE" '{type:"comment.add",quote:"text",by:"ai:compound-engineering",text:"comment",baseToken:$base}')")
-NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
-[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
+  -d '{"name":"Compound Engineering","status":"reading","summary":"Reviewing doc"}'
 
-# Suggest edit (tracked, pending)
-OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
-  -H "Content-Type: application/json" \
-  -H "x-share-token: xxx" \
-  -H "X-Agent-Id: ai:compound-engineering" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d "$(jq -n --arg base "$BASE" '{type:"suggestion.add",kind:"replace",quote:"old",by:"ai:compound-engineering",content:"new",baseToken:$base}')")
-NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
-[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
+DOC=$(curl -sS "https://www.proofeditor.ai/api/agent/$SLUG/v3/document" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT")
+REVISION=$(printf '%s' "$DOC" | jq -r '.revision // empty')
 
-# Suggest and immediately apply (tracked, committed)
-OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/abc123/ops" \
+# Comment on visible text
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
   -H "Content-Type: application/json" \
-  -H "x-share-token: xxx" \
-  -H "X-Agent-Id: ai:compound-engineering" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
   -H "Idempotency-Key: $(uuidgen)" \
-  -d "$(jq -n --arg base "$BASE" '{type:"suggestion.add",kind:"replace",quote:"old",by:"ai:compound-engineering",content:"new",status:"accepted",baseToken:$base}')")
-NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
-[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
+  -d "$(jq -n --argjson rev "${REVISION:-null}" '{
+    by:"ai:compound-engineering",
+    baseRevision: (if $rev == null then null else $rev end),
+    operations:[{op:"comment",on:"text to comment on",body:"Your comment here"}]
+  } | if .baseRevision == null then del(.baseRevision) else . end')"
 
-# Direct content edit (preferred when visible suggestion marks are not needed)
-SNAPSHOT=$(curl -s "https://www.proofeditor.ai/api/agent/abc123/snapshot" \
-  -H "x-share-token: xxx")
-EDIT_BASE=$(printf '%s' "$SNAPSHOT" | jq -r '.mutationBase.token')
-curl -X POST "https://www.proofeditor.ai/api/agent/abc123/edit/v2?return=minimal" \
+# Narrow content edit
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
   -H "Content-Type: application/json" \
-  -H "x-share-token: xxx" \
-  -H "X-Agent-Id: ai:compound-engineering" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
   -H "Idempotency-Key: $(uuidgen)" \
-  -d "$(jq -n --arg base "$EDIT_BASE" '{by:"ai:compound-engineering",baseToken:$base,operations:[{op:"find_replace_in_doc",find:"old",replace:"new",occurrence:"all"}]}')"
+  -d '{"by":"ai:compound-engineering","operations":[{"op":"replace","find":"old","with":"new"}]}'
+
+# Tracked suggestion
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d '{"by":"ai:compound-engineering","operations":[{"op":"suggest","kind":"replace","find":"old","with":"new"}]}'
 ```
 
 ## Workflow: Create and Share a New Document
 
-**Publishing a local file (the primary case):** read the file and JSON-encode its full contents into the `markdown` field with `jq --rawfile` so newlines, quotes, and backticks are escaped correctly. Never hand-write the body or leave the inline placeholder — that publishes a placeholder doc instead of the source artifact (the plan, requirements, or ideation file the caller passed).
+**Publishing a local file (the primary case):** read the file and JSON-encode its full contents into the `markdown` field with `jq --rawfile` so newlines, quotes, and backticks are escaped correctly. Never hand-write the body or leave an inline placeholder — that publishes a placeholder doc instead of the source artifact.
 
 ```bash
-SRC="docs/plans/2026-05-04-001-feat-foo-plan.md"   # source file from the caller
-TITLE="Plan: Foo"                                   # caller-provided title
+SRC="docs/plans/2026-05-04-001-feat-foo-plan.md"
+TITLE="Plan: Foo"
 
-# 1. Create — from a local source file:
 RESPONSE=$(jq -n --arg title "$TITLE" --rawfile md "$SRC" '{title:$title, markdown:$md}' \
-  | curl -s -X POST https://www.proofeditor.ai/share/markdown \
+  | curl -sS -X POST https://www.proofeditor.ai/share/markdown \
     -H "Content-Type: application/json" -d @-)
-# (Ad-hoc inline content instead of a file:
-#  -d '{"title":"My Doc","markdown":"# Title\n\nContent here."}')
 
-# 2. Extract URL and token
 URL=$(echo "$RESPONSE" | jq -r '.tokenUrl')
 SLUG=$(echo "$RESPONSE" | jq -r '.slug')
 TOKEN=$(echo "$RESPONSE" | jq -r '.accessToken')
+OWNER_SECRET=$(echo "$RESPONSE" | jq -r '.ownerSecret')   # required for owner delete while unclaimed
 
-# 3. Bind display name via presence
-curl -s -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
+# Keep OWNER_SECRET in session memory only — never write it into the repo tree.
+
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
   -H "Content-Type: application/json" \
-  -H "x-share-token: $TOKEN" \
+  -H "Authorization: Bearer $TOKEN" \
   -H "X-Agent-Id: ai:compound-engineering" \
   -d '{"name":"Compound Engineering","status":"reading","summary":"Uploaded doc"}'
 
-# 4. Share the URL
 echo "$URL"
+```
 
-# 5. Make comment/suggestion edits using the ops endpoint (baseToken required)
-BASE=$(curl -s "https://www.proofeditor.ai/api/agent/$SLUG/state" \
-  -H "x-share-token: $TOKEN" | jq -r '.mutationBase.token')
-OP_RESP=$(curl -s -X POST "https://www.proofeditor.ai/api/agent/$SLUG/ops" \
-  -H "Content-Type: application/json" \
-  -H "x-share-token: $TOKEN" \
-  -H "X-Agent-Id: ai:compound-engineering" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d "$(jq -n --arg base "$BASE" '{type:"comment.add",quote:"Content here",by:"ai:compound-engineering",text:"Added a note",baseToken:$base}')")
-NEXT_BASE=$(printf '%s' "$OP_RESP" | jq -r '.mutationBase.token // empty')
-[ -n "$NEXT_BASE" ] && BASE="$NEXT_BASE"
+After publish handoffs from planning workflows, surface the URL and return control — do not delete the doc automatically.
 
-# For content edits, prefer /edit/v2 over rewrite.apply.
-SNAPSHOT=$(curl -s "https://www.proofeditor.ai/api/agent/$SLUG/snapshot" \
-  -H "x-share-token: $TOKEN")
-EDIT_BASE=$(printf '%s' "$SNAPSHOT" | jq -r '.mutationBase.token')
-curl -X POST "https://www.proofeditor.ai/api/agent/$SLUG/edit/v2?return=minimal" \
-  -H "Content-Type: application/json" \
-  -H "x-share-token: $TOKEN" \
-  -H "X-Agent-Id: ai:compound-engineering" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d "$(jq -n --arg base "$EDIT_BASE" '{by:"ai:compound-engineering",baseToken:$base,operations:[{op:"find_replace_in_doc",find:"Content",replace:"Updated content",occurrence:"all"}]}')"
+When the user later asks to clean up an unclaimed doc you created:
+
+```bash
+curl -sS -X DELETE "https://www.proofeditor.ai/api/documents/$SLUG" \
+  -H "Authorization: Bearer $OWNER_SECRET"
 ```
 
 ## Workflow: Pull a Proof Doc to Local
 
 Sync the current Proof doc state to a local markdown file. Used for:
 
-- Ad-hoc snapshots of a Proof doc to disk (before closing the tab, archiving, handing off)
+- Ad-hoc snapshots of a Proof doc to disk
 - Pulling a shared Proof doc that the user (or others) edited back down to a local working copy
 - Refreshing a local working copy against the live Proof version
+
+Canonical read for this workflow: `GET /api/agent/$SLUG/v3/document`.
 
 ```bash
 SLUG=<slug>
 TOKEN=<accessToken>
 LOCAL=<absolute-path>
 
-# One read to a temp file — avoids passing markdown through $(...), which would strip trailing newlines.
 STATE_TMP=$(mktemp)
-curl -s "https://www.proofeditor.ai/api/agent/$SLUG/state" \
-  -H "x-share-token: $TOKEN" > "$STATE_TMP"
-REVISION=$(jq -r '.revision' "$STATE_TMP")
+curl -sS "https://www.proofeditor.ai/api/agent/$SLUG/v3/document" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: ai:compound-engineering" > "$STATE_TMP"
+REVISION=$(jq -r '.revision // empty' "$STATE_TMP")
 
-# Atomic write: stream .markdown bytes directly to a temp sibling, then rename.
 TMP="${LOCAL}.proof-sync.$$"
 jq -jr '.markdown' "$STATE_TMP" > "$TMP" && mv "$TMP" "$LOCAL"
 rm "$STATE_TMP"
 ```
 
-`jq -jr` (`-j` no trailing newline, `-r` raw string) streams the markdown bytes straight to the temp file without going through a shell variable, so trailing newlines survive intact. `mv` within the same filesystem is atomic — a crashed write leaves the original untouched rather than a half-written file.
+`jq -jr` streams markdown bytes without going through a shell variable, so trailing newlines survive. `mv` within the same filesystem is atomic.
 
-**Confirm before writing when the pull isn't directly asked for.** If a workflow ends up pulling as a side-effect of a different action, surface the impending write with a short confirm like "Sync Proof doc to `<localPath>`?" A silent overwrite is surprising — the user may have forgotten the local file exists in that session, or expected Proof to stay canonical until they explicitly asked to pull.
+**Confirm before writing when the pull isn't directly asked for.** If a workflow ends up pulling as a side-effect of a different action, surface the impending write with a short confirm like "Sync Proof doc to `<localPath>`?" A silent overwrite is surprising.
 
 ## Safety
 
-- Use `/state` content as source of truth before editing
-- During active collab use `edit/v2` (direct block changes) or `suggestion.add` (tracked changes); reserve `rewrite.apply` for no-client scenarios since it's blocked by `LIVE_CLIENTS_PRESENT` when anyone is connected
-- Prefer `find_replace_in_doc` and block-level `/edit/v2` edits before considering `rewrite.apply`
-- Don't span table cells in a single replace
-- Always include `by: "ai:compound-engineering"` on every op and `X-Agent-Id: ai:compound-engineering` in headers for consistent attribution
-- Reuse `baseToken` from your most recent `/state` or `/snapshot` read; on `STALE_BASE`, re-read and retry once
+- Use `v3/document` as source of truth before editing
+- Prefer narrow `replace` / `insert` / `delete` before `suggest` or `set_document`
+- Always include `by: "ai:compound-engineering"` on writes and `X-Agent-Id: ai:compound-engineering` in headers
+- Use `accessToken` for everyday calls; reserve `ownerSecret` for owner delete
+- Never commit share tokens or owner secrets to the project tree
+- On `TARGET_AMBIGUOUS` / retryable errors, re-resolve against `error.current` — do not double-apply comments blindly

--- a/tests/skills/ce-proof-contract.test.ts
+++ b/tests/skills/ce-proof-contract.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(process.cwd(), relativePath), "utf8")
+}
+
+const skill = readRepoFile("skills/ce-proof/SKILL.md")
+const catalog = readRepoFile("docs/skills/ce-proof.md")
+const skillsIndex = readRepoFile("docs/skills/README.md")
+
+describe("ce-proof v3 + owner lifecycle contract", () => {
+  test("skill teaches Proof v3 read/edit surfaces", () => {
+    expect(skill).toContain("/api/agent/")
+    expect(skill).toContain("v3/document")
+    expect(skill).toContain("v3/edit")
+    expect(skill).toContain("share/markdown")
+  })
+
+  test("create workflow persists ownerSecret separately from accessToken", () => {
+    expect(skill).toMatch(/OWNER_SECRET|ownerSecret.*required for|persist.*ownerSecret/i)
+    expect(skill).toContain("accessToken")
+    expect(skill).toContain("ownerSecret")
+    expect(skill).toContain("tokenUrl")
+    expect(skill).toMatch(/everyday bearer|everyday bearer for/i)
+  })
+
+  test("skill documents delete and claim/revocation", () => {
+    expect(skill).toContain("DELETE")
+    expect(skill).toContain("/api/documents/")
+    expect(skill).toMatch(/DOCUMENT_DELETE_FORBIDDEN|permanently revok/i)
+    expect(skill).toMatch(/claim/i)
+  })
+
+  test("skill warns that content wipe does not scrub comments", () => {
+    expect(skill).toMatch(
+      /do not support deleting comments|does \*{0,2}not\*{0,2} scrub|scrub comment marks/i,
+    )
+  })
+
+  test("skill and catalog have no legacy HTTP or Local Bridge teaching", () => {
+    for (const [label, body] of [
+      ["skill", skill],
+      ["catalog", catalog],
+    ] as const) {
+      expect(body, label).not.toContain("Local Bridge")
+      expect(body, label).not.toContain("localhost:9847")
+      expect(body, label).not.toContain("/edit/v2")
+      expect(body, label).not.toContain("baseToken")
+      expect(body, label).not.toContain("rewrite.apply")
+      // Path-precise negatives so shareState: "DELETED" etc. do not false-fail.
+      expect(body, label).not.toContain("/api/agent/{slug}/state")
+      expect(body, label).not.toContain("/api/agent/<slug>/state")
+      expect(body, label).not.toMatch(/\/api\/agent\/\$SLUG\/state/)
+      expect(body, label).not.toContain("/api/agent/{slug}/ops")
+      expect(body, label).not.toContain("/api/agent/<slug>/ops")
+      expect(body, label).not.toMatch(/\/api\/agent\/\$SLUG\/ops/)
+    }
+  })
+
+  test("catalog and skills index are web-first", () => {
+    expect(catalog).toContain("v3/document")
+    expect(catalog).toContain("ownerSecret")
+    expect(skillsIndex).toMatch(/ce-proof/)
+    expect(skillsIndex).not.toContain("Local Bridge")
+  })
+
+  test("preserves unified-plan publish contract phrases", () => {
+    expect(skill).toContain("Only publish markdown")
+    expect(skill).toContain("requirements-only")
+  })
+})


### PR DESCRIPTION
## Summary
- Rewrite `ce-proof` to Proof's current hosted agent HTTP surface (`v3/document` / `v3/edit`) and remove Local Bridge plus legacy `/ops` + `/edit/v2` + `baseToken` teaching.
- Document Proof's ownership model: persist `accessToken` (everyday) and `ownerSecret` (delete), hand `tokenUrl`, teach claim/revocation and when to delete vs leave review docs.
- Add content-contract tests and update the skill catalog page so the create-example ownerSecret gap from #876 cannot regress.

Fixes #876

## Test plan
- [x] `bun test` (full suite)
- [x] `bun run release:validate`
- [ ] Optional: create a throwaway Proof doc, confirm `ownerSecret` is returned, edit via v3 with `accessToken`, DELETE with `ownerSecret`, confirm editor token cannot DELETE

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — documentation/skill protocol change with no production runtime surface in this repo.