### PR TITLE
fix(ce-brainstorm): stop prompts overstating what the run will do

### DIFF
--- a/skills/ce-brainstorm/references/handoff.md
+++ b/skills/ce-brainstorm/references/handoff.md
@@ -43,12 +43,14 @@ What would you like to do next? (Pick a number or describe what you want.)
 **Preamble when blocking questions remain and user wants to pause:**
 
 ```
-Brainstorm paused. Planning is blocked until the remaining questions are resolved.
+Brainstorm paused. I'm holding planning until the remaining questions are resolved — say the word and I'll proceed anyway, recording each open item as an explicit assumption or a question deferred to planning.
 
 Plan artifact: <absolute path to requirements-only unified plan>  # omit line if no artifact was created
 
 What would you like to do next? (Pick a number or describe what you want.)
 ```
+
+The override sentence is load-bearing, not padding: the planning options are hidden while `Resolve Before Planning` is non-empty, so without it the user is told planning is blocked and is never told the block is theirs to lift. `Resolve Before Planning` is your own judgment call — an over-cautious read of it must not silently strand the user with no visible way forward. Hiding the option withholds the *recommendation*; it never withholds the *choice*.
 
 Present only the options that apply. Renumber so visible options stay contiguous starting at 1.
 
@@ -57,7 +59,7 @@ Present only the options that apply. Renumber so visible options stay contiguous
 3. **Pressure-test the requirements** - Dispatch reviewer agents with `ce-doc-review` to find gaps, conflicts, weak premises, and scope issues in the requirements; auto-apply safe fixes; route the rest interactively. Shown only when a markdown unified plan exists **and `OUTPUT_FORMAT=md`** — ce-doc-review's walkthrough applies markdown-only mutations (`##`/`###` heading inserts, single-file markdown edits via apply-set) and would corrupt an HTML artifact, so HTML brainstorms skip this option until ce-doc-review gains HTML-aware mutation support. Under HTML mode, surface a one-line note above the menu: `Requirements review unavailable in output:html mode — ce-doc-review is markdown-only today. Switch to output:md if you want a review pass.`
 4. **Publish to Proof — shareable link** - Publish the markdown unified plan to Every's Proof editor and get a shareable link to read, comment on, or share with others. One-way: the local doc stays canonical. Shown only when a markdown unified plan exists. **Render only when `OUTPUT_FORMAT=md`** (Proof operates on markdown and cannot ingest HTML).
 4. **Open in browser** — open the HTML unified plan locally for review and sharing. Shown only when an HTML unified plan exists. **Render only when `OUTPUT_FORMAT=html`.** Replaces "Publish to Proof" at the same slot under exclusive output mode — the artifact is either markdown OR HTML, never both, so exactly one of the two labels applies per run.
-5. **More clarifying questions to sharpen the doc** - Keep refining scope, edge cases, constraints, and preferences through further dialogue. Always shown.
+5. **More clarifying questions to sharpen the scope** - Keep refining scope, edge cases, constraints, and preferences through further dialogue. Always shown — so the label names the scope rather than the doc, which stays true on a run that correctly skipped doc creation.
 
 There is no "done" / "pause" option — the blocking question already waits, and the user ends by dismissing it (Esc) or saying they're finished. The unified plan artifact is already saved.
 
@@ -104,7 +106,7 @@ open a PR from this artifact.
 
 Do not print the closing summary first.
 
-**If user selects "More clarifying questions to sharpen the doc":** Return to Phase 1.3 (Collaborative Dialogue) and continue asking the user clarifying questions one at a time to further refine scope, edge cases, constraints, and preferences. Continue until the user is satisfied, then return to Phase 4. Do not show the closing summary yet.
+**If user selects "More clarifying questions to sharpen the scope":** Return to Phase 1.3 (Collaborative Dialogue) and continue asking the user clarifying questions one at a time to further refine scope, edge cases, constraints, and preferences. Continue until the user is satisfied, then return to Phase 4. Do not show the closing summary yet.
 
 **If user selects "Publish to Proof — shareable link":**
 
@@ -158,9 +160,9 @@ Brainstorm paused.
 
 Plan artifact: <absolute path to unified plan>  # omit line if no artifact was created
 
-Planning is blocked by:
+Planning is held on:
 - [Blocking question 1]
 - [Blocking question 2]
 
