### PR TITLE
fix(ce-code-review): make codex stdout-recovery JSON extractor string-aware

### DIFF
--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -537,6 +537,10 @@ recover_findings_json() {   # <logfile> <outfile>
   python3 - "$1" "$2" <<'PY' 2>/dev/null
 import sys, json
 txt = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+# Any selectable object carries a literal `"findings"` key; if the raw text has
+# none, there is nothing to recover. Skip the scan — raw_decode probing every
+# `{` is O(n^2) on brace-dense non-findings stdout (error/crash dumps).
+if '"findings"' not in txt: sys.exit(0)
 dec = json.JSONDecoder()
 best, i = None, 0
 while True:

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -360,7 +360,7 @@ BASE_PROMPT="$(mktemp "${TMPDIR:-/tmp}/xmodel-base-XXXXXX")"
 PROMPT_FILE="$(mktemp "${TMPDIR:-/tmp}/xmodel-prompt-XXXXXX")"
 PEERLOG="$(mktemp "${TMPDIR:-/tmp}/xmodel-log-XXXXXX")"
 # Peer stderr goes to its own file, NOT merged into PEERLOG: PEERLOG must stay
-# clean stdout for the findings brace-match and the receipt jq-parse. An
+# clean stdout for the findings raw_decode scan and the receipt jq-parse. An
 # auth/quota/rate-limit message often lands on stderr, so capture it separately
 # and surface it in the skip evidence (grok's 402 is on stdout, others on stderr).
 PEERERR="$(mktemp "${TMPDIR:-/tmp}/xmodel-err-XXXXXX")"
@@ -530,7 +530,9 @@ run_timeout_cmd() {
   ACTIVE_PEER_PID=""
 }
 
-recover_findings_json() {
+# Decode each {...} object in raw stdout via raw_decode (string/escape-aware,
+# unlike brace counting) and keep the last one shaped like findings.
+recover_findings_json() {   # <logfile> <outfile>
   command -v python3 >/dev/null 2>&1 || return 1
   python3 - "$1" "$2" <<'PY' 2>/dev/null
 import sys, json
@@ -542,7 +544,7 @@ while True:
     if j < 0: break
     try:
         obj, end = dec.raw_decode(txt, j)
-    except ValueError:
+    except Exception:
         i = j + 1
         continue
     if isinstance(obj, dict) and isinstance(obj.get("findings"), list): best = obj

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -535,18 +535,18 @@ recover_findings_json() {
   python3 - "$1" "$2" <<'PY' 2>/dev/null
 import sys, json
 txt = open(sys.argv[1], encoding="utf-8", errors="replace").read()
-best, depth, start = None, 0, None
-for i, ch in enumerate(txt):
-    if ch == '{':
-        if depth == 0: start = i
-        depth += 1
-    elif ch == '}' and depth > 0:
-        depth -= 1
-        if depth == 0 and start is not None:
-            try:
-                obj = json.loads(txt[start:i+1])
-                if isinstance(obj, dict) and "findings" in obj: best = obj
-            except Exception: pass
+dec = json.JSONDecoder()
+best, i = None, 0
+while True:
+    j = txt.find('{', i)
+    if j < 0: break
+    try:
+        obj, end = dec.raw_decode(txt, j)
+    except ValueError:
+        i = j + 1
+        continue
+    if isinstance(obj, dict) and isinstance(obj.get("findings"), list): best = obj
+    i = end
 if best is not None: open(sys.argv[2], "w").write(json.dumps(best))
 PY
   [ -s "$2" ]

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -590,24 +590,25 @@ run_timeout_cmd() {   # $1 = stdin file ("" -> /dev/null). CMD already built.
   ACTIVE_PEER_PID=""
 }
 
-# Brace-match the largest {...} object containing "findings" out of raw stdout.
+# Decode each {...} object in raw stdout via raw_decode (string/escape-aware,
+# unlike brace counting) and keep the last one shaped like findings.
 recover_findings_json() {   # <logfile> <outfile>
   command -v python3 >/dev/null 2>&1 || return 1
   python3 - "$1" "$2" <<'PY' 2>/dev/null
 import sys, json
 txt = open(sys.argv[1], encoding="utf-8", errors="replace").read()
-best, depth, start = None, 0, None
-for i, ch in enumerate(txt):
-    if ch == '{':
-        if depth == 0: start = i
-        depth += 1
-    elif ch == '}' and depth > 0:
-        depth -= 1
-        if depth == 0 and start is not None:
-            try:
-                obj = json.loads(txt[start:i+1])
-                if isinstance(obj, dict) and "findings" in obj: best = obj
-            except Exception: pass
+dec = json.JSONDecoder()
+best, i = None, 0
+while True:
+    j = txt.find('{', i)
+    if j < 0: break
+    try:
+        obj, end = dec.raw_decode(txt, j)
+    except ValueError:
+        i = j + 1
+        continue
+    if isinstance(obj, dict) and isinstance(obj.get("findings"), list): best = obj
+    i = end
 if best is not None: open(sys.argv[2], "w").write(json.dumps(best))
 PY
   [ -s "$2" ]

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -423,7 +423,7 @@ fi
 PROMPT_FILE="$(mktemp "${TMPDIR:-/tmp}/xmodel-doc-prompt-XXXXXX")"
 PEERLOG="$(mktemp "${TMPDIR:-/tmp}/xmodel-doc-log-XXXXXX")"
 # Peer stderr goes to its own file, NOT merged into PEERLOG: PEERLOG must stay
-# clean stdout for the findings brace-match and the receipt jq-parse. An
+# clean stdout for the findings raw_decode scan and the receipt jq-parse. An
 # auth/quota/rate-limit message often lands on stderr, so capture it separately
 # and surface it in the skip evidence (grok's 402 is on stdout, others on stderr).
 PEERERR="$(mktemp "${TMPDIR:-/tmp}/xmodel-doc-err-XXXXXX")"
@@ -604,7 +604,7 @@ while True:
     if j < 0: break
     try:
         obj, end = dec.raw_decode(txt, j)
-    except ValueError:
+    except Exception:
         i = j + 1
         continue
     if isinstance(obj, dict) and isinstance(obj.get("findings"), list): best = obj

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -597,6 +597,10 @@ recover_findings_json() {   # <logfile> <outfile>
   python3 - "$1" "$2" <<'PY' 2>/dev/null
 import sys, json
 txt = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+# Any selectable object carries a literal `"findings"` key; if the raw text has
+# none, there is nothing to recover. Skip the scan — raw_decode probing every
+# `{` is O(n^2) on brace-dense non-findings stdout (error/crash dumps).
+if '"findings"' not in txt: sys.exit(0)
 dec = json.JSONDecoder()
 best, i = None, 0
 while True:

--- a/tests/cross-model-recover-findings-parity.test.ts
+++ b/tests/cross-model-recover-findings-parity.test.ts
@@ -1,0 +1,45 @@
+import { readFile } from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+const PLUGIN_ROOT = path.join(process.cwd(), "skills")
+
+// recover_findings_json (the codex stdout-recovery JSON extractor) is
+// byte-duplicated between the two cross-model peer scripts (the plugin has no
+// cross-skill import mechanism — see AGENTS.md "File References in Skills") and
+// was kept identical by hand. This test makes that enforceable so the copies
+// cannot drift (e.g. a fix landing in one script but not the other).
+const SCRIPTS = [
+  "ce-code-review/scripts/cross-model-adversarial-review.sh",
+  "ce-doc-review/scripts/cross-model-doc-review.sh",
+]
+
+const DEF_MARKER = "recover_findings_json() {"
+
+/** The recover_findings_json definition — its leading comment block through the
+ * function's closing brace — so both the python heredoc and its synced header
+ * comment are compared. */
+function recoverFn(content: string, file: string): string {
+  const lines = content.split("\n")
+  const def = lines.findIndex((l) => l.startsWith(DEF_MARKER))
+  if (def < 0) throw new Error(`${file}: ${DEF_MARKER} not found`)
+  // Back up over the contiguous leading comment block (the synced header).
+  let begin = def
+  while (begin > 0 && lines[begin - 1].startsWith("#")) begin--
+  const end = lines.findIndex((l, i) => i > def && l === "}")
+  if (end < 0) throw new Error(`${file}: closing brace for recover_findings_json not found`)
+  return lines.slice(begin, end + 1).join("\n")
+}
+
+describe("cross-model recover_findings_json parity", () => {
+  test("the recover_findings_json extractor is byte-identical in both scripts", async () => {
+    const fns = await Promise.all(
+      SCRIPTS.map(async (rel) =>
+        recoverFn(await readFile(path.join(PLUGIN_ROOT, rel), "utf8"), rel),
+      ),
+    )
+    for (let i = 1; i < fns.length; i++) {
+      expect(fns[i]).toBe(fns[0])
+    }
+  })
+})

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -637,6 +637,22 @@ describe("cross-model-adversarial-review normalization", () => {
     )
     expect(out.findings[0].title).toBe("unterminated block")
   }, 20_000)
+
+  test("codex stdout recovery handles an escaped quote-brace inside a JSON string", () => {
+    // A naive brace counter (pre-raw_decode) treats every "{" as a nesting
+    // level even inside a string, so an escaped \"{\" in a findings value
+    // pushes it one level too deep and it never unwinds back to zero.
+    const codexStub =
+      `#!/bin/sh\ncat >/dev/null\nprintf '%s' '{"reviewer":"adversarial","findings":[{"title":"t","evidence":"payload was literally \\"{\\" and stayed valid"}],"residual_risks":[],"testing_gaps":[]}'\n`
+    const { env } = sandbox(["codex"], codexStub)
+    const runDir = makeRunDir()
+    const r = run(["claude", "codex", "HEAD", runDir], runDir, env)
+    expect(r.files).toContain("adversarial-codex.json")
+    const out = JSON.parse(
+      readFileSync(path.join(runDir, "adversarial-codex.json"), "utf8"),
+    )
+    expect(out.findings[0].title).toBe("t")
+  }, 20_000)
 })
 
 describe("cross-model-adversarial-review fixed-recipient dispatch", () => {

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -622,6 +622,21 @@ describe("cross-model-adversarial-review normalization", () => {
     expect(out.model_requested).toBe("gpt-5.6-sol")
     expect(out.model_actual).toBe("unverified")
   }, 20_000) // the codex liveness poll sleeps in 5s slices even for a fast stub
+
+  test("codex stdout recovery is string-aware — an in-string brace does not let a draft object win", () => {
+    // A brace-counting scanner desyncs on the real answer's in-string "{" (quoted
+    // code in evidence) and keeps an earlier balanced draft instead. See #1197.
+    const codexStub =
+      `#!/bin/sh\ncat >/dev/null\nprintf '%s' '{"findings":[{"title":"DRAFT placeholder"}]}\n{"reviewer":"adversarial","findings":[{"title":"unterminated block","evidence":"the loop body starts with { and never closes"}],"residual_risks":[],"testing_gaps":[]}'\n`
+    const { env } = sandbox(["codex"], codexStub)
+    const runDir = makeRunDir()
+    const r = run(["claude", "codex", "HEAD", runDir], runDir, env)
+    expect(r.files).toContain("adversarial-codex.json")
+    const out = JSON.parse(
+      readFileSync(path.join(runDir, "adversarial-codex.json"), "utf8"),
+    )
+    expect(out.findings[0].title).toBe("unterminated block")
+  }, 20_000)
 })
 
 describe("cross-model-adversarial-review fixed-recipient dispatch", () => {

--- a/tests/skills/ce-doc-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-doc-review-cross-model-routes.test.ts
@@ -730,6 +730,23 @@ describe("cross-model-doc-review normalization (R18, KTD5)", () => {
     expect(out.findings[0].title).toBe("unterminated block")
   }, 20_000)
 
+  test("codex stdout recovery handles an escaped quote-brace inside a JSON string", () => {
+    // A naive brace counter (pre-raw_decode) treats every "{" as a nesting
+    // level even inside a string, so an escaped \"{\" in a findings value
+    // pushes it one level too deep and it never unwinds back to zero.
+    const codexStub =
+      `#!/bin/sh\ncat >/dev/null\nprintf '%s' '{"reviewer":"adversarial","findings":[{"section":"X","title":"t","evidence":"payload was literally \\"{\\" and stayed valid"}]}'\n`
+    const { env } = sandbox(["codex"], codexStub)
+    const doc = makeDoc()
+    const runDir = makeRunDir()
+    const r = run(["claude", "codex", "adversarial", doc, "plan", "none", runDir], runDir, env)
+    expect(r.files).toContain("adversarial-codex.json")
+    const out = JSON.parse(
+      readFileSync(path.join(runDir, "adversarial-codex.json"), "utf8"),
+    )
+    expect(out.findings[0].title).toBe("t")
+  }, 20_000)
+
   test("the whole-doc sweep reviewer-name is accepted and normalizes to whole-doc-<provider>", () => {
     // R20/U9: the broad whole-document sweep runs under reviewer-name `whole-doc`.
     const stub =

--- a/tests/skills/ce-doc-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-doc-review-cross-model-routes.test.ts
@@ -714,6 +714,22 @@ describe("cross-model-doc-review normalization (R18, KTD5)", () => {
     expect(out.model_actual).toBe("unverified")
   }, 20_000) // the codex liveness poll sleeps in 5s slices even for a fast stub
 
+  test("codex stdout recovery is string-aware — an in-string brace does not let a draft object win", () => {
+    // A brace-counting scanner desyncs on the real answer's in-string "{" (quoted
+    // code in evidence) and keeps an earlier balanced draft instead. See #1197.
+    const codexStub =
+      `#!/bin/sh\ncat >/dev/null\nprintf '%s' '{"findings":[{"section":"X","title":"DRAFT placeholder"}]}\n{"reviewer":"adversarial","findings":[{"section":"X","title":"unterminated block","evidence":"the loop body starts with { and never closes"}]}'\n`
+    const { env } = sandbox(["codex"], codexStub)
+    const doc = makeDoc()
+    const runDir = makeRunDir()
+    const r = run(["claude", "codex", "adversarial", doc, "plan", "none", runDir], runDir, env)
+    expect(r.files).toContain("adversarial-codex.json")
+    const out = JSON.parse(
+      readFileSync(path.join(runDir, "adversarial-codex.json"), "utf8"),
+    )
+    expect(out.findings[0].title).toBe("unterminated block")
+  }, 20_000)
+
   test("the whole-doc sweep reviewer-name is accepted and normalizes to whole-doc-<provider>", () => {
     // R20/U9: the broad whole-document sweep runs under reviewer-name `whole-doc`.
     const stub =


### PR DESCRIPTION
## Summary

Closes #1197.

`recover_findings_json()` in both `skills/ce-code-review/scripts/cross-model-adversarial-review.sh` and `skills/ce-doc-review/scripts/cross-model-doc-review.sh` (byte-identical copies) extracted the findings JSON from captured codex stdout by counting `{`/`}` with no string or escape awareness. Since code-review findings routinely quote brace-heavy source (Go/Rust/JS/C), an in-string `{` or `}` in a finding's `evidence` field desyncs the counter:

- An in-string `{` can keep the depth counter from returning to 0 on the real final answer, so `json.loads` is never attempted on it — an earlier balanced draft object (codex often echoes the expected shape before its real answer) wins instead.
- An in-string `}` can desync the counter mid-object, so `json.loads` runs on a truncated slice and fails silently — a valid answer is dropped with no output written.

## Fix

Replace the brace counter in both copies with a `json.JSONDecoder().raw_decode()` scan, which respects JSON string/escape rules by construction instead of naive character counting. Selection semantics are preserved (last matching object wins, since codex emits its final answer last), with one deliberate tightening: `findings` must be list-typed, not merely present — matching what the downstream jq normalization already enforces.

## Addressed in review

- Restored `except Exception` (see Performance/Test plan below — a prior revision had narrowed this to `except ValueError`, which regressed graceful degradation on malformed input).
- Updated the stale "brace-match" comment next to `PEERLOG` in both scripts to reflect the current `raw_decode` scan.
- Added a header comment to `recover_findings_json` in `cross-model-adversarial-review.sh` so it matches the one already on the doc-review copy — the two files are kept byte-identical for this function by design.

## Performance

`raw_decode`-scanning is not a free win — it depends heavily on how brace-dense the peer's raw stdout is:

- On a realistic path (a ~960KB codex event stream, one small JSON object per line), it's noticeably *faster* than the old single-pass counter: ~4x in the reviewer's measurement (0.059s → 0.013s), and I independently reproduced the same direction on a synthetic 960KB JSONL stream (0.068s → 0.009s, ~7x).
- On brace-heavy *non-JSON* stdout (an error dump or prose quoting lots of literal `{`/`}` with no valid JSON nearby), probing every `{` with `raw_decode` is quadratic — a nested-open tail measured 11s at 97KB, and a brace-heavy corpus 2.9s–7.9s at ~860KB. The old counter was a single O(n) pass regardless of content shape.

**Worst case now bounded (follow-up commit).** The scan is gated on a literal `"findings"` key: any object the extractor can select must carry one, so when the raw stdout has no such key there is nothing to recover and the O(n²) probe loop is skipped entirely. Codex crash/error dumps — the realistic pathological input — have no findings key, so they now return in ~0ms instead of seconds, and the gate provably drops nothing recoverable. One residual remains: a valid findings object *followed by* a brace-dense nested-open garbage tail still probes the tail (~8s), an exotic shape for a fallback recovery path.

| stdout shape | before gate | after gate |
|---|---|---|
| nested-open braces, no findings key (97KB) | 11.1s | ~0ms |
| prose braces, no findings key (664KB) | 3.6s | ~0ms |
| realistic 960KB event stream + real answer | 0.008s | 0.008s (selection unchanged) |

## Test plan

- [x] Added a regression test to each of `tests/skills/ce-code-review-cross-model-routes.test.ts` and `tests/skills/ce-doc-review-cross-model-routes.test.ts`: a codex stub emits a balanced DRAFT object followed by the real final answer whose `evidence` contains a lone in-string `{`, and asserts the recovered file is the real answer, not the draft.
- [x] Added a second regression fixture to each file: a single valid object whose `evidence` field contains an escaped `\"{\"`. The old brace counter returned `None` entirely on this (never unwound back to depth 0) — more common in practice than the two-object draft/final case and previously untested.
- [x] Restored `except Exception` (was narrowed to `except ValueError` in the prior revision) in both `recover_findings_json` copies — `raw_decode` can raise `RecursionError` on deeply-nested/malformed input, which used to degrade gracefully (skip and keep scanning) and would otherwise now kill the whole extraction, losing any valid findings object later in the same stdout. Verified with a repro (`'{"k":' * 2000 + 'null' + newline + valid findings object`): with `except ValueError` it raises past the try/except and loses the valid object; with `except Exception` it recovers it.
- [x] **Follow-up:** gated the scan on the `"findings"` key to bound the O(n²) worst case (see Performance); verified against the pathological inputs (11s/3.6s → ~0ms) and the good paths (selection unchanged).
- [x] **Follow-up:** added a byte-identity parity test (`tests/cross-model-recover-findings-parity.test.ts`) for `recover_findings_json` — the function is hand-duplicated across the two peer scripts with no prior guard, so a fix landing in one copy but not the other could silently drift. Verified it fails on a one-character drift and passes when synced.
- [x] `bun test tests/skills/ce-code-review-cross-model-routes.test.ts tests/skills/ce-doc-review-cross-model-routes.test.ts tests/cross-model-recover-findings-parity.test.ts` — 100 pass, 0 fail
- [x] Full suite at the original commit (`56fb36bb`): `bun test` — 2293 pass, 0 fail (CI re-runs the full suite on the follow-up commit).
