### PR TITLE
fix(ce-compound,ce-compound-refresh): don't flag {{...}} in code as scaffold

### DIFF
--- a/skills/ce-compound-refresh/scripts/validate-doc-claims.py
+++ b/skills/ce-compound-refresh/scripts/validate-doc-claims.py
@@ -51,7 +51,7 @@ PLACEHOLDER_SUBSTRINGS = ("path/to", "...", "…")
 SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
 BACKTICK_RE = re.compile(r"`([^`\n]+)`")
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
-FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
 SCAFFOLD_RES = (
     re.compile(r"\bLearnings?\s+#?\d"),
     re.compile(r"\{\{[^}\n]*\}\}"),
@@ -131,8 +131,15 @@ def mask_code(lines: list[str]) -> list[str]:
             masked.append(" " * len(line))
             continue
         if fence is not None:
-            # CommonMark: a closing fence is the same char and at least as long.
-            if m and m.group(1)[0] == fence[0] and len(m.group(1)) >= len(fence):
+            # CommonMark: a closing fence is the same char, at least as long,
+            # and followed only by whitespace — an info string (```json) opens
+            # but never closes, so it stays block content.
+            if (
+                m
+                and m.group(1)[0] == fence[0]
+                and len(m.group(1)) >= len(fence)
+                and not m.group(2).strip()
+            ):
                 fence = None
             masked.append(" " * len(line))
             continue

--- a/skills/ce-compound-refresh/scripts/validate-doc-claims.py
+++ b/skills/ce-compound-refresh/scripts/validate-doc-claims.py
@@ -25,7 +25,10 @@ citations against the repository:
        HEAD and the upstream default branch.
     3. Relative markdown link targets resolve from the doc's location.
     4. Dangling drafting scaffold: "Learning(s) N" numbering and
-       unresolved {{...}} placeholder tokens.
+       unresolved {{...}} placeholder tokens. Inline code spans and fenced
+       code blocks are masked first, so a {{...}} shown as documented syntax
+       (Handlebars, a CI variable, a GitHub ruleset placeholder) is not
+       mistaken for a leaked scaffold; only a bare token in prose is flagged.
 
 Flags are adjudication input, NOT hard failures — a doc may legitimately
 cite a path deleted by the very fix it documents. The calling agent
@@ -48,6 +51,7 @@ PLACEHOLDER_SUBSTRINGS = ("path/to", "...", "…")
 SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
 BACKTICK_RE = re.compile(r"`([^`\n]+)`")
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 SCAFFOLD_RES = (
     re.compile(r"\bLearnings?\s+#?\d"),
     re.compile(r"\{\{[^}\n]*\}\}"),
@@ -112,6 +116,28 @@ def is_path_shaped(token: str, base: str) -> bool:
     if token.endswith("/"):
         return True
     return os.path.isdir(os.path.join(base, segments[0]))
+
+
+def mask_code(lines: list[str]) -> list[str]:
+    """Blank out fenced code blocks and inline code spans, preserving line
+    count and length. Illustrative {{...}} in quoted code must not read as a
+    leaked drafting scaffold; only bare tokens in prose should."""
+    masked: list[str] = []
+    fence: str | None = None  # active fence run (e.g. "```"), or None
+    for line in lines:
+        m = FENCE_RE.match(line)
+        if fence is None and m:
+            fence = m.group(1)
+            masked.append(" " * len(line))
+            continue
+        if fence is not None:
+            # CommonMark: a closing fence is the same char and at least as long.
+            if m and m.group(1)[0] == fence[0] and len(m.group(1)) >= len(fence):
+                fence = None
+            masked.append(" " * len(line))
+            continue
+        masked.append(BACKTICK_RE.sub(lambda x: " " * len(x.group(0)), line))
+    return masked
 
 
 def normalize_path(token: str) -> str:
@@ -317,7 +343,7 @@ def main(argv: list[str]) -> int:
             )
 
     # --- 4. Dangling drafting scaffold ---------------------------------------
-    for i, line_text in enumerate(body_lines):
+    for i, line_text in enumerate(mask_code(body_lines)):
         for pattern in SCAFFOLD_RES:
             m = pattern.search(line_text)
             if m:

--- a/skills/ce-compound/scripts/validate-doc-claims.py
+++ b/skills/ce-compound/scripts/validate-doc-claims.py
@@ -51,7 +51,7 @@ PLACEHOLDER_SUBSTRINGS = ("path/to", "...", "…")
 SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
 BACKTICK_RE = re.compile(r"`([^`\n]+)`")
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
-FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})(.*)$")
 SCAFFOLD_RES = (
     re.compile(r"\bLearnings?\s+#?\d"),
     re.compile(r"\{\{[^}\n]*\}\}"),
@@ -131,8 +131,15 @@ def mask_code(lines: list[str]) -> list[str]:
             masked.append(" " * len(line))
             continue
         if fence is not None:
-            # CommonMark: a closing fence is the same char and at least as long.
-            if m and m.group(1)[0] == fence[0] and len(m.group(1)) >= len(fence):
+            # CommonMark: a closing fence is the same char, at least as long,
+            # and followed only by whitespace — an info string (```json) opens
+            # but never closes, so it stays block content.
+            if (
+                m
+                and m.group(1)[0] == fence[0]
+                and len(m.group(1)) >= len(fence)
+                and not m.group(2).strip()
+            ):
                 fence = None
             masked.append(" " * len(line))
             continue

--- a/skills/ce-compound/scripts/validate-doc-claims.py
+++ b/skills/ce-compound/scripts/validate-doc-claims.py
@@ -25,7 +25,10 @@ citations against the repository:
        HEAD and the upstream default branch.
     3. Relative markdown link targets resolve from the doc's location.
     4. Dangling drafting scaffold: "Learning(s) N" numbering and
-       unresolved {{...}} placeholder tokens.
+       unresolved {{...}} placeholder tokens. Inline code spans and fenced
+       code blocks are masked first, so a {{...}} shown as documented syntax
+       (Handlebars, a CI variable, a GitHub ruleset placeholder) is not
+       mistaken for a leaked scaffold; only a bare token in prose is flagged.
 
 Flags are adjudication input, NOT hard failures — a doc may legitimately
 cite a path deleted by the very fix it documents. The calling agent
@@ -48,6 +51,7 @@ PLACEHOLDER_SUBSTRINGS = ("path/to", "...", "…")
 SHA_RE = re.compile(r"\b[0-9a-f]{7,40}\b")
 BACKTICK_RE = re.compile(r"`([^`\n]+)`")
 MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
 SCAFFOLD_RES = (
     re.compile(r"\bLearnings?\s+#?\d"),
     re.compile(r"\{\{[^}\n]*\}\}"),
@@ -112,6 +116,28 @@ def is_path_shaped(token: str, base: str) -> bool:
     if token.endswith("/"):
         return True
     return os.path.isdir(os.path.join(base, segments[0]))
+
+
+def mask_code(lines: list[str]) -> list[str]:
+    """Blank out fenced code blocks and inline code spans, preserving line
+    count and length. Illustrative {{...}} in quoted code must not read as a
+    leaked drafting scaffold; only bare tokens in prose should."""
+    masked: list[str] = []
+    fence: str | None = None  # active fence run (e.g. "```"), or None
+    for line in lines:
+        m = FENCE_RE.match(line)
+        if fence is None and m:
+            fence = m.group(1)
+            masked.append(" " * len(line))
+            continue
+        if fence is not None:
+            # CommonMark: a closing fence is the same char and at least as long.
+            if m and m.group(1)[0] == fence[0] and len(m.group(1)) >= len(fence):
+                fence = None
+            masked.append(" " * len(line))
+            continue
+        masked.append(BACKTICK_RE.sub(lambda x: " " * len(x.group(0)), line))
+    return masked
 
 
 def normalize_path(token: str) -> str:
@@ -317,7 +343,7 @@ def main(argv: list[str]) -> int:
             )
 
     # --- 4. Dangling drafting scaffold ---------------------------------------
-    for i, line_text in enumerate(body_lines):
+    for i, line_text in enumerate(mask_code(body_lines)):
         for pattern in SCAFFOLD_RES:
             m = pattern.search(line_text)
             if m:

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -296,6 +296,21 @@ describe("validate-doc-claims script", () => {
         expect(result.stdout).not.toContain("FLAG scaffold")
       })
 
+      test("keeps a same-length info-string fence line as block content", () => {
+        // A bare ``` block whose content demonstrates a ```json opener: the
+        // inner ```json has trailing text, so CommonMark does not treat it as
+        // a closing fence — the {{...}} after it stays masked.
+        const docPath = writeRepoDoc(
+          "```\n" +
+            "```json\n" +
+            '{ "actor_id": "{{PLACEHOLDER_APP_ID}}" }\n' +
+            "```\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).not.toContain("FLAG scaffold")
+      })
+
       test("flags prose {{...}} after a closing fence, not the fenced content", () => {
         // Pins the fence toggle-off transition: content resumes prose masking
         // once the block closes.

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -249,6 +249,68 @@ describe("validate-doc-claims script", () => {
         expect(result.stdout).toContain("{{DOC:3}}")
       })
 
+      test("does not flag {{...}} inside an inline code span", () => {
+        const docPath = writeRepoDoc(
+          "The ruleset names `{{IP_RELEASER_APP_ID}}` as a bypass actor.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).not.toContain("FLAG scaffold")
+      })
+
+      test("does not flag {{...}} inside a fenced code block", () => {
+        const docPath = writeRepoDoc(
+          "Example ruleset actor:\n\n" +
+            "```json\n" +
+            '{ "bypass_actors": [{ "actor_id": "{{IP_RELEASER_APP_ID}}" }] }\n' +
+            "```\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).not.toContain("FLAG scaffold")
+      })
+
+      test("still flags a bare {{...}} scaffold leaked into prose", () => {
+        const docPath = writeRepoDoc(
+          "Save the output under {{run_dir}} before continuing.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("FLAG scaffold")
+        expect(result.stdout).toContain("{{run_dir}}")
+      })
+
+      test("keeps a nested shorter fence inside a longer one masked", () => {
+        // A 4-backtick fence that demonstrates an inner 3-backtick block: the
+        // inner ``` must not close the outer fence (CommonMark length rule),
+        // so the {{...}} it wraps stays masked.
+        const docPath = writeRepoDoc(
+          "````markdown\n" +
+            "```\n" +
+            "{{NESTED_PLACEHOLDER}}\n" +
+            "```\n" +
+            "````\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(0)
+        expect(result.stdout).not.toContain("FLAG scaffold")
+      })
+
+      test("flags prose {{...}} after a closing fence, not the fenced content", () => {
+        // Pins the fence toggle-off transition: content resumes prose masking
+        // once the block closes.
+        const docPath = writeRepoDoc(
+          "```json\n" +
+            '{ "actor_id": "{{IP_RELEASER_APP_ID}}" }\n' +
+            "```\n\n" +
+            "Then save under {{run_dir}} before continuing.\n",
+        )
+        const result = runValidator(skillDir, docPath)
+        expect(result.code).toBe(1)
+        expect(result.stdout).toContain("{{run_dir}}")
+        expect(result.stdout).not.toContain("{{IP_RELEASER_APP_ID}}")
+      })
+
       test("resolves a `../` code-formatted link label from the doc's location", () => {
         const docPath = writeRepoDoc(
           "See [`../best-practices/linked-target.md`]" +


### PR DESCRIPTION
Running `ce-compound` in a repo that documents `{{PLACEHOLDER}}` syntax — Handlebars, CI variable interpolation, GitHub org-ruleset apply-time substitutions — used to surface a `FLAG scaffold` on every such token, even when the token sat inside backticks or a code fence, on every run. The token is legitimate documented content, not a leaked drafting scaffold, so the flag was pure noise — and worse, it risked training users to reflex-dismiss the scaffold check, which still needs to catch genuine leaks like a bare `{{run_dir}}` dropped into prose.

The scaffold check now masks fenced code blocks and inline code spans before scanning, so a `{{...}}` shown as quoted syntax is ignored while a bare token (or `Learnings N`) left in prose still flags. Fence matching follows CommonMark's close rule — same character, at least as long, and no trailing text (an info string like ` ```json ` opens a block but never closes one) — so both a nested shorter fence and an info-string fence line used to demonstrate Markdown stay masked instead of closing the outer block early. The mask reuses the existing inline-code regex and preserves line/column offsets so flag line numbers stay accurate.

Validated with 6 new regression tests in `tests/doc-claims-validator.test.ts`, run against both byte-identical script copies (`ce-compound`, `ce-compound-refresh`): `{{...}}` in an inline span and in a fenced block no longer flag; and a bare prose token, a prose token after a closing fence, a nested shorter fence, and an info-string fence line as block content are each pinned. CI runs the full `bun test` suite and is green on the head commit.

Fixes #1212

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
