### PR TITLE
feat(ce-brainstorm): surface the workflow spine as tasks

### DIFF
--- a/docs/solutions/skill-design/cross-harness-cross-model-tool-invocation.md
+++ b/docs/solutions/skill-design/cross-harness-cross-model-tool-invocation.md
@@ -1,7 +1,8 @@
 ---
-title: "Cross-harness/cross-model skills drive agent tool calls, not slash commands — describe the capability, verify it live"
+title: "Cross-harness/cross-model skills drive agent tool calls, not slash commands — describe the capability, verify it by running it"
 category: skill-design
 date: 2026-07-11
+last_updated: 2026-07-16
 module: skills/ce-babysit-pr
 problem_type: design_pattern
 component: tooling
@@ -10,6 +11,7 @@ applies_when:
   - "Authoring a skill, once, for multiple agent harnesses and models where the skill needs the agent to invoke a capability (schedule/loop, ask the user, invoke a sub-skill, run background work, drive a browser)"
   - "Deciding whether to name a specific tool/command in skill prose or describe the capability"
   - "About to assume a particular tool or slash command exists or behaves a certain way on Codex/Grok/Cursor/Claude Code"
+  - "About to accept an agent's own description of its tool schema as verification"
   - "A skill's capability works on the harness/model you authored it in but fails on another"
   - "A skill can invoke a slash-command-like affordance interactively but not from within its own execution"
 tags:
@@ -18,6 +20,7 @@ tags:
   - capability-over-tool
   - tool-vs-slash-command
   - empirical-verification
+  - ask-vs-execute
   - portable-skills
   - orchestration
   - ce-babysit-pr
@@ -34,13 +37,17 @@ This crystallized while designing `ce-babysit-pr`'s self-sustaining loop, where 
 
 ## Guidance
 
-**1. The reliable unit a skill can drive is an agent *tool call*, not a user affordance.** Skill prose steers the agent; the agent invokes *tools*. It cannot press keys or type a slash command, so a user-typed command (e.g. Cursor's `/loop`) is **not skill-invocable** — verified live: the agent reported `/loop` "only loads instructions into context." The exception is a slash command the harness *also* exposes as a tool (Claude Code's `Skill` tool can invoke `/loop`, so that one counts). Design for tool calls; treat any "have the skill run /command" step as a smell to verify.
+**1. The reliable unit a skill can drive is an agent *tool call*, not a user affordance.** Skill prose steers the agent; the agent invokes *tools*. It cannot press keys or type a slash command, so a user-typed command (e.g. Cursor's `/loop`) is **not skill-invocable** — the agent *reported* that `/loop` "only loads instructions into context" (**reported, not executed** — see the provenance audit below; re-verify by execution before relying on it). The exception is a slash command the harness *also* exposes as a tool (Claude Code's `Skill` tool can invoke `/loop`, so that one counts). Design for tool calls; treat any "have the skill run /command" step as a smell to verify.
 
 **2. The tool surface varies by harness *and* model, and agents reach for the *simplest sufficient* tool, not the fanciest.** Given a capability need with the mechanism unspecified, fresh agents on all four harnesses built a plain background shell loop — **none reached for a first-class scheduler tool**, even Grok, whose `scheduler_create` (durable, agent-callable) was right there; it explicitly skipped it as overkill. So designing around a specific "correct" tool is doubly wrong: it may not exist on another harness, and even where it does, the model won't necessarily pick it.
 
 **3. Therefore: name the known tool as a short-circuit, but describe the *capability* as the portable fallback.** For a recognized harness, state the specific agent tool for an instant, unambiguous pick. Underneath it, describe what the tool must *do* ("a way to run a background process and be woken when it emits a line, without ending your turn"; "the platform's blocking-question capability"), so an agent whose tool is absent, renamed, or newer can still satisfy the need — and degrade explicitly when nothing fits. Both, not either: the named tool is speed, the capability description is robustness.
 
