### PR TITLE
fix(ce-pov): identify supplied approaches in approach-set verdicts

### DIFF
--- a/skills/ce-pov/references/method.md
+++ b/skills/ce-pov/references/method.md
@@ -61,7 +61,7 @@ Name the few strengths and risks that actually determine the bottom line; do not
 
 ## Approach-set position contract
 
-An approach-set POV judges only the options the user or conversation supplied; generating a new option field belongs to `ce-ideate` or `ce-brainstorm`. Lead with a plain-language **Position**, then state:
+An approach-set POV judges only the options the user or conversation supplied; generating a new option field belongs to `ce-ideate` or `ce-brainstorm`. Lead with a plain-language **Position**. Name each supplied approach by a short distinguishing gloss on first mention in the Position and Tradeoffs — never a bare label like "Option A" that only the original list defines — so the block stands alone for a reader who never saw that list. Then state:
 
 `Why` · `Tradeoffs by supplied approach` · `Verified facts (project + load-bearing external claims, kept distinct)` · `Conversation hypotheses (unverified — warm only)` · `Conditions` · `Handoff (optional separate continuation)`
 


### PR DESCRIPTION
## Summary

An approach-set POV could hand you a verdict you couldn't read. One run led with "Adopt Option A ... Reject Option B" and never said what A and B were — so the result only made sense to someone holding the conversation that assigned those labels, and the person who asked for it had to scroll back through a long session to interpret their own answer.

The external-adoption contract already guards exactly this ("Render the grade so the reader never has to decode it"), but the approach-set contract had no equivalent for option labels, so the model kept reusing the conversation's throwaway shorthand. Approach-set verdicts now name each supplied approach by a short distinguishing gloss on first mention, so the block stands on its own — which matters because that block is also the handoff seed passed to `ce-plan` / `ce-brainstorm`.

`document-take` is deliberately left alone. Its labels point into a document the reader already holds, and no failure was reproduced there — adding the rule to it would be prose without evidence.

## Validation

`bun test` 2289 pass / 0 fail; `release:validate` in sync.

Behavioral A/B eval (arms differ by exactly this one sentence), 2 hosts x 2 arms x 3 trials, on an unrelated fixture. The grader was blind — it saw only the emitted output, never the original option list, and had to say what each approach *is* or answer UNKNOWN.

| Measure | Claude before | Claude after | Codex before | Codex after |
|---|---|---|---|---|
| Position alone is self-contained | 0/3 | **3/3** | 0/3 | 0/3 |
| Tradeoffs headings glossed | 3/3 | 3/3 | 0/3 | **3/3** |
| Full block is self-contained | 3/3 | 3/3 | 3/3 | 3/3 |
| Total output size | 4297b | 4338b (+0.9%) | 2409b | 2504b (+4.0%) |

Each host had a different weak spot and the one sentence fixed the weak spot on each: Claude's lead was carrying bare labels, while Codex's lead was already tight but its Tradeoffs headings were bare `**Option A:**` (now `**In-process exponential backoff (Option A)**`).

Two things a reviewer should weigh:

- **The full block already passed in both arms.** This is a lead-legibility fix, not broken-to-fixed. The lead is still the right target — it's what you read first and what gets passed downstream — but the honest read is that the whole block was already interpretable on this fixture.
- **Codex's Position still omits the rejected options entirely.** Its glossed Tradeoffs sit three lines below in the same block, so there's no scroll-back through session history. Forcing rejected options into the lead would bloat it and fight Codex's tighter output economy, so the wording stays as-is.

Output size stayed flat while the Position grew ~40-48%, confirming the gloss lands as a phrase in the lead rather than a new paragraph. Decisiveness was unchanged across all 12 runs.

This stays a `skill-creator` eval rather than a `bun test` guard — it needs a model to judge, so pinning it as a string test would be brittle.

## Decision process

Adjudicated with a `ce-pov` oracle panel. Codex (OpenAI `gpt-5.6-sol`) and Grok (xAI `grok-4.5`), both independence-verified, formed independent POVs without seeing each other's or mine. Both concurred: fix at the approach-set contract only, reject a broad cross-shape rule as over-scoped, reject status-quo as under-claiming, leave document-take unchanged. Concurrence raises confidence but doesn't rule out a shared blind spot — all three of us leaned on a single reproduced run.
