### PR TITLE
fix(ce-commit-push-pr): avoid attribution-only PR rewrites

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -60,6 +60,12 @@
 # pr_teaching_section: false     # true | false (default: true)
 # pr_teaching_archive: true      # true | false (default: false; full-workflow runs only)
 
+# --- PR branding (ce-commit-push-pr) ---
+# New PRs include Compound Engineering and harness/model attribution by default.
+# Set false to omit that footer from newly created PRs (per-run override:
+# branding:on|off). Existing PR rewrites never add or refresh the footer.
+# pr_branding: false             # true | false (default: true; new PRs only)
+
 # --- ce-commit-push-pr babysit handoff ---
 # After a full-workflow PR is opened, ce-commit-push-pr auto-invokes ce-babysit-pr
 # to watch CI + incoming review and drive the PR toward merge-ready. Set false to

--- a/docs/skills/ce-commit-push-pr.md
+++ b/docs/skills/ce-commit-push-pr.md
@@ -46,6 +46,7 @@ Going from "code written" to "PR open" is supposed to be a one-step move, but it
 - **Full PR commit-range resolution** — descriptions cover all commits in the PR, not just the working-tree diff
 - **Related-reference preflight** — identifies work-item references and uses closing magic words only when the PR truly resolves the item
 - **Concept teaching** — when a PR introduces a concept new to the codebase (a pattern, technique, library, or domain idea), the description gains a `## New concepts` section teaching it, so readers can understand and re-explain the change without opening the diff
+- **No automatic branding** — PR bodies contain no Compound Engineering, model, or harness attribution unless the user explicitly asks for it; branding alone never triggers a rewrite
 
 ---
 

--- a/docs/skills/ce-commit-push-pr.md
+++ b/docs/skills/ce-commit-push-pr.md
@@ -46,7 +46,7 @@ Going from "code written" to "PR open" is supposed to be a one-step move, but it
 - **Full PR commit-range resolution** — descriptions cover all commits in the PR, not just the working-tree diff
 - **Related-reference preflight** — identifies work-item references and uses closing magic words only when the PR truly resolves the item
 - **Concept teaching** — when a PR introduces a concept new to the codebase (a pattern, technique, library, or domain idea), the description gains a `## New concepts` section teaching it, so readers can understand and re-explain the change without opening the diff
-- **No automatic branding** — PR bodies contain no Compound Engineering, model, or harness attribution unless the user explicitly asks for it; branding alone never triggers a rewrite
+- **Non-disruptive attribution** — newly created PRs include Compound Engineering and model/harness attribution by default, while existing-PR rewrites never add or refresh it; `pr_branding: false` or `branding:off` opts new PRs out
 
 ---
 
@@ -181,6 +181,7 @@ When the skill's mode detection picks the wrong path, you can prompt explicitly 
 | `"...<focus text>"` | Steers description composition (e.g., "include the benchmarking results") |
 | `mode:pipeline` | Non-interactive modifier for orchestrated callers; suppresses every blocking ask (existing-PR rewrite defaults to no) |
 | `archive:on\|off` | Per-run override of the `pr_teaching_archive` config key (explainer-doc archival to `docs/explainers/`) |
+| `branding:on\|off` | Per-run override of `pr_branding` for newly created PRs; existing-PR rewrites never add or refresh branding |
 
 ---
 

