### PR TITLE
fix(cli): quote reserved YAML scalar strings in frontmatter

### DIFF
--- a/src/utils/frontmatter.ts
+++ b/src/utils/frontmatter.ts
@@ -64,8 +64,20 @@ function formatYamlValue(value: unknown): string {
   if (raw.includes("\n")) {
     return `|\n${raw.split("\n").map((line) => `  ${line}`).join("\n")}`
   }
-  if (raw.includes(":") || raw.startsWith("[") || raw.startsWith("{") || raw === "*") {
+  if (raw.includes(":") || raw.startsWith("[") || raw.startsWith("{") || raw === "*" || parsesAsNonString(raw)) {
     return JSON.stringify(raw)
   }
   return raw
+}
+
+// A bare string that YAML reads back as a non-string (null, bool, number, date)
+// silently changes type on round-trip. Quote it. Re-parsing with the same loader
+// the read path uses keeps this rule in lockstep with js-yaml rather than a
+// hand-maintained token list that can drift from the parser's actual grammar.
+function parsesAsNonString(raw: string): boolean {
+  try {
+    return typeof load(raw) !== "string"
+  } catch {
+    return false
+  }
 }

--- a/tests/frontmatter.test.ts
+++ b/tests/frontmatter.test.ts
@@ -21,6 +21,22 @@ describe("frontmatter", () => {
     expect(parsed.body.trim()).toBe(body)
   })
 
+  test("formatFrontmatter quotes reserved scalar strings so they keep their type", () => {
+    // Emitted bare, each of these reparses as null/bool/number/date. See #613
+    // for the array-item sibling of the same YAML-safety class.
+    const reserved = ["null", "true", "false", "123", "1.5", "~", "0x1A", "2026-07-21", ""]
+    for (const value of reserved) {
+      const parsed = parseFrontmatter(formatFrontmatter({ description: value }, "body"))
+      expect(parsed.data.description, `"${value}" changed type on round-trip`).toBe(value)
+    }
+  })
+
+  test("formatFrontmatter leaves strings YAML reads back as themselves unquoted", () => {
+    const formatted = formatFrontmatter({ description: "yes", name: "off" }, "body")
+    expect(formatted).toContain("description: yes")
+    expect(formatted).toContain("name: off")
+  })
+
 })
 
 /**


### PR DESCRIPTION
## Problem

`formatYamlValue` emits some string values bare when the YAML reader parses them back as a different type. A frontmatter field whose string value is `null`, `true`, `123`, `1.5`, `~`, or a bare date like `2026-07-21` round trips to `null`, a boolean, a number, or a `Date`, silently losing its type.

Every converter (antigravity, codex, copilot, droid, kiro, opencode, pi) writes the agent and command frontmatter through `formatFrontmatter`. As such any plugin where the frontmatter value happens to be a reserved scalar gets a corrupted field in the output.

Round trip probe against the real `formatFrontmatter` → `parseFrontmatter` on this js-yaml:

```
in="null"        -> back=null  (object)
in="true"        -> back=true  (boolean)
in="123"         -> back=123   (number)
in="1.5"         -> back=1.5   (number)
in="~"           -> back=null  (object)
in="2026-07-21"  -> back="2026-07-21T00:00:00.000Z"  (Date)
in=""            -> back=null  (object)
```

## Root cause

The quoting predicate in `formatYamlValue` only quotes when the value contains `:`, starts with `[`/`{`, or equals `*`. It does not account for strings where the YAML reads as reserved (null/boolean/number/timestamp) scalars so those are written unquoted.

## Fix

Quote a string whenever the same `js-yaml` loader the read path uses parses its bare form as a non string:

```ts
function parsesAsNonString(raw: string): boolean {
  try {
    return typeof load(raw) !== "string"
  } catch {
    return false
  }
}
```

Added as another clause to the existing predicate, reusing the reader's own loader so it keeps the rule in step with js-yaml rather than having a hand maintained token list that can drift from the parser's grammar. 

Values that already correctly read back as themselves (`yes`/`no`/`on`/`off`, ordinary prose, `v1.2.3`) stay unquoted, so output is unchanged except for the values that were being corrupted.

## Tests

`tests/frontmatter.test.ts`:
- a round-trip test over `null`, `true`, `false`, `123`, `1.5`, `~`, `0x1A`, `2026-07-21`, `""` asserting each keeps its string type. Fails on the current code (`Expected "null", Received null`), passes with the fix.
- a test asserting `yes`/`off` still emit unquoted, guarding against over-quoting.

`bun test tests/frontmatter.test.ts` green; `tsc --noEmit` clean. Ran the seven converter suites alongside it — no change.

## Scope notes

- This is the scalar sibling of #613, which quoted array-item *reserved indicators* (`` ` ``, `[`, `*`, …) on the ce-compound skill side. This one is the CLI emitter and covers whole-value reserved scalars.
- #399 added the colon guard to this same function but not the scalar case.
- The predicate reparses each value with `load`. If you'd rather avoid a loader call on the write path, an explicit token regex is an option, but it has to track js-yaml's null/bool/number grammar by hand; happy to switch if you prefer that tradeoff.
