### PR TITLE
fix(ce-pov): document peer wait arguments

### DIFF
--- a/skills/ce-pov/references/cross-model-panel.md
+++ b/skills/ce-pov/references/cross-model-panel.md
@@ -180,11 +180,17 @@ repository. For named peers, start one job per exact target; for a selected pane
 start one job per selected peer. Start all jobs before waiting.
 
 Record every job id and the epoch after the final start. Poll all jobs in
-bounded slices with the runner's `wait --max-secs 30 --json` interface. Use one
-aggregate deadline of 610 seconds after the final start; never begin a wait that
-can cross it. At the deadline, reap each nonterminal job in a short call, then
-make one final `wait --max-secs 10 --json` call. Classify every started job from
-its terminal state; `done` alone does not prove a usable artifact exists.
+bounded slices with
+`python3 "$SKILL_DIR/scripts/peer-job-runner.py" wait --max-secs 30 --json <job-ids...>`.
+Job ids or job-directory paths are positional. `--skill`, `--run-id`, and
+`--label` are start-only; never pass them to `wait`. Do not add a separate shell
+sleep: `wait` itself provides the bounded polling delay. Use one aggregate
+deadline of 610 seconds after the final start; never begin a wait that can cross
+it. At the deadline, reap each nonterminal job in a short call, then make one
+final
+`python3 "$SKILL_DIR/scripts/peer-job-runner.py" wait --max-secs 10 --json <job-ids...>`
+call. Classify every started job from its terminal state; `done` alone does not
+prove a usable artifact exists.
 
 Read artifacts and logs only through the runner's ownership-checked `result`
 interface. Accept only schema-shaped artifacts with non-empty `position` and

--- a/tests/pov-skill-contract.test.ts
+++ b/tests/pov-skill-contract.test.ts
@@ -200,6 +200,16 @@ describe("ce-pov cross-model panel contract", () => {
     expect(panel).toContain("quota, authentication, or route failure")
   })
 
+  test("documents complete bounded wait invocations without a separate shell sleep", async () => {
+    const panel = await skillFile("references/cross-model-panel.md")
+    const prose = compact(panel)
+
+    expect(panel).toContain("wait --max-secs 30 --json <job-ids...>")
+    expect(panel).toContain("wait --max-secs 10 --json <job-ids...>")
+    expect(prose).toMatch(/`--skill`, `--run-id`, and `--label` are start-only/)
+    expect(prose).toMatch(/Do not add a separate shell sleep.*`wait` itself provides the bounded polling delay/)
+  })
+
   test("pins repository grounding, snapshot identity, and common reconcile evidence", async () => {
     const panel = await skillFile("references/cross-model-panel.md")
     const prose = compact(panel)


### PR DESCRIPTION
## Summary

ce-pov panel runs now give agents a complete, copyable `wait` command, so detached peer jobs are polled with positional job references instead of invalid start-only flags. The protocol also makes the bounded wait responsible for the delay, avoiding blocked `sleep` wrappers.

A focused contract test locks the normal and final wait forms plus both misuse guards.

## Validation

- `bun test tests/pov-skill-contract.test.ts tests/skills/ce-pov-cross-model-routes.test.ts tests/skills/peer-job-runner.test.ts tests/peer-job-runner-parity.test.ts`
- `bun run release:validate`
- `bun run plugin:validate`
- `bun test` (2,256 pass, 3 fail: one concurrent-load timeout passed in isolation; the remaining two are pre-existing Python 3.9.6 timestamp failures in `ce-babysit-pr`)
- Behavioral evals intentionally not run, per request

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
