### PR TITLE
fix(droid): match tool names on word boundaries when inferring agent tools

### DIFF
--- a/src/converters/claude-to-droid.ts
+++ b/src/converters/claude-to-droid.ts
@@ -106,7 +106,7 @@ function mapAgentTools(agent: ClaudeAgent): string[] | undefined {
 
   const mentionedTools = new Set<string>()
   for (const [claudeTool, droidTool] of Object.entries(CLAUDE_TO_DROID_TOOLS)) {
-    if (bodyLower.includes(claudeTool)) {
+    if (new RegExp(`\\b${claudeTool}\\b`).test(bodyLower)) {
       mentionedTools.add(droidTool)
     }
   }

--- a/src/converters/claude-to-droid.ts
+++ b/src/converters/claude-to-droid.ts
@@ -20,7 +20,7 @@ const CLAUDE_TO_DROID_TOOLS: Record<string, string> = {
   task: "Task",
   todowrite: "TodoWrite",
   todoread: "TodoWrite",
-  question: "AskUser",
+  askuserquestion: "AskUser",
 }
 
 const VALID_DROID_TOOLS = new Set([

--- a/tests/droid-converter.test.ts
+++ b/tests/droid-converter.test.ts
@@ -77,6 +77,56 @@ describe("convertClaudeToDroid", () => {
     expect(parsed.body).toContain("Focus on vulnerabilities.")
   })
 
+  test("does not infer tools from incidental substrings in agent prose", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [
+        {
+          name: "strategist",
+          description: "plans work",
+          body: "Review the request using already gathered context then do tasks as a checklist with details. Never open an editor and think globally about tradeoffs.",
+          sourcePath: "/tmp/plugin/agents/strategist.md",
+        },
+      ],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToDroid(plugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "none",
+    })
+
+    const parsed = parseFrontmatter(bundle.droids[0].content)
+    expect(parsed.data.tools).toBeUndefined()
+  })
+
+  test("still infers tools from whole-word references", () => {
+    const plugin: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [
+        {
+          name: "worker",
+          description: "does work",
+          body: "Use Read to inspect files and Bash to run commands.",
+          sourcePath: "/tmp/plugin/agents/worker.md",
+        },
+      ],
+      commands: [],
+      skills: [],
+    }
+
+    const bundle = convertClaudeToDroid(plugin, {
+      agentMode: "subagent",
+      inferTemperature: false,
+      permissions: "none",
+    })
+
+    const parsed = parseFrontmatter(bundle.droids[0].content)
+    expect(parsed.data.tools).toEqual(["Execute", "Read"])
+  })
+
   test("passes through skill directories", () => {
     const bundle = convertClaudeToDroid(fixturePlugin, {
       agentMode: "subagent",

--- a/tests/droid-converter.test.ts
+++ b/tests/droid-converter.test.ts
@@ -127,6 +127,27 @@ describe("convertClaudeToDroid", () => {
     expect(parsed.data.tools).toEqual(["Execute", "Read"])
   })
 
+  test("maps AskUserQuestion by its real tool name, not the bare word", () => {
+    // \bquestion\b never matches inside the CamelCase AskUserQuestion, so key on the full name.
+    const usesTool: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [{ name: "asker", description: "asks things", body: "Use AskUserQuestion after Read to gather files.", sourcePath: "/tmp/plugin/agents/asker.md" }],
+      commands: [],
+      skills: [],
+    }
+    const withTool = convertClaudeToDroid(usesTool, { agentMode: "subagent", inferTemperature: false, permissions: "none" })
+    expect(parseFrontmatter(withTool.droids[0].content).data.tools).toEqual(["AskUser", "Read"])
+
+    const prose: ClaudePlugin = {
+      ...fixturePlugin,
+      agents: [{ name: "asker", description: "asks things", body: "Answer the user's question after Read.", sourcePath: "/tmp/plugin/agents/asker.md" }],
+      commands: [],
+      skills: [],
+    }
+    const bareWord = convertClaudeToDroid(prose, { agentMode: "subagent", inferTemperature: false, permissions: "none" })
+    expect(parseFrontmatter(bareWord.droids[0].content).data.tools).toEqual(["Read"])
+  })
+
   test("passes through skill directories", () => {
     const bundle = convertClaudeToDroid(fixturePlugin, {
       agentMode: "subagent",


### PR DESCRIPTION
## Problem

When converting an agent to a Factory Droid, `mapAgentTools` infers the agent's tool list by scanning its name, description, and body for tool names with `bodyLower.includes(claudeTool)`. A tool name that appears as a substring of an ordinary word is treated as a reference, so a prose only agent that names no tools still gets a list:

```
body: "Review the request using already gathered context then do tasks
        as a checklist with details. Never open an editor and think globally
        about tradeoffs."

inferred tools: ["Edit", "Glob", "LS", "Read", "Task"]
```

Each is a false positive: `already` -> Read, `details` -> LS, `tasks` -> Task, `editor` -> Edit, `globally` -> Glob. Because the frontmatter `tools` list *restricts* the droid to those tools, a spurious match silently narrows the agent's access. An agent that should run with full tools gets locked to five it never asked for.

## Fix

Match tool names on word boundaries (`\bread\b`) instead of as substrings. This is the same approach the kiro converter already uses for its tool-name mapping in `claude-to-kiro.ts`. Real references still resolve; incidental substrings no longer do.

## Tests

Two cases added to `tests/droid-converter.test.ts`:

- the prose only agent above now infers no tools (was `["Edit", "Glob", "LS", "Read", "Task"]`)
- an agent that references Read and Bash still infers `["Execute", "Read"]`

Full droid suite green (14/14); `tsc --noEmit` clean.

## Note

The draft #358 also touches `mapAgentTools`: it adds a fast path for agents that declare an explicit `tools` field. Agents without one (the case above) still fall through to the substring inference.
