### PR TITLE
fix(ce-resolve-pr-feedback): post replies as real multiline Markdown

### DIFF
--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -173,13 +173,32 @@ GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBE
 The returned `id` is the authoritative thread ID to use for reply and resolve. If it differs from what `get-pr-comments` returned, use the one from this script.
 
 1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread). If the bundled script is missing, reply with `gh api --method POST repos/{owner}/{repo}/pulls/PR_NUMBER/comments/COMMENT_ID/replies -f body=...` against the thread's first comment — never `gh pr review` or a `/reviews` POST, which open an unsubmitted draft review that swallows this reply and every one after it:
+Feed the body through a quoted heredoc, never `echo "..."` or `printf`. A reply is multi-line Markdown (a quote line, a blank line, then the response), and `echo` neither interprets `\n` nor survives a body composed with escape sequences — the reviewer then sees a single run-on line containing literal `\n` characters. The quoted delimiter (`<<'EOF'`) also stops the shell from expanding backticks, `$`, and `!` inside quoted code:
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-echo "REPLY_TEXT" | GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/reply-to-pr-thread" THREAD_ID
+GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/reply-to-pr-thread" THREAD_ID <<'EOF'
+> the specific sentence being addressed from the reviewer's comment
+
+Fixed in abc1234 — the lookup now null-checks before dereferencing.
+EOF
 ```
 Check that the returned comment URL contains the correct `OWNER/REPO` and PR number before proceeding.
 
-2. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread) (if the bundled script is missing, resolve the thread with `gh api` if supported):
+2. **Verify the posted body renders as Markdown** before resolving. Take the numeric ID from the returned URL fragment (`#discussion_r2589700` → `2589700`) and read back what GitHub actually stored:
+```bash
+GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/COMMENT_ID --jq .body
+```
+The output must show real line breaks. If instead it shows `\n` (or `\n\n`) as literal backslash-n characters inside one line, the body was posted escaped: **do not resolve the thread**. Fix it first by rewriting the body through a heredoc, then re-verify:
+```bash
+GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api --method PATCH repos/{owner}/{repo}/pulls/comments/COMMENT_ID -f body="$(cat <<'EOF'
+> the specific sentence being addressed from the reviewer's comment
+
+Fixed in abc1234 — the lookup now null-checks before dereferencing.
+EOF
+)"
+```
+
+3. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread) (if the bundled script is missing, resolve the thread with `gh api` if supported):
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/resolve-pr-thread" THREAD_ID
@@ -190,8 +209,15 @@ GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/resolve-pr-thread" THREAD_ID
 These cannot be resolved via GitHub's API. Reply with a top-level PR comment referencing the original (pass `-R OWNER/REPO` — the parsed base repo — so a fork→upstream reply posts on the watched upstream PR, not the fork namespace):
 
 ```bash
-GH_HOST=<derived-host> gh pr comment PR_NUMBER -R OWNER/REPO --body "REPLY_TEXT"
+GH_HOST=<derived-host> gh pr comment PR_NUMBER -R OWNER/REPO --body "$(cat <<'EOF'
+> the specific sentence being addressed from the reviewer's comment
+
+Fixed in abc1234 — the lookup now null-checks before dereferencing.
+EOF
+)"
 ```
+
+The same escaping rule applies here: compose the body in a quoted heredoc so paragraph breaks are real newlines, and confirm the posted comment renders as Markdown rather than one line containing literal `\n`.
 
 Include enough quoted context in the reply so the reader can follow which comment is being addressed without scrolling.
 

