### PR TITLE
fix(peer-job-runner): clear error when os.fork is unavailable

### DIFF
--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -613,15 +613,6 @@ def detach_supervisor(job_dir: str, argv, result_path, conf: dict) -> bool:
     """setsid double-fork. The grandchild (new session, stdio on /dev/null,
     reparented to init) runs the supervisor; the parent returns once the
     supervisor acks that the pid file exists."""
-    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
-        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
-        # Fail with a clear message instead of AttributeError mid-detach (#1184).
-        raise RunnerError(
-            "detached peer jobs require os.fork/os.setsid (POSIX). "
-            "On native Windows, run Claude Code / this skill under WSL, or wait "
-            "for a Windows-native detach path (see EveryInc/compound-engineering-plugin#1184). "
-            f"Job left never-started at {job_dir}"
-        )
     sys.stdout.flush()
     sys.stderr.flush()
     read_fd, write_fd = os.pipe()
@@ -692,7 +683,23 @@ def sweep_stale_runs(skill_dir: str, keep: str) -> None:
         shutil.rmtree(entry.path, ignore_errors=True)
 
 
+def _require_posix_detach() -> None:
+    """Detached peer jobs need os.fork/os.setsid (POSIX). Checked first, before
+    jobs_root_base()/geteuid, so native Windows fails with this clear message
+    instead of jobs_root_base()'s unrelated "effective user ID is unavailable"
+    error (both are missing there) or an AttributeError mid-detach (#1184)."""
+    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
+        raise RunnerError(
+            "detached peer jobs require os.fork/os.setsid (POSIX); no job was "
+            "started. On native Windows, run Claude Code / this skill under WSL, "
+            "or wait for a Windows-native detach path (see "
+            "EveryInc/compound-engineering-plugin#1184)."
+        )
+
+
 def cmd_start(args, worker_argv) -> int:
+    _require_posix_detach()
     for flag, value in (("--skill", args.skill), ("--run-id", args.run_id)):
         if not _is_safe_token(value):
             raise RunnerError(f"{flag} must match [A-Za-z0-9._-]+ and not be all dots (got {value!r})")

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -613,6 +613,15 @@ def detach_supervisor(job_dir: str, argv, result_path, conf: dict) -> bool:
     """setsid double-fork. The grandchild (new session, stdio on /dev/null,
     reparented to init) runs the supervisor; the parent returns once the
     supervisor acks that the pid file exists."""
+    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
+        # Fail with a clear message instead of AttributeError mid-detach (#1184).
+        raise RunnerError(
+            "detached peer jobs require os.fork/os.setsid (POSIX). "
+            "On native Windows, run Claude Code / this skill under WSL, or wait "
+            "for a Windows-native detach path (see EveryInc/compound-engineering-plugin#1184). "
+            f"Job left never-started at {job_dir}"
+        )
     sys.stdout.flush()
     sys.stderr.flush()
     read_fd, write_fd = os.pipe()

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -613,15 +613,6 @@ def detach_supervisor(job_dir: str, argv, result_path, conf: dict) -> bool:
     """setsid double-fork. The grandchild (new session, stdio on /dev/null,
     reparented to init) runs the supervisor; the parent returns once the
     supervisor acks that the pid file exists."""
-    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
-        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
-        # Fail with a clear message instead of AttributeError mid-detach (#1184).
-        raise RunnerError(
-            "detached peer jobs require os.fork/os.setsid (POSIX). "
-            "On native Windows, run Claude Code / this skill under WSL, or wait "
-            "for a Windows-native detach path (see EveryInc/compound-engineering-plugin#1184). "
-            f"Job left never-started at {job_dir}"
-        )
     sys.stdout.flush()
     sys.stderr.flush()
     read_fd, write_fd = os.pipe()
@@ -692,7 +683,23 @@ def sweep_stale_runs(skill_dir: str, keep: str) -> None:
         shutil.rmtree(entry.path, ignore_errors=True)
 
 
+def _require_posix_detach() -> None:
+    """Detached peer jobs need os.fork/os.setsid (POSIX). Checked first, before
+    jobs_root_base()/geteuid, so native Windows fails with this clear message
+    instead of jobs_root_base()'s unrelated "effective user ID is unavailable"
+    error (both are missing there) or an AttributeError mid-detach (#1184)."""
+    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
+        raise RunnerError(
+            "detached peer jobs require os.fork/os.setsid (POSIX); no job was "
+            "started. On native Windows, run Claude Code / this skill under WSL, "
+            "or wait for a Windows-native detach path (see "
+            "EveryInc/compound-engineering-plugin#1184)."
+        )
+
+
 def cmd_start(args, worker_argv) -> int:
+    _require_posix_detach()
     for flag, value in (("--skill", args.skill), ("--run-id", args.run_id)):
         if not _is_safe_token(value):
             raise RunnerError(f"{flag} must match [A-Za-z0-9._-]+ and not be all dots (got {value!r})")

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -613,6 +613,15 @@ def detach_supervisor(job_dir: str, argv, result_path, conf: dict) -> bool:
     """setsid double-fork. The grandchild (new session, stdio on /dev/null,
     reparented to init) runs the supervisor; the parent returns once the
     supervisor acks that the pid file exists."""