-**4. Verify per-harness/per-model tool behavior *empirically*, with live agents — not from your authoring runtime.** Assumptions baked from one runtime ship wrong. Two live checks (fresh agents per harness, dispatched via orchestration) corrected real errors before they landed: Codex's CLI exposes **no** scheduler tool and a detached `nohup` is *reaped* the instant the tool call ends (only a runtime-owned handle survives); Cursor's `/loop` is not skill-invocable; Grok's `scheduler_create` is durable and agent-callable but goes unused. This operationalizes the "portable agent skill authoring" decentering principle: when a design rests on per-harness/per-model tool behavior, prove it with agents on those targets.
+**4. Verify per-harness/per-model tool behavior by making the agent *run the call* — its description of its own tools is not evidence.** Assumptions baked from one runtime ship wrong, so dispatch fresh agents on the target harnesses. But "live agent" is not the bar, and this is the clause that bites: an agent asked to *describe* its own tool schema produces a confident wrong answer as readily as a right one. Only an executed call counts. Two live checks (fresh agents per harness, dispatched via orchestration) corrected real errors before they landed: Codex's CLI exposes **no** scheduler tool and a detached `nohup` is *reaped* the instant the tool call ends (only a runtime-owned handle survives); Cursor's `/loop` is not skill-invocable; Grok's `scheduler_create` is durable and agent-callable but goes unused. This operationalizes the "portable agent skill authoring" decentering principle: when a design rests on per-harness/per-model tool behavior, prove it with agents on those targets — by running it, not by asking about it.
+
+**The measurement that forced this clause (2026-07-16).** Codex was asked to read its own `update_plan` schema and report the allowed step statuses and whether a step can be deleted. It answered: *"Allowed step statuses: `pending`, `in_progress`, `completed`. Skipped/cancelled status: No. Can a step be deleted: No."* It was then made to actually call `update_plan` — create three steps, then re-issue the plan with the middle one omitted. Result: *"Remove Step B: SUCCEEDED — resulting plan: Step A, Step C. Step B vanished."* `update_plan` takes the whole plan array, so omission deletes; the agent's self-report about its own tool was simply false. The same probe surfaced two facts nobody thought to ask for: Cursor has a native `cancelled` status, and Cursor deletion requires `merge: false` (a full-list replace) while rename-then-complete is a targeted `merge: true` — a mechanical-safety difference invisible to any schema read.
+
+Note the asymmetry that makes this sharp: on the same question, a prior assumption held from training happened to be *right* while the live agent's self-report was *wrong*. Neither asking the model nor trusting your memory is reliable. Only execution is.
 
 ## Why This Matters
 
@@ -62,10 +69,36 @@ One boundary the same experiments surfaced: agents pick the *simplest* sufficien
 
 **Capability over tool (asking the user):** prose that says `AskUserQuestion` breaks off-Claude. `ce-babysit-pr` instead says "use the platform's blocking-question tool" and lists `AskUserQuestion` / `request_user_input` / `ask_question` / `ask_user` as examples with a chat fallback — one capability, many tools.
 
