### PR TITLE
docs(skills): add practical invocation examples

### DIFF
--- a/docs/skills/ce-babysit-pr.md
+++ b/docs/skills/ce-babysit-pr.md
@@ -22,6 +22,25 @@ The compound-engineering shipping chain is `/ce-work → /ce-commit-push-pr → 
 
 ---
 
+## Example invocations
+
+```text
+# Watch the pull request for the current branch until it is ready or blocked
+/ce-babysit-pr
+
+# Watch a specific pull request by number or URL
+/ce-babysit-pr 1234
+/ce-babysit-pr https://github.com/acme/widgets/pull/1234
+
+# Run one checkpoint tick and return a copyable resume command
+/ce-babysit-pr 1234 checkpoint
+
+# Force the self-sustaining in-session watch when the harness supports it
+/ce-babysit-pr 1234 watch
+```
+
+---
+
 ## The Problem
 
 Babysitting a PR by hand — or with a naive loop — fails in predictable ways:

--- a/docs/skills/ce-babysit-pr.md
+++ b/docs/skills/ce-babysit-pr.md
@@ -34,9 +34,6 @@ The compound-engineering shipping chain is `/ce-work → /ce-commit-push-pr → 
 
 # Run one checkpoint tick and return a copyable resume command
 /ce-babysit-pr 1234 checkpoint
-
-# Force the self-sustaining in-session watch when the harness supports it
-/ce-babysit-pr 1234 watch
 ```
 
 ---

--- a/docs/skills/ce-brainstorm.md
+++ b/docs/skills/ce-brainstorm.md
@@ -35,6 +35,9 @@ One thing it deliberately does *not* do is render a verdict. When a request is r
 ## Example invocations
 
 ```text
+# Shape an ambitious feature or project before committing to a plan
+/ce-brainstorm design a self-serve migration platform for enterprise customers
+
 # Turn a rough feature idea into a requirements artifact
 /ce-brainstorm add a way for users to pause notifications
 
@@ -44,7 +47,10 @@ One thing it deliberately does *not* do is render a verdict. When a request is r
 # Brainstorm non-software work with the same scope and decision discipline
 /ce-brainstorm plan a two-day customer advisory workshop
 
-# Produce a self-contained HTML artifact instead of Markdown
+# Ask for a self-contained HTML artifact in plain language
+/ce-brainstorm add account-level notification settings and make the artifact a self-contained HTML page
+
+# Equivalent shorthand when a repeatable automation needs it
 /ce-brainstorm add account-level notification settings output:html
 ```
 

--- a/docs/skills/ce-brainstorm.md
+++ b/docs/skills/ce-brainstorm.md
@@ -32,6 +32,24 @@ One thing it deliberately does *not* do is render a verdict. When a request is r
 
 ---
 
+## Example invocations
+
+```text
+# Turn a rough feature idea into a requirements artifact
+/ce-brainstorm add a way for users to pause notifications
+
+# Explore a problem without prescribing the solution up front
+/ce-brainstorm support agents get paged overnight for non-urgent events
+
+# Brainstorm non-software work with the same scope and decision discipline
+/ce-brainstorm plan a two-day customer advisory workshop
+
+# Produce a self-contained HTML artifact instead of Markdown
+/ce-brainstorm add account-level notification settings output:html
+```
+
+---
+
 ## The Problem
 
 Going straight from a vague idea to implementation produces:

--- a/docs/skills/ce-code-review.md
+++ b/docs/skills/ce-code-review.md
@@ -22,23 +22,18 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 ## Example invocations
 
 ```text
-# Review the current branch and report findings without changing files
+# Deep-review the current branch; relevant plan and session context are discovered automatically
 /ce-code-review
-
-# Review the current checkout against a known base
-/ce-code-review base:origin/main
 
 # Review a specific PR without checking it out
 /ce-code-review https://github.com/acme/widgets/pull/1234
 
-# Verify the diff against an explicit implementation plan
-/ce-code-review plan:docs/plans/notification-mute.md
+# Review the current branch and fix verified findings in this checkout
+/ce-code-review review this branch and fix eligible findings locally
 
-# Explicitly authorize eligible fixes in the local checkout
-/ce-code-review apply:local
+# Ask for a lighter pass when the full multi-agent review is unnecessary
+/ce-code-review give this branch a quick review
 ```
-
-Do not combine a PR or branch target with `base:`: a base ref means the current checkout is already the intended review scope.
 
 ---
 

--- a/docs/skills/ce-code-review.md
+++ b/docs/skills/ce-code-review.md
@@ -19,6 +19,29 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Review the current branch and report findings without changing files
+/ce-code-review
+
+# Review the current checkout against a known base
+/ce-code-review base:origin/main
+
+# Review a specific PR without checking it out
+/ce-code-review https://github.com/acme/widgets/pull/1234
+
+# Verify the diff against an explicit implementation plan
+/ce-code-review plan:docs/plans/notification-mute.md
+
+# Explicitly authorize eligible fixes in the local checkout
+/ce-code-review apply:local
+```
+
+Do not combine a PR or branch target with `base:`: a base ref means the current checkout is already the intended review scope.
+
+---
+
 ## The Problem
 
 Generalist code review prompts collapse in predictable ways:

--- a/docs/skills/ce-commit-push-pr.md
+++ b/docs/skills/ce-commit-push-pr.md
@@ -35,9 +35,6 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 # Describe a different PR from its complete branch scope
 /ce-commit-push-pr https://github.com/acme/widgets/pull/1234
-
-# Ship but leave CI and review monitoring to the caller
-/ce-commit-push-pr mode:pipeline
 ```
 
 ---

--- a/docs/skills/ce-commit-push-pr.md
+++ b/docs/skills/ce-commit-push-pr.md
@@ -21,6 +21,27 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Commit current work, push the branch, and open a PR
+/ce-commit-push-pr
+
+# Draft a PR description without applying it
+/ce-commit-push-pr draft a PR description for this branch
+
+# Rewrite the current PR description with a specific emphasis
+/ce-commit-push-pr update the PR description to include benchmark results
+
+# Describe a different PR from its complete branch scope
+/ce-commit-push-pr https://github.com/acme/widgets/pull/1234
+
+# Ship but leave CI and review monitoring to the caller
+/ce-commit-push-pr mode:pipeline
+```
+
+---
+
 ## The Problem
 
 Going from "code written" to "PR open" is supposed to be a one-step move, but it tends to fail in predictable ways:

