### PR TITLE
fix(ce-brainstorm): check platform aggregators first

### DIFF
--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -173,7 +173,9 @@ If the scan and scout surface nothing relevant, say so and continue. Two rules g
 
 1. **Verify before claiming** — When the brainstorm touches checkable infrastructure (database tables, routes, config files, dependencies, model definitions), read the relevant source files to confirm what actually exists. Any claim that something is absent — a missing table, an endpoint that doesn't exist, a dependency not in the Gemfile, a config option with no current support — must be verified against the codebase first; if not verified, label it as an unverified assumption. This applies to every brainstorm regardless of topic.
 
-2. **Defer design decisions to planning** — Implementation details like schemas, migration strategies, endpoint structure, or deployment topology belong in planning, not here — unless the brainstorm is itself about a technical or architectural decision, in which case those details are the subject of the brainstorm and should be explored.
+2. **Check for aggregation before multiplying integrations** — When the topic involves several devices, providers, data sources, or vendor APIs, verify whether an existing OS, platform, or project-level aggregator already covers them before framing each source as separate product work. Record direct integrations only where the aggregator cannot satisfy a named requirement; do not infer that one connector per vendor is necessary from the vendor list alone.
+
+3. **Defer design decisions to planning** — Implementation details like schemas, migration strategies, endpoint structure, or deployment topology belong in planning, not here — unless the brainstorm is itself about a technical or architectural decision, in which case those details are the subject of the brainstorm and should be explored.
 
 **Slack context** (opt-in, Standard and Deep only) — never auto-dispatch. Route by condition:
 

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -22,6 +22,7 @@ This skill does not implement code. It explores, clarifies, and documents decisi
 4. **Keep implementation out of the Product Contract by default** - Do not include libraries, schemas, endpoints, file layouts, or code-level design unless the brainstorm itself is inherently about a technical or architectural change.
 5. **Right-size the artifact** - Simple work gets a compact requirements-only unified plan or brief alignment. Larger work gets a fuller Product Contract. Do not add ceremony that does not help planning.
 6. **Apply YAGNI to carrying cost, not coding effort** - Prefer the simplest approach that delivers meaningful value. Avoid speculative complexity and hypothetical future-proofing, but low-cost polish or delight is worth including when its ongoing cost is small and easy to maintain.
+7. **Do not turn coverage into decomposition** - For software brainstorms, treat named devices, providers, and data sources as coverage requirements, not automatically as separate integration workstreams. Split them only when a shared access path cannot satisfy a named requirement. Leave connector selection to planning unless that choice materially changes product scope or behavior.
 
 ## Interaction Rules
 
@@ -173,9 +174,7 @@ If the scan and scout surface nothing relevant, say so and continue. Two rules g
 
 1. **Verify before claiming** — When the brainstorm touches checkable infrastructure (database tables, routes, config files, dependencies, model definitions), read the relevant source files to confirm what actually exists. Any claim that something is absent — a missing table, an endpoint that doesn't exist, a dependency not in the Gemfile, a config option with no current support — must be verified against the codebase first; if not verified, label it as an unverified assumption. This applies to every brainstorm regardless of topic.
 
-2. **Check for aggregation before multiplying integrations** — When the topic involves several devices, providers, data sources, or vendor APIs, verify whether an existing OS, platform, or project-level aggregator already covers them before framing each source as separate product work. Record direct integrations only where the aggregator cannot satisfy a named requirement; do not infer that one connector per vendor is necessary from the vendor list alone.
-
-3. **Defer design decisions to planning** — Implementation details like schemas, migration strategies, endpoint structure, or deployment topology belong in planning, not here — unless the brainstorm is itself about a technical or architectural decision, in which case those details are the subject of the brainstorm and should be explored.
+2. **Defer design decisions to planning** — Implementation details like schemas, migration strategies, endpoint structure, or deployment topology belong in planning, not here — unless the brainstorm is itself about a technical or architectural decision, in which case those details are the subject of the brainstorm and should be explored.
 
 **Slack context** (opt-in, Standard and Deep only) — never auto-dispatch. Route by condition:
 

