### PR TITLE
fix(ce-commit-push-pr): reconcile complete branch scope

### DIFF
--- a/skills/ce-commit-push-pr/references/pr-description-writing.md
+++ b/skills/ce-commit-push-pr/references/pr-description-writing.md
@@ -61,7 +61,9 @@ Note in the user-facing summary when the API fallback was used.
 
 **Size by decision cost, not diff shape.** What a description must cover is set by how much a reviewer cannot establish from the diff alone — not changed-line count, file extension, or visual surface. A 5-line edit to ranking logic or a deploy manifest can carry more reviewer uncertainty than a 500-line mechanical rename.
 
-Before sizing, name the change's **material claims** — what became possible, what was fixed, what risk changed, what design decision the reviewer must assess — and which of them the diff alone can't establish. Surface those; let the rest stay implicit. **Classify each changed file by runtime purpose, not extension** when you judge this: markdown or YAML may be inert docs and examples, or runtime agent instructions, configuration, product content, or production deployment behavior — a "docs-only" diff that is really runtime instruction carries real claims and is not auto-sized to one line.
+Before composing anything, build a compact internal **scope map** from the **complete oneline commit list and final three-dot diff**. Use the oneline subjects for full-range coverage; use the final diff to merge overlaps, discard fix-up-only work, and correct stale or misleading subjects; consult the fuller messages only when a subject remains opaque or conflicts with the diff. Group the remaining work into material outcome clusters (one is fine), name one umbrella outcome that covers them, and identify each cluster's **material claims** — what became possible, what was fixed, what risk changed, or what design decision the reviewer must assess. Derive this map from the full range, never from the latest commit, tracker title, branch name, or original request. The map is internal: do not expand the body to enumerate clusters the umbrella already covers. **Classify each changed file by runtime purpose, not extension** when you judge this: markdown or YAML may be inert docs and examples, or runtime agent instructions, configuration, product content, or production deployment behavior — a "docs-only" diff that is really runtime instruction carries real claims and is not auto-sized to one line.
+
+Surface the material claims the diff alone cannot establish; let the rest stay implicit.
 
 Decision cost sets **what you surface, not how long you run** — it raises the content floor, not the length ceiling. A high-uncertainty *small* diff earns a sharper lead and at most a one-line validation caveat, not a multi-section essay; reviewer uncertainty moves a change at most one size row, and only when the diff genuinely can't carry the claim. Fold risk and residual uncertainty into the narrative rather than spawning dedicated `##` sections unless the PR is already large. The one-rule replacement for "shorter is safer":
 
@@ -92,7 +94,7 @@ For small + non-trivial bugfixes, the 3-5 sentence target still needs a user-vis
 
 - Type by intent, not file extension. When `fix` and `feat` both seem to fit, default to `fix` — adding code to remedy missing behavior is `fix`. Reserve `feat` for capabilities the user could not previously accomplish. Use `refactor`/`docs`/`chore`/`perf`/`test` when more precise.
 - Scope (optional): narrowest useful label. Omit when no single label adds clarity.
-- Description: imperative, lowercase, under 72 chars, no trailing period.
+- Description: derive it from the scope map's umbrella outcome, not one outcome cluster or implementation mechanism. It need not enumerate every cluster, but it must not make another material outcome sound incidental. Keep it imperative, lowercase, under 72 chars, with no trailing period.
 - Match repo conventions visible in recent commits.
 - **Never use `!` or `BREAKING CHANGE:` without explicit user confirmation** — they trigger automated major-version bumps.
 
@@ -210,8 +212,10 @@ Branding alone is never a reason to rewrite a PR description. If branding is the
 
 ## Step E: Pre-apply coverage audit
 
-Before returning the body, check it against the material claims from Step A and revise if any answer is wrong:
+Before returning the title and body, check them against the scope map and material claims from Step A and revise if any answer is wrong:
 
+- Does the title express the umbrella outcome rather than one cluster or implementation mechanism?
+- Is every material outcome represented by the umbrella framing or body, or intentionally omitted because it is supporting-only?
 - Is every claim the diff can't establish present — and is any claim the diff *does* show restated needlessly?
 - Is decision-changing evidence stated as a result rather than collapsed into an unexplained "tests passed", with demonstrated results kept distinct from assumptions and from mixed or negative outcomes?
 - Can any sentence or section of the *description* be cut without lowering reviewer confidence? If so, cut it, except for headings, fields, checklists, or boilerplate the project's PR-body contract requires. For a new PR with branding enabled, retain the Step D footer; it is intentional attribution rather than descriptive content. Likewise retain the session-settled provenance sentence when Step C included one; it carries decision provenance the diff cannot show.

--- a/tests/commit-push-pr-contract.test.ts
+++ b/tests/commit-push-pr-contract.test.ts
@@ -7,6 +7,33 @@ async function readRepoFile(relativePath: string): Promise<string> {
 }
 
 describe("ce-commit-push-pr contract", () => {
+  test("reconciles the complete branch scope before composition", async () => {
+    const content = await readRepoFile(
+      "skills/ce-commit-push-pr/references/pr-description-writing.md",
+    )
+
+    expect(content).not.toContain("Read every commit")
+    const sizingSection = content.match(
+      /## Step A: Size the description([\s\S]+?)## Step B:/,
+    )?.[1]
+    expect(sizingSection).toContain(
+      "complete oneline commit list and final three-dot diff",
+    )
+    expect(sizingSection).toContain("scope map")
+    expect(sizingSection).toContain("umbrella outcome")
+    expect(sizingSection).toContain("consult the fuller messages only")
+    const titleSection = content.match(
+      /## Step B: Compose the title([\s\S]+?)## Step B1:/,
+    )?.[1]
+    expect(titleSection).toContain("scope map")
+    expect(titleSection).toContain("umbrella outcome")
+    const auditSection = content.match(
+      /## Step E: Pre-apply coverage audit([\s\S]+)\s*$/,
+    )?.[1]
+    expect(auditSection).toContain("scope map")
+    expect(auditSection).toContain("every material outcome")
+  })
+
   test("repository PR-body contracts set structure without replacing editorial guidance", async () => {
     const content = await readRepoFile(
       "skills/ce-commit-push-pr/references/pr-description-writing.md",


### PR DESCRIPTION
## Summary

PR titles and descriptions now reconcile the complete base-to-head branch scope before composition, preventing a recent commit, tracker title, branch name, or session request from narrowing a broader change. The skill builds a compact internal scope map from every oneline subject and the final diff, consulting fuller messages only when evidence conflicts or remains opaque; material outcomes feed one umbrella title and body while supporting fixups stay implicit.

Existing decision-cost, anti-enumeration, and length rules remain in force, so long histories increase coverage rather than description length.

## Validation

- Fresh-agent fixtures covering 1, 5, 20, and 40 commits all produced complete, right-sized summaries; the 40-commit adversarial case excluded reverted work and resisted a narrow final-commit distractor.
- A blind old-vs-new comparison succeeded under both contracts on the strong model, so it establishes scale coverage and no regression rather than causal improvement.
- `bun test tests/commit-push-pr-contract.test.ts`: 11 passed, 0 failed.
- `bun test`: 2,249 passed, 0 failed.
