### PR TITLE
fix(ce-resolve-pr-feedback): stop replying into an unsubmitted review

### DIFF
--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -28,13 +28,16 @@ GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER OWNER
 
 **Pass the base `OWNER/REPO`** (parsed from the PR URL, when one was given) as the second arg. `get-pr-comments` otherwise falls back to `gh repo view` in the *current checkout* — so for a fork→upstream PR handed in as a URL, omitting it would fetch review feedback from the fork (or fail) instead of the upstream base repo. Every `get-pr-comments` call below (fetch and verify) takes the same `OWNER/REPO`.
 
-Returns a JSON object with three keys:
+Returns a JSON object with four keys:
 
 | Key | Contents | Has file/line? | Resolvable? |
 |-----|----------|---------------|-------------|
+| `pending_review` | Node ID of your own unsubmitted (PENDING) review on this PR, or `null` | n/a | n/a |
 | `review_threads` | Unresolved inline code review threads (includes outdated; each carries its `isOutdated` flag so line drift can be accounted for) | Yes | Yes (GraphQL) |
 | `pr_comments` | Top-level PR conversation comments (excludes PR author) | No | No |
 | `review_bodies` | Review submission bodies with non-empty text (excludes PR author) | No | No |
+
+**Stop here if `pending_review` is non-null.** Thread replies posted while you hold an unsubmitted review are absorbed into that draft: the reply call returns a comment ID and URL as if it succeeded, but nothing is visible to the reviewer until the draft is submitted. Do not proceed into steps 2-8 — the fixes would land while every reply silently disappeared. Tell the user they have an unsubmitted review on the PR, that it must be submitted or discarded before this skill can reply, and stop. Do not submit or discard it yourself; a draft review is unsent human writing.
 
 If the script fails, fall back to:
 ```bash
@@ -169,7 +172,7 @@ GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBE
 ```
 The returned `id` is the authoritative thread ID to use for reply and resolve. If it differs from what `get-pr-comments` returned, use the one from this script.
 
-1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread) (if the bundled script is missing, post the reply with `gh api` or `gh pr comment` as appropriate):
+1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread). If the bundled script is missing, reply with `gh api --method POST repos/{owner}/{repo}/pulls/PR_NUMBER/comments/COMMENT_ID/replies -f body=...` against the thread's first comment — never `gh pr review` or a `/reviews` POST, which open an unsubmitted draft review that swallows this reply and every one after it:
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 echo "REPLY_TEXT" | GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/reply-to-pr-thread" THREAD_ID

--- a/skills/ce-resolve-pr-feedback/references/targeted-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/targeted-mode.md
@@ -27,9 +27,11 @@ This fetches thread IDs and their first comment IDs (minimal fields, no bodies) 
 
 **Step 3** -- Check for your own unsubmitted review before doing any work. A reply posted while you hold one is absorbed into that draft: the call returns a comment ID and URL as if it succeeded, but the reviewer sees nothing until the draft is submitted. Full Mode gets this free from `get-pr-comments`; targeted mode never calls that script, so check directly (PENDING reviews are only visible to their author, so any hit is yours):
 ```bash
-GH_HOST=<host> gh api repos/OWNER/REPO/pulls/PR_NUMBER/reviews --jq '[.[] | select(.state == "PENDING")] | length'
+GH_HOST=<host> gh api --paginate repos/OWNER/REPO/pulls/PR_NUMBER/reviews --jq '.[] | select(.state == "PENDING") | .id'
 ```
-If this returns anything other than `0`, stop. Tell the user they have an unsubmitted review on the PR and that it must be submitted or discarded before this skill can reply. Do not submit or discard it yourself; a draft review is unsent human writing.
+`--paginate` is required: this endpoint is chronological and pages at 30, so a draft can sort past page 1. Print IDs rather than a count — `--jq` runs per page, so a count emits one number per page, but IDs simply concatenate and stay empty when there is no draft. (`--slurp` is not an option; `gh` rejects it alongside `--jq`.)
+
+If this prints anything, stop. Tell the user they have an unsubmitted review on the PR and that it must be submitted or discarded before this skill can reply. Do not submit or discard it yourself; a draft review is unsent human writing.
 
 ## 2. Judge, Fix, Reply, Resolve
 

--- a/skills/ce-resolve-pr-feedback/references/targeted-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/targeted-mode.md
@@ -25,6 +25,12 @@ GH_HOST=<host> bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBER COMMEN
 
 This fetches thread IDs and their first comment IDs (minimal fields, no bodies) and returns the matching thread with full comment details.
 
+**Step 3** -- Check for your own unsubmitted review before doing any work. A reply posted while you hold one is absorbed into that draft: the call returns a comment ID and URL as if it succeeded, but the reviewer sees nothing until the draft is submitted. Full Mode gets this free from `get-pr-comments`; targeted mode never calls that script, so check directly (PENDING reviews are only visible to their author, so any hit is yours):
+```bash
+GH_HOST=<host> gh api repos/OWNER/REPO/pulls/PR_NUMBER/reviews --jq '[.[] | select(.state == "PENDING")] | length'
+```
+If this returns anything other than `0`, stop. Tell the user they have an unsubmitted review on the PR and that it must be submitted or discarded before this skill can reply. Do not submit or discard it yourself; a draft review is unsent human writing.
+
 ## 2. Judge, Fix, Reply, Resolve
 
 **Judge first (the gate).** Apply the rubric in `references/evaluation-rubric.md` to this one thread, in your own context. Account for `isOutdated` and the location fields (`line`, `originalLine`, `startLine`, `originalStartLine`) -- targeted threads can be outdated too and need the same relocation handling. The cross-item reasoning in the rubric is a no-op for a single thread, but the read-depth and divert logic apply in full: deep-read (callers, invariants, `git blame`/PR rationale for author intent) before accepting a contestable finding or overriding code that looks deliberate. This is the legitimacy check — don't fix on the reviewer's authority alone.