--- a/docs/skills/ce-work.md
+++ b/docs/skills/ce-work.md
@@ -96,7 +96,7 @@ A plan with four implementation units arrives. `ce-work` reads it, picks up an `
 
 The Parallel Safety Check finds no file overlap across the four units and worktree isolation is available — so all four dispatch in parallel, each on its own branch. They complete; the orchestrator merges them in dependency order; tests pass after each merge. The idempotency check catches that one unit's verification was already satisfied by a prior session and marks it complete without reimplementation.
 
-The diff isn't on a sensitive surface and isn't large/diffuse, so harness-native review handles it; the two suggested findings are addressed inline. Final validation passes; the operational validation plan is drafted; and `ce-commit-push-pr` opens the PR with summary, testing notes, the operational section, and a Compound Engineered badge. The plan itself is left untouched — it's a decision artifact, and whether it shipped is derived from git, not recorded in the doc.
+The diff isn't on a sensitive surface and isn't large/diffuse, so harness-native review handles it; the two suggested findings are addressed inline. Final validation passes; the operational validation plan is drafted; and `ce-commit-push-pr` opens the PR with summary, testing notes, and the operational section. The plan itself is left untouched — it's a decision artifact, and whether it shipped is derived from git, not recorded in the doc.
 
 ---
 

--- a/docs/skills/ce-work.md
+++ b/docs/skills/ce-work.md
@@ -96,7 +96,7 @@ A plan with four implementation units arrives. `ce-work` reads it, picks up an `
 
 The Parallel Safety Check finds no file overlap across the four units and worktree isolation is available — so all four dispatch in parallel, each on its own branch. They complete; the orchestrator merges them in dependency order; tests pass after each merge. The idempotency check catches that one unit's verification was already satisfied by a prior session and marks it complete without reimplementation.
 
-The diff isn't on a sensitive surface and isn't large/diffuse, so harness-native review handles it; the two suggested findings are addressed inline. Final validation passes; the operational validation plan is drafted; and `ce-commit-push-pr` opens the PR with summary, testing notes, and the operational section. The plan itself is left untouched — it's a decision artifact, and whether it shipped is derived from git, not recorded in the doc.
+The diff isn't on a sensitive surface and isn't large/diffuse, so harness-native review handles it; the two suggested findings are addressed inline. Final validation passes; the operational validation plan is drafted; and `ce-commit-push-pr` opens the PR with summary, testing notes, the operational section, and default-on Compound Engineering attribution. The plan itself is left untouched — it's a decision artifact, and whether it shipped is derived from git, not recorded in the doc.
 
 ---
 

--- a/skills/ce-commit-push-pr/SKILL.md
+++ b/skills/ce-commit-push-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ce-commit-push-pr
 description: Commit, push, and open a PR. Use when asked to ship/open a PR, or for PR-description-only flows like writing, rewriting, or describing a PR body.
-argument-hint: "[PR ref] [mode:pipeline] [archive:on|off] [babysit:off|continuous|checkpoint]"
+argument-hint: "[PR ref] [mode:pipeline] [archive:on|off] [branding:on|off] [babysit:off|continuous|checkpoint]"
 ---
 
 # Git Commit, Push, and PR
@@ -100,6 +100,8 @@ Do not block PR creation solely because no visual artifact exists. Test output a
 - Gate **on** — judge concept novelty and compose the section per **Step B2** of the reference. The gate is single: when it is off, skip judgment, the section, the Step 5 trailer and offer, and archival entirely.
 - Gate **off** — compose the description without any concept handling.
 
+**PR branding gate** before composition. From that same config read, resolve `pr_branding:` using the same active-key rule. Branding is **on by default** and turns off only when the active value is exactly `false`; a per-run `branding:on|off` token overrides the config. Pass the resolved gate and whether the target is a new or existing PR into Step D of the reference. The gate controls adding branding to a new PR body only. It never authorizes adding, refreshing, or deleting branding on an existing PR; existing branding is preserved unless the user explicitly asks to remove or replace it.
+
 Then continue with the rest of the reference (Steps A through E, including the Step B2 concept judgment when the gate is on) to compose the title and body — Step E is the pre-apply coverage audit and must run before the body is returned.
 
 ## Step 5: Apply and report