+    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
+        # Fail with a clear message instead of AttributeError mid-detach (#1184).
+        raise RunnerError(
+            "detached peer jobs require os.fork/os.setsid (POSIX). "
+            "On native Windows, run Claude Code / this skill under WSL, or wait "
+            "for a Windows-native detach path (see EveryInc/compound-engineering-plugin#1184). "
+            f"Job left never-started at {job_dir}"
+        )
     sys.stdout.flush()
     sys.stderr.flush()
     read_fd, write_fd = os.pipe()

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -613,15 +613,6 @@ def detach_supervisor(job_dir: str, argv, result_path, conf: dict) -> bool:
     """setsid double-fork. The grandchild (new session, stdio on /dev/null,
     reparented to init) runs the supervisor; the parent returns once the
     supervisor acks that the pid file exists."""
-    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
-        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
-        # Fail with a clear message instead of AttributeError mid-detach (#1184).
-        raise RunnerError(
-            "detached peer jobs require os.fork/os.setsid (POSIX). "
-            "On native Windows, run Claude Code / this skill under WSL, or wait "
-            "for a Windows-native detach path (see EveryInc/compound-engineering-plugin#1184). "
-            f"Job left never-started at {job_dir}"
-        )
     sys.stdout.flush()
     sys.stderr.flush()
     read_fd, write_fd = os.pipe()
@@ -692,7 +683,23 @@ def sweep_stale_runs(skill_dir: str, keep: str) -> None:
         shutil.rmtree(entry.path, ignore_errors=True)
 
 
+def _require_posix_detach() -> None:
+    """Detached peer jobs need os.fork/os.setsid (POSIX). Checked first, before
+    jobs_root_base()/geteuid, so native Windows fails with this clear message
+    instead of jobs_root_base()'s unrelated "effective user ID is unavailable"
+    error (both are missing there) or an AttributeError mid-detach (#1184)."""
+    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
+        raise RunnerError(
+            "detached peer jobs require os.fork/os.setsid (POSIX); no job was "
+            "started. On native Windows, run Claude Code / this skill under WSL, "
+            "or wait for a Windows-native detach path (see "
+            "EveryInc/compound-engineering-plugin#1184)."
+        )
+
+
 def cmd_start(args, worker_argv) -> int:
+    _require_posix_detach()
     for flag, value in (("--skill", args.skill), ("--run-id", args.run_id)):
         if not _is_safe_token(value):
             raise RunnerError(f"{flag} must match [A-Za-z0-9._-]+ and not be all dots (got {value!r})")

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -613,6 +613,15 @@ def detach_supervisor(job_dir: str, argv, result_path, conf: dict) -> bool:
     """setsid double-fork. The grandchild (new session, stdio on /dev/null,
     reparented to init) runs the supervisor; the parent returns once the
     supervisor acks that the pid file exists."""
+    if not hasattr(os, "fork") or not hasattr(os, "setsid"):
+        # Native Windows (and some embedded Pythons) lack POSIX process APIs.
+        # Fail with a clear message instead of AttributeError mid-detach (#1184).
+        raise RunnerError(
+            "detached peer jobs require os.fork/os.setsid (POSIX). "
+            "On native Windows, run Claude Code / this skill under WSL, or wait "
+            "for a Windows-native detach path (see EveryInc/compound-engineering-plugin#1184). "
+            f"Job left never-started at {job_dir}"
+        )
     sys.stdout.flush()
     sys.stderr.flush()
     read_fd, write_fd = os.pipe()

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -163,6 +163,38 @@ class SafeTokenAllDots(unittest.TestCase):
                 MOD.resolve_job_dir("..")
 
 
+class PosixDetachPreflight(unittest.TestCase):
+    def test_returns_silently_when_fork_and_setsid_present(self):
+        self.assertIsNone(MOD._require_posix_detach())
+
+    def test_blocks_before_jobs_root_base_when_fork_setsid_missing(self):
+        # Regression (#1186 review): on native Windows, os.fork/os.setsid are
+        # ALSO missing alongside os.geteuid/os.getuid, so cmd_start must reject
+        # via _require_posix_detach() before ever calling jobs_root_base() --
+        # otherwise jobs_root_base()'s unrelated "effective user ID is
+        # unavailable" error fires first and the clearer WSL/#1184 message
+        # never shows on the default (no CE_PEER_JOBS_ROOT) invocation path.
+        real_fork, real_setsid = os.fork, os.setsid
+        del os.fork
+        del os.setsid
+        try:
+            with mock.patch.object(
+                MOD,
+                "jobs_root_base",
+                side_effect=AssertionError(
+                    "jobs_root_base must not run before the POSIX detach check"
+                ),
+            ):
+                with self.assertRaises(MOD.RunnerError) as cm:
+                    MOD.cmd_start(None, None)
+            message = str(cm.exception)
+            self.assertIn("os.fork/os.setsid", message)
+            self.assertIn("1184", message)
+        finally:
+            os.fork = real_fork
+            os.setsid = real_setsid
+
+
 class PidRunningZombie(unittest.TestCase):
     def test_zombie_leader_counts_as_not_running(self):
         # A just-exited leader is briefly a <defunct> zombie: os.kill(pid, 0)


### PR DESCRIPTION
## Summary
- On native Windows, `detach_supervisor` called `os.fork()` / `os.setsid()` and crashed with `AttributeError`.
- Guard those APIs and raise `RunnerError` with a clear WSL / tracking-issue message instead.
- Full Windows-native detach (subprocess / job objects) is still follow-up work for #1184; this stops the opaque crash and points users at a working path.

Fixes: https://github.com/EveryInc/compound-engineering-plugin/issues/1184

## Test plan
- [x] Confirmed all three skill copies of `peer-job-runner.py` stay in sync
- [ ] On Windows native Python: `peer-job-runner.py start ...` should print the RunnerError text instead of `AttributeError: module 'os' has no attribute 'fork'`
- [ ] On macOS/Linux: existing detach path unchanged

Made with [Cursor](https://cursor.com)