-Resume with `ce-brainstorm` when ready to resolve these before planning.
+Resume with `ce-brainstorm` to resolve these — or say to plan anyway, and I'll record each open item as an explicit assumption or a question deferred to planning.
 ```

--- a/skills/ce-brainstorm/references/synthesis-summary.md
+++ b/skills/ce-brainstorm/references/synthesis-summary.md
@@ -48,7 +48,9 @@ Each section answers a different question:
 
 Then the confirmation, which names **what actually happens next** so the user knows what is coming and can interrupt without ambiguity. When a doc is expected — the common case — that is the artifact write: *"Confirm and I'll write the requirements-only plan next, drawing on our dialogue and this synthesis. Or tell me what to change."*
 
-When a doc is already ruled out — the user declined one, or `brainstorm-sections.md`'s "Decide whether a doc is warranted at all" criteria plainly hold — name where the decisions go instead: *"Confirm and we're done here — the scope above goes straight into your commit message. Or tell me what to change."* Phase 3, not this phase, owns the doc-warranted decision, so promising the write here makes a user who already declined a doc decline it a second time.
+When a doc is already ruled out — the user declined one, or `brainstorm-sections.md`'s "Decide whether a doc is warranted at all" criteria plainly hold — name where the decisions actually go instead, which is whichever of that rule's alternatives *this run* established (`ce-plan`, the user's commit message, `docs/solutions/`): *"Confirm and we're done here — the scope above carries straight into [the destination the dialogue established]. Or tell me what to change."* When the dialogue named none, drop the clause rather than picking one: *"Confirm and we're done here — no doc, as you asked. Or tell me what to change."*
+
+Do not hardcode a destination. This phase writes no commit message and hands off at Phase 4, so asserting a downstream action the run will not take is the same overreach as promising the doc. Phase 3, not this phase, owns the doc-warranted decision, so promising the write here makes a user who already declined a doc decline it a second time.
 
 ### Path A vs Path B: the gate that fires the confirmation question
 
@@ -159,7 +161,7 @@ Based on our dialogue, here's the scope I'm proposing for the Product Contract:
 - [scope-level fork or non-obvious consequence the user can affirm or redirect]
 - [same]
 
-[Closing line — name what actually happens next, per "the confirmation" above. Doc expected (the common case):] Confirm and I'll write the requirements-only plan next, drawing on our dialogue and this synthesis. Or tell me what to change — even something I captured correctly earlier is fair game to revise (you may have changed your mind or want to correct an unstated assumption). [Doc already ruled out — user declined one, or the skip criteria plainly hold:] Confirm and we're done here — the scope above goes straight into your commit message. Or tell me what to change — even something I captured correctly earlier is fair game to revise.
+[Closing line — name what actually happens next, per "the confirmation" above. Doc expected (the common case):] Confirm and I'll write the requirements-only plan next, drawing on our dialogue and this synthesis. Or tell me what to change — even something I captured correctly earlier is fair game to revise (you may have changed your mind or want to correct an unstated assumption). [Doc already ruled out — user declined one, or the skip criteria plainly hold:] Confirm and we're done here — the scope above carries straight into [the destination this run established; drop this clause when none was named]. Or tell me what to change — even something I captured correctly earlier is fair game to revise.
 ```
 
 ### Path A template (no questions were asked — typically Phase 0.2 short-circuit)

--- a/skills/ce-brainstorm/references/synthesis-summary.md
+++ b/skills/ce-brainstorm/references/synthesis-summary.md
@@ -46,7 +46,9 @@ Each section answers a different question:
 - **What did we cut?** → deferred items a reader would expect to see acknowledged
 - **Where might you redirect?** → residual forks: post-dialogue consequences, silent inferences, late-cycle bets
 
-Then the confirmation: *"Confirm and I'll write the requirements-only plan next, drawing on our dialogue and this synthesis. Or tell me what to change."* The phrasing sets the expectation that confirm -> artifact-write, so the user knows what's about to happen and can interrupt without ambiguity.
+Then the confirmation, which names **what actually happens next** so the user knows what is coming and can interrupt without ambiguity. When a doc is expected — the common case — that is the artifact write: *"Confirm and I'll write the requirements-only plan next, drawing on our dialogue and this synthesis. Or tell me what to change."*
+
+When a doc is already ruled out — the user declined one, or `brainstorm-sections.md`'s "Decide whether a doc is warranted at all" criteria plainly hold — name where the decisions go instead: *"Confirm and we're done here — the scope above goes straight into your commit message. Or tell me what to change."* Phase 3, not this phase, owns the doc-warranted decision, so promising the write here makes a user who already declined a doc decline it a second time.
 
 ### Path A vs Path B: the gate that fires the confirmation question
 