--- a/docs/skills/ce-compound-refresh.md
+++ b/docs/skills/ce-compound-refresh.md
@@ -15,7 +15,27 @@ It pairs with `ce-compound`: that skill **captures** new learnings; this skill *
 | What does it do? | Reviews learnings in `docs/solutions/` against the current codebase and applies one of five outcomes: Keep, Update, Consolidate, Replace, Delete |
 | When to use it | After significant refactors; when `ce-compound` flags an older doc as superseded; when learnings are accumulating drift; periodic hygiene sweeps |
 | What it produces | Updated, consolidated, replaced, or deleted docs — plus a maintenance report |
-| Modes | **Interactive** (default) and **Autofix** (`mode:autofix`) |
+| Modes | **Interactive** (default) and **Headless** (`mode:headless`) |
+
+---
+
+## Example invocations
+
+```text
+# Refresh learnings related to one module or topic
+/ce-compound-refresh authentication
+
+# Review one known learning or pattern document
+/ce-compound-refresh plugin-versioning-requirements
+
+# Sweep the full learning set when a narrow scope is not available
+/ce-compound-refresh
+
+# Apply unambiguous maintenance without interactive decisions
+/ce-compound-refresh authentication mode:headless
+```
+
+Prefer a topic, module, category, or filename hint: an unscoped run first has to triage the entire learning set.
 
 ---
 
