### PR TITLE
fix(opencode): register CE skills as /commands in opencode plugin

### DIFF
--- a/.opencode/plugins/compound-engineering.js
+++ b/.opencode/plugins/compound-engineering.js
@@ -19,7 +19,7 @@ function loadSkills() {
       if (!m) continue
       const name = m[1]
       commands[name] = {
-        template: `Execute the "${name}" skill.`,
+        template: `Execute the "${name}" skill.\n\nTask: $ARGUMENTS`,
       }
     }
   } catch {}
@@ -36,7 +36,11 @@ export const CompoundEngineeringPlugin = async () => ({
       config.skills.paths.push(skillsDir)
     }
     config.command = config.command || {}
-    Object.assign(config.command, skillCommands)
+    for (const [name, cmd] of Object.entries(skillCommands)) {
+      if (!(name in config.command)) {
+        config.command[name] = cmd
+      }
+    }
   },
 })
 

--- a/.opencode/plugins/compound-engineering.js
+++ b/.opencode/plugins/compound-engineering.js
@@ -5,24 +5,51 @@ import { fileURLToPath } from "url"
 const pluginDir = path.dirname(fileURLToPath(import.meta.url))
 const skillsDir = path.resolve(pluginDir, "../../skills")
 
+function unquote(value) {
+  if (value.length < 2) return value
+  const quote = value[0]
+  if ((quote !== '"' && quote !== "'") || value[value.length - 1] !== quote) return value
+  const inner = value.slice(1, -1)
+  return quote === '"' ? inner.replace(/\\(["\\])/g, "$1") : inner.replace(/''/g, "'")
+}
+
+// Scoped to the leading `---` block so a `name:`/`description:` line inside a
+// fenced YAML example in the skill body cannot register a bogus command.
+function parseFrontmatter(content) {
+  const block = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!block) return null
+  const fields = {}
+  for (const line of block[1].split(/\r?\n/)) {
+    const pair = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/)
+    if (pair) fields[pair[1]] = unquote(pair[2].trim())
+  }
+  return fields
+}
+
 function loadSkills() {
   const commands = {}
+  let entries
   try {
-    const entries = fs.readdirSync(skillsDir)
-    for (const entry of entries) {
-      const skillPath = path.join(skillsDir, entry)
-      if (!fs.statSync(skillPath).isDirectory()) continue
-      const filePath = path.join(skillPath, "SKILL.md")
-      if (!fs.existsSync(filePath)) continue
-      const content = fs.readFileSync(filePath, "utf8")
-      const m = content.match(/^name:\s*(\S+)/m)
-      if (!m) continue
-      const name = m[1]
-      commands[name] = {
-        template: `Execute the "${name}" skill.\n\nTask: $ARGUMENTS`,
-      }
+    entries = fs.readdirSync(skillsDir)
+  } catch {
+    return commands
+  }
+  for (const entry of entries) {
+    let content
+    try {
+      content = fs.readFileSync(path.join(skillsDir, entry, "SKILL.md"), "utf8")
+    } catch {
+      continue
     }
-  } catch {}
+    const fields = parseFrontmatter(content)
+    if (!fields || !fields.name) continue
+    if (fields["user-invocable"] === "false") continue
+    const command = {
+      template: `Load and execute the \`${fields.name}\` skill.\n\n$ARGUMENTS`,
+    }
+    if (fields.description) command.description = fields.description
+    commands[fields.name] = command
+  }
   return commands
 }
 

--- a/.opencode/plugins/compound-engineering.js
+++ b/.opencode/plugins/compound-engineering.js
@@ -1,8 +1,32 @@
 import path from "path"
+import fs from "fs"
 import { fileURLToPath } from "url"
 
 const pluginDir = path.dirname(fileURLToPath(import.meta.url))
 const skillsDir = path.resolve(pluginDir, "../../skills")
+
+function loadSkills() {
+  const commands = {}
+  try {
+    const entries = fs.readdirSync(skillsDir)
+    for (const entry of entries) {
+      const skillPath = path.join(skillsDir, entry)
+      if (!fs.statSync(skillPath).isDirectory()) continue
+      const filePath = path.join(skillPath, "SKILL.md")
+      if (!fs.existsSync(filePath)) continue
+      const content = fs.readFileSync(filePath, "utf8")
+      const m = content.match(/^name:\s*(\S+)/m)
+      if (!m) continue
+      const name = m[1]
+      commands[name] = {
+        template: `Execute the "${name}" skill.`,
+      }
+    }
+  } catch {}
+  return commands
+}
+
+const skillCommands = loadSkills()
 
 export const CompoundEngineeringPlugin = async () => ({
   config: async (config) => {
@@ -11,6 +35,8 @@ export const CompoundEngineeringPlugin = async () => ({
     if (!config.skills.paths.includes(skillsDir)) {
       config.skills.paths.push(skillsDir)
     }
+    config.command = config.command || {}
+    Object.assign(config.command, skillCommands)
   },
 })
 

--- a/tests/opencode-plugin-commands.test.ts
+++ b/tests/opencode-plugin-commands.test.ts
@@ -1,0 +1,101 @@
+import fs from "fs"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+// @ts-expect-error -- plain JS plugin entrypoint, no type declarations
+import { CompoundEngineeringPlugin } from "../.opencode/plugins/compound-engineering.js"
+import { parseFrontmatter } from "../src/utils/frontmatter"
+
+const skillsDir = path.resolve(import.meta.dir, "../skills")
+
+type OpenCodeCommand = { template: string; description?: string }
+type OpenCodeConfig = {
+  skills?: { paths?: string[] }
+  command?: Record<string, OpenCodeCommand>
+}
+
+async function applyPlugin(config: OpenCodeConfig = {}): Promise<OpenCodeConfig> {
+  const plugin = await CompoundEngineeringPlugin()
+  await plugin.config(config)
+  return config
+}
+
+// The plugin ships a dependency-free regex parser because the OpenCode runtime loads
+// it as plain JS; this oracle uses the repo's js-yaml parser so the two disagree if
+// the regex one drifts.
+const skills = fs
+  .readdirSync(skillsDir)
+  .filter((entry) => fs.existsSync(path.join(skillsDir, entry, "SKILL.md")))
+  .map((dir) => {
+    const raw = fs.readFileSync(path.join(skillsDir, dir, "SKILL.md"), "utf8")
+    const { data } = parseFrontmatter(raw, `${dir}/SKILL.md`)
+    return {
+      dir,
+      name: data.name as string,
+      description: data.description as string | undefined,
+      suppressed: data["user-invocable"] === false || data["user-invocable"] === "false",
+    }
+  })
+
+const expectedTemplate = (name: string) => `Load and execute the \`${name}\` skill.\n\n$ARGUMENTS`
+
+describe("opencode plugin skill commands", () => {
+  test("registers a command for every user-invocable skill", async () => {
+    const config = await applyPlugin()
+    const expected = skills
+      .filter((skill) => !skill.suppressed)
+      .map((skill) => skill.name)
+      .sort()
+
+    expect(Object.keys(config.command ?? {}).sort()).toEqual(expected)
+  })
+
+  test("each command carries a $ARGUMENTS template and the skill description", async () => {
+    const config = await applyPlugin()
+    for (const skill of skills) {
+      const command = config.command?.[skill.name]
+      if (skill.suppressed) {
+        expect(command).toBeUndefined()
+        continue
+      }
+      expect(command?.template).toBe(expectedTemplate(skill.name))
+      expect(command?.description).toBe(skill.description)
+    }
+  })
+
+  // additionalProperties: false in the opencode config schema -- an unknown key
+  // here is a config validation error, not an ignored field.
+  test("commands use only keys the opencode config schema allows", async () => {
+    const allowed = new Set(["template", "description", "agent", "model", "variant", "subtask"])
+    const config = await applyPlugin()
+    for (const command of Object.values(config.command ?? {})) {
+      for (const key of Object.keys(command)) {
+        expect(allowed.has(key)).toBe(true)
+      }
+    }
+  })
+
+  test("does not clobber a user-defined command of the same name", async () => {
+    const mine: OpenCodeCommand = { template: "my own ce-plan wrapper" }
+    const config = await applyPlugin({ command: { "ce-plan": mine } })
+
+    expect(config.command?.["ce-plan"]).toBe(mine)
+    expect(config.command?.["ce-debug"]?.template).toBe(expectedTemplate("ce-debug"))
+  })
+
+  test("registers the skills directory once, preserving existing paths", async () => {
+    const config = await applyPlugin({ skills: { paths: ["/somewhere/else"] } })
+    await applyPlugin(config)
+
+    expect(config.skills?.paths).toEqual(["/somewhere/else", skillsDir])
+  })
+
+  // Guards the frontmatter-scoped parse: a whole-file `name:` match could pick up
+  // a line from a fenced YAML example and register a command with no skill behind it.
+  test("every registered command name is a skill directory name", async () => {
+    const config = await applyPlugin()
+    const dirs = new Set(skills.map((skill) => skill.dir))
+    for (const name of Object.keys(config.command ?? {})) {
+      expect(dirs.has(name)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

In **pi**, CE skills appear automatically as invocable commands. In **opencode**, skills
are only loaded on-demand by the AI via the `skill` tool — there are no `/command`
entrypoints. Users must describe the task and hope the AI loads the right skill.

## Solution

The V1 opencode plugin now scans the `skills/` directory at load time (reads `name:`
from SKILL.md frontmatter) and registers one `/command` per skill in the opencode config
via the `config` hook.

Each command template is:
```
Execute the "<skill-name>" skill.
```

When you type `/ce-plan` or `/ce-debug` in the TUI, the AI loads that skill.

31 commands registered — 30 `ce-*` + `lfg`.

## Verification

- All 31 skills parsed and registered correctly
- Plugin loads without errors (verified with `bun -e`)
- All existing `bun test` tests pass