@@ -157,7 +159,7 @@ Based on our dialogue, here's the scope I'm proposing for the Product Contract:
 - [scope-level fork or non-obvious consequence the user can affirm or redirect]
 - [same]
 
-Confirm and I'll write the requirements-only plan next, drawing on our dialogue and this synthesis. Or tell me what to change — even something I captured correctly earlier is fair game to revise (you may have changed your mind or want to correct an unstated assumption).
+[Closing line — name what actually happens next, per "the confirmation" above. Doc expected (the common case):] Confirm and I'll write the requirements-only plan next, drawing on our dialogue and this synthesis. Or tell me what to change — even something I captured correctly earlier is fair game to revise (you may have changed your mind or want to correct an unstated assumption). [Doc already ruled out — user declined one, or the skip criteria plainly hold:] Confirm and we're done here — the scope above goes straight into your commit message. Or tell me what to change — even something I captured correctly earlier is fair game to revise.
 ```
 
 ### Path A template (no questions were asked — typically Phase 0.2 short-circuit)


### PR DESCRIPTION
## Summary

Three prompts in `ce-brainstorm` told the user things the skill's own rules contradict. Before this, a user who opened with "I do NOT want a plan document" was asked to confirm — and the confirmation promised to write one, so they had to refuse a second time. A user with open blocking questions was told "Planning is blocked until the remaining questions are resolved," when in fact the skill has always allowed them to proceed anyway. And a run that correctly skipped doc creation still offered "More clarifying questions to sharpen **the doc**" — a doc that doesn't exist.

Each is now consistent with what the run will actually do.

Follow-up to #1165.

## What changed

**Phase 2.5 no longer promises a doc Phase 3 may decline.** Phase 3 owns the doc-warranted decision; 2.5 was pre-announcing its outcome. The closing line now names what actually happens next, with a variant for when the doc is already ruled out ("the scope above goes straight into your commit message"). The fix lands on the rule that governs the template rather than only the template, so the next person writing a variant inherits it. The worked example further down the file is untouched — it depicts a normal doc-warranted run, where the original wording is correct.

**The proceed-anyway override is now visible.** It already existed, but only in the agent's instructions — the user was told they were blocked, full stop. Since `Resolve Before Planning` is the agent's own judgment call, an over-cautious read of it could strand a user with no visible way forward. Both blocked preambles now offer the override and say what it costs (each open item becomes an explicit assumption or a question deferred to planning).

The gate itself is deliberately unchanged. Hiding "Create the implementation plan" while blockers stand is right — the agent shouldn't *recommend* planning into unresolved questions. Hiding the option withholds the recommendation; it should never withhold the choice.

**The refine option names the scope, not the doc**, which is true whether or not an artifact exists. Its dispatch key moves with the label so routing still matches.

## Validation

Regression test on Codex against the same scenario that originally caught the first bug, with a real `update_plan`:

| | Before | After |
|---|---|---|
| Times the user had to decline the document | 2 | **1** (the opening prompt only) |

Phase 2.5 now closes with *"Confirm and we're done here — the scope above goes straight into your commit message."* The user answered "Confirmed" and never had to refuse again. Phase 3 skipped correctly — *"Skipping the requirements-only plan. You asked for brief alignment and the durable outcome is going straight into the commit message, so an intermediary brainstorm artifact is not warranted."* — and the task spine still recorded the skip as `{"step":"Skipped: no doc warranted","status":"completed"}`.

That same run is what surfaced the "sharpen the doc" label, which is why it's fixed here rather than filed for later.

`bun test` 2230 pass / 0 fail; `release:validate` and `plugin:validate` pass. No test pins the renamed label — checked before renaming. `tests/skills/flatten-safety.test.ts` remains a known pre-existing intermittent flake (~2 of 3 runs on a clean tree, unrelated to this diff); it passed on the final run.

## One reported item that isn't a bug

#1165 listed "Phase 4 offers *Create the implementation plan (recommended)* when no artifact exists" as follow-up work. It's working as designed, so nothing here changes it: `handoff.md` already specifies that with no artifact "there is nothing to enrich; offer option 1 instead, which can plan interactively from the conversation." The file hides the review and Proof options in that state and keeps option 1 on purpose. The regression run confirmed Phase 4 offered exactly the two options permitted with no artifact.