--- a/tests/skills/ce-brainstorm-aggregation-check.test.ts
+++ b/tests/skills/ce-brainstorm-aggregation-check.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+
+const skillPath = path.join(process.cwd(), "skills/ce-brainstorm/SKILL.md")
+
+describe("ce-brainstorm integration aggregation check", () => {
+  test("checks platform aggregators before multiplying vendor integrations", async () => {
+    const skill = await readFile(skillPath, "utf8")
+
+    expect(skill).toContain("Check for aggregation before multiplying integrations")
+    expect(skill).toContain(
+      "verify whether an existing OS, platform, or project-level aggregator already covers them",
+    )
+    expect(skill).toContain(
+      "do not infer that one connector per vendor is necessary from the vendor list alone",
+    )
+  })
+})

--- a/tests/skills/ce-brainstorm-aggregation-check.test.ts
+++ b/tests/skills/ce-brainstorm-aggregation-check.test.ts
@@ -4,16 +4,24 @@ import path from "node:path"
 
 const skillPath = path.join(process.cwd(), "skills/ce-brainstorm/SKILL.md")
 
-describe("ce-brainstorm integration aggregation check", () => {
-  test("checks platform aggregators before multiplying vendor integrations", async () => {
+describe("ce-brainstorm integration scope check", () => {
+  test("treats named sources as coverage before splitting implementation work", async () => {
     const skill = await readFile(skillPath, "utf8")
+    const corePrinciplesStart = skill.indexOf("## Core Principles")
+    const interactionRulesStart = skill.indexOf("## Interaction Rules")
+    const corePrinciples = skill.slice(corePrinciplesStart, interactionRulesStart)
 
-    expect(skill).toContain("Check for aggregation before multiplying integrations")
-    expect(skill).toContain(
-      "verify whether an existing OS, platform, or project-level aggregator already covers them",
+    expect(corePrinciplesStart).toBeGreaterThanOrEqual(0)
+    expect(interactionRulesStart).toBeGreaterThan(corePrinciplesStart)
+    expect(corePrinciples).toContain("Do not turn coverage into decomposition")
+    expect(corePrinciples).toContain(
+      "treat named devices, providers, and data sources as coverage requirements, not automatically as separate integration workstreams",
     )
-    expect(skill).toContain(
-      "do not infer that one connector per vendor is necessary from the vendor list alone",
+    expect(corePrinciples).toContain(
+      "Split them only when a shared access path cannot satisfy a named requirement",
+    )
+    expect(corePrinciples).toContain(
+      "Leave connector selection to planning unless that choice materially changes product scope or behavior",
     )
   })
 })


### PR DESCRIPTION
## Summary

- Treat named devices, providers, and data sources as coverage requirements instead of automatically turning each one into a separate integration workstream.
- Allow separate paths when a shared source cannot satisfy a named requirement.
- Leave connector selection to planning unless it materially changes product scope or behavior.
- Keep the safeguard in the always-loaded core principles so requirements-complete prompts cannot skip it.
- Pin the full contract, including the direct-integration exception, in the regression test.

## Why

A list of sources describes what the product needs to cover. It does not by itself prove that the product needs one connector per source. Making that distinction during brainstorming prevents implementation scope from being invented before the requirements justify it.

The original aggregation check captured the right failure mode. This revision generalizes it beyond a specific platform shape and keeps technical connector verification in planning, where deeper implementation research belongs.

## Verification

- `bun test` (1908 pass, 0 fail)
- `bun run release:validate`
- `git diff --check`
- Fresh behavioral smoke checks covered both sides of the rule:
  - A requirements-complete iPhone recovery prompt used one phone-local data path instead of four vendor connectors.
  - An industrial monitoring prompt retained one-second telemetry and vendor-specific diagnostics when the shared platform could not meet those named requirements.

<details>
<summary>Original contributor description</summary>

## Summary
- verify whether an OS or platform aggregator covers multiple requested data sources before treating them as separate integrations
- require a named unmet requirement before retaining direct vendor connectors
- add a regression test for the instruction contract

## Verification
- `bun test` (1908 pass, 0 fail)
- `bun run release:validate`
- `git diff --check`

</details>
