### PR TITLE
fix(ce-code-review): skip cross-model adversarial peer when the diff is empty

### DIFF
--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -302,6 +302,18 @@ SCHEMA_REF="$SCHEMA_CONTENT"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || skip "not inside a git repository; skipping"
 PEER_WORKDIR="$REPO_ROOT"
 
+# Fail closed before embedding or instructing a diff: an unresolvable base ref or
+# an empty working-tree diff produces a structurally valid prompt with no code
+# changes, which invites confabulated adversarial findings.
+git -C "$REPO_ROOT" rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null \
+  || skip "base ref '$BASE' does not resolve to a commit in this repository; skipping"
+git -C "$REPO_ROOT" diff --quiet "$BASE" -- 2>/dev/null; _diff_rc=$?
+case "$_diff_rc" in
+  1) ;;  # differences exist — the reviewable case
+  0) skip "no changes between '$BASE' and the working tree; nothing to review; skipping" ;;
+  *) skip "git diff '$BASE' failed (exit $_diff_rc); skipping" ;;
+esac
+
 # --- resolve which provider(s) to run (exclude host, allowlist, availability) --
 ALLOW="${CROSS_MODEL_PEERS:-}"
 MAX_PEERS="${CROSS_MODEL_MAX_PEERS:-1}"

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -302,18 +302,6 @@ SCHEMA_REF="$SCHEMA_CONTENT"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || skip "not inside a git repository; skipping"
 PEER_WORKDIR="$REPO_ROOT"
 
-# Fail closed before embedding or instructing a diff: an unresolvable base ref or
-# an empty working-tree diff produces a structurally valid prompt with no code
-# changes, which invites confabulated adversarial findings.
-git -C "$REPO_ROOT" rev-parse --verify --quiet "${BASE}^{commit}" >/dev/null \
-  || skip "base ref '$BASE' does not resolve to a commit in this repository; skipping"
-git -C "$REPO_ROOT" diff --quiet "$BASE" -- 2>/dev/null; _diff_rc=$?
-case "$_diff_rc" in
-  1) ;;  # differences exist — the reviewable case
-  0) skip "no changes between '$BASE' and the working tree; nothing to review; skipping" ;;
-  *) skip "git diff '$BASE' failed (exit $_diff_rc); skipping" ;;
-esac
-
 # --- resolve which provider(s) to run (exclude host, allowlist, availability) --
 ALLOW="${CROSS_MODEL_PEERS:-}"
 MAX_PEERS="${CROSS_MODEL_MAX_PEERS:-1}"
@@ -394,6 +382,10 @@ DIFF_SOURCE="$RAW_DIR/review.diff"
 git -C "$REPO_ROOT" diff --no-ext-diff --no-color "$BASE" -- > "$DIFF_SOURCE" 2>/dev/null || skip "cannot stage reviewed diff; skipping"
 chmod 600 "$DIFF_SOURCE" || skip "cannot secure staged diff; skipping"
 DIFF_BYTES="$(wc -c < "$DIFF_SOURCE" 2>/dev/null || echo 0)"
+# An empty diff (valid base, no changes) still composes a structurally valid
+# prompt with an empty diff region, which invites confabulated findings. The
+# staging guard above already fail-closes an unresolvable base ref or diff error.
+[ "$DIFF_BYTES" -gt 0 ] || skip "no changes between '$BASE' and the working tree; nothing to review; skipping"
 DIFF_FILES="$(awk '/^diff --git / { n += 1 } END { print n + 0 }' "$DIFF_SOURCE")"
 ESTIMATED_DIFF_TOKENS=$(( (DIFF_BYTES + 1) / 2 ))
 

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -461,7 +461,7 @@ describe("cross-model-adversarial-review skip paths — non-blocking, no file", 
     expect(run(["claude", "codex", "HEAD", "/no/such/run-dir"], runDir, env).files).toHaveLength(0)
   })
 
