### PR TITLE
fix(ce-doc-review): make findings decidable without close doc knowledge

### DIFF
--- a/skills/ce-doc-review/references/walkthrough.md
+++ b/skills/ce-doc-review/references/walkthrough.md
@@ -88,9 +88,9 @@ Section: {section}
 
 {suggested_fix — rendered per the substitution rules below: prose-first, intent-language}
 
-**Why it works**
+**If this is left as-is**
 
-{short reasoning, grounded in a pattern cited in the document or codebase when available}
+{one sentence naming the concrete downstream cost}
 
 {Conflict-context line, when applicable — see below}
 ```
@@ -99,8 +99,11 @@ Substitutions:
 
 - **`{plain-English title}`** — a 3–8 word summary suitable as a heading. Derived from the merged finding's `title` field but rephrased so it reads as observable consequence (e.g., "Implementers will pick different tiers" rather than "Section X-Y lists four tiers"). For document-review findings, observable consequence is the *effect on a reader, implementer, or downstream decision*, not runtime behavior.
 - **`{section}`** — from the finding's `section` field.
-- **Document-defined identifiers** — any requirement or unit ID (`R6`, `U3`) appearing anywhere in this rendered block carries a short plain-language handle on its first mention (e.g., `R6 (suppress peer panels on low-stakes calls)`) — never a bare identifier as the block's only description of what it names. Keep the ID itself: it anchors the finding for anyone editing the document, and later mentions within the same block stay bare so the block scans. Look the handle up in the document already in context; the finding's fields carry the bare ID and do not supply it. This applies to `{section}` and to the body fields below — it is the one exception to rendering those fields as-is, and it is narrow: gloss the identifier at first mention and leave the surrounding prose untouched. Per the self-contained-rendered-lines rule in `references/synthesis-and-presentation.md`. Respect the code-span budget below.
-- **`why_it_matters`** — from the merged finding's `why_it_matters` field. Rendered as-is apart from the identifier gloss above; the subagent template's framing guidance ensures it's already observable-consequence-first.
+- **Opaque identifiers** — any token the user would have to open the document or the code to understand carries a short plain-language handle on its first mention. This covers both document-defined IDs (`R6`, `U3`, `KTD2`) and implementation identifiers the document happens to name — functions, files, variables, and line references such as `run_codex_cmd`, `$PEERLOG`, or `peer-job-runner.py`. Gloss each on first mention (e.g., `R6 (suppress peer panels on low-stakes calls)`); never leave a bare identifier as the block's only description of what it names. Keep the ID itself: it anchors the finding for anyone editing the document, and later mentions within the same block stay bare so the block scans. Look the handle up in the document already in context; the finding's fields carry the bare ID and do not supply it. This applies to `{section}` and to the body fields below — it is the one exception to rendering those fields as-is, and it is narrow: gloss the identifier at first mention and leave the surrounding prose untouched. Per the self-contained-rendered-lines rule in `references/synthesis-and-presentation.md`. Respect the code-span budget below.
+- **`why_it_matters`** — from the merged finding's `why_it_matters` field, held to the same altitude cap as `suggested_fix` below. Rules:
+  - **First sentence states the consequence, and contains no identifier at all.** What goes wrong, for whom. A reader who skimmed the document once must be able to judge it without looking anything up.
+  - **At most two further sentences of mechanism**, glossed per the identifier rule above. Mechanism explains *how* the problem arises; it is supporting detail, not the finding.
+  - **Everything past that is detail the user can ask for.** When the merged field carries more — file-level tracing, multi-hop interactions, competing call paths — compress it out and add one closing line offering it (e.g. `Ask for the trace if you want the call-path detail.`). Do not print it by default. A block that traces internals across several paragraphs is not more rigorous; it moves the reading cost onto a user who has less document context than the review does, which is the condition this walk-through exists to serve.
 - **`suggested_fix`** — from the merged finding's `suggested_fix` field. Render as prose describing intent, not as raw markup. The user's job is to trust or reject the action — they don't need to review exact text. Rules:
   - **Default — one sentence describing the effect.** What does the fix achieve, and where does it live? Prefer intent language over quoted text.
     - Good: `Drop the Advisory tier from the enum; advisory-style findings surface in an FYI subsection at the presentation layer.`
@@ -109,7 +112,7 @@ Substitutions:
   - **Code-span budget** — at most 2 inline backtick spans per sentence, each a single identifier, flag, or short phrase (e.g., `` `safe_auto` ``, `` `<work-context>` ``). Always leave a space before and after each backtick span.
   - **Raw code blocks** — only for short (≤5-line) genuinely additive content where no before-state exists. Above 5 lines, switch to a summary.
   - **No diff blocks.** Document mutations render as prose.
-- **`Why it works`** — grounded reasoning that, where possible, references a similar pattern already used in the document or codebase. One to three sentences.
+- **`If this is left as-is`** — one sentence naming the concrete downstream cost of not acting: what breaks, for whom, at what point. This is the line the user's decision turns on when they have not read the document as closely as the review did, so it must be evaluable on its own — no identifier the user would have to look up, no appeal to a claim only the reviewer can verify. When the honest answer is that the cost is small or speculative, say so plainly rather than inflating it.
 - **Conflict-context line (when applicable)** — when contributing personas implied different actions for this finding and synthesis step 3.6 broke the tie, surface that briefly. Example: `Coherence recommends Apply; scope-guardian recommends Skip. Agent's recommendation: Skip.` The orchestrator's recommendation — the post-tie-break value — is what the menu labels "recommended."
 
 ### Question stem (short, decision-focused)


### PR DESCRIPTION
## Summary

Walking a `ce-doc-review` findings list manually was hard to decide on when you hadn't read the document as closely as the review had. Findings arrived as several paragraphs of mechanism tracing — bare function names, variables, file paths, and line references — and the section meant to help you judge them justified the *fix* rather than naming the *cost of not acting*, which you can't evaluate against a document you only skimmed.

Three changes to the per-finding presentation contract:

| Gap | Change |
|---|---|
| The identifier-gloss rule reached only document-defined IDs (`R6`, `U3`), so code identifiers stayed bare | Widened to any token a reader would have to open the document or the code to understand |
| `why_it_matters` had no altitude cap while `suggested_fix` had a strict one, leaving it the only section free to sprawl | Capped: first sentence states the consequence with no identifier in it, then at most two of mechanism, rest offered on request |
| `Why it works` asked you to verify a claim you had no basis to check | Replaced with `If this is left as-is` — one sentence on the concrete downstream cost |

The third is the substantive call. A justification of the fix is only useful to someone who can check it; the cost of inaction is decidable on its own, and it's what the choice actually turns on.

This continues #1198, which introduced the gloss rule for document IDs. That rule was correct but scoped to the wrong half of the problem — real findings cited implementation identifiers, which it never covered.

## Validation

`bun test` passes (2298 pass, 0 fail). That confirms nothing else in the repo was coupled to the removed `Why it works` label — a repo-wide grep found it only in the two lines this PR edits — but it does **not** demonstrate the presentation change itself. This is model-interpreted skill prose, so per the repo's mechanical-vs-behavioral split it needs a `skill-creator` eval on Claude and Codex to show findings actually render at the intended altitude. That eval has not been run.

The change is scoped to the presentation layer. `references/subagent-template.md`, where personas author `why_it_matters` in the first place, is untouched — the orchestrator now compresses verbose input rather than personas producing tighter input. If findings still arrive over-detailed after an eval, that template is the owning layer.
