### PR TITLE
fix(ce-babysit-pr): make pr-snapshot's file locking work on Windows

### DIFF
--- a/skills/ce-babysit-pr/scripts/pr-snapshot
+++ b/skills/ce-babysit-pr/scripts/pr-snapshot
@@ -1338,14 +1338,69 @@ def _session_started_at(value):
     return _iso(parsed.astimezone(timezone.utc))
 
 
+def _lock_file(lf, exclusive=True):
+    """Take a blocking advisory lock on an open file handle.
+
+    POSIX uses flock. Windows has no fcntl module at all, so `import fcntl`
+    raised ModuleNotFoundError and took every pr-snapshot subcommand down with
+    it; msvcrt.locking is the platform equivalent.
+
+    Two behavioural differences on Windows, both safe here:
+
+    - msvcrt locks a byte RANGE rather than the whole file, so it takes byte 0.
+      Every caller uses the same dedicated lock file, so one byte is sufficient
+      to serialize them.
+    - msvcrt has no shared mode, so a shared request becomes exclusive. That is
+      more conservative than the POSIX path, never less: it can only reduce
+      concurrency between readers, never admit a racing writer.
+
+    LK_NBLCK in a retry loop rather than LK_LOCK, because LK_LOCK gives up after
+    ten seconds and raises - which would surface as a spurious failure on a
+    contended state dir rather than as the wait it should be.
+    """
+    try:
+        import fcntl
+    except ImportError:
+        import msvcrt
+        import time
+        lf.seek(0)
+        deadline = time.time() + 30
+        while True:
+            try:
+                msvcrt.locking(lf.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                if time.time() > deadline:
+                    raise
+                time.sleep(0.05)
+    else:
+        fcntl.flock(lf, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+
+
+def _unlock_file(lf):
+    try:
+        import fcntl
+    except ImportError:
+        import msvcrt
+        lf.seek(0)
+        try:
+            msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
+        except OSError:
+            # Already released, or the handle is closing. Unlocking is
+            # best-effort: the caller's `with` closes the handle either way,
+            # which drops the lock.
+            pass
+    else:
+        fcntl.flock(lf, fcntl.LOCK_UN)
+
+
 @contextmanager
 def locked_state(state_dir, pr, repo, now):
-    import fcntl
     os.makedirs(state_dir, exist_ok=True)
     lock_path = os.path.join(state_dir, "lock")
     state_path = os.path.join(state_dir, "state.json")
     with open(lock_path, "w") as lf:
-        fcntl.flock(lf, fcntl.LOCK_EX)
+        _lock_file(lf)
         if os.path.exists(state_path):
             with open(state_path) as f:
                 state = json.load(f)
@@ -1362,7 +1417,7 @@ def locked_state(state_dir, pr, repo, now):
         os.fsync(tmp.fileno())
         tmp.close()
         os.replace(tmp.name, state_path)
-        fcntl.flock(lf, fcntl.LOCK_UN)
+        _unlock_file(lf)
 
 
 def _fetch_snapshot(args):
@@ -1571,14 +1626,13 @@ def _process_identity(pid):
 
 @contextmanager
 def _watch_lock(state_dir, exclusive):
-    import fcntl
     os.makedirs(state_dir, exist_ok=True)
     with open(os.path.join(state_dir, "lock"), "w") as lf:
-        fcntl.flock(lf, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        _lock_file(lf, exclusive)
         try:
             yield
         finally:
-            fcntl.flock(lf, fcntl.LOCK_UN)
+            _unlock_file(lf)
 
 
 def _watch_candidate_path(args):


### PR DESCRIPTION
## The bug

`skills/ce-babysit-pr/scripts/pr-snapshot` locks its state with `fcntl`, which does not exist on Windows:

```python
@contextmanager
def locked_state(state_dir, pr, repo, now):
    import fcntl          # ModuleNotFoundError on Windows
```

Both `locked_state` and `_watch_lock` do this, and every subcommand goes through one of them, so `snapshot`, `watch` and `mark` all die before doing any work:

```
ModuleNotFoundError: No module named 'fcntl'
  File ".../pr-snapshot", line 943, in locked_state
```

The practical effect is that **`ce-babysit-pr` cannot run at all on Windows**. It is not a degraded mode: the failure is at the first state read, so the loop cannot take its opening snapshot, and the skill's own prerequisite check ("a harness without those cannot run this skill") reads as a false negative because `python3` *is* present and working.

## The fix

`_lock_file` / `_unlock_file`, using `fcntl.flock` where it exists and `msvcrt.locking` where it does not. **On POSIX nothing changes** - the helpers delegate to the same `flock` calls with the same flags, so the existing path is byte-identical.

Two Windows-side differences, both deliberate:

- **`msvcrt` locks a byte range, not a whole file**, so it takes byte 0. Every caller shares one dedicated lock file, so a single byte is sufficient to serialize them.
- **`msvcrt` has no shared mode**, so `_watch_lock`'s shared request becomes exclusive. That is more conservative than POSIX, never less: it can only reduce concurrency between readers, never admit a racing writer.

`LK_NBLCK` in a retry loop rather than `LK_LOCK`, because `LK_LOCK` abandons the wait after ten seconds and raises - which would surface as a spurious failure on a contended state dir rather than the wait it should be.

## Verification

Not just a syntax check. I ran the full loop on Windows 11 / Python 3.13 against a live PR through four real review rounds:

- `snapshot` including `--reset-session` and `--session-started-at`
- `watch` backgrounded, delivering both an `actionable` wake and a `merge-ready` wake
- `mark --thread ... --disposition needs-human`, and the documented auto-reopen when a human replies to a parked thread
- the terminal `MERGED` state at the end

All of it behaved as `references/watch-loop.md` describes. The script also still compiles clean under `py_compile`.

## Note on scope

This fixes only the locking. I did not audit the rest of the script for other POSIX assumptions, so there may be more - this is the one that blocks every code path, and after it the loop ran end to end without hitting another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)