-  test("unresolvable base ref skips before peer invoke (no output file)", () => {
+  test("unresolvable base ref skips at diff staging (no output file)", () => {
     const { env } = sandbox(
       ["claude"],
       "#!/bin/sh\ncat >/dev/null\nprintf '%s' '{\"structured_output\":{\"reviewer\":\"adversarial\",\"findings\":[{\"title\":\"confabulated\"}]}}'\n",
@@ -470,7 +470,8 @@ describe("cross-model-adversarial-review skip paths — non-blocking, no file", 
     const r = run(["codex", "claude", "no-such-ref-1193", runDir], runDir, env)
     expect(r.code).toBe(0)
     expect(r.files).toHaveLength(0)
-    expect(r.stderr).toContain("base ref 'no-such-ref-1193' does not resolve")
+    // git diff against an unresolvable ref exits non-zero -> the staging guard skips.
+    expect(r.stderr).toContain("cannot stage reviewed diff")
   })
 
   test("empty working-tree diff skips before peer invoke", () => {

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -121,6 +121,7 @@ function run(
   args: string[],
   runDir: string,
   env: NodeJS.ProcessEnv = process.env,
+  cwd = path.join(__dirname, "../.."), // repo root — script needs git
 ) {
   const effectiveEnv = { ...env }
   if (!("CROSS_MODEL_DRY_RUN" in effectiveEnv) && !("CROSS_MODEL_FIXED_ROUTE" in effectiveEnv)) {
@@ -137,7 +138,7 @@ function run(
   const r = spawnSync("bash", [SCRIPT, ...args], {
     encoding: "utf8",
     env: effectiveEnv,
-    cwd: path.join(__dirname, "../.."), // repo root — script needs git
+    cwd,
   })
   return {
     code: r.status ?? -1,
@@ -436,6 +437,37 @@ describe("cross-model-adversarial-review skip paths — non-blocking, no file", 
     const runDir = makeRunDir()
     expect(run(["claude", "codex", "", runDir], runDir, env).code).toBe(0)
     expect(run(["claude", "codex", "HEAD", "/no/such/run-dir"], runDir, env).files).toHaveLength(0)
+  })
+
+  test("unresolvable base ref skips before peer invoke (no output file)", () => {
+    const { env } = sandbox(
+      ["claude"],
+      "#!/bin/sh\ncat >/dev/null\nprintf '%s' '{\"structured_output\":{\"reviewer\":\"adversarial\",\"findings\":[{\"title\":\"confabulated\"}]}}'\n",
+    )
+    const runDir = makeRunDir()
+    const r = run(["codex", "claude", "no-such-ref-1193", runDir], runDir, env)
+    expect(r.code).toBe(0)
+    expect(r.files).toHaveLength(0)
+    expect(r.stderr).toContain("base ref 'no-such-ref-1193' does not resolve")
+  })
+
+  test("empty working-tree diff skips before peer invoke", () => {
+    const repo = mkTempRoot("xmodel-cr-empty-")
+    spawnSync("git", ["init", "-b", "main"], { cwd: repo })
+    spawnSync("git", ["config", "user.email", "test@test"], { cwd: repo })
+    spawnSync("git", ["config", "user.name", "test"], { cwd: repo })
+    writeFileSync(path.join(repo, "f"), "x")
+    spawnSync("git", ["add", "f"], { cwd: repo })
+    spawnSync("git", ["commit", "-m", "init"], { cwd: repo })
+    const { env } = sandbox(
+      ["claude"],
+      "#!/bin/sh\ncat >/dev/null\nprintf '%s' '{\"structured_output\":{\"reviewer\":\"adversarial\",\"findings\":[{\"title\":\"confabulated\"}]}}'\n",
+    )
+    const runDir = makeRunDir()
+    const r = run(["codex", "claude", "HEAD", runDir], runDir, env, repo)
+    expect(r.code).toBe(0)
+    expect(r.files).toHaveLength(0)
+    expect(r.stderr).toContain("no changes between 'HEAD' and the working tree")
   })
 
   test("surfaces short provider errors without dropping the diagnostic", () => {

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -17,6 +17,8 @@ import path from "node:path"
 const tempRoots: string[] = []
 const REPO_ROOT = path.join(__dirname, "../..")
 const DIRTY_MARKER = path.join(REPO_ROOT, ".xmodel-cr-test-dirty")
+const DIRTY_MARKER_REL = ".xmodel-cr-test-dirty"
+let dirtyTreeStaged = false
 function mkTempRoot(prefix: string): string {
   const dir = mkdtempSync(path.join(tmpdir(), prefix))
   tempRoots.push(dir)
@@ -24,7 +26,11 @@ function mkTempRoot(prefix: string): string {
 }
 afterAll(() => {
   for (const dir of tempRoots) rmSync(dir, { recursive: true, force: true })
-  if (existsSync(DIRTY_MARKER)) rmSync(DIRTY_MARKER, { force: true })
+  if (dirtyTreeStaged || existsSync(DIRTY_MARKER)) {
+    spawnSync("git", ["reset", "HEAD", "--", DIRTY_MARKER_REL], { cwd: REPO_ROOT })
+    if (existsSync(DIRTY_MARKER)) rmSync(DIRTY_MARKER, { force: true })
+    dirtyTreeStaged = false
+  }
 })
 
 const REAL_TOOLS = [
@@ -119,10 +125,12 @@ function makeRunDir(): string {
   return mkTempRoot("xmodel-cr-run-")
 }
 
-/** Untracked file so `git diff HEAD --` is non-empty on a clean checkout. */
+/** Stage a fixture file so `git diff --quiet HEAD --` sees changes (untracked alone is ignored). */
 function ensureDirtyTree(cwd: string): void {
   if (cwd !== REPO_ROOT) return
   writeFileSync(DIRTY_MARKER, `fixture ${Date.now()}\n`)
+  const r = spawnSync("git", ["add", "--", DIRTY_MARKER_REL], { cwd: REPO_ROOT })
+  if (r.status === 0) dirtyTreeStaged = true
 }
 
 /** Run the script and return exit code, stdout, stderr, and run-dir file list. */

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -15,6 +15,8 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 
 const tempRoots: string[] = []
+const REPO_ROOT = path.join(__dirname, "../..")
+const DIRTY_MARKER = path.join(REPO_ROOT, ".xmodel-cr-test-dirty")
 function mkTempRoot(prefix: string): string {
   const dir = mkdtempSync(path.join(tmpdir(), prefix))
   tempRoots.push(dir)
@@ -22,6 +24,7 @@ function mkTempRoot(prefix: string): string {
 }
 afterAll(() => {
   for (const dir of tempRoots) rmSync(dir, { recursive: true, force: true })
+  if (existsSync(DIRTY_MARKER)) rmSync(DIRTY_MARKER, { force: true })
 })
 
 const REAL_TOOLS = [
@@ -116,13 +119,24 @@ function makeRunDir(): string {
   return mkTempRoot("xmodel-cr-run-")
 }
 
+/** Untracked file so `git diff HEAD --` is non-empty on a clean checkout. */
+function ensureDirtyTree(cwd: string): void {
+  if (cwd !== REPO_ROOT) return
+  writeFileSync(DIRTY_MARKER, `fixture ${Date.now()}\n`)
+}
+
 /** Run the script and return exit code, stdout, stderr, and run-dir file list. */
 function run(
   args: string[],
   runDir: string,
   env: NodeJS.ProcessEnv = process.env,
-  cwd = path.join(__dirname, "../.."), // repo root — script needs git
+  cwd = REPO_ROOT, // repo root — script needs git
+  opts: { skipDirtyTree?: boolean } = {},
 ) {
+  const baseRef = args[2]
+  if (!opts.skipDirtyTree && baseRef === "HEAD" && cwd === REPO_ROOT) {
+    ensureDirtyTree(cwd)
+  }
   const effectiveEnv = { ...env }
   if (!("CROSS_MODEL_DRY_RUN" in effectiveEnv) && !("CROSS_MODEL_FIXED_ROUTE" in effectiveEnv)) {
     const target = args[1]
@@ -459,12 +473,16 @@ describe("cross-model-adversarial-review skip paths — non-blocking, no file", 
     writeFileSync(path.join(repo, "f"), "x")
     spawnSync("git", ["add", "f"], { cwd: repo })
     spawnSync("git", ["commit", "-m", "init"], { cwd: repo })
+    const invoked = path.join(mkTempRoot("xmodel-cr-empty-invoked-"), "marker")
     const { env } = sandbox(
       ["claude"],
-      "#!/bin/sh\ncat >/dev/null\nprintf '%s' '{\"structured_output\":{\"reviewer\":\"adversarial\",\"findings\":[{\"title\":\"confabulated\"}]}}'\n",
+      `#!/bin/sh\n: > '${invoked}'\ncat >/dev/null\nprintf '%s' '{"structured_output":{"reviewer":"adversarial","findings":[{"title":"confabulated"}]}}'\n`,
     )
     const runDir = makeRunDir()
-    const r = run(["codex", "claude", "HEAD", runDir], runDir, env, repo)
+    const r = run(["codex", "claude", "HEAD", runDir], runDir, env, repo, {
+      skipDirtyTree: true,
+    })
+    expect(existsSync(invoked)).toBe(false)
     expect(r.code).toBe(0)
     expect(r.files).toHaveLength(0)
     expect(r.stderr).toContain("no changes between 'HEAD' and the working tree")


### PR DESCRIPTION
Closes #1193.

## Summary

Skips the cross-model adversarial peer when there is nothing to review: a valid
base ref with an empty working-tree diff. Composing a peer prompt against an
empty diff region invites schema-valid but confabulated adversarial findings.

The guard lives where the diff is staged and `DIFF_BYTES` is already computed:

```sh
[ "$DIFF_BYTES" -gt 0 ] || skip "no changes between '$BASE' and the working tree; nothing to review; skipping"
```

It uses the script's existing non-blocking `skip()` contract (exit 0, no output
file, peer never invoked) and preserves working-tree diff semantics
(`git diff "$BASE" --`, not `git diff "$BASE" HEAD`).

### Scope note (maintainer edit)

Originally opened to also fail-closed on an **unresolvable** base ref (issue
#1193). That case is already handled on current `main`: since #1200, the diff is
staged once with `... || skip "cannot stage reviewed diff; skipping"`, and an
invalid ref makes `git diff` exit non-zero, so the peer is never reached. The
`DIFF_APPENDIX` inline-embed mechanism #1193 describes no longer exists on
`main`. This branch was therefore rebased onto `main` and trimmed to the one
genuinely-uncovered case (empty diff); the redundant `rev-parse` gate and second
`git diff --quiet` were removed. See the discussion comment for the full
rationale.

## Test plan

- [x] `bun test tests/skills/ce-code-review-cross-model-routes.test.ts` — 52 pass
- [x] Regression: empty working-tree diff (clean temp repo, `HEAD` base) skips before peer invoke; stub peer never runs; no output file
- [x] Regression: unresolvable base ref (`no-such-ref-1193`) skips at the staging guard; no peer invoke; no output file
- [x] Parity + shell-safety suites green

## Notes

- Does **not** address #1197 (JSON brace recovery) — separate issue

---

<details>
<summary>Original description by @arimu1 (opened against pre-#1200 base)</summary>

## Summary

Fixes https://github.com/EveryInc/compound-engineering-plugin/issues/1193.

When `<base-ref>` did not resolve (stale branch, typo, unfetched remote ref), `compose_prompt_embedded()` still built a structurally valid prompt with an empty region between the `=== BEGIN DIFF ===` / `=== END DIFF ===` markers. The peer was invoked anyway and could return schema-valid adversarial findings confabulated against no actual code changes.

This adds fail-closed pre-flight validation immediately after `REPO_ROOT` is derived:

- `git rev-parse --verify "${BASE}^{commit}"` — skip when the base ref does not resolve
- `git diff --quiet "$BASE" --` — skip when there are no working-tree changes to review (exit 0) or when diff fails (exit >1)

Both paths use the script's existing non-blocking `skip()` contract (exit 0, no output file, peer never invoked).

## Test plan

- [x] `bun test tests/skills/ce-code-review-cross-model-routes.test.ts` — all 50 tests pass
- [x] New regression: unresolvable base ref (`no-such-ref-1193`) skips before peer invoke; stub peer that would emit findings is never reached; no output file written
- [x] New regression: clean temp git repo with `HEAD` base skips with "no changes between 'HEAD' and the working tree"
- [ ] Manual: in any repo, run with an invalid base ref and confirm stderr skip message + no `adversarial-*.json` in run-dir

## Notes

- Does **not** address #1197 (JSON brace recovery) — separate issue
- Preserves working-tree diff semantics (`git diff "$BASE" --`, not `git diff "$BASE" HEAD`)

Made with [Cursor](https://cursor.com)

</details>