@@ -113,7 +115,7 @@ Then continue with the rest of the reference (Steps A through E, including the S
 - **No** — done.
 - **Yes** — run Step 4 if not already done, then preview and apply (see below).
 
-**Description update mode, or existing-PR rewrite confirmed** — preview before applying. First compare the proposed title and body with the existing PR. If they are identical, or if the only difference is Compound Engineering attribution, model/harness badges, or other tool branding, keep the existing title and body and do not call `gh pr edit`; a no-op or branding-only delta is never a meaningful update. Otherwise ask: "New title: `<title>` (`<N>` chars). Summary leads with: `<first two sentences>`. Total body: `<L>` lines. Apply?" If declined, the user may pass focus text back for a regenerate; do not apply. If confirmed, apply per "Applying via gh" below using `gh pr edit` and report the URL.
+**Description update mode, or existing-PR rewrite confirmed** — preview before applying. First compare the proposed title and body with the existing PR. If they are identical, or if the only difference is Compound Engineering attribution, model/harness badges, or other tool branding, keep the existing title and body and do not call `gh pr edit`; a no-op or branding-only delta is never a meaningful update. Otherwise ask: "New title: `<title>` (`<N>` chars). Summary leads with: `<first two sentences>`. Total body: `<L>` lines. Apply?" If declined, the user may pass focus text back for a regenerate; do not apply. If confirmed, apply per "Applying via gh" below using `gh pr edit` and report the URL. The `pr_branding` gate never creates apply intent for an existing PR.
 
 **Explainer archival** — runs only in full workflow, with `pr_teaching_archive` on, a composed `## New concepts` section, and the apply confirmed (new-PR create, or existing-PR rewrite accepted); a declined rewrite skips archival entirely so no unlinked doc commit is left behind. All paths resolve from the repo root gathered in Context, never the CWD. With two taught concepts, write one file per concept and stage both in the single commit. Execute as explicit transitions immediately before the `gh` call:
 

--- a/skills/ce-commit-push-pr/SKILL.md
+++ b/skills/ce-commit-push-pr/SKILL.md
@@ -113,7 +113,7 @@ Then continue with the rest of the reference (Steps A through E, including the S
 - **No** — done.
 - **Yes** — run Step 4 if not already done, then preview and apply (see below).
 
-**Description update mode, or existing-PR rewrite confirmed** — preview before applying. Ask: "New title: `<title>` (`<N>` chars). Summary leads with: `<first two sentences>`. Total body: `<L>` lines. Apply?" If declined, the user may pass focus text back for a regenerate; do not apply. If confirmed, apply per "Applying via gh" below using `gh pr edit` and report the URL.
+**Description update mode, or existing-PR rewrite confirmed** — preview before applying. First compare the proposed title and body with the existing PR. If they are identical, or if the only difference is Compound Engineering attribution, model/harness badges, or other tool branding, keep the existing title and body and do not call `gh pr edit`; a no-op or branding-only delta is never a meaningful update. Otherwise ask: "New title: `<title>` (`<N>` chars). Summary leads with: `<first two sentences>`. Total body: `<L>` lines. Apply?" If declined, the user may pass focus text back for a regenerate; do not apply. If confirmed, apply per "Applying via gh" below using `gh pr edit` and report the URL.
 
 **Explainer archival** — runs only in full workflow, with `pr_teaching_archive` on, a composed `## New concepts` section, and the apply confirmed (new-PR create, or existing-PR rewrite accepted); a declined rewrite skips archival entirely so no unlinked doc commit is left behind. All paths resolve from the repo root gathered in Context, never the CWD. With two taught concepts, write one file per concept and stage both in the single commit. Execute as explicit transitions immediately before the `gh` call:
 

--- a/skills/ce-commit-push-pr/references/pr-description-writing.md
+++ b/skills/ce-commit-push-pr/references/pr-description-writing.md
@@ -170,11 +170,11 @@ Lead with the point, then the mechanism, then the caveat. Dense is good; long is
 
 ## Step C: Assemble the body
 
-In order: opening → body sections that earn their keep → related references when they need their own block → test plan if non-obvious → New concepts section when Step B2 produced one → evidence block if one exists → Compound Engineering badge after a `---` rule.
+In order: opening → body sections that earn their keep → related references when they need their own block → test plan if non-obvious → New concepts section when Step B2 produced one → evidence block if one exists.
 
 The opening goes under `## Summary` if the body uses any `##` headings; bare paragraph otherwise. No orphaned opening paragraphs above the first heading.
 
-**Evidence handling:** preserve any existing `## Demo` or `## Screenshots` block verbatim unless the user's focus asks to refresh it. If the caller passed a freshly captured URL or path, splice as `## Demo`. Otherwise omit. Place before the badge. Never label test output as "Demo" or "Screenshots."
+**Evidence handling:** preserve any existing `## Demo` or `## Screenshots` block verbatim unless the user's focus asks to refresh it. If the caller passed a freshly captured URL or path, splice as `## Demo`. Otherwise omit. Never label test output as "Demo" or "Screenshots."
 
 **Visual aids:** reach for a diagram or table when it conveys the change faster than prose — relationships, flows, state transitions, sequences, trade-offs, before/after data, or any structure prose would have to enumerate. Mermaid and markdown tables cover most shapes; don't be limited to a particular type if a different one fits the change better. Place inline at the point of relevance. Skip for simple, prose-clear, or rename/dep-bump changes. Prose is authoritative when it conflicts with a visual.
 
@@ -182,24 +182,11 @@ The opening goes under `## Summary` if the body uses any `##` headings; bare par
 
 ---
 
-## Step D: Badge
+## Step D: No automatic branding
 
-```markdown
----
+Do not add Compound Engineering attribution, model badges, harness badges, or other tool branding unless the user explicitly asks for that exact content in this invocation. Do not add, refresh, normalize, or remove existing branding on your own; preserve an existing branding block verbatim during an otherwise requested rewrite.
 
-[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
-![HARNESS](https://img.shields.io/badge/MODEL_SLUG-COLOR?logo=LOGO&logoColor=white)
-```
-
-| Harness | `LOGO` | `COLOR` |
-|---|---|---|
-| Claude Code | `claude` | `D97757` |
-| Codex | (omit `?logo=` param) | `000000` |
-| Antigravity CLI (`agy`) | `googlegemini` | `4285F4` |
-
-**Model slug:** spaces become underscores; append context window and thinking level in parens if known. **URL-encode literal parens as `%28` / `%29`** — unencoded parens inside markdown image URLs break release-please's commit parser, which silently drops the commit from the changelog. Examples: `Opus_4.6_%281M,_Extended_Thinking%29`, `Sonnet_4.6_%28200K%29`, `Gemini_3.1_Pro`.
-
-Skip the badge if regenerating a body that already contains it.
+Branding alone is never a reason to rewrite a PR description. If branding is the only difference between the existing and proposed bodies, keep the existing body and do not apply an update.
 
 ---
 
@@ -209,4 +196,4 @@ Before returning the body, check it against the material claims from Step A and 
 
 - Is every claim the diff can't establish present — and is any claim the diff *does* show restated needlessly?
 - Is decision-changing evidence stated as a result rather than collapsed into an unexplained "tests passed", with demonstrated results kept distinct from assumptions and from mixed or negative outcomes?
-- Can any sentence or section of the *description* be cut without lowering reviewer confidence? If so, cut it — but never the required Step D badge/footer, which is mandated boilerplate, not descriptive content subject to this trim.
+- Can any sentence or section of the *description* be cut without lowering reviewer confidence? If so, cut it.

--- a/skills/ce-commit-push-pr/references/pr-description-writing.md
+++ b/skills/ce-commit-push-pr/references/pr-description-writing.md
@@ -170,7 +170,7 @@ Lead with the point, then the mechanism, then the caveat. Dense is good; long is
 
 ## Step C: Assemble the body
 
-In order: opening → body sections that earn their keep → related references when they need their own block → test plan if non-obvious → New concepts section when Step B2 produced one → evidence block if one exists.
+In order: opening → body sections that earn their keep → related references when they need their own block → test plan if non-obvious → New concepts section when Step B2 produced one → evidence block if one exists → branding block when Step D calls for one.
 
 The opening goes under `## Summary` if the body uses any `##` headings; bare paragraph otherwise. No orphaned opening paragraphs above the first heading.
 
@@ -182,9 +182,26 @@ The opening goes under `## Summary` if the body uses any `##` headings; bare par
 
 ---
 
-## Step D: No automatic branding
+## Step D: Non-disruptive branding
 
-Do not add Compound Engineering attribution, model badges, harness badges, or other tool branding unless the user explicitly asks for that exact content in this invocation. Do not add, refresh, normalize, or remove existing branding on your own; preserve an existing branding block verbatim during an otherwise requested rewrite.
+For a **new PR body**, append the following block after a `---` rule when the resolved `pr_branding` gate is on (the default). Omit it when `pr_branding: false` or `branding:off` applies.
+
+```markdown
+---
+
+[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
+![HARNESS](https://img.shields.io/badge/MODEL_SLUG-COLOR?logo=LOGO&logoColor=white)
+```
+
+| Harness | `LOGO` | `COLOR` |
+|---|---|---|
+| Claude Code | `claude` | `D97757` |
+| Codex | (omit `?logo=` param) | `000000` |
+| Antigravity CLI (`agy`) | `googlegemini` | `4285F4` |
+
+**Model slug:** spaces become underscores; append context window and thinking level in parens if known. **URL-encode literal parens as `%28` / `%29`** — unencoded parens inside markdown image URLs break release-please's commit parser, which silently drops the commit from the changelog. Examples: `Opus_4.6_%281M,_Extended_Thinking%29`, `Sonnet_4.6_%28200K%29`, `Gemini_3.1_Pro`.
+
+For an **existing PR body**, preserve an existing branding block verbatim. Never add one when absent, and never refresh, normalize, or remove one unless the user explicitly asks to remove or replace that exact content. The branding gate controls new-PR composition only; turning it off does not silently delete existing content.
 
 Branding alone is never a reason to rewrite a PR description. If branding is the only difference between the existing and proposed bodies, keep the existing body and do not apply an update.
 
@@ -196,4 +213,4 @@ Before returning the body, check it against the material claims from Step A and 
 
 - Is every claim the diff can't establish present — and is any claim the diff *does* show restated needlessly?
 - Is decision-changing evidence stated as a result rather than collapsed into an unexplained "tests passed", with demonstrated results kept distinct from assumptions and from mixed or negative outcomes?
-- Can any sentence or section of the *description* be cut without lowering reviewer confidence? If so, cut it.
+- Can any sentence or section of the *description* be cut without lowering reviewer confidence? If so, cut it. For a new PR with branding enabled, retain the Step D footer; it is intentional attribution rather than descriptive content.

--- a/skills/ce-setup/references/config-template.yaml
+++ b/skills/ce-setup/references/config-template.yaml
@@ -60,6 +60,12 @@
 # pr_teaching_section: false     # true | false (default: true)
 # pr_teaching_archive: true      # true | false (default: false; full-workflow runs only)
 
+# --- PR branding (ce-commit-push-pr) ---
+# New PRs include Compound Engineering and harness/model attribution by default.
+# Set false to omit that footer from newly created PRs (per-run override:
+# branding:on|off). Existing PR rewrites never add or refresh the footer.
+# pr_branding: false             # true | false (default: true; new PRs only)
+
 # --- ce-commit-push-pr babysit handoff ---
 # After a full-workflow PR is opened, ce-commit-push-pr auto-invokes ce-babysit-pr
 # to watch CI + incoming review and drive the PR toward merge-ready. Set false to

--- a/tests/commit-push-pr-contract.test.ts
+++ b/tests/commit-push-pr-contract.test.ts
@@ -51,19 +51,22 @@ describe("ce-commit-push-pr contract", () => {
     expect(content).toMatch(/PR description.+not.+comment/i)
   })
 
-  test("never adds or updates PR branding unless the user explicitly requests it", async () => {
+  test("keeps default new-PR attribution without branding-only rewrites", async () => {
     const reference = await readRepoFile(
       "skills/ce-commit-push-pr/references/pr-description-writing.md",
     )
     const skill = await readRepoFile("skills/ce-commit-push-pr/SKILL.md")
 
-    expect(reference).not.toContain("Built_with-Compound_Engineering")
-    expect(reference).not.toContain("MODEL_SLUG")
-    expect(reference).toMatch(/do not add Compound Engineering attribution.+unless the user explicitly asks/is)
+    expect(reference).toContain("Built_with-Compound_Engineering")
+    expect(reference).toContain("MODEL_SLUG")
+    expect(reference).toMatch(/new PR body.+pr_branding.+on \(the default\)/is)
+    expect(reference).toMatch(/existing PR body.+never add one when absent/is)
     expect(reference).toMatch(/branding alone is never a reason to rewrite a PR description/i)
     expect(skill).toMatch(/if they are identical.+only difference is Compound Engineering attribution/is)
     expect(skill).toMatch(/a no-op or branding-only delta is never a meaningful update/i)
     expect(skill).toContain("do not call `gh pr edit`")
+    expect(skill).toMatch(/pr_branding.+on by default/is)
+    expect(skill).toMatch(/branding:on\|off/)
   })
 
   test("babysit handoff is default-on with off-switches and drivable fork PRs", async () => {
@@ -85,13 +88,15 @@ describe("ce-commit-push-pr contract", () => {
     expect(content).toMatch(/pushes fixes to the \*\*head\*\* repo/i)
   })
 
-  test("config template and example document the auto_babysit opt-out", async () => {
+  test("config template and example document PR branding and babysit opt-outs", async () => {
     for (const p of [
       "skills/ce-setup/references/config-template.yaml",
       ".compound-engineering/config.local.example.yaml",
     ]) {
       const template = await readRepoFile(p)
       expect(template).toContain("auto_babysit")
+      expect(template).toContain("pr_branding")
+      expect(template).toContain("branding:on|off")
     }
   })
 })

--- a/tests/commit-push-pr-contract.test.ts
+++ b/tests/commit-push-pr-contract.test.ts
@@ -51,6 +51,21 @@ describe("ce-commit-push-pr contract", () => {
     expect(content).toMatch(/PR description.+not.+comment/i)
   })
 
+  test("never adds or updates PR branding unless the user explicitly requests it", async () => {
+    const reference = await readRepoFile(
+      "skills/ce-commit-push-pr/references/pr-description-writing.md",
+    )
+    const skill = await readRepoFile("skills/ce-commit-push-pr/SKILL.md")
+
+    expect(reference).not.toContain("Built_with-Compound_Engineering")
+    expect(reference).not.toContain("MODEL_SLUG")
+    expect(reference).toMatch(/do not add Compound Engineering attribution.+unless the user explicitly asks/is)
+    expect(reference).toMatch(/branding alone is never a reason to rewrite a PR description/i)
+    expect(skill).toMatch(/if they are identical.+only difference is Compound Engineering attribution/is)
+    expect(skill).toMatch(/a no-op or branding-only delta is never a meaningful update/i)
+    expect(skill).toContain("do not call `gh pr edit`")
+  })
+
   test("babysit handoff is default-on with off-switches and drivable fork PRs", async () => {
     const content = await readRepoFile("skills/ce-commit-push-pr/SKILL.md")
 


### PR DESCRIPTION
## Summary

- preserve default Compound Engineering and model/harness attribution when the skill creates a new PR
- never add, refresh, or remove attribution during an existing-PR rewrite unless the user explicitly requests that exact change
- skip `gh pr edit` for exact no-ops and attribution-only deltas
- add `pr_branding: false` and `branding:off` as scoped opt-outs for newly created PRs

## Why

Attribution should be established when Compound Engineering creates the PR, not introduced later by mutating an existing reviewer-facing description. This keeps the plugin's public attribution while preventing branding-only churn.

## Testing

- `bun test tests/commit-push-pr-contract.test.ts tests/skills/ce-setup-check-health.test.ts`
- `bun run release:validate`
- `bun run plugin:validate`
- read-only four-scenario skill evaluation: default new PR, opted-out new PR, meaningful existing-PR rewrite, and attribution-only existing-PR delta
- full `bun test` previously attempted: 2,003 passed and 16 unrelated local-environment cases failed in session-history, repo-profile-cache, and cross-model provider tests