--- a/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
+++ b/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
@@ -29,7 +29,14 @@ if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
     exit 1
 fi
 
-# Output is a JSON object with three keys:
+# Output is a JSON object with four keys:
+#   pending_review   - node ID of the viewer's own unsubmitted (PENDING) review
+#                      on this PR, or null. Replies posted while one exists get
+#                      silently absorbed into that draft and stay invisible
+#                      until it is submitted, so the modes must stop before the
+#                      reply loop when this is non-null. Costs no extra request:
+#                      the reviews query below already selects `state`, and a
+#                      PENDING review is only visible to its own author.
 #   review_threads   - unresolved inline review threads, edge-wrapped as
 #                      [{ node: { id, isResolved, isOutdated, path, line, ...,
 #                                 comments: { nodes: [...] } } }]
@@ -109,6 +116,7 @@ reviews_pages=$(gh api graphql --paginate --slurp \
   -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
   -f query='
 query Reviews($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
+  viewer { login }
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
       reviews(first: 100, after: $endCursor) {
@@ -138,7 +146,12 @@ jq -n \
   [$comments[].data.repository.pullRequest.comments.nodes[]] as $all_comments |
   [$reviews[].data.repository.pullRequest.reviews.nodes[]] as $all_reviews |
   [$all_threads[] | select(.isResolved == false)] as $unresolved |
+  ($reviews[0].data.viewer.login) as $viewer |
   {
+    pending_review: (first($all_reviews[]
+      | select(.state == "PENDING")
+      | select(($viewer == null) or (.author.login == $viewer))
+      | .id) // null),
     review_threads: [$unresolved[] | { node: . }],
     pr_comments: [$all_comments[]
       | select(($author.login == null) or (.author.login != $author.login))

--- a/skills/ce-resolve-pr-feedback/scripts/reply-to-pr-thread
+++ b/skills/ce-resolve-pr-feedback/scripts/reply-to-pr-thread
@@ -2,6 +2,18 @@
 
 # Replies to a PR review thread. Body is read from stdin to avoid
 # shell escaping issues with markdown (quotes, newlines, etc.).
+#
+# GraphQL rather than REST (`POST pulls/{n}/comments/{id}/replies`) because the
+# surrounding pipeline is thread-node-ID-native: get-pr-comments returns PRRT_
+# IDs and resolveReviewThread has no REST equivalent, so replying by thread ID
+# keeps one ID currency end to end. REST addresses a *comment*, which would mean
+# carrying the thread's root comment databaseId purely for this call. Both
+# produce a real inline threaded reply -- this is not a capability difference.
+#
+# Omitting pullRequestReviewId below means the reply is absorbed into the
+# viewer's PENDING review when one exists, returning success while staying
+# invisible until that draft is submitted. The modes guard against this via
+# get-pr-comments' pending_review key; do not add a reviewId here without one.
 
 set -e
 


### PR DESCRIPTION
Replies to review threads sometimes never reached the reviewer. The skill reported them as posted — the API returned a comment ID and URL and exited 0 — while the fixes landed and the replies stayed invisible.

The cause: `addPullRequestReviewThreadReply` is called without a `pullRequestReviewId`, so when the acting account already holds an unsubmitted (draft) review on the PR, the reply is absorbed into that draft and stays hidden until it is submitted. Whether a stray draft happens to exist is incidental to the PR being worked on, which is why this reproduced only sometimes.

Both modes now detect the draft and stop before the reply loop, telling the user to submit or discard it rather than doing either automatically — a draft review is unsent human writing. Full mode gets the signal for free: `get-pr-comments` already selected review `state` and was discarding it, so this adds an output key, not a request. Targeted mode never calls that script, so it does one direct REST check.

Full mode's reply fallback also told the agent to improvise with "`gh api` or `gh pr comment` as appropriate", which invited `gh pr review` or a `/reviews` POST — commands that *create* a draft review and cause this same failure directly. It now names the REST replies endpoint and rules those out.

Validation: exercised the new `jq` against five fixtures — no draft, own draft, another user's pending review (correctly ignored, since a PENDING review is only visible to its author), two drafts, and no reviews at all. That caught a generator-in-object-construction bug that would have emitted multiple JSON objects instead of one. `bun test` 2298 pass, `release:validate` clean.

One caveat worth carrying: the root cause is consistent with the symptom but **unverified against a live PR** — GitHub's published schema docs don't document the omitted-`pullRequestReviewId` behavior, and this was not reproduced end to end. The guard is defensible either way, since a dangling draft review breaks this skill's reply path regardless of mechanism. If the intermittency recurs after this ships, re-examine that assumption before anything else.
