### PR TITLE
fix(ce-doc-review): show bulk preview before confirmation

### DIFF
--- a/skills/ce-doc-review/references/bulk-preview.md
+++ b/skills/ce-doc-review/references/bulk-preview.md
@@ -81,7 +81,14 @@ When no `why_it_matters` is available for a finding (rare — only if persona ou
 
 ## Question and options
 
-After the preview body is rendered, ask the user using the platform's blocking question tool (`AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension)). In Claude Code, the tool should already be loaded from the Interactive-mode pre-load step — if it isn't, call `ToolSearch` with query `select:AskUserQuestion` now. The text fallback below applies only when the harness genuinely lacks a blocking tool — `ToolSearch` returns no match, the tool call explicitly fails, or the runtime mode does not expose it (e.g., Codex edit modes without `request_user_input`). A pending schema load is not a fallback trigger. Never silently skip the question.
+Treat the preview and its confirmation as two ordered user-facing events:
+
+1. **Preview event** — emit the complete preview body as user-visible assistant text in the conversation. Content composed only in hidden thinking or reasoning does not count. Do not place the preview only inside the question interface's input.
+2. **Decision event** — after the preview event is visible, invoke the harness's agent-callable blocking-question capability and wait for the answer. Success means the user can see the preview while choosing `Proceed` or `Cancel`, and the workflow does not continue until they answer.
+
+If the preview event has not occurred, do not invoke the blocking-question capability. If the harness exposes no such capability or the call errors, preserve the same interaction as visible chat: put the numbered `Proceed` / `Cancel` options immediately below the visible preview and wait for the user's reply. Never omit the preview or continue silently.
+
+**Non-exhaustive adapters:** `AskUserQuestion` in Claude Code, `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), and `ask_user` in Pi with the `pi-ask-user` extension. In Claude Code, `AskUserQuestion` should already be loaded from the Interactive-mode pre-load step; if it is not, call `ToolSearch` with query `select:AskUserQuestion` now. A pending schema load is not a fallback trigger.
 
 Stem (adapted to the path):
 
@@ -93,8 +100,6 @@ Options (exactly two, in all three cases):
 
 - `Proceed` — execute the plan as shown
 - `Cancel` — do nothing, return to the originating question
-
-Only when `ToolSearch` explicitly returns no match or the tool call errors — or on a platform with no blocking question tool — fall back to presenting numbered options and waiting for the user's next reply.
 
 ---
 

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -580,6 +580,20 @@ describe("ce-doc-review contract", () => {
     expect(bulkPreview).toContain("Appending to Open Questions (N):")
     expect(bulkPreview).toContain("Skipping (N):")
 
+    // The preview and question are two ordered user-facing events. The
+    // portable contract names the capability before non-exhaustive adapters.
+    const previewEvent = bulkPreview.indexOf("Preview event")
+    const questionCapability = bulkPreview.indexOf(
+      "agent-callable blocking-question capability"
+    )
+    const adapters = bulkPreview.indexOf("Non-exhaustive adapters")
+    expect(previewEvent).toBeGreaterThan(-1)
+    expect(questionCapability).toBeGreaterThan(previewEvent)
+    expect(adapters).toBeGreaterThan(questionCapability)
+    expect(bulkPreview).toContain("user-visible assistant text")
+    expect(bulkPreview).toMatch(/(?:thinking|reasoning).*does not count/)
+    expect(bulkPreview).toContain("do not invoke the blocking-question capability")
+
     // No Acknowledge bucket in bulk preview either
     expect(bulkPreview).not.toContain("Acknowledging (N):")
   })


### PR DESCRIPTION
## Summary

`ce-doc-review` bulk actions now emit the complete proposed plan as visible assistant output before asking the user to proceed or cancel. Previously, the preview could remain in hidden model reasoning while the blocking prompt referred to a "plan above," leaving the user with nothing to inspect.

The interaction contract is capability-first across harnesses: it defines the observable blocking behavior and visible-chat fallback before listing tool-specific adapters. A focused contract test pins the preview-before-question ordering and prevents hidden reasoning from satisfying the visibility requirement.

Fixes #1147.

## Validation

- `bun test tests/pipeline-review-contract.test.ts` (40 passed)
- `bun test` (2,186 passed)
- `bun run release:validate`
- An isolated Claude Fable probe emitted the preview visibly; the complete `AskUserQuestion` round trip was not exercised because the probe exceeded its budget.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