@@ -52,9 +72,9 @@ The skill investigates first (Phase 1 reads each doc against the current codebas
 
 Most "review the docs" prompts collapse into "is this still right?" → vague answers. The five-outcome model forces a specific decision per doc and a specific action: Keep does nothing, Update applies in-place fixes, Consolidate merges and deletes, Replace writes a successor, Delete removes the file. Each has its own evidence bar.
 
-### 2. Two modes — Interactive default, Autofix on `mode:autofix`
+### 2. Two modes — Interactive default, Headless on `mode:headless`
 
-**Interactive** (default) asks one question at a time on ambiguous cases, leads with a recommendation. **Autofix** processes all docs without user interaction, applies all unambiguous actions, and marks ambiguous cases as stale (with `status: stale`, `stale_reason`, `stale_date` in frontmatter) for later human review. The autofix report has two sections: **Applied** (writes that succeeded) and **Recommended** (writes that couldn't be applied — e.g., permission denied — with full rationale so a human can apply them).
+**Interactive** (default) asks one question at a time on ambiguous cases, leads with a recommendation. **Headless** processes all docs without user interaction, applies all unambiguous actions, and marks ambiguous cases as stale (with `status: stale`, `stale_reason`, `stale_date` in frontmatter) for later human review. The headless report has two sections: **Applied** (writes that succeeded) and **Recommended** (writes that couldn't be applied — e.g., permission denied — with full rationale so a human can apply them).
 
 ### 3. Document-set analysis — catches what per-doc review misses
 
@@ -98,7 +118,7 @@ Deleted docs are deleted, not moved to `_archived/`. Git history preserves every
 
 ### 10. Discoverability check carries over
 
-Like `ce-compound`, every refresh run checks whether `AGENTS.md`/`CLAUDE.md` surfaces `docs/solutions/`. The check runs every time — knowledge only compounds value when agents can find it. In autofix mode, the recommendation appears in the report rather than being applied (autofix scope is doc maintenance, not project config).
+Like `ce-compound`, every refresh run checks whether `AGENTS.md`/`CLAUDE.md` surfaces `docs/solutions/`. The check runs every time — knowledge only compounds value when agents can find it. In headless mode, the recommendation appears in the report rather than being applied (headless scope is doc maintenance, not project config).
 
 ---
 
@@ -158,7 +178,7 @@ The skill is invoked directly with a scope hint that narrows the review:
 - **Module/component** — `/ce-compound-refresh payments`
 - **Category** — `/ce-compound-refresh performance-issues`
 - **Pattern topic** — `/ce-compound-refresh critical-patterns`
-- **Autofix mode** — `/ce-compound-refresh auth mode:autofix` (no user interaction; report is the deliverable)
+- **Headless mode** — `/ce-compound-refresh auth mode:headless` (no user interaction; report is the deliverable)
 - **Broad sweep** (rare) — `/ce-compound-refresh` with no scope, processes everything
 
 Without a scope hint, the skill discovers the candidate set, does broad-scope triage (groups by module/component, identifies highest-impact clusters), and recommends a starting area before deep investigation.
@@ -173,7 +193,7 @@ Without a scope hint, the skill discovers the candidate set, does broad-scope tr
 | `<directory>` | e.g., `performance-issues` — narrows by category |
 | `<filename slug>` | e.g., `plugin-versioning-requirements` — narrows by file |
 | `<module/keyword>` | e.g., `auth`, `payments` — narrows by content/frontmatter |
-| `mode:autofix` | Append to any of the above; runs without user interaction, applies all unambiguous actions, marks ambiguous as stale |
+| `mode:headless` | Append to any of the above; runs without user interaction, applies all unambiguous actions, marks ambiguous as stale |
 
 ---
 
@@ -185,11 +205,11 @@ Update fixes drift while keeping the core solution intact (renamed file, moved c
 **Why doesn't the skill ask whether code changes were intentional?**
 Stay-in-your-lane discipline. The skill's job is doc accuracy — match the doc to current code. Whether the code change was right or wrong is a code-review concern; if the user thinks the code is wrong, that's a separate workflow.
 
-**When should I use autofix mode?**
-For periodic sweeps, scheduled maintenance runs, or large-scope reviews where stopping for every question would be impractical. Autofix marks ambiguous cases as stale rather than incorrectly resolving them, so the deliverable is a self-contained report a human can review.
+**When should I use headless mode?**
+For periodic sweeps, scheduled maintenance runs, or large-scope reviews where stopping for every question would be impractical. Headless mode marks ambiguous cases as stale rather than incorrectly resolving them, so the deliverable is a self-contained report a human can review.
 
 **What if the skill wants to delete a doc I think should be kept?**
-In interactive mode, you'll see the recommendation with evidence before deletion. Decline and the doc stays. In autofix mode, the auto-delete safety conditions are conservative — substantive citations downgrade to stale-marking automatically.
+In interactive mode, you'll see the recommendation with evidence before deletion. Decline and the doc stays. In headless mode, the auto-delete safety conditions are conservative — substantive citations downgrade to stale-marking automatically.
 
 **Why delete instead of archive?**
 Archive folders accumulate and pollute search results, nobody reads them, and they create the illusion of "we'll come back to this" without actually doing it. Git history preserves every deleted file. `git log --diff-filter=D -- docs/solutions/` finds anything you need to recover.

--- a/docs/skills/ce-compound.md
+++ b/docs/skills/ce-compound.md
@@ -28,11 +28,8 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 # Focus capture when the session contains several solved problems
 /ce-compound the email digest race condition we fixed
 
-# Capture unattended with the full research and review path
-/ce-compound mode:headless depth:full the verified caching fix
-
-# Use the lower-overhead unattended path when the context is already clear
-/ce-compound mode:headless depth:lightweight the verified caching fix
+# Capture unattended when invoked from automation or standing instructions
+/ce-compound mode:headless the verified caching fix
 ```
 
 Use headless mode only when the caller should own any follow-up decisions; ordinary interactive capture can still ask before changing project guidance.

--- a/docs/skills/ce-compound.md
+++ b/docs/skills/ce-compound.md
@@ -19,6 +19,26 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Capture the verified solution from the current conversation
+/ce-compound
+
+# Focus capture when the session contains several solved problems
+/ce-compound the email digest race condition we fixed
+
+# Capture unattended with the full research and review path
+/ce-compound mode:headless depth:full the verified caching fix
+
+# Use the lower-overhead unattended path when the context is already clear
+/ce-compound mode:headless depth:lightweight the verified caching fix
+```
+
+Use headless mode only when the caller should own any follow-up decisions; ordinary interactive capture can still ask before changing project guidance.
+
+---
+
 ## The Problem
 
 Most teams solve the same problem twice — sometimes with the same person — because the first solution lives in conversation, chat history, or a teammate's head. Common failure shapes:

--- a/docs/skills/ce-debug.md
+++ b/docs/skills/ce-debug.md
@@ -21,6 +21,27 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Start from a failing test
+/ce-debug spec/models/notification_subscription_spec.rb
+
+# Start from an issue or ticket and include its full discussion
+/ce-debug https://github.com/acme/widgets/issues/1234
+/ce-debug ABC-456
+
+# Start from observed behavior when no ticket exists
+/ce-debug the digest job sends duplicate emails after a retry
+
+# Invoke first, then paste a stack trace when the error is the best evidence
+/ce-debug
+```
+
+Describe what is observably broken, not the fix you suspect; the skill validates the causal chain before changing code.
+
+---
+
 ## The Problem
 
 Common debugging anti-patterns:

--- a/docs/skills/ce-doc-review.md
+++ b/docs/skills/ce-doc-review.md
@@ -19,6 +19,23 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Review a specific requirements or plan document interactively
+/ce-doc-review docs/plans/notification-mute.md
+
+# Let the skill find the most recent planning document
+/ce-doc-review
+
+# Return structured findings to a calling workflow without questions
+/ce-doc-review mode:headless docs/plans/notification-mute.md
+```
+
+Interactive mode is for deciding findings now. Headless mode preserves the same classifications but leaves non-safe decisions to its caller.
+
+---
+
 ## The Problem
 
 Document review is harder than code review in specific ways:

--- a/docs/skills/ce-doc-review.md
+++ b/docs/skills/ce-doc-review.md
@@ -27,12 +27,7 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 # Let the skill find the most recent planning document
 /ce-doc-review
-
-# Return structured findings to a calling workflow without questions
-/ce-doc-review mode:headless docs/plans/notification-mute.md
 ```
-
-Interactive mode is for deciding findings now. Headless mode preserves the same classifications but leaves non-safe decisions to its caller.
 
 ---
 

--- a/docs/skills/ce-dogfood.md
+++ b/docs/skills/ce-dogfood.md
@@ -20,6 +20,24 @@ It is **diff-scoped**, not whole-app exploration, and it is **hands-off**: once 
 
 ---
 
+## Example invocations
+
+```text
+# Dogfood the diff on the current feature branch
+/ce-dogfood
+
+# Dogfood a specific pull request or branch
+/ce-dogfood 847
+/ce-dogfood feature/new-dashboard
+
+# Reuse a dev server already running on a custom port
+/ce-dogfood --port 5000
+```
+
+Use `ce-test-browser` instead when you want a bounded route test rather than exploratory, experience-focused QA.
+
+---
+
 ## The Problem
 
 A branch can pass static review and unit tests and still be broken or rough in the browser — and finding that out usually means a manual click-through that:

--- a/docs/skills/ce-explain.md
+++ b/docs/skills/ce-explain.md
@@ -4,6 +4,22 @@
 
 Point it at a concept, a diff, an idea, or a window of your own recent work, and get a dense, visual explainer written for you personally — with an optional check-in (predict what a diff does before the reveal; answer exercises that get corrected) that makes the material actually stick.
 
+## Example invocations
+
+```text
+# Explain a recent code change from its diff
+/ce-explain diff:HEAD~3..HEAD
+
+# Teach an external technical concept
+/ce-explain Ruby garbage compaction
+
+# Build a timeline for meeting preparation
+/ce-explain since:monday
+
+# Turn an early idea into a visual thinking artifact
+/ce-explain my idea of caching explainers per repository
+```
+
 ## The Problem
 
 Agent-driven development removed the learning that writing code by hand used to provide. You ship work through agents, rarely read the code, and stop accumulating the understanding that typing it yourself once forced. The cost shows up twice: comprehension debt on your own projects, and recall gaps when a meeting needs you to speak to what happened last week. The plugin's other skills capture knowledge for the *repo* (`/ce-compound`) or judge options (`/ce-pov`); none of them teaches *you*.
@@ -26,15 +42,6 @@ The explainer is HTML-first (markdown on request), show-n-tell by default — di
 3. **Skippable by design.** Routine recaps skip the check-in; you can always decline. Some things don't need a learning loop.
 4. **Capability-detected destinations.** The destination ask offers only what your environment supports, with a local file as the always-present floor — and the artifact exists on disk before the ask, so declining everything loses nothing.
 5. **Honest external grounding.** External topics with no web access fall back to model knowledge — labeled as unverified in the artifact, never passed off as checked.
-
-## Quick Example
-
-```text
-/ce-explain diff:HEAD~3..HEAD
-/ce-explain ruby garbage compaction
-/ce-explain since:monday          # meeting prep
-/ce-explain my idea of caching explainers per repo
-```
 
 ## When to Reach For It
 

--- a/docs/skills/ce-explain.md
+++ b/docs/skills/ce-explain.md
@@ -8,13 +8,13 @@ Point it at a concept, a diff, an idea, or a window of your own recent work, and
 
 ```text
 # Explain a recent code change from its diff
-/ce-explain diff:HEAD~3..HEAD
+/ce-explain teach me how the changes in the last three commits work
 
 # Teach an external technical concept
 /ce-explain Ruby garbage compaction
 
 # Build a timeline for meeting preparation
-/ce-explain since:monday
+/ce-explain build a timeline of what changed since Monday
 
 # Turn an early idea into a visual thinking artifact
 /ce-explain my idea of caching explainers per repository

--- a/docs/skills/ce-handoff.md
+++ b/docs/skills/ce-handoff.md
@@ -21,6 +21,28 @@ The skill is prose-first and uses the active agent's available capabilities. It 
 
 ---
 
+## Example invocations
+
+```text
+# End the current session and create a handoff in managed temporary storage
+/ce-handoff
+
+# Create a handoff with a specific focus for the receiving agent
+/ce-handoff create finish the authentication migration
+
+# Find likely handoffs by topic, then choose one before its body is read
+/ce-handoff resume authentication migration
+
+# Resume directly when you already have the source
+/ce-handoff resume /path/to/authentication-migration.md
+/ce-handoff resume https://example.com/authentication-migration-handoff
+
+# Make the handoff reachable from another machine or container
+/ce-handoff create a handoff and publish it to ht-ml.app
+```
+
+---
+
 ## The Problem
 
 A productive agent session contains more than changed files. It accumulates the user's intent, decisions, rejected alternatives, constraints, failed attempts, verification results, and knowledge of fragile local state. A fresh agent in another model or harness cannot rely on that session history being available.
@@ -52,14 +74,7 @@ Automatic managed-store discovery works when the receiving session can see the s
 
 ## Create and Resume Ergonomics
 
-The direction is determined by intent:
-
-```text
-/ce-handoff
-/ce-handoff create focus on the failing integration test
-```
-
-Both create a new handoff. The bare form always means create.
+The direction is determined by intent. A bare invocation always means create; `create <focus>` makes the next session's intended objective explicit.
 
 Creation ends with the exact command needed in the receiving session:
 
@@ -69,13 +84,7 @@ Creation ends with the exact command needed in the receiving session:
 
 Before the command, the creation response briefly summarizes what the handoff captured so the user can confirm its substance without opening the file. The skill then prints this compact command as the source of truth rather than generating a longer launch prompt.
 
-```text
-/ce-handoff resume https://example.com/team/auth-migration-handoff
-/ce-handoff resume authentication migration
-Find the handoff about the authentication migration
-```
-
-These resume from an explicit source or discover likely candidates. A selected source may be a local file, text file, URL/page, pasted handoff, or another readable artifact. It may come from any person, agent, or system and does not need CE frontmatter or even need to have been created as a formal handoff. Natural language avoids forcing the user to remember command syntax when “handoff” feels directionally awkward in a new session.
+Resume intent either reads an explicit source or discovers likely candidates. A selected source may be a local file, text file, URL/page, pasted handoff, or another readable artifact. It may come from any person, agent, or system and does not need CE frontmatter or even need to have been created as a formal handoff. Natural language such as “Find the handoff about the authentication migration” avoids forcing the user to remember command syntax when “handoff” feels directionally awkward in a new session.
 
 ## Safe Discovery
 

--- a/docs/skills/ce-ideate.md
+++ b/docs/skills/ce-ideate.md
@@ -42,9 +42,6 @@ The chain works across domains — every step supports universal mode. `ce-ideat
 # Find solution opportunities across patterns in open GitHub issues
 /ce-ideate what product opportunities do you see across our open GitHub issues?
 
-# Ideate from the unresolved work in a Linear project
-/ce-ideate find solution opportunities across the open tickets in https://linear.app/acme/project/customer-onboarding-1234
-
 # Ask for non-obvious directions without naming a subject
 /ce-ideate surprise me
 

--- a/docs/skills/ce-ideate.md
+++ b/docs/skills/ce-ideate.md
@@ -30,6 +30,29 @@ The chain works across domains — every step supports universal mode. `ce-ideat
 
 ---
 
+## Example invocations
+
+```text
+# Generate grounded product or codebase opportunities
+/ce-ideate what should we improve in this repository?
+
+# Focus ideation on a specific product surface
+/ce-ideate onboarding improvements for new team administrators
+
+# Ask for non-obvious directions without naming a subject
+/ce-ideate surprise me
+
+# Use the same engine for non-software ideation
+/ce-ideate names for a neighborhood coffee shop
+
+# Write Markdown instead of the default self-contained HTML artifact
+/ce-ideate developer experience improvements output:md
+```
+
+Use `ce-pov` when the candidates are already known and need judgment; use `ce-brainstorm` when one candidate needs scope.
+
+---
+
 ## The Problem
 
 Asking an AI "what's worth exploring here?" usually returns:

--- a/docs/skills/ce-ideate.md
+++ b/docs/skills/ce-ideate.md
@@ -42,6 +42,9 @@ The chain works across domains — every step supports universal mode. `ce-ideat
 # Find solution opportunities across patterns in open GitHub issues
 /ce-ideate what product opportunities do you see across our open GitHub issues?
 
+# Ideate from the open work in an accessible Linear project
+/ce-ideate find solution opportunities across https://linear.app/acme/project/customer-onboarding-1234
+
 # Ask for non-obvious directions without naming a subject
 /ce-ideate surprise me
 

--- a/docs/skills/ce-ideate.md
+++ b/docs/skills/ce-ideate.md
@@ -39,13 +39,22 @@ The chain works across domains — every step supports universal mode. `ce-ideat
 # Focus ideation on a specific product surface
 /ce-ideate onboarding improvements for new team administrators
 
+# Find solution opportunities across patterns in open GitHub issues
+/ce-ideate what product opportunities do you see across our open GitHub issues?
+
+# Ideate from the unresolved work in a Linear project
+/ce-ideate find solution opportunities across the open tickets in https://linear.app/acme/project/customer-onboarding-1234
+
 # Ask for non-obvious directions without naming a subject
 /ce-ideate surprise me
 
 # Use the same engine for non-software ideation
 /ce-ideate names for a neighborhood coffee shop
 
-# Write Markdown instead of the default self-contained HTML artifact
+# Ask for Markdown instead of the default self-contained HTML artifact
+/ce-ideate developer experience improvements, and write the artifact in Markdown
+
+# Equivalent shorthand when a repeatable automation needs it
 /ce-ideate developer experience improvements output:md
 ```
 

--- a/docs/skills/ce-optimize.md
+++ b/docs/skills/ce-optimize.md
@@ -19,6 +19,26 @@ Inspired by Karpathy's autoresearch, generalized for multi-file code changes and
 
 ---
 
+## Example invocations
+
+```text
+# Start from a plain-language outcome and build the measurement spec together
+/ce-optimize reduce build time by 30%
+
+# Optimize a qualitative result with an LLM-as-judge rubric
+/ce-optimize improve clustering quality for notification categories
+
+# Run from an existing, reviewable optimization specification
+/ce-optimize path/to/clustering-quality.yaml
+
+# Resume a persisted run from its saved specification
+/ce-optimize .context/compound-engineering/ce-optimize/clustering-quality/spec.yaml
+```
+
+Use a spec when the metric, gates, budget, or stopping rule must be reviewed before experiments start.
+
+---
+
 ## The Problem
 
 For optimization-shaped problems, the common failure modes:
@@ -148,7 +168,7 @@ The branch (`optimize/<spec-name>`) and experiment log are preserved through Pha
 
 - **From a spec** — `/ce-optimize path/to/spec.yaml` (use `references/example-hard-spec.yaml` or `references/example-judge-spec.yaml` as starting points)
 - **From a description** — `/ce-optimize "reduce build time by 30%"` walks you through writing the spec interactively
-- **Resume an existing run** — `/ce-optimize <spec-name>` detects the existing branch and offers Resume vs Fresh Start
+- **Resume an existing run** — `/ce-optimize .context/compound-engineering/ce-optimize/<spec-name>/spec.yaml` detects the existing branch and offers Resume vs Fresh Start
 
 For a friendly overview of what the skill is for, when to use hard metrics vs LLM-as-judge, and example kickoff prompts, see `references/usage-guide.md`.
 

--- a/docs/skills/ce-plan.md
+++ b/docs/skills/ce-plan.md
@@ -33,6 +33,33 @@ But it stands alone just as well — many teams reach for `ce-plan` directly wit
 
 ---
 
+## Example invocations
+
+```text
+# Enrich a requirements-only brainstorm artifact into an implementation-ready plan
+/ce-plan docs/plans/notification-mute.md
+
+# Plan directly from an issue or PRD
+/ce-plan https://github.com/acme/widgets/issues/1234
+/ce-plan docs/product/account-notifications-prd.md
+
+# Bootstrap planning from a clear rough idea
+/ce-plan add a background email digest at 8am UTC
+
+# Revisit and deepen an existing plan
+/ce-plan deepen docs/plans/auth-rewrite.md
+
+# Plan a non-software multi-step project
+/ce-plan organize a two-day customer advisory workshop
+
+# Produce a self-contained HTML artifact
+/ce-plan docs/plans/notification-mute.md output:html
+```
+
+Start with `ce-brainstorm` when the product shape is still unsettled; direct planning works best when the intended outcome is already clear.
+
+---
+
 ## The Problem
 
 Plans written by humans (or AI without structure) tend to fail in predictable ways:

--- a/docs/skills/ce-plan.md
+++ b/docs/skills/ce-plan.md
@@ -36,6 +36,9 @@ But it stands alone just as well — many teams reach for `ce-plan` directly wit
 ## Example invocations
 
 ```text
+# Plan from the current conversation, including a completed ce-brainstorm
+/ce-plan
+
 # Enrich a requirements-only brainstorm artifact into an implementation-ready plan
 /ce-plan docs/plans/notification-mute.md
 
@@ -52,8 +55,11 @@ But it stands alone just as well — many teams reach for `ce-plan` directly wit
 # Plan a non-software multi-step project
 /ce-plan organize a two-day customer advisory workshop
 
-# Produce a self-contained HTML artifact
-/ce-plan docs/plans/notification-mute.md output:html
+# Ask for a self-contained HTML artifact in plain language
+/ce-plan turn the notification mute requirements into an implementation-ready plan and make it a self-contained HTML page
+
+# Equivalent shorthand when a repeatable automation needs it
+/ce-plan turn the notification mute requirements into an implementation-ready plan output:html
 ```
 
 Start with `ce-brainstorm` when the product shape is still unsettled; direct planning works best when the intended outcome is already clear.

--- a/docs/skills/ce-pov.md
+++ b/docs/skills/ce-pov.md
@@ -21,6 +21,32 @@ It fills the judgment gap between exploring (`/ce-ideate`), scoping (`/ce-brains
 
 ---
 
+## Example invocations
+
+```text
+# Decide whether an external tool fits this project
+/ce-pov should we adopt Drizzle ORM here?
+
+# Get a holistic bottom line on a document
+# Use ce-doc-review instead when you want issue-by-issue findings
+/ce-pov what do you think of docs/plans/new-checkout.md?
+
+# Choose between approaches that are already on the table
+/ce-pov for this service, should we use polling or webhooks?
+
+# Supply a bare link when you want ce-pov to propose the possible questions first
+/ce-pov https://example.com/tool
+
+# Ask for an independent cross-model check
+/ce-pov oracle: should we adopt this auth provider?
+/ce-pov compare your take on docs/plans/new-checkout.md with Grok and Composer
+
+# Invoke it mid-session for a grounded second opinion on the current direction
+/ce-pov
+```
+
+---
+
 ## The Problem
 
 A bare agent asked "what's your POV on X?" fails in predictable ways:
@@ -142,19 +168,7 @@ Skip `ce-pov` when:
 
 ## Use Standalone
 
-- **Adoption** — `/ce-pov should we adopt Drizzle ORM here?`
-- **Migration** — `/ce-pov should we migrate off Moment to Temporal?`
-- **Selection** — `/ce-pov what should we use for feature flags?`
-- **Comparison** — `/ce-pov how does Biome compare to our ESLint + Prettier setup?`
-- **Exposure** — `/ce-pov does CVE-2026-1234 in tar affect us?`
-- **Revisit** — `/ce-pov we passed on tRPC last year — still the right call?`
-- **Bare link** — paste a URL with nothing else; the intake gate proposes framings
-- **Warm** — `/ce-pov` mid-brainstorm for a second opinion
-- **Document take** — `/ce-pov what do you think of docs/plans/new-checkout.md?`
-- **Approach set** — `/ce-pov for this service, should we use polling or webhooks?`
-- **Named cross-check** — `/ce-pov compare your take with Grok and Composer`
-- **Cursor default** — `/ce-pov compare your take with Cursor`
-- **Oracle** — `/ce-pov oracle: should we adopt this auth provider?`
+The examples near the top cover the main subject shapes and panel routes. Other useful prompts include migration decisions, bounded technology selection, CVE exposure, revisiting a past decision, and a Cursor-default cross-check.
 
 ---
 

--- a/docs/skills/ce-pov.md
+++ b/docs/skills/ce-pov.md
@@ -37,8 +37,11 @@ It fills the judgment gap between exploring (`/ce-ideate`), scoping (`/ce-brains
 # Supply a bare link when you want ce-pov to propose the possible questions first
 /ce-pov https://example.com/tool
 
-# Ask for an independent cross-model check
-/ce-pov oracle: should we adopt this auth provider?
+# Ask an independent panel to pressure-test the proposal already in this conversation
+/ce-pov oracle that proposal
+
+# Ask for an independent cross-model check on an explicit question
+/ce-pov ask an independent panel whether we should adopt this auth provider
 /ce-pov compare your take on docs/plans/new-checkout.md with Grok and Composer
 
 # Invoke it mid-session for a grounded second opinion on the current direction

--- a/docs/skills/ce-product-pulse.md
+++ b/docs/skills/ce-product-pulse.md
@@ -19,6 +19,26 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Use the configured default window, or 24 hours when none is configured
+/ce-product-pulse
+
+# Review a weekly window
+/ce-product-pulse 7d
+
+# Run a narrow launch check while still respecting ingestion delay
+/ce-product-pulse 1h
+
+# Re-run the source and metric setup interview
+/ce-product-pulse reconfigure
+```
+
+Choose the shortest window that answers the question: a launch check and a weekly operating review should not use the same horizon.
+
+---
+
 ## The Problem
 
 Most "how are we doing?" reports fail in predictable ways:

--- a/docs/skills/ce-promote.md
+++ b/docs/skills/ce-promote.md
@@ -19,6 +19,26 @@ It drafts only. It never posts, publishes, commits, or opens PRs — shipping th
 
 ---
 
+## Example invocations
+
+```text
+# Derive what shipped from the current project and draft the default channels
+/ce-promote
+
+# Supply the shipped value when the repository context is not enough
+/ce-promote announce one-click CSV export for account reports
+
+# Ask for several alternatives on one channel
+/ce-promote 3 tweet options for the new one-click CSV export
+
+# Draft a coordinated cross-channel launch set
+/ce-promote a launch across X, LinkedIn, and email for one-click CSV export
+```
+
+Name channels when you need a particular distribution shape; otherwise the skill chooses a small default set. It always drafts and never posts.
+
+---
+
 ## The Problem
 
 Messaging usually waits for a separate marketing pass, so it lags the ship — and the engineer who has the most context on the user value isn't the one who writes the copy. When announcement copy *is* written ad hoc, it tends toward AI tells ("We're thrilled to announce…"), hashtag spam, and implementation-speak instead of user value.

--- a/docs/skills/ce-proof.md
+++ b/docs/skills/ce-proof.md
@@ -19,6 +19,26 @@
 
 ---
 
+## Example invocations
+
+```text
+# Publish a local Markdown document and keep the file canonical
+/ce-proof share docs/plans/notification-mute.md to Proof
+
+# Read or collaborate on an existing Proof document
+/ce-proof https://www.proofeditor.ai/d/example?token=example
+
+# Publish the Markdown file that was just edited
+/ce-proof share this to Proof
+
+# Pull current Proof content to a local file as a separate explicit action
+/ce-proof pull this Proof document to docs/reviews/notification-mute.md
+```
+
+Publishing is one-way by default. Pulling remote content back to disk is separate because it changes the local source of truth.
+
+---
+
 ## The Problem
 
 Sharing markdown drafts for review is harder than it looks:

--- a/docs/skills/ce-resolve-pr-feedback.md
+++ b/docs/skills/ce-resolve-pr-feedback.md
@@ -19,6 +19,23 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Resolve all new actionable feedback on the current branch's PR
+/ce-resolve-pr-feedback
+
+# Resolve all new actionable feedback on a specific PR
+/ce-resolve-pr-feedback 1234
+
+# Address only one review thread and leave every other thread untouched
+/ce-resolve-pr-feedback https://github.com/acme/widgets/pull/1234#discussion_r5678901
+```
+
+Use a discussion URL for surgical follow-up. A PR number or bare invocation runs the full unresolved-feedback workflow.
+
+---
+
 ## The Problem
 
 Resolving PR feedback at scale fails in predictable ways:

--- a/docs/skills/ce-riffrec-feedback-analysis.md
+++ b/docs/skills/ce-riffrec-feedback-analysis.md
@@ -17,6 +17,25 @@
 
 ---
 
+## Example invocations
+
+```text
+# Analyze a complete Riffrec capture bundle
+/ce-riffrec-feedback-analysis riffrec-2026-05-04-checkout-flow.zip
+
+# Analyze video, audio, or written feedback through the same router
+/ce-riffrec-feedback-analysis demo.mp4
+/ce-riffrec-feedback-analysis voice-memo.m4a
+/ce-riffrec-feedback-analysis meeting-notes.md
+
+# Get capture setup help when no recording exists yet
+/ce-riffrec-feedback-analysis how do I install and use Riffrec?
+```
+
+Short single-issue inputs become concise bug reports; longer or multi-issue inputs produce structured analysis and hand off to `ce-brainstorm`.
+
+---
+
 ## The Problem
 
 Raw user-feedback recordings don't reduce to structured input automatically:

--- a/docs/skills/ce-simplify-code.md
+++ b/docs/skills/ce-simplify-code.md
@@ -23,6 +23,26 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Simplify the current branch diff before review or PR creation
+/ce-simplify-code
+
+# Limit the pass to one file
+/ce-simplify-code app/services/notification_dispatcher.rb
+
+# Describe a conversational scope when paths alone are not expressive enough
+/ce-simplify-code the changes I made to NotificationDispatcher
+
+# Clean up code an agent just generated before it becomes review noise
+/ce-simplify-code the authentication code from the last implementation step
+```
+
+User-named scope is authoritative. A bare invocation prefers the branch diff, then staged or unstaged work, then files recently edited in the conversation.
+
+---
+
 ## The Problem
 
 After writing a feature, the code usually has refinement debt that's easy to miss in the moment:

--- a/docs/skills/ce-strategy.md
+++ b/docs/skills/ce-strategy.md
@@ -19,6 +19,26 @@ The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /c
 
 ---
 
+## Example invocations
+
+```text
+# Create STRATEGY.md through the full interview when none exists
+/ce-strategy
+
+# Revisit one section without reopening the entire strategy
+/ce-strategy approach
+
+# Focus a section update on a specific question
+/ce-strategy metrics for retention
+
+# Invoke without arguments on an existing strategy to choose sections interactively
+/ce-strategy
+```
+
+Prefer a section or scope hint for targeted maintenance; a bare invocation is intentionally broader when `STRATEGY.md` already exists.
+
+---
+
 ## The Problem
 
 Most teams either don't have a strategy doc, or have one that's so long nobody reads it. Failure shapes:

--- a/docs/skills/ce-sweep.md
+++ b/docs/skills/ce-sweep.md
@@ -8,6 +8,25 @@
 | **Invocation** | Manual (`/ce-sweep`) or scheduled (`/ce-sweep mode:headless`); never model-invoked |
 | **Position** | Around the loop — feeds `/lfg` and `ce-plan` from customer feedback |
 
+## Example invocations
+
+```text
+# First run: configure sources, approvals, state location, and scheduling
+/ce-sweep
+
+# Later runs: fetch, acknowledge, analyze, verify, and reconcile the plan
+/ce-sweep
+
+# Scheduled or unattended run: defer ambiguous decisions into the plan
+/ce-sweep mode:headless
+
+# Re-enter setup to add or edit feedback sources
+/ce-sweep reconfigure
+
+# Ship the reconciled open items through the autonomous pipeline
+/lfg docs/plans/feedback-sweep-plan.md
+```
+
 ## Problem
 
 Feedback triage tends to become a bespoke, per-repo ritual: scan a Slack channel since last time, react to show it was seen, download and watch screen recordings, figure out whether something already got fixed, and keep a private list of what's still open. Every project rebuilds this by hand, the state lives in someone's head or a one-off file, and "fixed" claims get trusted without evidence.
@@ -25,17 +44,6 @@ Every item's lifecycle lives in a durable YAML state file with a versioned schem
 3. **Fix verification trusts only merge evidence.** Thread claims never close an item — only a verified merge to the default branch does, recorded with the merge SHA.
 4. **The plan is a view, not a log.** One rolling plan at a stable path is reconciled every run: new items append, verified-fixed items drain, and a human-owned notes region survives untouched. If `/lfg` has enriched the plan in place, the sweep archives it and starts a fresh view rather than clobbering execution state.
 5. **Headless-safe by contract.** `mode:headless` never prompts: ambiguous product calls defer into the plan's outstanding questions, and an acknowledgment volume circuit-breaker defers rather than mass-reacting when a cursor looks wrong.
-
-## Quick Example
-
-```
-/ce-sweep                    # first run: interactive setup (sources, approvals, state location, schedule offer)
-/ce-sweep                    # subsequent runs: sweep, acknowledge, analyze, verify, reconcile plan
-/ce-sweep mode:headless      # scheduled/unattended run — defers decisions into the plan
-/ce-sweep reconfigure        # re-enter setup to add or edit sources
-```
-
-After a sweep: `/lfg docs/plans/feedback-sweep-plan.md` ships the open items.
 
 ## When to Reach For It
 

--- a/docs/skills/ce-test-browser.md
+++ b/docs/skills/ce-test-browser.md
@@ -23,7 +23,7 @@
 # Test routes affected by the current branch; the user owns the dev server
 /ce-test-browser
 
-# Test a specific pull request or branch
+# Derive routes from a PR or branch already checked out locally; test its running server
 /ce-test-browser 847
 /ce-test-browser feature/new-dashboard
 
@@ -31,7 +31,7 @@
 /ce-test-browser --port 5000
 ```
 
-When no server is running, the skill stops with the correct command to start one.
+PR and branch arguments select the diff used to derive routes; they do not switch the local checkout. Check out the target code and start its server before invoking the skill. When no server is running, the skill stops with the correct command to start one.
 
 ---
 

--- a/docs/skills/ce-test-browser.md
+++ b/docs/skills/ce-test-browser.md
@@ -17,6 +17,27 @@
 
 ---
 
+## Example invocations
+
+```text
+# Test routes affected by the current branch; the user owns the dev server
+/ce-test-browser
+
+# Test a specific pull request or branch
+/ce-test-browser 847
+/ce-test-browser feature/new-dashboard
+
+# Connect manual mode to an existing server on a custom port
+/ce-test-browser --port 5000
+
+# Let an outer workflow start the server and choose a free port
+/ce-test-browser mode:pipeline
+```
+
+Manual mode stops with the correct start command when no server is running. Pipeline mode owns server startup because its caller cannot pause for setup.
+
+---
+
 ## The Problem
 
 End-to-end browser testing is fragmented across tools and easy to skip:

--- a/docs/skills/ce-test-browser.md
+++ b/docs/skills/ce-test-browser.md
@@ -29,12 +29,9 @@
 
 # Connect manual mode to an existing server on a custom port
 /ce-test-browser --port 5000
-
-# Let an outer workflow start the server and choose a free port
-/ce-test-browser mode:pipeline
 ```
 
-Manual mode stops with the correct start command when no server is running. Pipeline mode owns server startup because its caller cannot pause for setup.
+When no server is running, the skill stops with the correct command to start one.
 
 ---
 

--- a/docs/skills/ce-work.md
+++ b/docs/skills/ce-work.md
@@ -41,12 +41,7 @@ This is the fourth and final step in the compound-engineering ideation chain:
 
 # Resume the latest eligible plan in docs/plans
 /ce-work
-
-# Return implementation evidence to an outer orchestrator without opening a PR
-/ce-work mode:return-to-caller docs/plans/notification-mute.md
 ```
-
-Use caller-owned mode only from an outer workflow such as `lfg`; direct users normally want the standalone path that verifies, reviews, and ships the work.
 
 ---
 

--- a/docs/skills/ce-work.md
+++ b/docs/skills/ce-work.md
@@ -30,6 +30,26 @@ This is the fourth and final step in the compound-engineering ideation chain:
 
 ---
 
+## Example invocations
+
+```text
+# Execute a specific implementation-ready plan and own the shipping tail
+/ce-work docs/plans/notification-mute.md
+
+# Implement a clear small or medium task without writing a plan first
+/ce-work extract a shared duration formatter from the notification views
+
+# Resume the latest eligible plan in docs/plans
+/ce-work
+
+# Return implementation evidence to an outer orchestrator without opening a PR
+/ce-work mode:return-to-caller docs/plans/notification-mute.md
+```
+
+Use caller-owned mode only from an outer workflow such as `lfg`; direct users normally want the standalone path that verifies, reviews, and ships the work.
+
+---
+
 ## The Problem
 
 Asking an agent "implement this plan" goes wrong in predictable ways:

--- a/docs/skills/ce-worktree.md
+++ b/docs/skills/ce-worktree.md
@@ -19,6 +19,23 @@ It is pure prose + inline git, with **no bundled script**, so it works verbatim 
 
 ---
 
+## Example invocations
+
+```text
+# Start fresh work in isolation; existing isolation is detected first
+/ce-worktree for the account-notifications feature
+
+# Isolate an existing branch rather than creating a new one
+/ce-worktree isolate feature/account-notifications
+
+# Isolate a pull request without disturbing the current checkout
+/ce-worktree isolate PR 1234
+```
+
+If the current checkout is already an isolated worktree, every form works in place rather than nesting another worktree.
+
+---
+
 ## The Problem
 
 Asking an agent to "make a worktree" is increasingly the *wrong* default, because the agent is usually already in one:

--- a/docs/skills/lfg.md
+++ b/docs/skills/lfg.md
@@ -23,18 +23,18 @@ Use it when you want the full agentic shipping path and are comfortable with the
 ## Example invocations
 
 ```text
-# Ship a clear software task autonomously from planning through a green PR
-/lfg add account-level notification mute settings
-
-# Use the requirements already established in the current conversation
-/ce-brainstorm add account-level notification mute settings
+# Most common: settle an ambitious feature's requirements, then ship from that context
+/ce-brainstorm design account-level notification controls for enterprise teams
 /lfg
+
+# Ship a clear, already-well-bounded software task directly
+/lfg add a CSV export button to the account reports page
 
 # Ship an existing feedback-sweep plan after customer items are reconciled
 /lfg docs/plans/feedback-sweep-plan.md
 ```
 
-Invoke `lfg` only when you want the full hands-off shipping pipeline. Use the individual skills when you want to inspect or approve each stage.
+The most common handoff is `/ce-brainstorm` -> `/lfg`: brainstorm settles the requirements and scenarios, then `lfg` turns that context into a plan and carries it through implementation, review, PR, and CI. Invoke `lfg` directly when the task is already equally well bounded. Use individual skills when you want to inspect or approve stages yourself.
 
 ---
 

--- a/docs/skills/lfg.md
+++ b/docs/skills/lfg.md
@@ -20,6 +20,24 @@ Use it when you want the full agentic shipping path and are comfortable with the
 
 ---
 
+## Example invocations
+
+```text
+# Ship a clear software task autonomously from planning through a green PR
+/lfg add account-level notification mute settings
+
+# Use the requirements already established in the current conversation
+/ce-brainstorm add account-level notification mute settings
+/lfg
+
+# Ship an existing feedback-sweep plan after customer items are reconciled
+/lfg docs/plans/feedback-sweep-plan.md
+```
+
+Invoke `lfg` only when you want the full hands-off shipping pipeline. Use the individual skills when you want to inspect or approve each stage.
+
+---
+
 ## The Problem
 
 The normal CE workflow is deliberately staged: plan, work, simplify, review, ship. That is useful when you want to inspect each step, but too much handoff when the task is well-bounded and you want the agent to carry the whole thing.


### PR DESCRIPTION
## Summary

Skill documentation now shows practical, commented invocations near the top of each page when a skill has multiple useful entry points. The 27 qualifying pages cover distinct modes, input shapes, caller contracts, and best-use nuances so readers can quickly choose an effective prompt; single-path and already-sufficient pages remain unchanged.

This also consolidates redundant lower-page examples and aligns two stale examples with their current skill contracts: `ce-compound-refresh` uses `mode:headless`, and `ce-optimize` resumes from a spec YAML path.

## Validation

- `bun test`
- `bun run release:validate`
- `bun run plugin:validate`
- `git diff --check`

## Post-deploy monitoring

No additional operational monitoring is required because this changes static skill documentation, not runtime behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