-**Live verification (the reusable technique):** publish a controllable external artifact (an [ht-ml.app](https://ht-ml.app) page), dispatch a fresh agent per harness with intent-only instructions to watch it and react to a change, then change it and confirm each caught the change unattended with an unguessable value. Proof beats assumption for anything that varies by harness or model — and it is how "Codex `nohup` is reaped" and "Cursor `/loop` isn't skill-invocable" were caught before shipping.
+**Live verification (the reusable technique):** publish a controllable external artifact (an [ht-ml.app](https://ht-ml.app) page), dispatch a fresh agent per harness with intent-only instructions to watch it and react to a change, then change it and confirm each caught the change unattended with an unguessable value. Proof beats assumption for anything that varies by harness or model — and it is how "Codex `nohup` is reaped" was caught before shipping.
+
+**The ask-vs-execute probe (the cheaper reusable technique).** When the question is "what can this tool do," do not ask — make the agent exercise it and report what happened, including errors. Adapt this shape:
+
+> ACTUALLY CALL your `<plan/task tool>` for each step — do not describe or simulate in prose, make the real calls and report what happened. 1. Create a plan with 3 steps: 'Step A', 'Step B', 'Step C'. 2. Now attempt to REMOVE 'Step B' entirely. Actually try it. 3. Now attempt to RENAME 'Step C' and mark it completed. Actually try it. For each: did the call SUCCEED or ERROR, and what did the resulting plan actually contain?
+
+The instruction to *actually call* is load-bearing — without it the agent answers from its schema, which is the failure this doc now warns about. Report what rendered, too: the rename-then-complete probe showed Codex printing `✓ Step C (skipped)`, a completion checkmark contradicting its own name, which a schema read would never reveal.
+
+**Claimed vs actual (why the probe pays for itself).** From the 2026-07-16 `update_plan` measurement:
+
+| Question | Codex's self-report | What running it showed |
+|---|---|---|
+| Allowed statuses | `pending`, `in_progress`, `completed` | Same — self-report correct here |
+| Skipped/cancelled status? | No | Same — but Cursor *does* have native `cancelled`, unasked and unmentioned |
+| Can a step be deleted? | **No** | **Yes** — omit it from the array; "Step B vanished" |
+
+**Provenance audit of this doc's own claims (2026-07-16).** This doc predates the ask-vs-execute distinction, so its evidence is mixed. Treat accordingly, and re-verify by execution before relying on a *reported* row:
+
+| Claim | Provenance |
+|---|---|
+| Codex `nohup` is reaped when the tool call ends | **Executed** — observed behavior |
+| Fresh agents on all four harnesses built a plain shell loop; none reached for a scheduler | **Executed** — observed behavior |
+| Grok's `scheduler_create` goes unused despite being available | **Executed** — observed behavior |
+| Cursor's `/loop` "only loads instructions into context" | **Reported** — agent self-description; now suspect |
+| Codex's CLI exposes no scheduler tool | **Indeterminate** — not recorded whether executed or reported |
+| Grok's `scheduler_create` is durable and agent-callable | **Indeterminate** — likely from docs/self-report |
 
 ## Related
 
 - [Watch-loop skills need a blocked-external terminal state for fork-PR CI approval gates](./watch-loops-need-a-blocked-external-terminal-state.md) — a sibling `ce-babysit-pr` learning; the motivating example (its self-sustaining loop) is where this general principle surfaced.
 - [Bundled script path resolution across harnesses](./bundled-script-path-resolution-across-harnesses.md), [`arguments` token is Claude-only in skill bodies](./arguments-token-is-claude-only-in-skill-bodies.md) — sibling cross-harness-portability learnings; same "don't assume your runtime is universal" root.
+- [Requested vs verified model identity](./requested-vs-verified-model-identity.md) — the **receipt** layer of the same epistemics, with the opposite prescription. Same root ("a self-report is not evidence"), but model identity *cannot* be settled by execution — there is no call that reveals the serving backend — so that doc prescribes an out-of-band receipt and accepts "unverified" as an honest terminal state. Tool capability *can* be settled by execution, cheaply, so "unverified" is never acceptable here: run the call. Do not fold the two together; the receipt-vs-execution split is the actionable content of each.
 - Design artifact: `docs/plans/2026-07-11-001-feat-babysit-self-initiating-loop-plan.md`.

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -143,6 +143,29 @@ Product-tier triggers additional Phase 1.2 questions and additional Product Cont
 
 **Unfamiliarity tripwire.** If the user signals they lack working knowledge of the domain or the territory the topic touches — "I know nothing about X", "never touched the auth modules", "I don't know what's possible / what I should be asking" — read `references/blindspot-pass.md` now. Loading here is readiness only; the reference owns when the offer fires (territory-scoped, before the first substantive question into the flagged territory), the map's shape, and how mapped decisions re-enter the dialogue.
 
+#### 0.4 Surface the Workflow Spine
+
+For **Standard and Deep** scope, create a task list with the platform's task tracking tool (`TaskCreate`/`TaskUpdate`/`TaskList` in Claude Code, `update_plan` in Codex, or the equivalent on other harnesses). Skip it entirely for Lightweight and on the Phase 0.1b non-software route. Create it here, not earlier — 0.1b and 0.1c exit before this point, and the tier is unknown until 0.3.
+
+If the harness exposes no task primitive — including `ToolSearch` or its equivalent returning no match — name the six tasks once in chat and continue without per-task updates, rather than dropping the spine silently. Do not restate the list to simulate progress you cannot track.
+
+The spine is six tasks, in order:
+
+1. Check what already exists
+2. Ask scoping questions
+3. Weigh approaches and recommend
+4. Confirm scope before writing
+5. Write the requirements plan
+6. Offer next steps
+
+**Conditional work earns a task only when its gate fires** — never at creation, and never as a placeholder for a branch that may not run. A branch earns one when the user is either waiting on it or would be surprised to learn it happened: an accepted blindspot pass, a dispatched Slack researcher, a Phase 2.6 verifier working in the background. A step that fires per-decision rather than once does not — it would thrash the list. Insert it at the position where it runs.
+
+**Name every task you add the way the spine is named:** verb first, five words or fewer, naming the outcome the user can hold you to — not the phase, the internal activity, or the tool. `Verify claims against the code`, not `Phase 2.6 claim verification`. Never restate counts, quotas, or pacing in a name; that contract lives in the phase that owns it.
+
+**When a gate resolves such that a listed task will not run, record the skip — never mark it plainly complete, and never let it vanish unexplained.** In order of preference: set a `cancelled` or `skipped` status if the harness has one; otherwise rename the task to name the skip (`Skipped: no doc warranted`) and then mark it complete; only if the name cannot be changed, delete it. Say why in the conversation either way — the list carries the fact, not the reason. If Phase 3 decides no doc is warranted, that is task 5. If the 0.1c handoff is accepted mid-dialogue, clear the list entirely — `ce-pov` owns the run from there. A task you find yourself skipping routinely is misnamed: it encodes a branch rather than an outcome, so rename it to what happens in the common case.
+
+The list is a view for the user, not an instruction to you. It does not change when a phase fires or what that phase requires, and it never substitutes for a phase's own exit condition.
+
 ### Phase 1: Understand the Idea
 
 #### 1.1 Existing Context Scan


### PR DESCRIPTION
## Summary

A Standard or Deep brainstorm now shows its own shape. The agent puts up a six-task list before the dialogue starts and works it visibly, so you can see where the run is and what it still intends to do rather than inferring it from the conversation. Lightweight brainstorms and the non-software route are untouched: no list, no ceremony.

The second commit corrects a learning that this work proved was teaching an insufficient rule.

## The design decisions worth reviewing

**Task names are a view for the user, not an instruction to the agent.** This is the load-bearing rule, because a visible checklist is a completion-pressure device — and ce-brainstorm's whole stance is right-sizing. Concretely, no counts in names: task 3 is `Weigh approaches and recommend`, never "propose 2-3 approaches". The 2-3 contract already lives in Phase 2, which owns it; restating it in a name turns a conditional into a quota and pressures the agent to manufacture a third option that doesn't exist.

The same rule explains the task set. Every name is the outcome that holds in the common case, so nothing needs routine deletion — a task you'd delete routinely is misnamed, because it encoded a branch instead of an outcome.

**A skipped task is recorded, not erased.** When a gate means a listed task won't run, the agent sets a `cancelled`/`skipped` status if the harness has one, else renames the task to name the skip and completes it, else deletes it — and says why in chat either way, since the list can carry the fact but not the reason. Deleting silently was the obvious alternative and is the wrong one: it's information-lossy, and on Cursor it needs a `merge: false` full-list replace that can clobber the rest of the list, where the rename is a targeted `merge: true`. The known cost is that Codex and Claude Code have no faithful skipped state, so the entry renders with a completion checkmark beside a name that says skipped. That's accepted deliberately: a mildly contradictory glyph beats a vanished decision.

**Placement.** Phase 0.4 sits after 0.3 because the routing gates (non-software, ce-pov handoff) exit before it and the tier isn't known until 0.3. Any earlier and the list would be built for runs that route away.

## Validation

Behavioral evals on Codex, with a real `update_plan` and fixtures verified against the tree. All three risks came back clean:

| Risk | Result |
|---|---|
| Completion pressure — does task 3 manufacture filler when only one approach is viable? | No. Stated a single recommendation and refused to pad: *"I would not present orchestrator-only, reviewer-only, or cross-skill import as alternatives."* |
| Lightweight restraint — does the list appear where it shouldn't? | No. Zero `update_plan` calls with the tool available. |
| Skip handling — is a skip recorded or quietly ticked off? | Recorded. Produced `{ step: "Skipped: no doc warranted", status: "completed" }` and explained why in chat. |

A control run against the pre-change skill is what established that Phase 2's existing "use at least one non-obvious angle" line — not the new task list — is the standing pressure toward a third option. In the treatment run that line sharpened the single recommendation instead of splitting it.

The no-task-primitive fallback exists because three independent eval agents flagged its absence: Interaction Rule 4 specifies a chat fallback for a missing blocking-question tool, and 0.4 specified nothing, so the spine would vanish with no user-visible trace on a harness without the tool.

`bun test`: 2229 pass. The single failure is a pre-existing flake in `ce-resolve-pr-feedback`'s flatten-safety test, confirmed failing 2 of 3 runs on a clean tree with these changes stashed. `release:validate` passes.

## On the second commit

`cross-harness-cross-model-tool-invocation.md` already said to verify tool behavior empirically with live agents. That turned out to be under-specified in a way this work hit directly: an agent asked to *describe* its own tool schema answers confidently and can be wrong. Codex reported that its `update_plan` cannot delete a step, then deleted one when made to actually issue the call.

So the doc is corrected rather than duplicated — a new doc would have left the more prominent one still teaching the looser rule. It's retitled off "verify it live", since *live* is exactly the word the evidence disqualifies, and it now carries a provenance audit marking which of its own claims were executed and which were only reported. That audit matters: the doc cited an agent's report as proof that empirical verification works, which is the same class of evidence that just proved false.

## Follow-up, not addressed here

Two pre-existing ce-brainstorm bugs surfaced during evaluation, each confirmed by two independent runs. They're unrelated to this change and shouldn't ride along in it:

- `synthesis-summary.md`'s Path B template hardcodes "Confirm and I'll write the requirements-only plan next" even when the user has forbidden a doc. Phase 3, not 2.5, owns that decision, so the template promises an artifact the skill may correctly decline — both skip-handling runs hit this and the user had to repeat the refusal.
- Phase 4 offers "Create the implementation plan (recommended)" when no artifact exists.
