### PR TITLE
docs(readme): move Install section above Philosophy

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,157 @@ Remove the obsolete Compound Engineering Codex tool-map block from my Codex home
 
 Re-running the Bun convert/install CLI for Codex also strips the block if it is still present; it no longer inserts it.
 
+**Another editor or CLI?** Kimi Code CLI, Cline, Grok Build CLI, Devin CLI, GitHub Copilot, Factory Droid, Qwen Code, OpenCode, Pi, and Antigravity CLI are all supported — see [More install options](#more-install-options).
+
+---
+
+## Philosophy
+
+**Each unit of engineering work should make subsequent units easier -- not harder.**
+
+Traditional development accumulates technical debt. Every feature adds complexity. Every bug fix leaves behind a little more local knowledge that someone has to rediscover later. The codebase gets larger, the context gets harder to hold, and the next change becomes slower.
+
+Compound engineering inverts this. 80% is in planning and review, 20% is in execution:
+
+- Plan thoroughly before writing code with `/ce-brainstorm` and `/ce-plan` using one readiness-based plan artifact
+- Review to catch issues and calibrate judgment with `/ce-code-review` and `/ce-doc-review`
+- Codify knowledge so it is reusable with `/ce-compound`
+- Keep quality high so future changes are easy
+
+The point is not ceremony. The point is leverage. A good brainstorm makes the plan sharper. A good plan makes execution smaller. A good review catches the pattern, not just the bug. A good compound note means the next agent does not have to learn the same lesson from scratch.
+
+**Learn more**
+
+- [Skill documentation catalog](docs/skills/README.md)
+- [Compound engineering: how Every codes with agents](https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents)
+- [The story behind compounding engineering](https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it)
+
+## Workflow
+
+The core loop is six steps: **brainstorm** the requirements, **plan** the implementation, **work** through the plan, **simplify** what you wrote, **review** the result, then **compound** the learning -- and repeat with better context.
+
+| Skill | Purpose |
+|-------|---------|
+| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Interactive Q&A to think through a feature or problem and write a requirements-only unified plan before planning |
+| [`/ce-plan`](docs/skills/ce-plan.md) | Enrich feature ideas or requirements-only plans into implementation-ready plans |
+| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation-ready plans with worktrees and task tracking |
+| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Refine the freshly written code for clarity and reuse before review |
+| [`/ce-code-review`](docs/skills/ce-code-review.md) | Multi-agent review against the plan before merging |
+| [`/ce-compound`](docs/skills/ce-compound.md) | Capture the learning into `docs/solutions/` so the next loop starts smarter |
+
+Each cycle compounds: `/ce-compound` writes learnings that the next `/ce-brainstorm` and `/ce-plan` read as grounding -- brainstorms sharpen plans, plans inform future plans, reviews catch more issues, patterns get documented. That return arrow is the whole point.
+
+### Additional skills
+
+These sit around the loop or get reached for on demand -- not every cycle needs them.
+
+| Skill | When to reach for it |
+|-------|---------|
+| [`/ce-ideate`](docs/skills/ce-ideate.md) | *Before the loop*, when you don't yet know what to build -- generates and critically ranks grounded ideas, then routes the strongest one into `/ce-brainstorm` |
+| [`/ce-strategy`](docs/skills/ce-strategy.md) | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
+| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
+| [`/ce-debug`](docs/skills/ce-debug.md) | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace root cause, fix, then polish/review before PR handoff when warranted |
+| [`/ce-pov`](docs/skills/ce-pov.md) | *On demand, before you commit* -- a decisive, project-grounded verdict on whether to adopt, switch to, or revisit an external technology, library, pattern, or platform; works cold or mid-session, and proposes the next step (`/ce-plan`, `/ce-brainstorm`, or a spike) from the verdict |
+| [`/ce-explain`](docs/skills/ce-explain.md) | *On demand, to keep learning* -- turns a concept, a diff, an idea, or "what did I do this week?" into a dense, visual explainer written for you personally, with an optional check-in (predict-then-reveal for diffs, corrected exercises) that makes it stick |
+
+For the full catalog and how each skill chains together, see [docs/skills](docs/skills/README.md). The complete inventory is [below](#full-skill-inventory).
+
+## Quick Example
+
+**Finding a direction** -- when you don't have a specific idea yet, ideate first, then carry the strongest survivor into the loop:
+
+```text
+/ce-ideate new drawing tools
+/ce-ideate surprise me
+/ce-ideate github issues   # ground ideas in your open issues instead of a prompt
+```
+
+`/ce-ideate` does the homework first (codebase, past learnings, prior art on the web, optionally your issue tracker), then hands you a ranked set of grounded candidates to take into `/ce-brainstorm`.
+
+**Standard feature loop** -- turn a rough idea into shipped, reviewed code:
+
+```text
+/ce-brainstorm make background job retries safer
+/ce-plan
+/ce-work
+/ce-simplify-code
+/ce-code-review
+/ce-compound
+```
+
+**Simplifying code** -- use it after fresh implementation work, or point it at code that keeps slowing changes down:
+
+```text
+/ce-simplify-code
+/ce-simplify-code simplify the code in my most-churned file
+```
+
+The first pass tightens recent branch changes before review. The targeted pass is useful when one file keeps absorbing unrelated fixes, follow-ups, or merge conflicts.
+
+**Debugging a bug** -- when you start from broken behavior instead of a feature:
+
+```text
+/ce-debug the checkout webhook sometimes creates duplicate invoices
+/ce-code-review
+/ce-compound
+```
+
+**Autonomous** -- hand off a feature and let the agent run the whole pipeline:
+
+```text
+/ce-brainstorm describe the feature
+/lfg
+```
+
+`/lfg` runs the loop hands-off: it plans, works through the plan, simplifies, runs code review and applies the fixes, runs browser tests, commits, pushes, opens a PR, then watches CI and repairs failures until it's green. Start it after `/ce-brainstorm` so it plans against real requirements rather than a one-line prompt. It's the autopilot version of the standard loop -- neat when you want to step away and come back to an open, green PR.
+
+## Getting Started
+
+After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
+
+The `compound-engineering` plugin currently ships 30 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+
+### Full Skill Inventory
+
+| Skill | Purpose |
+|-------|---------|
+| [`/ce-strategy`](docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` |
+| [`/ce-ideate`](docs/skills/ce-ideate.md) | Generate and critically evaluate grounded ideas |
+| [`/ce-pov`](docs/skills/ce-pov.md) | Form a decisive, project-grounded verdict on an external input |
+| [`/ce-explain`](docs/skills/ce-explain.md) | Explain a concept, diff, idea, or window of your own work as a personal learning artifact |
+| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Explore requirements and write a right-sized requirements doc |
+| [`/ce-plan`](docs/skills/ce-plan.md) | Create structured implementation plans |
+| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation plans systematically |
+| [`/ce-code-review`](docs/skills/ce-code-review.md) | Review code with skill-local reviewer personas |
+| [`/ce-doc-review`](docs/skills/ce-doc-review.md) | Review requirements and plan documents |
+| [`/ce-debug`](docs/skills/ce-debug.md) | Reproduce failures, trace root cause, fix bugs, and prepare non-trivial fixes for PR |
+| [`/ce-compound`](docs/skills/ce-compound.md) | Document solved problems to compound team knowledge |
+| [`/ce-compound-refresh`](docs/skills/ce-compound-refresh.md) | Refresh stale or drifting learnings |
+| [`/ce-optimize`](docs/skills/ce-optimize.md) | Run iterative optimization loops |
+| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | Generate time-windowed product pulse reports |
+| [`/ce-riffrec-feedback-analysis`](docs/skills/ce-riffrec-feedback-analysis.md) | Convert Riffrec recordings or notes into structured feedback |
+| [`/ce-sweep`](docs/skills/ce-sweep.md) | Sweep feedback sources, track item lifecycles, and emit an `/lfg`-ready plan |
+| [`/ce-resolve-pr-feedback`](docs/skills/ce-resolve-pr-feedback.md) | Resolve PR review feedback |
+| [`/ce-commit`](docs/skills/ce-commit.md) | Create a git commit with a clear message |
+| [`/ce-commit-push-pr`](docs/skills/ce-commit-push-pr.md) | Commit, push, and open a PR that teaches any concept the change newly introduces |
+| [`/ce-babysit-pr`](docs/skills/ce-babysit-pr.md) | Watch an open PR and keep it moving toward merge, reacting to review comments and CI as they arrive |
+| [`/ce-worktree`](docs/skills/ce-worktree.md) | Ensure work happens in an isolated git worktree |
+| [`/ce-promote`](docs/skills/ce-promote.md) | Draft user-facing announcement copy |
+| [`/ce-test-browser`](docs/skills/ce-test-browser.md) | Run browser tests on PR-affected pages |
+| [`/ce-test-xcode`](docs/skills/ce-test-xcode.md) | Build and test iOS apps on simulator |
+| [`/ce-setup`](docs/skills/ce-setup.md) | Diagnose optional tool capabilities and project config |
+| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Simplify recent code changes |
+| [`/ce-polish`](docs/skills/ce-polish.md) | Start a dev server and iterate on UX polish |
+| [`/ce-proof`](docs/skills/ce-proof.md) | Create, edit, and share Proof documents |
+| [`/ce-dogfood`](docs/skills/ce-dogfood.md) | Hands-off diff-scoped browser QA of the active branch, with autonomous fixes |
+| [`/lfg`](docs/skills/lfg.md) | Full autonomous engineering workflow |
+
+---
+
+## More Install Options
+
+[Claude Code, Cursor, and Codex](#install) are at the top. Everything here is equally supported.
+
 ### Kimi Code CLI
 
 Kimi Code CLI can install Compound Engineering directly from this repository because the repo ships a native `.kimi-plugin/plugin.json` manifest:
@@ -298,149 +449,6 @@ cd /tmp/compound-engineering-plugin-cleanup
 bun install
 bun run cleanup --target all
 ```
-
----
-
-## Philosophy
-
-**Each unit of engineering work should make subsequent units easier -- not harder.**
-
-Traditional development accumulates technical debt. Every feature adds complexity. Every bug fix leaves behind a little more local knowledge that someone has to rediscover later. The codebase gets larger, the context gets harder to hold, and the next change becomes slower.
-
-Compound engineering inverts this. 80% is in planning and review, 20% is in execution:
-
-- Plan thoroughly before writing code with `/ce-brainstorm` and `/ce-plan` using one readiness-based plan artifact
-- Review to catch issues and calibrate judgment with `/ce-code-review` and `/ce-doc-review`
-- Codify knowledge so it is reusable with `/ce-compound`
-- Keep quality high so future changes are easy
-
-The point is not ceremony. The point is leverage. A good brainstorm makes the plan sharper. A good plan makes execution smaller. A good review catches the pattern, not just the bug. A good compound note means the next agent does not have to learn the same lesson from scratch.
-
-**Learn more**
-
-- [Skill documentation catalog](docs/skills/README.md)
-- [Compound engineering: how Every codes with agents](https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents)
-- [The story behind compounding engineering](https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it)
-
-## Workflow
-
-The core loop is six steps: **brainstorm** the requirements, **plan** the implementation, **work** through the plan, **simplify** what you wrote, **review** the result, then **compound** the learning -- and repeat with better context.
-
-| Skill | Purpose |
-|-------|---------|
-| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Interactive Q&A to think through a feature or problem and write a requirements-only unified plan before planning |
-| [`/ce-plan`](docs/skills/ce-plan.md) | Enrich feature ideas or requirements-only plans into implementation-ready plans |
-| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation-ready plans with worktrees and task tracking |
-| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Refine the freshly written code for clarity and reuse before review |
-| [`/ce-code-review`](docs/skills/ce-code-review.md) | Multi-agent review against the plan before merging |
-| [`/ce-compound`](docs/skills/ce-compound.md) | Capture the learning into `docs/solutions/` so the next loop starts smarter |
-
-Each cycle compounds: `/ce-compound` writes learnings that the next `/ce-brainstorm` and `/ce-plan` read as grounding -- brainstorms sharpen plans, plans inform future plans, reviews catch more issues, patterns get documented. That return arrow is the whole point.
-
-### Additional skills
-
-These sit around the loop or get reached for on demand -- not every cycle needs them.
-
-| Skill | When to reach for it |
-|-------|---------|
-| [`/ce-ideate`](docs/skills/ce-ideate.md) | *Before the loop*, when you don't yet know what to build -- generates and critically ranks grounded ideas, then routes the strongest one into `/ce-brainstorm` |
-| [`/ce-strategy`](docs/skills/ce-strategy.md) | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
-| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
-| [`/ce-debug`](docs/skills/ce-debug.md) | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace root cause, fix, then polish/review before PR handoff when warranted |
-| [`/ce-pov`](docs/skills/ce-pov.md) | *On demand, before you commit* -- a decisive, project-grounded verdict on whether to adopt, switch to, or revisit an external technology, library, pattern, or platform; works cold or mid-session, and proposes the next step (`/ce-plan`, `/ce-brainstorm`, or a spike) from the verdict |
-| [`/ce-explain`](docs/skills/ce-explain.md) | *On demand, to keep learning* -- turns a concept, a diff, an idea, or "what did I do this week?" into a dense, visual explainer written for you personally, with an optional check-in (predict-then-reveal for diffs, corrected exercises) that makes it stick |
-
-For the full catalog and how each skill chains together, see [docs/skills](docs/skills/README.md). The complete inventory is [below](#full-skill-inventory).
-
-## Quick Example
-
-**Finding a direction** -- when you don't have a specific idea yet, ideate first, then carry the strongest survivor into the loop:
-
-```text
-/ce-ideate new drawing tools
-/ce-ideate surprise me
-/ce-ideate github issues   # ground ideas in your open issues instead of a prompt
-```
-
-`/ce-ideate` does the homework first (codebase, past learnings, prior art on the web, optionally your issue tracker), then hands you a ranked set of grounded candidates to take into `/ce-brainstorm`.
-
-**Standard feature loop** -- turn a rough idea into shipped, reviewed code:
-
-```text
-/ce-brainstorm make background job retries safer
-/ce-plan
-/ce-work
-/ce-simplify-code
-/ce-code-review
-/ce-compound
-```
-
-**Simplifying code** -- use it after fresh implementation work, or point it at code that keeps slowing changes down:
-
-```text
-/ce-simplify-code
-/ce-simplify-code simplify the code in my most-churned file
-```
-
-The first pass tightens recent branch changes before review. The targeted pass is useful when one file keeps absorbing unrelated fixes, follow-ups, or merge conflicts.
-
-**Debugging a bug** -- when you start from broken behavior instead of a feature:
-
-```text
-/ce-debug the checkout webhook sometimes creates duplicate invoices
-/ce-code-review
-/ce-compound
-```
-
-**Autonomous** -- hand off a feature and let the agent run the whole pipeline:
-
-```text
-/ce-brainstorm describe the feature
-/lfg
-```
-
-`/lfg` runs the loop hands-off: it plans, works through the plan, simplifies, runs code review and applies the fixes, runs browser tests, commits, pushes, opens a PR, then watches CI and repairs failures until it's green. Start it after `/ce-brainstorm` so it plans against real requirements rather than a one-line prompt. It's the autopilot version of the standard loop -- neat when you want to step away and come back to an open, green PR.
-
-## Getting Started
-
-After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
-
-The `compound-engineering` plugin currently ships 30 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
-
-### Full Skill Inventory
-
-| Skill | Purpose |
-|-------|---------|
-| [`/ce-strategy`](docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` |
-| [`/ce-ideate`](docs/skills/ce-ideate.md) | Generate and critically evaluate grounded ideas |
-| [`/ce-pov`](docs/skills/ce-pov.md) | Form a decisive, project-grounded verdict on an external input |
-| [`/ce-explain`](docs/skills/ce-explain.md) | Explain a concept, diff, idea, or window of your own work as a personal learning artifact |
-| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Explore requirements and write a right-sized requirements doc |
-| [`/ce-plan`](docs/skills/ce-plan.md) | Create structured implementation plans |
-| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation plans systematically |
-| [`/ce-code-review`](docs/skills/ce-code-review.md) | Review code with skill-local reviewer personas |
-| [`/ce-doc-review`](docs/skills/ce-doc-review.md) | Review requirements and plan documents |
-| [`/ce-debug`](docs/skills/ce-debug.md) | Reproduce failures, trace root cause, fix bugs, and prepare non-trivial fixes for PR |
-| [`/ce-compound`](docs/skills/ce-compound.md) | Document solved problems to compound team knowledge |
-| [`/ce-compound-refresh`](docs/skills/ce-compound-refresh.md) | Refresh stale or drifting learnings |
-| [`/ce-optimize`](docs/skills/ce-optimize.md) | Run iterative optimization loops |
-| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | Generate time-windowed product pulse reports |
-| [`/ce-riffrec-feedback-analysis`](docs/skills/ce-riffrec-feedback-analysis.md) | Convert Riffrec recordings or notes into structured feedback |
-| [`/ce-sweep`](docs/skills/ce-sweep.md) | Sweep feedback sources, track item lifecycles, and emit an `/lfg`-ready plan |
-| [`/ce-resolve-pr-feedback`](docs/skills/ce-resolve-pr-feedback.md) | Resolve PR review feedback |
-| [`/ce-commit`](docs/skills/ce-commit.md) | Create a git commit with a clear message |
-| [`/ce-commit-push-pr`](docs/skills/ce-commit-push-pr.md) | Commit, push, and open a PR that teaches any concept the change newly introduces |
-| [`/ce-babysit-pr`](docs/skills/ce-babysit-pr.md) | Watch an open PR and keep it moving toward merge, reacting to review comments and CI as they arrive |
-| [`/ce-worktree`](docs/skills/ce-worktree.md) | Ensure work happens in an isolated git worktree |
-| [`/ce-promote`](docs/skills/ce-promote.md) | Draft user-facing announcement copy |
-| [`/ce-test-browser`](docs/skills/ce-test-browser.md) | Run browser tests on PR-affected pages |
-| [`/ce-test-xcode`](docs/skills/ce-test-xcode.md) | Build and test iOS apps on simulator |
-| [`/ce-setup`](docs/skills/ce-setup.md) | Diagnose optional tool capabilities and project config |
-| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Simplify recent code changes |
-| [`/ce-polish`](docs/skills/ce-polish.md) | Start a dev server and iterate on UX polish |
-| [`/ce-proof`](docs/skills/ce-proof.md) | Create, edit, and share Proof documents |
-| [`/ce-dogfood`](docs/skills/ce-dogfood.md) | Hands-off diff-scoped browser QA of the active branch, with autonomous fixes |
-| [`/lfg`](docs/skills/lfg.md) | Full autonomous engineering workflow |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,149 +4,6 @@
 
 AI skills that make each unit of engineering work easier than the last.
 
-## Philosophy
-
-**Each unit of engineering work should make subsequent units easier -- not harder.**
-
-Traditional development accumulates technical debt. Every feature adds complexity. Every bug fix leaves behind a little more local knowledge that someone has to rediscover later. The codebase gets larger, the context gets harder to hold, and the next change becomes slower.
-
-Compound engineering inverts this. 80% is in planning and review, 20% is in execution:
-
-- Plan thoroughly before writing code with `/ce-brainstorm` and `/ce-plan` using one readiness-based plan artifact
-- Review to catch issues and calibrate judgment with `/ce-code-review` and `/ce-doc-review`
-- Codify knowledge so it is reusable with `/ce-compound`
-- Keep quality high so future changes are easy
-
-The point is not ceremony. The point is leverage. A good brainstorm makes the plan sharper. A good plan makes execution smaller. A good review catches the pattern, not just the bug. A good compound note means the next agent does not have to learn the same lesson from scratch.
-
-**Learn more**
-
-- [Skill documentation catalog](docs/skills/README.md)
-- [Compound engineering: how Every codes with agents](https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents)
-- [The story behind compounding engineering](https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it)
-
-## Workflow
-
-The core loop is six steps: **brainstorm** the requirements, **plan** the implementation, **work** through the plan, **simplify** what you wrote, **review** the result, then **compound** the learning -- and repeat with better context.
-
-| Skill | Purpose |
-|-------|---------|
-| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Interactive Q&A to think through a feature or problem and write a requirements-only unified plan before planning |
-| [`/ce-plan`](docs/skills/ce-plan.md) | Enrich feature ideas or requirements-only plans into implementation-ready plans |
-| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation-ready plans with worktrees and task tracking |
-| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Refine the freshly written code for clarity and reuse before review |
-| [`/ce-code-review`](docs/skills/ce-code-review.md) | Multi-agent review against the plan before merging |
-| [`/ce-compound`](docs/skills/ce-compound.md) | Capture the learning into `docs/solutions/` so the next loop starts smarter |
-
-Each cycle compounds: `/ce-compound` writes learnings that the next `/ce-brainstorm` and `/ce-plan` read as grounding -- brainstorms sharpen plans, plans inform future plans, reviews catch more issues, patterns get documented. That return arrow is the whole point.
-
-### Additional skills
-
-These sit around the loop or get reached for on demand -- not every cycle needs them.
-
-| Skill | When to reach for it |
-|-------|---------|
-| [`/ce-ideate`](docs/skills/ce-ideate.md) | *Before the loop*, when you don't yet know what to build -- generates and critically ranks grounded ideas, then routes the strongest one into `/ce-brainstorm` |
-| [`/ce-strategy`](docs/skills/ce-strategy.md) | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
-| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
-| [`/ce-debug`](docs/skills/ce-debug.md) | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace root cause, fix, then polish/review before PR handoff when warranted |
-| [`/ce-pov`](docs/skills/ce-pov.md) | *On demand, before you commit* -- a decisive, project-grounded verdict on whether to adopt, switch to, or revisit an external technology, library, pattern, or platform; works cold or mid-session, and proposes the next step (`/ce-plan`, `/ce-brainstorm`, or a spike) from the verdict |
-| [`/ce-explain`](docs/skills/ce-explain.md) | *On demand, to keep learning* -- turns a concept, a diff, an idea, or "what did I do this week?" into a dense, visual explainer written for you personally, with an optional check-in (predict-then-reveal for diffs, corrected exercises) that makes it stick |
-
-For the full catalog and how each skill chains together, see [docs/skills](docs/skills/README.md). The complete inventory is [below](#full-skill-inventory).
-
-## Quick Example
-
-**Finding a direction** -- when you don't have a specific idea yet, ideate first, then carry the strongest survivor into the loop:
-
-```text
-/ce-ideate new drawing tools
-/ce-ideate surprise me
-/ce-ideate github issues   # ground ideas in your open issues instead of a prompt
-```
-
-`/ce-ideate` does the homework first (codebase, past learnings, prior art on the web, optionally your issue tracker), then hands you a ranked set of grounded candidates to take into `/ce-brainstorm`.
-
-**Standard feature loop** -- turn a rough idea into shipped, reviewed code:
-
-```text
-/ce-brainstorm make background job retries safer
-/ce-plan
-/ce-work
-/ce-simplify-code
-/ce-code-review
-/ce-compound
-```
-
-**Simplifying code** -- use it after fresh implementation work, or point it at code that keeps slowing changes down:
-
-```text
-/ce-simplify-code
-/ce-simplify-code simplify the code in my most-churned file
-```
-
-The first pass tightens recent branch changes before review. The targeted pass is useful when one file keeps absorbing unrelated fixes, follow-ups, or merge conflicts.
-
-**Debugging a bug** -- when you start from broken behavior instead of a feature:
-
-```text
-/ce-debug the checkout webhook sometimes creates duplicate invoices
-/ce-code-review
-/ce-compound
-```
-
-**Autonomous** -- hand off a feature and let the agent run the whole pipeline:
-
-```text
-/ce-brainstorm describe the feature
-/lfg
-```
-
-`/lfg` runs the loop hands-off: it plans, works through the plan, simplifies, runs code review and applies the fixes, runs browser tests, commits, pushes, opens a PR, then watches CI and repairs failures until it's green. Start it after `/ce-brainstorm` so it plans against real requirements rather than a one-line prompt. It's the autopilot version of the standard loop -- neat when you want to step away and come back to an open, green PR.
-
-## Getting Started
-
-After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
-
-The `compound-engineering` plugin currently ships 30 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
-
-### Full Skill Inventory
-
-| Skill | Purpose |
-|-------|---------|
-| [`/ce-strategy`](docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` |
-| [`/ce-ideate`](docs/skills/ce-ideate.md) | Generate and critically evaluate grounded ideas |
-| [`/ce-pov`](docs/skills/ce-pov.md) | Form a decisive, project-grounded verdict on an external input |
-| [`/ce-explain`](docs/skills/ce-explain.md) | Explain a concept, diff, idea, or window of your own work as a personal learning artifact |
-| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Explore requirements and write a right-sized requirements doc |
-| [`/ce-plan`](docs/skills/ce-plan.md) | Create structured implementation plans |
-| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation plans systematically |
-| [`/ce-code-review`](docs/skills/ce-code-review.md) | Review code with skill-local reviewer personas |
-| [`/ce-doc-review`](docs/skills/ce-doc-review.md) | Review requirements and plan documents |
-| [`/ce-debug`](docs/skills/ce-debug.md) | Reproduce failures, trace root cause, fix bugs, and prepare non-trivial fixes for PR |
-| [`/ce-compound`](docs/skills/ce-compound.md) | Document solved problems to compound team knowledge |
-| [`/ce-compound-refresh`](docs/skills/ce-compound-refresh.md) | Refresh stale or drifting learnings |
-| [`/ce-optimize`](docs/skills/ce-optimize.md) | Run iterative optimization loops |
-| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | Generate time-windowed product pulse reports |
-| [`/ce-riffrec-feedback-analysis`](docs/skills/ce-riffrec-feedback-analysis.md) | Convert Riffrec recordings or notes into structured feedback |
-| [`/ce-sweep`](docs/skills/ce-sweep.md) | Sweep feedback sources, track item lifecycles, and emit an `/lfg`-ready plan |
-| [`/ce-resolve-pr-feedback`](docs/skills/ce-resolve-pr-feedback.md) | Resolve PR review feedback |
-| [`/ce-commit`](docs/skills/ce-commit.md) | Create a git commit with a clear message |
-| [`/ce-commit-push-pr`](docs/skills/ce-commit-push-pr.md) | Commit, push, and open a PR that teaches any concept the change newly introduces |
-| [`/ce-babysit-pr`](docs/skills/ce-babysit-pr.md) | Watch an open PR and keep it moving toward merge, reacting to review comments and CI as they arrive |
-| [`/ce-worktree`](docs/skills/ce-worktree.md) | Ensure work happens in an isolated git worktree |
-| [`/ce-promote`](docs/skills/ce-promote.md) | Draft user-facing announcement copy |
-| [`/ce-test-browser`](docs/skills/ce-test-browser.md) | Run browser tests on PR-affected pages |
-| [`/ce-test-xcode`](docs/skills/ce-test-xcode.md) | Build and test iOS apps on simulator |
-| [`/ce-setup`](docs/skills/ce-setup.md) | Diagnose optional tool capabilities and project config |
-| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Simplify recent code changes |
-| [`/ce-polish`](docs/skills/ce-polish.md) | Start a dev server and iterate on UX polish |
-| [`/ce-proof`](docs/skills/ce-proof.md) | Create, edit, and share Proof documents |
-| [`/ce-dogfood`](docs/skills/ce-dogfood.md) | Hands-off diff-scoped browser QA of the active branch, with autonomous fixes |
-| [`/lfg`](docs/skills/lfg.md) | Full autonomous engineering workflow |
-
----
-
 ## Install
 
 ### Claude Code
@@ -441,6 +298,149 @@ cd /tmp/compound-engineering-plugin-cleanup
 bun install
 bun run cleanup --target all
 ```
+
+---
+
+## Philosophy
+
+**Each unit of engineering work should make subsequent units easier -- not harder.**
+
+Traditional development accumulates technical debt. Every feature adds complexity. Every bug fix leaves behind a little more local knowledge that someone has to rediscover later. The codebase gets larger, the context gets harder to hold, and the next change becomes slower.
+
+Compound engineering inverts this. 80% is in planning and review, 20% is in execution:
+
+- Plan thoroughly before writing code with `/ce-brainstorm` and `/ce-plan` using one readiness-based plan artifact
+- Review to catch issues and calibrate judgment with `/ce-code-review` and `/ce-doc-review`
+- Codify knowledge so it is reusable with `/ce-compound`
+- Keep quality high so future changes are easy
+
+The point is not ceremony. The point is leverage. A good brainstorm makes the plan sharper. A good plan makes execution smaller. A good review catches the pattern, not just the bug. A good compound note means the next agent does not have to learn the same lesson from scratch.
+
+**Learn more**
+
+- [Skill documentation catalog](docs/skills/README.md)
+- [Compound engineering: how Every codes with agents](https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents)
+- [The story behind compounding engineering](https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it)
+
+## Workflow
+
+The core loop is six steps: **brainstorm** the requirements, **plan** the implementation, **work** through the plan, **simplify** what you wrote, **review** the result, then **compound** the learning -- and repeat with better context.
+
+| Skill | Purpose |
+|-------|---------|
+| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Interactive Q&A to think through a feature or problem and write a requirements-only unified plan before planning |
+| [`/ce-plan`](docs/skills/ce-plan.md) | Enrich feature ideas or requirements-only plans into implementation-ready plans |
+| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation-ready plans with worktrees and task tracking |
+| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Refine the freshly written code for clarity and reuse before review |
+| [`/ce-code-review`](docs/skills/ce-code-review.md) | Multi-agent review against the plan before merging |
+| [`/ce-compound`](docs/skills/ce-compound.md) | Capture the learning into `docs/solutions/` so the next loop starts smarter |
+
+Each cycle compounds: `/ce-compound` writes learnings that the next `/ce-brainstorm` and `/ce-plan` read as grounding -- brainstorms sharpen plans, plans inform future plans, reviews catch more issues, patterns get documented. That return arrow is the whole point.
+
+### Additional skills
+
+These sit around the loop or get reached for on demand -- not every cycle needs them.
+
+| Skill | When to reach for it |
+|-------|---------|
+| [`/ce-ideate`](docs/skills/ce-ideate.md) | *Before the loop*, when you don't yet know what to build -- generates and critically ranks grounded ideas, then routes the strongest one into `/ce-brainstorm` |
+| [`/ce-strategy`](docs/skills/ce-strategy.md) | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
+| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
+| [`/ce-debug`](docs/skills/ce-debug.md) | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace root cause, fix, then polish/review before PR handoff when warranted |
+| [`/ce-pov`](docs/skills/ce-pov.md) | *On demand, before you commit* -- a decisive, project-grounded verdict on whether to adopt, switch to, or revisit an external technology, library, pattern, or platform; works cold or mid-session, and proposes the next step (`/ce-plan`, `/ce-brainstorm`, or a spike) from the verdict |
+| [`/ce-explain`](docs/skills/ce-explain.md) | *On demand, to keep learning* -- turns a concept, a diff, an idea, or "what did I do this week?" into a dense, visual explainer written for you personally, with an optional check-in (predict-then-reveal for diffs, corrected exercises) that makes it stick |
+
+For the full catalog and how each skill chains together, see [docs/skills](docs/skills/README.md). The complete inventory is [below](#full-skill-inventory).
+
+## Quick Example
+
+**Finding a direction** -- when you don't have a specific idea yet, ideate first, then carry the strongest survivor into the loop:
+
+```text
+/ce-ideate new drawing tools
+/ce-ideate surprise me
+/ce-ideate github issues   # ground ideas in your open issues instead of a prompt
+```
+
+`/ce-ideate` does the homework first (codebase, past learnings, prior art on the web, optionally your issue tracker), then hands you a ranked set of grounded candidates to take into `/ce-brainstorm`.
+
+**Standard feature loop** -- turn a rough idea into shipped, reviewed code:
+
+```text
+/ce-brainstorm make background job retries safer
+/ce-plan
+/ce-work
+/ce-simplify-code
+/ce-code-review
+/ce-compound
+```
+
+**Simplifying code** -- use it after fresh implementation work, or point it at code that keeps slowing changes down:
+
+```text
+/ce-simplify-code
+/ce-simplify-code simplify the code in my most-churned file
+```
+
+The first pass tightens recent branch changes before review. The targeted pass is useful when one file keeps absorbing unrelated fixes, follow-ups, or merge conflicts.
+
+**Debugging a bug** -- when you start from broken behavior instead of a feature:
+
+```text
+/ce-debug the checkout webhook sometimes creates duplicate invoices
+/ce-code-review
+/ce-compound
+```
+
+**Autonomous** -- hand off a feature and let the agent run the whole pipeline:
+
+```text
+/ce-brainstorm describe the feature
+/lfg
+```
+
+`/lfg` runs the loop hands-off: it plans, works through the plan, simplifies, runs code review and applies the fixes, runs browser tests, commits, pushes, opens a PR, then watches CI and repairs failures until it's green. Start it after `/ce-brainstorm` so it plans against real requirements rather than a one-line prompt. It's the autopilot version of the standard loop -- neat when you want to step away and come back to an open, green PR.
+
+## Getting Started
+
+After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
+
+The `compound-engineering` plugin currently ships 30 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+
+### Full Skill Inventory
+
+| Skill | Purpose |
+|-------|---------|
+| [`/ce-strategy`](docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` |
+| [`/ce-ideate`](docs/skills/ce-ideate.md) | Generate and critically evaluate grounded ideas |
+| [`/ce-pov`](docs/skills/ce-pov.md) | Form a decisive, project-grounded verdict on an external input |
+| [`/ce-explain`](docs/skills/ce-explain.md) | Explain a concept, diff, idea, or window of your own work as a personal learning artifact |
+| [`/ce-brainstorm`](docs/skills/ce-brainstorm.md) | Explore requirements and write a right-sized requirements doc |
+| [`/ce-plan`](docs/skills/ce-plan.md) | Create structured implementation plans |
+| [`/ce-work`](docs/skills/ce-work.md) | Execute implementation plans systematically |
+| [`/ce-code-review`](docs/skills/ce-code-review.md) | Review code with skill-local reviewer personas |
+| [`/ce-doc-review`](docs/skills/ce-doc-review.md) | Review requirements and plan documents |
+| [`/ce-debug`](docs/skills/ce-debug.md) | Reproduce failures, trace root cause, fix bugs, and prepare non-trivial fixes for PR |
+| [`/ce-compound`](docs/skills/ce-compound.md) | Document solved problems to compound team knowledge |
+| [`/ce-compound-refresh`](docs/skills/ce-compound-refresh.md) | Refresh stale or drifting learnings |
+| [`/ce-optimize`](docs/skills/ce-optimize.md) | Run iterative optimization loops |
+| [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | Generate time-windowed product pulse reports |
+| [`/ce-riffrec-feedback-analysis`](docs/skills/ce-riffrec-feedback-analysis.md) | Convert Riffrec recordings or notes into structured feedback |
+| [`/ce-sweep`](docs/skills/ce-sweep.md) | Sweep feedback sources, track item lifecycles, and emit an `/lfg`-ready plan |
+| [`/ce-resolve-pr-feedback`](docs/skills/ce-resolve-pr-feedback.md) | Resolve PR review feedback |
+| [`/ce-commit`](docs/skills/ce-commit.md) | Create a git commit with a clear message |
+| [`/ce-commit-push-pr`](docs/skills/ce-commit-push-pr.md) | Commit, push, and open a PR that teaches any concept the change newly introduces |
+| [`/ce-babysit-pr`](docs/skills/ce-babysit-pr.md) | Watch an open PR and keep it moving toward merge, reacting to review comments and CI as they arrive |
+| [`/ce-worktree`](docs/skills/ce-worktree.md) | Ensure work happens in an isolated git worktree |
+| [`/ce-promote`](docs/skills/ce-promote.md) | Draft user-facing announcement copy |
+| [`/ce-test-browser`](docs/skills/ce-test-browser.md) | Run browser tests on PR-affected pages |
+| [`/ce-test-xcode`](docs/skills/ce-test-xcode.md) | Build and test iOS apps on simulator |
+| [`/ce-setup`](docs/skills/ce-setup.md) | Diagnose optional tool capabilities and project config |
+| [`/ce-simplify-code`](docs/skills/ce-simplify-code.md) | Simplify recent code changes |
+| [`/ce-polish`](docs/skills/ce-polish.md) | Start a dev server and iterate on UX polish |
+| [`/ce-proof`](docs/skills/ce-proof.md) | Create, edit, and share Proof documents |
+| [`/ce-dogfood`](docs/skills/ce-dogfood.md) | Hands-off diff-scoped browser QA of the active branch, with autonomous fixes |
+| [`/lfg`](docs/skills/lfg.md) | Full autonomous engineering workflow |
 
 ---
 

--- a/docs/plans/2026-07-15-001-docs-readme-install-first-plan.md
+++ b/docs/plans/2026-07-15-001-docs-readme-install-first-plan.md
@@ -1,0 +1,198 @@
+---
+title: README Install-First Reorder - Plan
+type: docs
+date: 2026-07-15
+topic: readme-install-first
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# README Install-First Reorder - Plan
+
+> **Base note.** This plan was first drafted against `README.md` at 481 lines with eleven platform paths, then re-derived against `origin/main` at `1f29eabc`, where the README is **575 lines with fourteen platform paths** (Cline, Grok Build CLI, and Devin CLI landed in between). Every line number, count, and percentage below reflects the current base. The growth is not incidental — see **OQ1**, whose arithmetic it inverts.
+
+## Goal Capsule
+
+- **Objective:** A visitor landing on the `compound-engineering-plugin` repo sees how to install Compound Engineering as the first substantive content, immediately below the project's name and one-line description.
+- **Product authority:** The Product Contract below (bootstrapped from the user's request; no upstream brainstorm).
+- **Stop conditions:** Surface a blocker instead of guessing if the relocation cannot preserve the Install content verbatim, if any anchor would break, or if the change would require editing install instructions rather than reordering them.
+- **Execution profile:** Documentation-only content relocation in `README.md`. No code, no tests, no runtime behavior.
+- **Open blockers:** None. OQ1 and OQ2 are decisions for PR review, not blockers.
+
+**Product Contract preservation:** N/A — solo invocation, no upstream Product Contract to preserve. Requirements below were bootstrapped from the user's request.
+
+---
+
+## Product Contract
+
+### Summary
+
+`README.md` currently opens with Philosophy, Workflow, Quick Example, and a 30-row skill inventory, and places `## Install` at line 150 — roughly 26% of the way down a 575-line file. This plan moves the entire `## Install` section, unchanged, to sit directly beneath the H1, badge, and tagline, so the Claude Code install commands are visible within the first ~14 lines. Nothing else about the README's content changes.
+
+### Problem Frame
+
+The README's front matter sells the idea before it lets anyone act on it. A visitor who already wants the plugin — see A5 on how load-bearing and unvalidated that assumption is — must scroll past ~146 lines of philosophy, a six-step workflow table, additional-skills table, five code-block examples, and the full 30-skill inventory before finding `/plugin marketplace add`. The information is present and correct; it is ordered for persuasion rather than for action.
+
+A secondary incoherence falls out of the same ordering: `## Getting Started` (line 107) opens with "After installing, run `/ce-setup` in any project" while sitting *above* the install instructions it refers to.
+
+### Requirements
+
+- **R1.** Install is the first substantive content — a visitor sees how to install without scrolling past philosophy, workflow, examples, or the skill inventory.
+- **R2.** The Install section's content is preserved verbatim: all fourteen platform paths (Claude Code, Cursor, Codex App, Codex CLI, Kimi Code CLI, Cline, Grok Build CLI, Devin CLI, GitHub Copilot, Factory Droid, Qwen Code, OpenCode, Pi, Antigravity CLI) plus `### Existing Installs`, with no additions, deletions, or rewording.
+- **R3.** Every existing anchor continues to resolve — the two intra-README links (`#full-skill-inventory`, `#existing-installs`) and any external deep-link to `#install`.
+- **R4.** The rendered document has no doubled or stray horizontal rules, and all non-Install sections keep their current relative order.
+- **R5.** The project's identity — name, CI badge, and the one-line "AI skills that make each unit of engineering work easier than the last." — remains above the install instructions.
+
+### Acceptance Examples
+
+- **AE1.** A visitor reading the README sees the project name, badge, tagline, then immediately `## Install`, `### Claude Code`, and the two `/plugin` commands — no README content intervenes, and the commands land within the first ~14 source lines. (On github.com the repo file browser and header render above the README, so absolute viewport visibility is not achievable on the landing page and is not claimed here.)
+- **AE2.** A Codex CLI user following the in-page find for "Codex CLI" lands on the same instructions they would have found before this change, worded identically.
+- **AE3.** A visitor following an existing external link to `…/compound-engineering-plugin#install` still lands on the Install heading.
+- **AE4.** A reader who scrolls past Install reaches Philosophy, then Workflow, Quick Example, Getting Started, Local Development, Limitations, FAQ, Contributing, License — the same order as before.
+
+---
+
+## Assumptions
+
+Headless run (LFG pipeline) — the scoping confirmation was skipped, so the inferred calls below are recorded here for review rather than confirmed in chat. Each is cheap to reverse; the whole change is a reorder.
+
+- **A1.** "All the way to the top" means immediately after the H1 + badge + tagline identity block, not above it. The H1 cannot be displaced, and a reader needs one line of what-it-is before install commands. This places the install commands at lines 12-13 — the goal is fully met without a contentless opening.
+- **A2.** The ask is ordering-only. The Install section's internal structure — fourteen platform subsections, ~296 lines — moves unchanged. Restructuring it to shrink its visible height is a separate decision (see OQ1).
+- **A3.** `## Getting Started` does not travel with Install. It stays where it is and becomes a correct forward-reference once Install precedes it.
+- **A4.** Philosophy, Workflow, and Quick Example moving below the Install block is the intended tradeoff of "really focus on that," not an unwanted side effect. This is the load-bearing scope assumption: if A4 is wrong, the change is not mis-scoped, it is unwanted. **OQ1 documents why the re-derived base makes this assumption harder to hold than it looked at first draft.**
+- **A5.** The dominant repo visitor already intends to install, rather than arriving from a linked article to evaluate the idea. **Unvalidated** — there is no README traffic data, no issue history on install discoverability, and no upstream brainstorm; the README itself links two Every articles as inbound paths, and readers arriving that way are mid-evaluation, not mid-install. The whole plan's value rests on this assumption. It came from the user's direct instruction, which is authority enough to proceed, but it is a bet, not an established fact.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD-1. Insertion point: after the tagline (line 5), before `## Philosophy`.** The identity block (H1, badge, tagline) is five lines and cannot be moved below Install without leaving the page contentless at the top. Install starting at line 7 puts `### Claude Code` and its two commands at lines 12-13 — the first thing a visitor reads after learning what the project is. Rejected: inserting above the badge/tagline, which trades a one-line orientation cost for no scroll benefit.
+
+- **KTD-2. Pure block relocation — content unchanged.** Lines 149-445 — the Install content (150-443) plus its trailing blank and horizontal rule (444-445) and the blank line at 149 that precedes the heading, per KTD-4 — move as one unit with zero edits. `### Claude Code` is already the first platform inside Install, so the primary audience gets its two commands immediately without any restructuring. This keeps the diff reviewable as a move, keeps R2 trivially verifiable, and carries no risk of corrupting install instructions across fourteen platforms.
+
+- **KTD-3. Anchors are heading-text-derived and all heading text is unique, so a reorder cannot break them.** GitHub slugifies heading text position-independently **except** for duplicate heading text, which it disambiguates with positional `-1`/`-2` suffixes — so a reorder *can* swap anchors when two headings share text. That precondition is satisfied here: verified that all 33 of the README's headings are textually unique. (The per-platform labels under `## Local Development` and `### Existing Installs` are bold text, not headings, so they generate no anchors and cannot collide with `### Claude Code` and its peers.) With no duplicate slugs and no heading text changing, `#install`, `#existing-installs`, and `#full-skill-inventory` all survive. This is the finding that de-risks the change: R3 needs no link edits. Verified by grep — the README contains exactly two anchor references (line 56 → `#full-skill-inventory`, line 159 → `#existing-installs`), and no file outside `docs/plans/` links to a README anchor.
+
+- **KTD-4. Cut lines 149-445 — the blank line, the heading, the content, and the trailing rule — and leave the leading rule at 148 in place.** Install is currently fenced by `---` at 148 and `---` at 445. Two off-by-one traps sit here, both empirically simulated:
+  - Moving only **150-443** leaves the two rules adjacent — a visible `---` `---` artifact that R4 forbids.
+  - Moving **150-445** fixes the rules but strands the blank at 149 next to the blank at 446, leaving two consecutive blanks before `## Local Development`. Worse, the block then needs a *new* blank inserted above it at the top, so the diff adds one more line than it removes, the file grows to 576 lines, and R2's "added and removed line sets are equal" check becomes false.
+  - Moving **149-445** (297 lines: blank + heading + content + trailing blank + rule) is correct. The traveling blank supplies the separator after the tagline, so no new line is added. At the vacated position, `---` (148) is followed by the surviving blank (446) and `## Local Development` — mirroring the original rule/blank/heading spacing exactly. The file stays at 575 lines and the added and removed line sets are exactly equal. Verified by simulation: the two `/plugin` commands land at lines 12-13, rules end at 302 and 445, and no doubled blank appears at either seam.
+
+  **The content-anchored description is authoritative over these line numbers.** Every span here is pinned to `README.md` at `origin/main` = `1f29eabc`; any commit touching the README before U1 executes silently rots them — which already happened once during this plan's own drafting (see the Base note). If the numbers and the description disagree, re-derive the span from the description (the blank line before `## Install` through the `---` following `### Existing Installs`) rather than cutting the stated range.
+
+- **KTD-5. `## Getting Started` stays put.** It owns the `### Full Skill Inventory` table (~35 lines of reference content, not install content), so promoting it with Install would drag the inventory to the top and undercut R1. Leaving it fixes its "After installing…" opening as a side effect of Install moving above it.
+
+- **KTD-6. Plan depth: Lightweight; no flow analysis or deepening pass.** Phase 1.4b would escalate to Standard for work touching "documentation referenced by external URLs," but KTD-3 establishes that the externally-referenced surface — the anchors — is provably undisturbed by a heading-text-preserving reorder. There is no user flow, state transition, or contract to analyze in a single-block content move. Recorded here so a reviewer can challenge the classification rather than infer it.
+
+### Scope Boundaries
+
+#### Non-Goals
+
+- No changes to install instruction content, commands, or platform coverage.
+- No changes to any other section's content or internal order.
+- No new sections, and no removal of existing ones.
+- No changes to `docs/skills/README.md`, `.opencode/INSTALL.md`, `.agy/INSTALL.md`, or any platform manifest.
+
+#### Deferred to Follow-Up Work
+
+- **Collapse the thirteen non-primary platform subsections into `<details>` blocks.** Would cut Install's visible height at the top from ~296 lines to ~15, so install-first costs almost no vertical space. Real tradeoff to weigh first: GitHub's in-page find does not search collapsed `<details>` content, which would hurt discoverability for the thirteen non-Claude platforms and directly conflicts with AE2. This is a decision about Install's internal structure, distinct from this plan's ordering question. See OQ1 for the stronger alternative.
+- **Split `### Existing Installs` out of Install.** It is upgrade guidance, not first-install guidance, and currently adds ~35 lines to the section now sitting at the top.
+- **Reconcile `## Local Development`'s "From your local checkout" per-harness list with Install's per-platform list.** The two maintain parallel per-platform instructions that can drift.
+- **Trim per-platform install prose.** Several subsections repeat a "no separate Bun install step is needed" explanation.
+
+---
+
+## Implementation Units
+
+### U1. Move the Install block above Philosophy
+
+- **Goal:** Relocate `## Install` (with its trailing horizontal rule) from line 150 to directly below the tagline, leaving all content byte-identical.
+- **Requirements:** R1, R2, R3, R4, R5 (all of them — this is a single-unit plan).
+- **Dependencies:** None.
+- **Files:** `README.md`
+- **Approach:** Cut lines 149-445 — the blank line preceding `## Install`, through the `---` that follows `### Existing Installs` — and reinsert the block immediately after line 5 (the tagline). Do not add a separator blank: the blank at 149 travels with the block and supplies it. Leave the `---` at line 148 in place; it becomes the rule between `### Full Skill Inventory` and `## Local Development`, followed by the surviving blank at 446 (KTD-4 — read its off-by-one analysis before cutting). Touch nothing inside the moved block and nothing in any other section. Resulting top-level order: identity block → Install → `---` → Philosophy → Workflow → Quick Example → Getting Started → `---` → Local Development → Limitations → FAQ → Contributing → License.
+- **Execution note:** Docs-only relocation. Prove the block moved verbatim by comparing the file's sorted line-multiset against `HEAD` — that equality, not new test coverage, is the evidence R2 is met. Do not add tests; there is no behavior to assert.
+- **Patterns to follow:** The README's existing `---` convention — horizontal rules fence major structural blocks (currently Install; after this change, Install at the top and the Local-Development boundary). Section heading levels and text stay exactly as-is.
+- **Test scenarios:** `Test expectation: none -- pure content reordering of a documentation file.` No behavior changes and no test in the suite asserts README structure. Verified: `tests/release-preview.test.ts:25` uses `"README.md"` only as a synthetic changed-file path for release-component mapping, and `src/release/components.ts` maps it by path (order-agnostic); `tests/release-metadata.test.ts` does not read the README. The `bun test` and `release:validate` runs in Verification are regression guards against unexpected coupling, not new coverage.
+- **Verification:**
+  - The file is still 575 lines, and the sorted multiset of its lines is unchanged from `HEAD` — the strongest single proof that the move added and removed nothing (R2).
+  - `## Install`, `### Claude Code`, and both `/plugin` commands appear within the first ~14 source lines (AE1).
+  - Top-level section order matches the sequence in **Approach** above (AE4).
+  - The file contains exactly two `^---$` horizontal rules, none adjacent to another (R4), and no two consecutive blank lines were introduced at either seam.
+  - Both anchor references still resolve to headings present in the file: `#full-skill-inventory` and `#existing-installs` (R3, AE3).
+  - No two headings share the same text, so no positional `-1`/`-2` slug suffix exists for the reorder to swap (R3, KTD-3's precondition).
+  - `git diff --stat` shows `README.md` as the only changed file, and the diff's added and removed line sets are equal apart from position — no content edits smuggled into the move (R2, AE2).
+  - `bun test` passes and `bun run release:validate` passes.
+
+---
+
+## Verification Contract
+
+- **Structural:** Install is the first `##` heading in the file; the identity block precedes it; every other section retains its prior relative order.
+- **Content fidelity:** The file is still 575 lines and its sorted line-multiset is unchanged from `HEAD`. `git diff` on `README.md` shows relocation only — no reworded, added, or dropped lines.
+- **Link integrity:** Both intra-README anchors resolve; no heading text changed and no two headings share text, so no slug is position-dependent and external `#install` deep-links survive.
+- **Rendering:** Exactly two horizontal rules, no doubling, no stray rule left at the vacated position, and no doubled blank line at either seam.
+- **Regression:** `bun test` green, `bun run release:validate` green.
+
+## Definition of Done
+
+- `README.md` opens with the identity block followed immediately by the complete `## Install` section.
+- All fourteen platform install paths and `### Existing Installs` are present and verbatim.
+- Exactly two horizontal rules remain, correctly placed per KTD-4.
+- Both anchor references resolve; no heading text changed.
+- `bun test` and `bun run release:validate` pass.
+- The change lands as a single `docs(readme):` commit on a feature branch via PR (README.md is docs-only per the repo's commit conventions; the intent is reordering documentation, not changing product behavior).
+
+---
+
+## Open Questions
+
+### OQ1. Should Install be split rather than moved whole?
+
+**Not a blocker.** The plan proceeds on the literal instruction — move the section — and this question is recorded so the reviewer can redirect on the PR rather than discover the tradeoff after merge.
+
+Document review raised a sharper alternative than either arm this plan considered, and **re-deriving against the current base inverted the arithmetic in its favor.** The observation: only **R1** is load-bearing ("a visitor sees how to install"), and `### Claude Code`'s two commands (~8 lines) satisfy it by themselves. The other thirteen platform paths are what create the cost.
+
+The measured effect of moving the block whole, on the current 575-line base:
+
+| | Position | Depth |
+|---|---|---|
+| `## Install` today (the stated problem) | line 150 | **26%** down |
+| `## Philosophy` after the move (the cost) | line 304 | **53%** down |
+
+The change does not just trade one burial for a comparable one — it buries the "what is this" content **twice as deep as the install content currently sits.** At first draft, against a 481-line README with eleven platforms, the same math read 31% vs 47% and was arguable. Fourteen platforms later it is not close. Adversarial review predicted this drift explicitly ("Install's height at the top grows with each platform added"), and it grew by three platforms *during this plan's own drafting*.
+
+The alternative: keep `## Install` at the top containing only `### Claude Code` plus a one-line pointer, and move the remaining thirteen platform subsections and `### Existing Installs` verbatim into a second section below Quick Example. That meets R1 and R5 at ~10 lines instead of ~297, keeps orientation content near the top, preserves both `#install` and `#existing-installs` anchors (both headings survive), and avoids the in-page-find problem that makes the deferred `<details>` mitigation unattractive.
+
+Why it is not the plan of record:
+
+- It is a different change than the one requested. "Move the install section all the way to the top" asks for a relocation; splitting the section into two is a restructuring, and **A2**, **KTD-2**, **R2**, and the Goal Capsule's stop condition all commit to ordering-only by construction. Adopting it means amending all four.
+- It has its own cost: install guidance would live in two places, which is worse for the thirteen non-Claude platforms — they would land on a top section that does not contain their instructions.
+- The plan's whole premise (**A5**) is already an unvalidated bet on visitor intent. Layering a second unvalidated bet — that splitting reads better than moving — on top of it compounds the guess rather than reducing it.
+
+If the reviewer wants the split, the cheapest path is to amend A2/KTD-2/R2 and the stop condition, then re-scope U1 into two units (extract Claude Code; relocate the remainder). Nothing in this plan forecloses that — the move is trivially revertable.
+
+### OQ2. What signal would trigger revisiting the ordering?
+
+The first entry under **Risks** accepts the below-the-fold cost as "reversible, and intended," but names no condition for reconsidering it, and an open-source README has no analytics to supply one. Absent a trigger, the ~297-line front page ships and stays by default — reversible in principle, unexercised in practice. The install matrix also grows with each platform added (fourteen today, up from eleven within this session), so the accepted tradeoff worsens monotonically. A cheap convention: revisit the ordering the next time a README change touches Philosophy or the platform list, whichever comes first.
+
+---
+
+## Risks
+
+- **The "what is this?" content moves below the fold — measurably further than Install is buried today.** A first-time visitor who does not yet want the plugin now meets ~297 lines of install matrix before Philosophy (line 304, 53% down, vs Install's current line 150, 26% down). This is the accepted tradeoff of the explicit ask ("to really focus on that") and it is cheap to reverse, but the re-derived numbers make it a sharper cost than the first draft implied. OQ1 carries the alternative that would eliminate it. *Severity: medium — reversible and intended, but no longer a small cost.*
+- **Monotonic worsening.** Each new platform path lengthens the block now sitting at the top. Three landed during this plan's drafting alone. Without OQ2's trigger, nothing prompts a revisit. *Severity: low now, rising.*
+- **Silent content edit inside the moved block.** A 297-line cut-and-paste is the one way this change could do real damage. The sorted-multiset equality check in U1's Verification is the specific guard. *Severity: low, given the check.*
+- **Line-number rot.** Every span is pinned to `origin/main` = `1f29eabc`. This already bit once mid-drafting. KTD-4's content-anchored override is the mitigation. *Severity: low, given the override.*
+
+## Sources & Research
+
+- `README.md` at `origin/main` = `1f29eabc` — current structure: 575 lines; `## Install` at 150-443; horizontal rules at 148 and 445; `## Getting Started` at 107 opening with "After installing…"; `### Full Skill Inventory` at 113; 30 inventory rows; fourteen platform subsections; 33 headings, all textually unique.
+- Cut simulation (`149-445` → insert after line 5) — verified: 575 lines preserved, sorted line-multiset identical to `HEAD`, `/plugin` commands at lines 12-13, rules at 302 and 445, zero consecutive blank-line pairs, `## Philosophy` at 304. Also verified the two rejected ranges produce the artifacts KTD-4 describes.
+- Anchor-reference grep (`*.md`, `*.ts`, `*.json`, `*.yaml`) — exactly two README anchor references exist, both intra-file (line 56, line 159); no file outside `docs/plans/` deep-links a README anchor. Supports KTD-3 and R3.
+- Test-coupling grep — no test asserts README content or section order; `src/release/components.ts` maps `README.md` to the `compound-engineering` release component by path only. Supports U1's `Test expectation: none`.
+- Directional-language grep — the only positional claim in the README is line 56's "The complete inventory is [below](#full-skill-inventory)", which remains accurate (`### Full Skill Inventory` stays below line 56).
+- Repo conventions (project instructions in context) — `docs:` is reserved for docs-only files including `README.md`; feature branches and PRs are required for all changes to `main`; markdown tables must stay pipe-delimited.

--- a/docs/plans/2026-07-15-001-docs-readme-install-first-plan.md
+++ b/docs/plans/2026-07-15-001-docs-readme-install-first-plan.md
@@ -11,13 +11,13 @@ execution: code
 
 # README Install-First Reorder - Plan
 
-> **Base note.** This plan was first drafted against `README.md` at 481 lines with eleven platform paths, then re-derived against `origin/main` at `1f29eabc`, where the README is **575 lines with fourteen platform paths** (Cline, Grok Build CLI, and Devin CLI landed in between). Every line number, count, and percentage below reflects the current base. The growth is not incidental — see **OQ1**, whose arithmetic it inverts.
+> **Base note.** This plan was first drafted against `README.md` at 481 lines with eleven platform paths, then re-derived against `origin/main` at `1f29eabc`, where the README is **575 lines with fourteen platform paths** (Cline, Grok Build CLI, and Devin CLI landed in between). Every line number, count, and percentage below reflects that base. The growth is not incidental: it inverted **OQ1**'s arithmetic, and on review the user redirected from a whole-block move to the split this plan now specifies. OQ1 records that resolution.
 
 ## Goal Capsule
 
 - **Objective:** A visitor landing on the `compound-engineering-plugin` repo sees how to install Compound Engineering as the first substantive content, immediately below the project's name and one-line description.
 - **Product authority:** The Product Contract below (bootstrapped from the user's request; no upstream brainstorm).
-- **Stop conditions:** Surface a blocker instead of guessing if the relocation cannot preserve the Install content verbatim, if any anchor would break, or if the change would require editing install instructions rather than reordering them.
+- **Stop conditions:** Surface a blocker instead of guessing if the change cannot preserve every platform's install instructions verbatim, or if any anchor would break. Adding minimal navigation (a pointer line, a section heading) is in scope; **rewording, merging, or dropping any platform's instructions is not.**
 - **Execution profile:** Documentation-only content relocation in `README.md`. No code, no tests, no runtime behavior.
 - **Open blockers:** None. OQ1 and OQ2 are decisions for PR review, not blockers.
 
@@ -29,7 +29,7 @@ execution: code
 
 ### Summary
 
-`README.md` currently opens with Philosophy, Workflow, Quick Example, and a 30-row skill inventory, and places `## Install` at line 150 — roughly 26% of the way down a 575-line file. This plan moves the entire `## Install` section, unchanged, to sit directly beneath the H1, badge, and tagline, so the Claude Code install commands are visible within the first ~14 lines. Nothing else about the README's content changes.
+`README.md` opened with Philosophy, Workflow, Quick Example, and a 30-row skill inventory, placing `## Install` at line 150 — roughly 26% of the way down a 575-line file. This plan puts `## Install` directly beneath the H1, badge, and tagline, carrying the three primary platforms (Claude Code, Cursor, and Codex — both its App and CLI surfaces). The Claude Code commands land at lines 12-13. The other eleven subsections move verbatim to a `## More Install Options` section lower in the file, reachable by one pointer link, so leading with install costs ~90 lines instead of ~297 and `## Philosophy` lands at 17% down — shallower than Install itself began. No platform's instructions change.
 
 ### Problem Frame
 
@@ -40,10 +40,11 @@ A secondary incoherence falls out of the same ordering: `## Getting Started` (li
 ### Requirements
 
 - **R1.** Install is the first substantive content — a visitor sees how to install without scrolling past philosophy, workflow, examples, or the skill inventory.
-- **R2.** The Install section's content is preserved verbatim: all fourteen platform paths (Claude Code, Cursor, Codex App, Codex CLI, Kimi Code CLI, Cline, Grok Build CLI, Devin CLI, GitHub Copilot, Factory Droid, Qwen Code, OpenCode, Pi, Antigravity CLI) plus `### Existing Installs`, with no additions, deletions, or rewording.
+- **R2.** Every platform's install instructions are preserved verbatim: all fourteen platform paths (Claude Code, Cursor, Codex App, Codex CLI, Kimi Code CLI, Cline, Grok Build CLI, Devin CLI, GitHub Copilot, Factory Droid, Qwen Code, OpenCode, Pi, Antigravity CLI) plus `### Existing Installs`, with nothing reworded, merged, or dropped. The only permitted additions are navigation: one pointer line from the top section to the overflow section, the overflow section's heading, and its one-line intro.
 - **R3.** Every existing anchor continues to resolve — the two intra-README links (`#full-skill-inventory`, `#existing-installs`) and any external deep-link to `#install`.
 - **R4.** The rendered document has no doubled or stray horizontal rules, and all non-Install sections keep their current relative order.
 - **R5.** The project's identity — name, CI badge, and the one-line "AI skills that make each unit of engineering work easier than the last." — remains above the install instructions.
+- **R6.** The top section carries the three primary platforms — Claude Code, Cursor, and Codex (both its App and CLI surfaces, which must not be split across the boundary) — and the remaining eleven subsections live in a single overflow section reachable by one link.
 
 ### Acceptance Examples
 
@@ -59,9 +60,9 @@ A secondary incoherence falls out of the same ordering: `## Getting Started` (li
 Headless run (LFG pipeline) — the scoping confirmation was skipped, so the inferred calls below are recorded here for review rather than confirmed in chat. Each is cheap to reverse; the whole change is a reorder.
 
 - **A1.** "All the way to the top" means immediately after the H1 + badge + tagline identity block, not above it. The H1 cannot be displaced, and a reader needs one line of what-it-is before install commands. This places the install commands at lines 12-13 — the goal is fully met without a contentless opening.
-- **A2.** The ask is ordering-only. The Install section's internal structure — fourteen platform subsections, ~296 lines — moves unchanged. Restructuring it to shrink its visible height is a separate decision (see OQ1).
+- **A2.** ~~The ask is ordering-only.~~ **Superseded 2026-07-15 by the user's redirect on PR #1146 — see OQ1 (resolved).** The ask is now split-and-order: the three primary platforms lead at the top, the other eleven subsections move to an overflow section reachable by one link. Each platform's instructions still move verbatim; the only additions are navigation.
 - **A3.** `## Getting Started` does not travel with Install. It stays where it is and becomes a correct forward-reference once Install precedes it.
-- **A4.** Philosophy, Workflow, and Quick Example moving below the Install block is the intended tradeoff of "really focus on that," not an unwanted side effect. This is the load-bearing scope assumption: if A4 is wrong, the change is not mis-scoped, it is unwanted. **OQ1 documents why the re-derived base makes this assumption harder to hold than it looked at first draft.**
+- **A4.** ~~Philosophy, Workflow, and Quick Example moving below the whole Install block is the intended tradeoff.~~ **Largely dissolved by the OQ1 split.** The split was adopted precisely because this assumption did not survive the re-derived base: a whole-block move put Philosophy at 53% down, deeper than Install's original 26%. With only three platforms leading, Philosophy sits at 17% — shallower than the status quo — so the tradeoff this assumption asked the user to accept is no longer being asked.
 - **A5.** The dominant repo visitor already intends to install, rather than arriving from a linked article to evaluate the idea. **Unvalidated** — there is no README traffic data, no issue history on install discoverability, and no upstream brainstorm; the README itself links two Every articles as inbound paths, and readers arriving that way are mid-evaluation, not mid-install. The whole plan's value rests on this assumption. It came from the user's direct instruction, which is authority enough to proceed, but it is a bet, not an established fact.
 
 ---
@@ -72,7 +73,11 @@ Headless run (LFG pipeline) — the scoping confirmation was skipped, so the inf
 
 - **KTD-1. Insertion point: after the tagline (line 5), before `## Philosophy`.** The identity block (H1, badge, tagline) is five lines and cannot be moved below Install without leaving the page contentless at the top. Install starting at line 7 puts `### Claude Code` and its two commands at lines 12-13 — the first thing a visitor reads after learning what the project is. Rejected: inserting above the badge/tagline, which trades a one-line orientation cost for no scroll benefit.
 
-- **KTD-2. Pure block relocation — content unchanged.** Lines 149-445 — the Install content (150-443) plus its trailing blank and horizontal rule (444-445) and the blank line at 149 that precedes the heading, per KTD-4 — move as one unit with zero edits. `### Claude Code` is already the first platform inside Install, so the primary audience gets its two commands immediately without any restructuring. This keeps the diff reviewable as a move, keeps R2 trivially verifiable, and carries no risk of corrupting install instructions across fourteen platforms.
+- **KTD-2. Split relocation — three platforms lead, eleven overflow, every instruction verbatim.** Supersedes the original pure-move decision after the user's redirect (OQ1, resolved). `## Install` keeps its heading text (so `#install` survives) and carries Claude Code, Cursor, Codex App, and Codex CLI. The remaining eleven subsections (Kimi Code CLI through Antigravity CLI, plus `### Existing Installs`) move verbatim into a new `## More Install Options` section placed between `### Full Skill Inventory` and `## Local Development` — grouping it with the install-adjacent "From your local checkout" content rather than stranding it mid-narrative.
+
+  **Codex is one platform with two surfaces.** Codex App and Codex CLI both stay at the top. Splitting them across the boundary would land a Codex App user on a top section that does not contain their instructions — the exact failure the split exists to avoid.
+
+  **Verification changes shape.** This is no longer a pure relocation, so sorted-multiset equality against `HEAD` no longer holds. The replacement guarantee is stricter than a line count: the *removed* set against `origin/main` must be **empty** (nothing dropped or reworded anywhere in the file), and the *added* set must contain only the intended navigation lines. See U1's Verification.
 
 - **KTD-3. Anchors are heading-text-derived and all heading text is unique, so a reorder cannot break them.** GitHub slugifies heading text position-independently **except** for duplicate heading text, which it disambiguates with positional `-1`/`-2` suffixes — so a reorder *can* swap anchors when two headings share text. That precondition is satisfied here: verified that all 33 of the README's headings are textually unique. (The per-platform labels under `## Local Development` and `### Existing Installs` are bold text, not headings, so they generate no anchors and cannot collide with `### Claude Code` and its peers.) With no duplicate slugs and no heading text changing, `#install`, `#existing-installs`, and `#full-skill-inventory` all survive. This is the finding that de-risks the change: R3 needs no link edits. Verified by grep — the README contains exactly two anchor references (line 56 → `#full-skill-inventory`, line 159 → `#existing-installs`), and no file outside `docs/plans/` links to a README anchor.
 
@@ -91,58 +96,66 @@ Headless run (LFG pipeline) — the scoping confirmation was skipped, so the inf
 
 #### Non-Goals
 
-- No changes to install instruction content, commands, or platform coverage.
+- No changes to any platform's install instruction content, commands, or coverage — all fourteen stay, worded identically.
 - No changes to any other section's content or internal order.
-- No new sections, and no removal of existing ones.
 - No changes to `docs/skills/README.md`, `.opencode/INSTALL.md`, `.agy/INSTALL.md`, or any platform manifest.
 
 #### Deferred to Follow-Up Work
 
-- **Collapse the thirteen non-primary platform subsections into `<details>` blocks.** Would cut Install's visible height at the top from ~296 lines to ~15, so install-first costs almost no vertical space. Real tradeoff to weigh first: GitHub's in-page find does not search collapsed `<details>` content, which would hurt discoverability for the thirteen non-Claude platforms and directly conflicts with AE2. This is a decision about Install's internal structure, distinct from this plan's ordering question. See OQ1 for the stronger alternative.
-- **Split `### Existing Installs` out of Install.** It is upgrade guidance, not first-install guidance, and currently adds ~35 lines to the section now sitting at the top.
-- **Reconcile `## Local Development`'s "From your local checkout" per-harness list with Install's per-platform list.** The two maintain parallel per-platform instructions that can drift.
+- **Reconcile `## Local Development`'s "From your local checkout" per-harness list with the install per-platform lists.** The two maintain parallel per-platform instructions that can drift. The split puts `## More Install Options` directly above `## Local Development`, which makes the duplication more visible and this consolidation more attractive.
 - **Trim per-platform install prose.** Several subsections repeat a "no separate Bun install step is needed" explanation.
+- **Revisit the top-three boundary as the target matrix shifts.** See the split-boundary staleness risk. Not actionable now.
+
+**No longer deferred — the split resolved these:**
+
+- ~~Collapse the non-primary platform subsections into `<details>` blocks.~~ The whole point was to shrink Install's height at the top; the split does that (~90 lines instead of ~297) without `<details>`'s cost — GitHub's in-page find does not search collapsed content, which would have hurt the eleven overflow platforms and conflicted with AE2. A plain link has no such penalty.
+- ~~Split `### Existing Installs` out of Install.~~ Done: it moved into `## More Install Options`, still linked from the Claude Code blockquote at the top.
 
 ---
 
 ## Implementation Units
 
-### U1. Move the Install block above Philosophy
+### U1. Lead with the three primary platforms; move the rest to an overflow section
 
-- **Goal:** Relocate `## Install` (with its trailing horizontal rule) from line 150 to directly below the tagline, leaving all content byte-identical.
-- **Requirements:** R1, R2, R3, R4, R5 (all of them — this is a single-unit plan).
+- **Goal:** `## Install` sits directly below the tagline carrying Claude Code, Cursor, Codex App, and Codex CLI; the other eleven subsections live verbatim in a new `## More Install Options` section lower in the file, reachable by one link.
+- **Requirements:** R1, R2, R3, R4, R5, R6 (all of them — this is a single-unit plan).
 - **Dependencies:** None.
 - **Files:** `README.md`
-- **Approach:** Cut lines 149-445 — the blank line preceding `## Install`, through the `---` that follows `### Existing Installs` — and reinsert the block immediately after line 5 (the tagline). Do not add a separator blank: the blank at 149 travels with the block and supplies it. Leave the `---` at line 148 in place; it becomes the rule between `### Full Skill Inventory` and `## Local Development`, followed by the surviving blank at 446 (KTD-4 — read its off-by-one analysis before cutting). Touch nothing inside the moved block and nothing in any other section. Resulting top-level order: identity block → Install → `---` → Philosophy → Workflow → Quick Example → Getting Started → `---` → Local Development → Limitations → FAQ → Contributing → License.
-- **Execution note:** Docs-only relocation. Prove the block moved verbatim by comparing the file's sorted line-multiset against `HEAD` — that equality, not new test coverage, is the evidence R2 is met. Do not add tests; there is no behavior to assert.
-- **Patterns to follow:** The README's existing `---` convention — horizontal rules fence major structural blocks (currently Install; after this change, Install at the top and the Local-Development boundary). Section heading levels and text stay exactly as-is.
-- **Test scenarios:** `Test expectation: none -- pure content reordering of a documentation file.` No behavior changes and no test in the suite asserts README structure. Verified: `tests/release-preview.test.ts:25` uses `"README.md"` only as a synthetic changed-file path for release-component mapping, and `src/release/components.ts` maps it by path (order-agnostic); `tests/release-metadata.test.ts` does not read the README. The `bun test` and `release:validate` runs in Verification are regression guards against unexpected coupling, not new coverage.
+- **Approach:** Resolve every span by content anchor, not line number (KTD-4's rot lesson). Cut from the blank line preceding `### Kimi Code CLI` through the last content line of `### Existing Installs` — leaving the `---` that follows it in place at the top, where it continues to fence `## Install` from `## Philosophy`. Reinsert that block verbatim after the blank following the `---` that precedes `## Local Development`, prefixed by the `## More Install Options` heading and its one-line intro, and suffixed by a blank + `---` + blank so `## Local Development` keeps its own fence. Add one pointer line at the tail of the top section, after Codex CLI's last line. Touch nothing inside any platform subsection.
+
+  Resulting top-level order: identity block → Install (Claude Code, Cursor, Codex App, Codex CLI) → `---` → Philosophy → Workflow → Quick Example → Getting Started → `---` → More Install Options (eleven subsections) → `---` → Local Development → Limitations → FAQ → Contributing → License.
+- **Execution note:** Docs-only restructuring. The evidence for R2 is that the **removed set against `origin/main` is empty** — not a line count and not multiset equality, both of which a split breaks by design. Do not add tests; there is no behavior to assert.
+- **Patterns to follow:** The README's `---` convention — every rule is blank-fenced on both sides and separates a major structural block. The new section inherits that shape. Section heading levels and text stay exactly as-is for every existing heading.
+- **Test scenarios:** `Test expectation: none -- content restructuring of a documentation file.` No behavior changes and no test in the suite asserts README structure. Verified: `tests/release-preview.test.ts:25` uses `"README.md"` only as a synthetic changed-file path for release-component mapping, and `src/release/components.ts` maps it by path (order-agnostic); `tests/release-metadata.test.ts` does not read the README. The `bun test` and `release:validate` runs in Verification are regression guards against unexpected coupling, not new coverage.
 - **Verification:**
-  - The file is still 575 lines, and the sorted multiset of its lines is unchanged from `HEAD` — the strongest single proof that the move added and removed nothing (R2).
+  - **`diff <(git show origin/main:README.md | sort) <(sort README.md)` emits no `<` lines** — the removed set is empty, proving nothing anywhere in the file was dropped or reworded (R2). The `>` lines must contain only the intended navigation: the `## More Install Options` heading, its intro line, the pointer line, one `---`, and blank lines.
+  - All fourteen `### <Platform>` subsections plus `### Existing Installs` appear exactly once each (R2, R6).
   - `## Install`, `### Claude Code`, and both `/plugin` commands appear within the first ~14 source lines (AE1).
+  - Codex App and Codex CLI both sit inside the top `## Install` section — neither is stranded in the overflow (R6).
   - Top-level section order matches the sequence in **Approach** above (AE4).
-  - The file contains exactly two `^---$` horizontal rules, none adjacent to another (R4), and no two consecutive blank lines were introduced at either seam.
-  - Both anchor references still resolve to headings present in the file: `#full-skill-inventory` and `#existing-installs` (R3, AE3).
+  - Every `^---$` rule is blank-fenced on both sides, and no two consecutive blank lines exist anywhere (R4).
+  - All four anchors resolve to exactly one heading each: `#install`, `#existing-installs`, `#full-skill-inventory`, and the new `#more-install-options` (R3, AE3).
   - No two headings share the same text, so no positional `-1`/`-2` slug suffix exists for the reorder to swap (R3, KTD-3's precondition).
-  - `git diff --stat` shows `README.md` as the only changed file, and the diff's added and removed line sets are equal apart from position — no content edits smuggled into the move (R2, AE2).
+  - `git diff --stat` shows `README.md` as the only changed file besides this plan.
   - `bun test` passes and `bun run release:validate` passes.
 
 ---
 
 ## Verification Contract
 
-- **Structural:** Install is the first `##` heading in the file; the identity block precedes it; every other section retains its prior relative order.
-- **Content fidelity:** The file is still 575 lines and its sorted line-multiset is unchanged from `HEAD`. `git diff` on `README.md` shows relocation only — no reworded, added, or dropped lines.
-- **Link integrity:** Both intra-README anchors resolve; no heading text changed and no two headings share text, so no slug is position-dependent and external `#install` deep-links survive.
-- **Rendering:** Exactly two horizontal rules, no doubling, no stray rule left at the vacated position, and no doubled blank line at either seam.
+- **Structural:** Install is the first `##` heading in the file and carries Claude Code, Cursor, Codex App, and Codex CLI; the identity block precedes it; the other eleven subsections sit in `## More Install Options` between `### Full Skill Inventory` and `## Local Development`; every other section retains its prior relative order.
+- **Content fidelity:** The removed set against `origin/main` is empty (`diff <(git show origin/main:README.md | sort) <(sort README.md)` emits no `<` lines), and the added set contains only the intended navigation lines. Every one of the fourteen platform subsections plus `### Existing Installs` is present exactly once, verbatim.
+- **Link integrity:** All four anchors resolve (`#install`, `#existing-installs`, `#full-skill-inventory`, `#more-install-options`); no existing heading text changed and no two headings share text, so no slug is position-dependent and external `#install` deep-links survive.
+- **Rendering:** Three horizontal rules (after Install, before More Install Options, before Local Development), each blank-fenced on both sides, with no doubled blank line at any seam.
 - **Regression:** `bun test` green, `bun run release:validate` green.
 
 ## Definition of Done
 
-- `README.md` opens with the identity block followed immediately by the complete `## Install` section.
-- All fourteen platform install paths and `### Existing Installs` are present and verbatim.
-- Exactly two horizontal rules remain, correctly placed per KTD-4.
-- Both anchor references resolve; no heading text changed.
+- `README.md` opens with the identity block followed immediately by `## Install` carrying Claude Code, Cursor, Codex App, and Codex CLI.
+- The other eleven subsections live verbatim in `## More Install Options`, reachable by one pointer link from the top section.
+- All fourteen platform install paths and `### Existing Installs` are present and verbatim; the removed set against `origin/main` is empty.
+- Three horizontal rules, each blank-fenced on both sides, correctly placed per KTD-2.
+- All four anchors resolve; no existing heading text changed.
 - `bun test` and `bun run release:validate` pass.
 - The change lands as a single `docs(readme):` commit on a feature branch via PR (README.md is docs-only per the repo's commit conventions; the intent is reordering documentation, not changing product behavior).
 
@@ -150,9 +163,11 @@ Headless run (LFG pipeline) — the scoping confirmation was skipped, so the inf
 
 ## Open Questions
 
-### OQ1. Should Install be split rather than moved whole?
+### OQ1. Should Install be split rather than moved whole? — **RESOLVED: yes, split (2026-07-15).**
 
-**Not a blocker.** The plan proceeds on the literal instruction — move the section — and this question is recorded so the reviewer can redirect on the PR rather than discover the tradeoff after merge.
+**Resolution.** Raised by document review, recorded here rather than acted on unilaterally, and **the user redirected to the split on PR #1146**: lead with Claude Code, Cursor, and Codex; link to the rest below. That is what this plan now specifies (R6, KTD-2, U1). The question is kept rather than deleted because the reasoning below is why the redirect was the right call — and because it is a worked example of the mechanism paying off: surfacing a tradeoff instead of burying it let the user correct the approach before merge, at the cost of one review cycle.
+
+The original framing follows.
 
 Document review raised a sharper alternative than either arm this plan considered, and **re-deriving against the current base inverted the arithmetic in its favor.** The observation: only **R1** is load-bearing ("a visitor sees how to install"), and `### Claude Code`'s two commands (~8 lines) satisfy it by themselves. The other thirteen platform paths are what create the cost.
 
@@ -173,7 +188,7 @@ Why it is not the plan of record:
 - It has its own cost: install guidance would live in two places, which is worse for the thirteen non-Claude platforms — they would land on a top section that does not contain their instructions.
 - The plan's whole premise (**A5**) is already an unvalidated bet on visitor intent. Layering a second unvalidated bet — that splitting reads better than moving — on top of it compounds the guess rather than reducing it.
 
-If the reviewer wants the split, the cheapest path is to amend A2/KTD-2/R2 and the stop condition, then re-scope U1 into two units (extract Claude Code; relocate the remainder). Nothing in this plan forecloses that — the move is trivially revertable.
+**What actually changed on adoption:** A2 superseded, A4 dissolved, R2 narrowed to "verbatim instructions, navigation may be added," R6 added, KTD-2 rewritten, the Goal Capsule stop condition adjusted, and U1 re-scoped. One unit still, not two — the split is a single coherent edit. The user's choice of **three** platforms rather than review's suggested one is the better call: Cursor and Codex are first-class targets, and Codex's App and CLI surfaces stay together so no Codex user lands on a section missing their instructions.
 
 ### OQ2. What signal would trigger revisiting the ordering?
 
@@ -183,15 +198,18 @@ The first entry under **Risks** accepts the below-the-fold cost as "reversible, 
 
 ## Risks
 
-- **The "what is this?" content moves below the fold — measurably further than Install is buried today.** A first-time visitor who does not yet want the plugin now meets ~297 lines of install matrix before Philosophy (line 304, 53% down, vs Install's current line 150, 26% down). This is the accepted tradeoff of the explicit ask ("to really focus on that") and it is cheap to reverse, but the re-derived numbers make it a sharper cost than the first draft implied. OQ1 carries the alternative that would eliminate it. *Severity: medium — reversible and intended, but no longer a small cost.*
-- **Monotonic worsening.** Each new platform path lengthens the block now sitting at the top. Three landed during this plan's drafting alone. Without OQ2's trigger, nothing prompts a revisit. *Severity: low now, rising.*
-- **Silent content edit inside the moved block.** A 297-line cut-and-paste is the one way this change could do real damage. The sorted-multiset equality check in U1's Verification is the specific guard. *Severity: low, given the check.*
-- **Line-number rot.** Every span is pinned to `origin/main` = `1f29eabc`. This already bit once mid-drafting. KTD-4's content-anchored override is the mitigation. *Severity: low, given the override.*
+- **~~The "what is this?" content moves below the fold~~ — resolved by the OQ1 split.** The whole-block move would have put `## Philosophy` at line 304 (53% down), deeper than `## Install` was buried at 150 (26%). Leading with three platforms puts Philosophy at **17% down** — shallower than the status quo — so this is no longer a cost the change imposes. Retained as a record of why the split was adopted rather than the literal move. *Severity: resolved.*
+- **Split-boundary staleness.** The top three are a judgment about which platforms most users want, frozen at a moment in time. If Cursor or Codex fades, or a new host becomes primary, the boundary is wrong and nothing signals it. Cheap to move a subsection across the boundary; nothing prompts anyone to. *Severity: low, and now the plan's main open risk.*
+- **Install guidance lives in two places.** A user on one of the eleven overflow platforms lands on a top section that does not contain their instructions and must follow the pointer. The pointer names all eleven explicitly so in-page find still hits the platform name at the top, which is the mitigation — but it is one hop, not zero. This is the cost the split trades for; the whole-block move had no such hop. *Severity: low.*
+- **Silent content edit inside the moved block.** A 204-line cut-and-paste is the one way this change could do real damage. The empty-removed-set check against `origin/main` in U1's Verification is the specific guard — stronger than the line-count and multiset checks a split invalidates. *Severity: low, given the check.*
+- **Monotonic worsening is now bounded, not eliminated.** Each new platform lengthens the overflow section rather than the top, so the front page no longer grows with the target matrix. That was the structural fix; OQ2's revisit trigger matters less as a result. *Severity: low.*
+- **Line-number rot.** Every span in this plan is pinned to `origin/main` = `1f29eabc`. This already bit once mid-drafting, which is why U1's Approach resolves spans by content anchor rather than number. *Severity: low, given the override.*
 
 ## Sources & Research
 
 - `README.md` at `origin/main` = `1f29eabc` — current structure: 575 lines; `## Install` at 150-443; horizontal rules at 148 and 445; `## Getting Started` at 107 opening with "After installing…"; `### Full Skill Inventory` at 113; 30 inventory rows; fourteen platform subsections; 33 headings, all textually unique.
-- Cut simulation (`149-445` → insert after line 5) — verified: 575 lines preserved, sorted line-multiset identical to `HEAD`, `/plugin` commands at lines 12-13, rules at 302 and 445, zero consecutive blank-line pairs, `## Philosophy` at 304. Also verified the two rejected ranges produce the artifacts KTD-4 describes.
+- Whole-block cut simulation (`149-445` → insert after line 5) — verified: 575 lines preserved, sorted line-multiset identical to `HEAD`, `/plugin` commands at lines 12-13, `## Philosophy` at 304 (53% down). Also verified the two rejected ranges produce the artifacts KTD-4 describes. This shape shipped first, then was superseded by the split per OQ1.
+- Split execution (top three + `## More Install Options`) — verified on the working tree: **removed set against `origin/main` is empty** (nothing dropped or reworded anywhere); added set is exactly 8 lines (the heading, its intro, the pointer, one `---`, and blanks); all fourteen platform subsections plus `### Existing Installs` present exactly once; 34 headings with zero duplicate text; all four anchors resolve; three rules each blank-fenced; zero consecutive blank pairs; `## Philosophy` at 102/583 = **17% down**. `bun test` 2087 pass / 0 fail; `release:validate` in sync.
 - Anchor-reference grep (`*.md`, `*.ts`, `*.json`, `*.yaml`) — exactly two README anchor references exist, both intra-file (line 56, line 159); no file outside `docs/plans/` deep-links a README anchor. Supports KTD-3 and R3.
 - Test-coupling grep — no test asserts README content or section order; `src/release/components.ts` maps `README.md` to the `compound-engineering` release component by path only. Supports U1's `Test expectation: none`.
 - Directional-language grep — the only positional claim in the README is line 56's "The complete inventory is [below](#full-skill-inventory)", which remains accurate (`### Full Skill Inventory` stays below line 56).


### PR DESCRIPTION
## What

The README opened with Philosophy, Workflow, Quick Example, and a 30-row skill inventory, placing `## Install` at line 150 (~26% down a 575-line file). Someone who already wanted the plugin scrolled past ~146 lines to reach `/plugin marketplace add`.

Now `## Install` sits directly beneath the H1, badge, and tagline, carrying the **three primary platforms** — Claude Code, Cursor, and Codex. The two Claude Code commands land at **lines 12-13**. The other eleven subsections plus `### Existing Installs` move verbatim into a new `## More Install Options` section above Local Development, reachable by one pointer link.

## Why three and not all fourteen

Moving the whole block first (commit 3629005) traded one burial for a worse one:

| | Position | Depth |
|---|---|---|
| `## Install` originally | line 150 | 26% down |
| `## Philosophy` after a whole-block move | line 304 | **53% down** |
| `## Philosophy` after this split | line 102 | **17% down** |

Fourteen platform paths is ~297 lines of front matter, and the matrix **grew from eleven to fourteen while this was being written** (Cline, Grok Build CLI, Devin CLI landed). Leading with everything would have buried the "what is this" content twice as deep as the install content it rescued, and gotten worse with every new target.

Leading with three costs ~90 lines. Philosophy now sits **shallower than Install itself originally did**, so putting install first no longer costs the orientation content anything — and the overflow section absorbs future platforms instead of the front page.

**Codex is one platform with two surfaces.** Codex App and Codex CLI both stay at the top; splitting them would land a Codex App user on a section that does not contain their instructions.

**Why a link rather than `<details>`:** collapsing the other platforms was the obvious alternative, but GitHub's in-page find does not search collapsed `<details>` content — it would have hurt discoverability for eleven platforms. The pointer line names all eleven explicitly, so Ctrl+F still hits your platform at the top.

## Why it's safe

Not a pure relocation anymore (a heading, an intro, and a pointer are new), so the proof is a stricter one:

- **The removed set against `main` is empty.** `diff <(git show origin/main:README.md | sort) <(sort README.md)` emits **no `<` lines** — nothing anywhere in the file was dropped or reworded. The added set is exactly **8 lines**: the heading, its intro, the pointer, one `---`, and blanks.
- **All fourteen platform subsections plus `### Existing Installs` present exactly once**, worded identically.
- **Anchors survive.** All 34 headings are textually unique, so no slug is position-dependent (GitHub only adds positional `-1`/`-2` suffixes to duplicate heading text). `#install`, `#existing-installs`, `#full-skill-inventory`, and the new `#more-install-options` all resolve — including external deep-links to `#install`.
- **Clean rendering.** Three horizontal rules, each blank-fenced on both sides; zero consecutive blank lines.
- `bun test` 2087 pass / 0 fail; `bun run release:validate` in sync.

**Side benefit:** `## Getting Started` opens with "After installing, run `/ce-setup`" — it previously sat *above* the install instructions. That now reads correctly.

## Notes

- The plan (`docs/plans/2026-07-15-001-docs-readme-install-first-plan.md`) records this as **OQ1, resolved**: review raised the split, recorded it rather than deciding unilaterally, and it was adopted on redirect. The amended assumptions (A2 superseded, A4 dissolved) are marked in place rather than rewritten away.
- **A5** still stands as the honest caveat: the premise — that the dominant visitor already intends to install rather than arriving from a linked article to evaluate — is an unvalidated bet.
- The remaining open risk is **split-boundary staleness**: "top three" is a judgment frozen at a moment in time, and nothing signals when it stops being true.
- Branch cut from fresh `origin/main` (`1f29eabc`) per the repo's `stale-local-base-contamination` learning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
