### PR TITLE
fix(review): keep cross-model schemas strict-compatible

### DIFF
--- a/CONCEPTS.md
+++ b/CONCEPTS.md
@@ -84,6 +84,9 @@ A delegated worker process launched into its own session so it outlives the shel
 
 The launching call returns as soon as the job exists; supervision (idle and hard limits, process-tree reaping) runs inside the detached worker, while the caller keeps its own aggregate deadline and proceeds without the job when that passes. A job publishes exactly one terminal record, atomically, and nothing in the detached path may prompt for input.
 
+### Cross-model pass
+An additive delegated run that sends the host workflow's review or judgment brief through a different model-provider route and folds the structured result back into the host's synthesis. It stays non-blocking when the peer cannot run, and it counts as independent corroboration only when the serving model family can be verified rather than merely requested.
+
 ### Model identity receipt
 The serving backend's own report of which model actually handled a delegated run, recorded alongside the requested model so the two can disagree visibly. A run's model identity is verified only by such a receipt — never by the request parameters or the model's own text — and outputs without one are labeled as requested-but-unverified; logic that weights cross-model agreement follows the receipt, not the request.
 

--- a/docs/solutions/integration-issues/portable-structured-output-schemas-across-model-clis.md
+++ b/docs/solutions/integration-issues/portable-structured-output-schemas-across-model-clis.md
@@ -1,0 +1,77 @@
+---
+title: Keep structured-output schemas portable across model CLIs
+date: 2026-07-15
+category: integration-issues
+module: cross-model structured output
+problem_type: integration_issue
+component: tooling
+severity: medium
+symptoms:
+  - A cross-model reviewer exits before model invocation when the target CLI rejects the supplied structured-output schema.
+  - The parent workflow can finish without peer findings when provider startup diagnostics are hidden or truncated.
+root_cause: wrong_api
+resolution_type: code_fix
+tags:
+  - cross-model
+  - structured-output
+  - json-schema
+  - schema-portability
+  - provider-cli
+  - startup-errors
+---
+
+# Keep structured-output schemas portable across model CLIs
+
+## Problem
+
+Structured-output schemas that cross model CLI or harness boundaries are API contracts, not arbitrary JSON containers: they must stay within the target validator's supported schema draft and vocabulary. In this incident, human-only metadata embedded beside schema keywords caused Claude to reject the request at startup, before the peer model could review anything.
+
+## Symptoms
+
+- The cross-model workers pass their schema as one `--json-schema` argument to Claude and Grok, so a schema startup rejection prevents the route from reaching inference (`skills/ce-code-review/scripts/cross-model-adversarial-review.sh:182-197`, `skills/ce-doc-review/scripts/cross-model-doc-review.sh:197-212`, `skills/ce-pov/scripts/cross-model-pov.sh:193-206`).
+- An observed Claude Code 2.1.211 probe rejected both the incident's `_meta` member and an unrelated `x-meta` member with `strict mode: unknown keyword`. The original code-review schema from `HEAD` failed; the current schema with the extension removed reached and succeeded through structured output.
+- The rejection was independent of response serialization: default output and `--output-format text`, `json`, and `stream-json` all remained strict whenever `--json-schema` was present. Omitting `--json-schema` avoided startup validation, but returned prompt-only or fenced JSON and forfeited schema-validated output.
+- Standard annotations and constraints were not rejected wholesale in the probe: `$comment`, `default`, `examples`, string constraints, and numeric constraints all passed startup. The issue was schema-vocabulary portability, not a blanket prohibition on descriptive schema content.
+- The startup failure could also look like a silent empty peer result. The code- and doc-review skip paths captured stderr, but their old unconditional negative-offset slice erased messages shorter than 300 characters on the shipped macOS Bash; the current guarded form makes the slice only for longer strings (`skills/ce-code-review/scripts/cross-model-adversarial-review.sh:645-660`, `skills/ce-doc-review/scripts/cross-model-doc-review.sh:739-754`).
+
+## What Didn't Work
+
+- Treating a declared JSON Schema as an extensible metadata envelope. A custom member may be harmless to a permissive validator yet be an unknown keyword to a strict provider validator; changing its spelling from `_meta` to another extension such as `x-meta` does not solve that boundary mismatch.
+- Trying a different Claude output mode. The CLI validates the `--json-schema` payload before response formatting matters. [Anthropic's Agent SDK structured-output contract](https://code.claude.com/docs/en/agent-sdk/structured-outputs#output-format-configuration) likewise says invalid schemas fail the run at startup in current releases.
+- Removing `--json-schema` as the workaround. That makes invocation more permissive only by abandoning the validated structured-output guarantee that these workers depend on before publishing a fold-in artifact.
+- Auditing only the launcher that produced the incident. The repository has three workers that send raw schemas through this boundary, and all three bind file contents directly to `SCHEMA_REF` (`skills/ce-code-review/scripts/cross-model-adversarial-review.sh:267-274`, `skills/ce-doc-review/scripts/cross-model-doc-review.sh:306-313`, `skills/ce-pov/scripts/cross-model-pov.sh:313-320`).
+- Capturing an error without testing that short errors remain visible. An expression such as `${value: -300}` asks Bash to start 300 characters from the end; when the string is shorter than that on the affected Bash, the start falls before the string and the expansion is empty.
+
+## Solution
+
+1. Keep the transported artifact a strict schema. Remove custom human-only extension members from the canonical schema and place calibration or operating guidance in standard schema annotations, the model prompt/persona, or a separate non-schema artifact. The current code-review schema keeps its five confidence anchors in the standard `description` for the `confidence` property rather than in a sibling extension object (`skills/ce-code-review/references/findings-schema.json:72-76`).
+2. Guard every cross-model schema, not only the one involved in the incident. The contract test recursively distinguishes draft-07 keywords from extension keywords (`tests/review-skill-contract.test.ts:9-118`) and applies the check to the code-review, doc-review, and POV schemas while also pinning their declared draft (`tests/review-skill-contract.test.ts:265-274`).
+3. Preserve the structured-output route. The workers continue to pass the complete multi-line schema as one argument; the code-review route test additionally proves that the transported object has no `_meta` member (`tests/skills/ce-code-review-cross-model-routes.test.ts:697-712`), while the doc-review route test protects the one-token argv behavior (`tests/skills/ce-doc-review-cross-model-routes.test.ts:752-774`).
+4. Surface startup diagnostics without turning an optional peer failure into a hard failure. For code review and doc review, normalize newlines, slice only when the captured text is longer than 300 characters, and then log the remaining text (`skills/ce-code-review/scripts/cross-model-adversarial-review.sh:652-660`, `skills/ce-doc-review/scripts/cross-model-doc-review.sh:746-754`). POV already uses the same length guard (`skills/ce-pov/scripts/cross-model-pov.sh:687-695`). Functional route tests now pin visibility of a short stderr message for both repaired workers (`tests/skills/ce-code-review-cross-model-routes.test.ts:388-397`, `tests/skills/ce-doc-review-cross-model-routes.test.ts:444-458`).
+
+## Why This Works
+
+The schemas now contain only vocabulary that the cross-model contract admits, while human guidance remains available through standard annotations or prompt-layer material. This preserves provider-enforced structured output instead of trading correctness for a prompt-only JSON convention.
+
+The recursive guard catches extensions at nested schema positions as well as the root, and its three-schema loop prevents a fix from being local to only one consumer. It is a deterministic portability baseline; direct CLI startup probes remain necessary because a provider can support a stricter subset than the nominal draft.
+
+The diagnostic guard fixes the separate observability failure because short strings bypass negative slicing and are logged intact, while strings over 300 characters still receive the bounded tail. Peer startup failures therefore remain non-blocking but no longer masquerade as unexplained no-findings results.
+
+## Prevention
+
+- Treat every schema passed to an external model CLI as a wire-format contract. Target the strictest supported vocabulary shared by the actual providers, not the most permissive behavior of a local JSON Schema library.
+- Keep custom human metadata out of transported schemas. Put it in standard annotations only when it genuinely describes the output field; otherwise use prompt/persona prose or a separate artifact.
+- Maintain a recursive mechanical guard over every cross-model schema consumer. When a new consumer or schema is added, add it to the shared loop rather than creating a one-off exception.
+- Smoke-test the exact production schema against each relevant installed CLI, including startup. Probe custom keywords and representative standard annotations separately so a provider-vocabulary failure is not misdiagnosed as a specific field-name bug.
+- Do not assume `--output-format` changes schema validation. Test schema acceptance and response serialization as separate contracts, and do not drop structured validation merely to make startup pass.
+- Assert failure-path observability with short and long stdout/stderr fixtures. Any bounded-tail implementation should prove that short messages survive intact and long messages are clipped, especially on the oldest supported Bash.
+
+## Related Issues
+
+- [OpenCode converter emits a temperature that Sonnet 5 / Opus 4.8 reject](../integrations/opencode-temperature-rejected-by-sonnet5-opus48.md) — the same provider-boundary compatibility pattern applied to sampling parameters rather than schema vocabulary.
+- [Don't pre-resolve fallible context with Claude-only load-time commands](../skill-design/no-load-time-pre-resolution-for-fallible-context.md) — another stricter-runtime, fail-before-execution portability bug.
+- [Portable agent skill authoring](../skill-design/portable-agent-skill-authoring.md) — the umbrella rule for verifying load-bearing behavior in the actual target harness.
+- [Cross-harness cross-model tool invocation](../skill-design/cross-harness-cross-model-tool-invocation.md) — the sibling empirical verification pattern for cross-harness mechanics.
+- [CE doc-review calibration patterns](../skill-design/ce-doc-review-calibration-patterns.md) — distinguishes model output conformance from CLI acceptance of the input schema.
+- [Issue #835](https://github.com/EveryInc/compound-engineering-plugin/issues/835) — adjacent cross-model review output differences, not the same startup-validation failure.
+- [Issue #1115](https://github.com/EveryInc/compound-engineering-plugin/issues/1115) — adjacent provider-routing work on the same cross-model launcher surface.

--- a/skills/ce-code-review/references/findings-schema.json
+++ b/skills/ce-code-review/references/findings-schema.json
@@ -97,41 +97,5 @@
       "description": "Missing test coverage the reviewer identified",
       "items": { "type": "string" }
     }
-  },
-
-  "_meta": {
-    "confidence_anchors": {
-      "description": "Confidence is one of 5 discrete anchors (0, 25, 50, 75, 100), each tied to a behavioral criterion the reviewer can honestly self-apply. Float values (e.g., 0.73) are not valid -- the model cannot meaningfully calibrate at finer granularity, and discrete anchors prevent false-precision gaming.",
-      "0": "False positive or pre-existing -- do not report",
-      "25": "Speculative; could not verify -- do not report",
-      "50": "Verified real but minor or stylistic -- report only when P0 or when synthesis routes to advisory/soft buckets",
-      "75": "Highly confident, will affect users or runtime in normal usage -- report",
-      "100": "Verifiable from code alone (compile error, type mismatch, definitive logic bug, quoted standards violation) -- report"
-    },
-    "confidence_thresholds": {
-      "suppress": "Below anchor 75 -- do not report. Exception: P0 findings at anchor 50+ may be reported (critical-but-uncertain issues must not be silently dropped).",
-      "report": "Anchor 75 or 100 -- include with full evidence."
-    },
-    "severity_definitions": {
-      "P0": "Critical breakage, exploitable vulnerability, data loss/corruption. Must fix before merge.",
-      "P1": "High-impact defect likely hit in normal usage, breaking contract. Should fix.",
-      "P2": "Moderate issue with meaningful downside (edge case, perf regression, maintainability trap). Fix if straightforward.",
-      "P3": "Low-impact, narrow scope, minor improvement. User's discretion."
-    },
-    "autofix_classes": {
-      "gated_auto": "Concrete suggested_fix proposed. Caller may apply after judgment — not by this skill.",
-      "manual": "Actionable issue requiring design decisions or cross-cutting changes.",
-      "advisory": "Informational or operational item for the report only."
-    },
-    "owners": {
-      "downstream-resolver": "Caller or human should act after review.",
-      "human": "Judgment required before implementation.",
-      "release": "Operational or rollout follow-up."
-    },
-    "return_tiers": {
-      "description": "Finding fields are split into two tiers. The full schema (with all required fields) applies to the artifact file on disk. The compact return to the orchestrator omits detail-tier fields. Both are valid uses of this schema in different contexts.",
-      "merge_tier": "Returned to orchestrator: title, severity, file, line, confidence, autofix_class, owner, requires_verification, pre_existing, suggested_fix (optional), first_evidence (required for anchor 75/100; the verbatim first evidence line, used to enforce the quote-the-line gate in-band). Plus top-level reviewer, residual_risks, testing_gaps.",
-      "detail_tier": "Required in artifact file, omitted from compact return: why_it_matters, and the full evidence array (the compact return carries only first_evidence). The artifact file must pass full schema validation including all required fields. Headless output depends on why_it_matters and evidence being present in the artifact."
-    }
   }
 }

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -650,10 +650,14 @@ run_provider() {
     # stdout (grok's 402) or stderr (claude/cursor auth/quota). Bash builtins only
     # (the route sandbox has no tail/tr); both are small on a failed route.
     if [ -s "$PEERLOG" ]; then
-      _pt="$(< "$PEERLOG")"; _pt="${_pt//$'\n'/ }"; log "  peer skip evidence: ${_pt: -300}"
+      _pt="$(< "$PEERLOG")"; _pt="${_pt//$'\n'/ }"
+      [ "${#_pt}" -gt 300 ] && _pt="${_pt: -300}"
+      log "  peer skip evidence: $_pt"
     fi
     if [ -s "$PEERERR" ]; then
-      _pe="$(< "$PEERERR")"; _pe="${_pe//$'\n'/ }"; log "  peer skip evidence (stderr): ${_pe: -300}"
+      _pe="$(< "$PEERERR")"; _pe="${_pe//$'\n'/ }"
+      [ "${#_pe}" -gt 300 ] && _pe="${_pe: -300}"
+      log "  peer skip evidence (stderr): $_pe"
     fi
     rm -f "$OUT" "$RAW_OUT"
   fi

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -744,10 +744,14 @@ run_provider() {   # <provider>
     # stdout (grok's 402) or stderr (claude/cursor auth/quota). Bash builtins only
     # (the route sandbox has no tail/tr); both are small on a failed route.
     if [ -s "$PEERLOG" ]; then
-      _pt="$(< "$PEERLOG")"; _pt="${_pt//$'\n'/ }"; log "  peer skip evidence: ${_pt: -300}"
+      _pt="$(< "$PEERLOG")"; _pt="${_pt//$'\n'/ }"
+      [ "${#_pt}" -gt 300 ] && _pt="${_pt: -300}"
+      log "  peer skip evidence: $_pt"
     fi
     if [ -s "$PEERERR" ]; then
-      _pe="$(< "$PEERERR")"; _pe="${_pe//$'\n'/ }"; log "  peer skip evidence (stderr): ${_pe: -300}"
+      _pe="$(< "$PEERERR")"; _pe="${_pe//$'\n'/ }"
+      [ "${#_pe}" -gt 300 ] && _pe="${_pe: -300}"
+      log "  peer skip evidence (stderr): $_pe"
     fi
     rm -f "$OUT" "$RAW_OUT"
   fi

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -57,6 +57,14 @@ let sharedSha: string
 let localOnlySha: string
 let upstreamOnlySha: string
 
+function mixedShaPrefix(sha: string): string {
+  for (let length = 7; length <= sha.length; length++) {
+    const prefix = sha.slice(0, length)
+    if (/\d/.test(prefix) && /[a-f]/.test(prefix)) return prefix
+  }
+  throw new Error(`commit SHA has no mixed digit/letter prefix: ${sha}`)
+}
+
 beforeAll(() => {
   repo = mkdtempSync(path.join(tmpdir(), "doc-claims-repo-"))
   sh(repo, "git", ["init", "-b", "main"])
@@ -123,7 +131,7 @@ describe("validate-doc-claims script", () => {
       test("passes a clean doc citing an existing path and a shared SHA", () => {
         const docPath = writeRepoDoc(
           "The fix lives in `src/real-file.ts` and landed in commit " +
-            `${sharedSha.slice(0, 12)}.\n` +
+            `${mixedShaPrefix(sharedSha)}.\n` +
             "See [the existing doc](existing-doc.md) for background.\n",
         )
         const result = runValidator(skillDir, docPath)
@@ -192,23 +200,25 @@ describe("validate-doc-claims script", () => {
       })
 
       test("flags a HEAD-only SHA as rewritable on merge", () => {
+        const sha = mixedShaPrefix(localOnlySha)
         const docPath = writeRepoDoc(
-          `Landed in ${localOnlySha.slice(0, 12)} on this branch.\n`,
+          `Landed in ${sha} on this branch.\n`,
         )
         const result = runValidator(skillDir, docPath)
         expect(result.code).toBe(1)
-        expect(result.stdout).toContain(`FLAG sha ${localOnlySha.slice(0, 12)}`)
+        expect(result.stdout).toContain(`FLAG sha ${sha}`)
         expect(result.stdout).toContain("local-only commit")
       })
 
       test("flags an upstream-only SHA as predating-the-merge (the stale-branch bug)", () => {
+        const sha = mixedShaPrefix(upstreamOnlySha)
         const docPath = writeRepoDoc(
-          `Fixed by ${upstreamOnlySha.slice(0, 12)} which merged upstream.\n`,
+          `Fixed by ${sha} which merged upstream.\n`,
         )
         const result = runValidator(skillDir, docPath)
         expect(result.code).toBe(1)
         expect(result.stdout).toContain(
-          `FLAG sha ${upstreamOnlySha.slice(0, 12)}`,
+          `FLAG sha ${sha}`,
         )
         expect(result.stdout).toContain("predates the merge")
       })

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -6,6 +6,117 @@ async function readRepoFile(relativePath: string): Promise<string> {
   return readFile(path.join(process.cwd(), relativePath), "utf8")
 }
 
+const STRICT_SCHEMA_KEYWORDS = new Set([
+  "$comment",
+  "$id",
+  "$ref",
+  "$schema",
+  "additionalItems",
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "const",
+  "contains",
+  "contentEncoding",
+  "contentMediaType",
+  "default",
+  "definitions",
+  "dependencies",
+  "description",
+  "else",
+  "enum",
+  "examples",
+  "exclusiveMaximum",
+  "exclusiveMinimum",
+  "format",
+  "if",
+  "items",
+  "maxItems",
+  "maxLength",
+  "maxProperties",
+  "maximum",
+  "minItems",
+  "minLength",
+  "minProperties",
+  "minimum",
+  "multipleOf",
+  "not",
+  "oneOf",
+  "pattern",
+  "patternProperties",
+  "properties",
+  "propertyNames",
+  "readOnly",
+  "required",
+  "then",
+  "title",
+  "type",
+  "uniqueItems",
+  "writeOnly",
+])
+
+function extensionSchemaKeywords(schema: unknown, location = "$."): string[] {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return []
+
+  const record = schema as Record<string, unknown>
+  const extensions = Object.keys(record)
+    .filter((key) => !STRICT_SCHEMA_KEYWORDS.has(key))
+    .map((key) => `${location}${key}`)
+
+  for (const container of ["properties", "patternProperties", "definitions"] as const) {
+    const children = record[container]
+    if (children && typeof children === "object" && !Array.isArray(children)) {
+      for (const [name, child] of Object.entries(children)) {
+        extensions.push(...extensionSchemaKeywords(child, `${location}${container}.${name}.`))
+      }
+    }
+  }
+
+  for (const keyword of [
+    "additionalItems",
+    "additionalProperties",
+    "contains",
+    "else",
+    "if",
+    "not",
+    "propertyNames",
+    "then",
+  ] as const) {
+    if (typeof record[keyword] === "object") {
+      extensions.push(...extensionSchemaKeywords(record[keyword], `${location}${keyword}.`))
+    }
+  }
+
+  const items = record.items
+  if (Array.isArray(items)) {
+    items.forEach((item, index) => {
+      extensions.push(...extensionSchemaKeywords(item, `${location}items[${index}].`))
+    })
+  } else if (items) {
+    extensions.push(...extensionSchemaKeywords(items, `${location}items.`))
+  }
+
+  for (const keyword of ["allOf", "anyOf", "oneOf"] as const) {
+    const alternatives = record[keyword]
+    if (Array.isArray(alternatives)) {
+      alternatives.forEach((alternative, index) => {
+        extensions.push(...extensionSchemaKeywords(alternative, `${location}${keyword}[${index}].`))
+      })
+    }
+  }
+
+  const dependencies = record.dependencies
+  if (dependencies && typeof dependencies === "object" && !Array.isArray(dependencies)) {
+    for (const [name, dependency] of Object.entries(dependencies)) {
+      if (!Array.isArray(dependency)) {
+        extensions.push(...extensionSchemaKeywords(dependency, `${location}dependencies.${name}.`))
+      }
+    }
+  }
+
+  return extensions
+}
+
 function personaPromptPath(personaName: string): string {
   return `skills/ce-code-review/references/personas/${personaName}.md`
 }
@@ -114,10 +225,6 @@ describe("ce-code-review contract", () => {
       "skills/ce-code-review/references/findings-schema.json",
     )
     const schema = JSON.parse(rawSchema) as {
-      _meta: {
-        confidence_thresholds: { suppress: string; report: string }
-        confidence_anchors: Record<string, string>
-      }
       properties: {
         findings: {
           items: {
@@ -152,19 +259,18 @@ describe("ce-code-review contract", () => {
     expect(schema.properties.findings.items.properties.confidence.type).toBe("integer")
     expect(schema.properties.findings.items.properties.confidence.enum).toEqual([0, 25, 50, 75, 100])
 
-    // Threshold: anchor 75 (P0 escape at anchor 50)
-    expect(schema._meta.confidence_thresholds.suppress).toContain("anchor 75")
-    expect(schema._meta.confidence_thresholds.suppress).toContain("anchor 50")
-    expect(schema._meta.confidence_thresholds.suppress).toMatch(/P0/)
+  })
 
-    // Behavioral anchors documented for personas
-    expect(schema._meta.confidence_anchors).toBeDefined()
-    expect(schema._meta.confidence_anchors["0"]).toBeDefined()
-    expect(schema._meta.confidence_anchors["25"]).toBeDefined()
-    expect(schema._meta.confidence_anchors["50"]).toBeDefined()
-    expect(schema._meta.confidence_anchors["75"]).toBeDefined()
-    expect(schema._meta.confidence_anchors["100"]).toBeDefined()
-
+  test("keeps extension keywords out of draft-07 cross-model schemas", async () => {
+    for (const schemaPath of [
+      "skills/ce-code-review/references/findings-schema.json",
+      "skills/ce-doc-review/references/findings-schema.json",
+      "skills/ce-pov/references/pov-schema.json",
+    ]) {
+      const schema = JSON.parse(await readRepoFile(schemaPath))
+      expect(schema.$schema).toBe("http://json-schema.org/draft-07/schema#")
+      expect(extensionSchemaKeywords(schema)).toEqual([])
+    }
   })
 
   test("subagent template carries verbatim 5-anchor rubric and lint-ignore suppression", async () => {

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -384,6 +384,17 @@ describe("cross-model-adversarial-review skip paths — non-blocking, no file", 
     expect(run(["claude", "codex", "", runDir], runDir, env).code).toBe(0)
     expect(run(["claude", "codex", "HEAD", "/no/such/run-dir"], runDir, env).files).toHaveLength(0)
   })
+
+  test("surfaces short provider errors without dropping the diagnostic", () => {
+    const { env } = sandbox(
+      ["claude"],
+      "#!/bin/sh\ncat >/dev/null\nprintf '%s' 'schema invalid' >&2\nexit 1\n",
+    )
+    const runDir = makeRunDir()
+    const r = run(["codex", "claude", "HEAD", runDir], runDir, env)
+    expect(r.code).toBe(0)
+    expect(r.stderr).toContain("peer skip evidence (stderr): schema invalid")
+  })
 })
 
 describe("cross-model-adversarial-review normalization", () => {
@@ -698,6 +709,7 @@ describe("cross-model-adversarial-review argv integrity", () => {
     const captured = readFileSync(capFile, "utf8")
     expect(captured).toContain('"$schema"')
     expect(captured).toContain("testing_gaps")
+    expect(JSON.parse(captured)).not.toHaveProperty("_meta")
   })
 
   test("cursor-agent routes receive the prompt via stdin", () => {

--- a/tests/skills/ce-doc-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-doc-review-cross-model-routes.test.ts
@@ -440,6 +440,22 @@ describe("cross-model-doc-review skip paths (R11, R16) — non-blocking, no file
     expect(run(["claude", "codex", "not-a-lens", doc, "plan", "none", runDir], runDir, env).code).toBe(0)
     expect(run(["claude", "codex", "adversarial", "/no/such/doc", "plan", "none", runDir], runDir, env).files).toHaveLength(0)
   })
+
+  test("surfaces short provider errors without dropping the diagnostic", () => {
+    const { env } = sandbox(
+      ["claude"],
+      "#!/bin/sh\ncat >/dev/null\nprintf '%s' 'schema invalid' >&2\nexit 1\n",
+    )
+    const doc = makeDoc()
+    const runDir = makeRunDir()
+    const r = run(
+      ["codex", "claude", "adversarial", doc, "plan", "none", runDir],
+      runDir,
+      env,
+    )
+    expect(r.code).toBe(0)
+    expect(r.stderr).toContain("peer skip evidence (stderr): schema invalid")
+  })
 })
 
 describe("cross-model-doc-review normalization (R18, KTD5)", () => {


### PR DESCRIPTION
## Summary

Cross-model code review no longer exits before inference when Claude validates the structured-output schema in strict mode. The transported schema now stays within draft-07 vocabulary, with a recursive contract guard covering code review, document review, and POV while preserving schema-enforced output. Optional peer startup failures also retain short stderr diagnostics instead of looking like unexplained no-findings results. The provider-boundary rule is captured as a general learning for future cross-model integrations.

## Validation

- `bun test` — 2,189 tests passed
- `bun run release:validate`
- `bun run plugin:validate` — both manifests passed strict Claude validation
- Claude Code 2.1.211 CLI matrix — custom schema keywords failed consistently across output formats; all three current production schemas completed through structured output