--- a/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { execFileSync } from "child_process"
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
+import { tmpdir } from "os"
+import path from "path"
+import { extractBashBlocks } from "./fenced-blocks"
+
+const SKILL_DIR = path.join(import.meta.dir, "..", "..", "skills", "ce-resolve-pr-feedback")
+const FULL_MODE = readFileSync(path.join(SKILL_DIR, "references", "full-mode.md"), "utf8")
+const REPLY_SCRIPT = path.join(SKILL_DIR, "scripts", "reply-to-pr-thread")
+
+const blocks = extractBashBlocks(FULL_MODE).map((b) => b.body)
+const replyBlock = blocks.find((b) => b.includes("scripts/reply-to-pr-thread"))
+
+const tempDirs: string[] = []
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
+})
+
+describe("ce-resolve-pr-feedback reply bodies keep real newlines", () => {
+  test("the reply example feeds a quoted heredoc, not echo", () => {
+    expect(replyBlock).toBeDefined()
+    // `echo "REPLY_TEXT"` emits a body whose escape sequences stay literal, so a composed
+    // "> quote\n\nparagraph" reaches GitHub as one line containing backslash-n.
+    expect(replyBlock!).not.toMatch(/\becho\b/)
+    expect(replyBlock!).not.toMatch(/\bprintf\b/)
+    expect(replyBlock!).toContain("<<'EOF'")
+  })
+
+  test("the reply example is multiline Markdown: a quote line, a blank line, then a paragraph", () => {
+    const body = replyBlock!.split("<<'EOF'\n")[1]!.split("\nEOF")[0]!.split("\n")
+    expect(body[0]!.startsWith(">")).toBe(true)
+    expect(body[1]!.trim()).toBe("")
+    expect(body.slice(2).join("\n").trim().length).toBeGreaterThan(0)
+    expect(replyBlock!).not.toContain("\\n")
+  })
+
+  test("full mode reads the posted body back and blocks resolve on literal \\n", () => {
+    const verifySection = FULL_MODE.slice(
+      FULL_MODE.indexOf("scripts/reply-to-pr-thread"),
+      FULL_MODE.indexOf("scripts/resolve-pr-thread"),
+    )
+    expect(verifySection).toContain("pulls/comments/COMMENT_ID --jq .body")
+    expect(verifySection).toMatch(/`\\n\\n`/)
+    expect(verifySection).toMatch(/do not resolve/i)
+  })
+
+  test("top-level PR comment replies also use a heredoc body", () => {
+    const commentBlock = blocks.find((b) => b.includes("gh pr comment"))
+    expect(commentBlock).toBeDefined()
+    expect(commentBlock!).toContain("<<'EOF'")
+    expect(commentBlock!).not.toContain("--body \"REPLY_TEXT\"")
+  })
+
+  test("reply-to-pr-thread passes stdin through to gh with newlines intact", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ce-reply-"))
+    tempDirs.push(dir)
+    const capture = path.join(dir, "args.txt")
+    const fakeGh = path.join(dir, "gh")
+    // Records every argv entry on its own NUL-delimited record so an embedded newline in
+    // the body argument is distinguishable from the separator.
+    writeFileSync(fakeGh, `#!/usr/bin/env bash\nprintf '%s\\0' "$@" > ${JSON.stringify(capture)}\n`)
+    chmodSync(fakeGh, 0o755)
+
+    const body = "> reviewer said this\n\nFixed in abc1234 — added the null check."
+    execFileSync("bash", [REPLY_SCRIPT, "PRRT_test"], {
+      input: body,
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+      stdio: ["pipe", "ignore", "pipe"],
+    })
+
+    const args = readFileSync(capture, "utf8").split("\0")
+    const bodyArg = args.find((a) => a.startsWith("body="))
+    expect(bodyArg).toBe(`body=${body}`)
+    expect(bodyArg).toContain("\n\n")
+    expect(bodyArg).not.toContain("\\n")
+  })
+
+  test("a body composed with escaped newlines is detectable in what gh would post", () => {
+    const escaped = "> reviewer said this\\n\\nFixed in abc1234."
+    // This is the failure the read-back step catches: no real break, literal backslash-n.
+    expect(escaped.includes("\n")).toBe(false)
+    expect(/\\n\\n/.test(escaped)).toBe(true)
+  })
+})


### PR DESCRIPTION
A reviewer could open a resolved thread and find the skill's reply as a single run-on line with literal `\n` characters where the quoted context and the response should have been separated. The reply example told the agent to pipe `echo "REPLY_TEXT"`, and `echo` does not interpret escape sequences — so any body composed with `\n\n` between the quote line and the paragraph shipped those two characters verbatim to GitHub.

Replies now go through a quoted heredoc carrying real multiline Markdown, which also stops the shell expanding `$`, backticks, and `!` inside quoted code. The same treatment covers the top-level `gh pr comment` path, which had the identical `--body "REPLY_TEXT"` shape.

The escaping bug was also silent: the mutation returns a comment ID and URL either way, and the thread got resolved on top of an unreadable reply. There is now a read-back step between reply and resolve — fetch the stored body and, if it still shows literal `\n`, fix the comment before resolving rather than closing the thread over it.

`reply-to-pr-thread` is unchanged; its stdin contract was already correct, so the fix belongs entirely in how callers compose the body.

## Validation

Six new tests in `tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts` — four pin the mode-file contract (heredoc present, `echo`/`printf` absent, quote-line/blank-line/paragraph shape, and the read-back plus do-not-resolve gate between the reply and resolve steps); one runs `reply-to-pr-thread` against a fake `gh` on `PATH` that captures NUL-delimited argv and asserts a multiline body round-trips with a real `\n\n` and no backslash-n. Full suite green (2304 pass), `release:validate` in sync.
