### PR TITLE
fix(lfg): make Step 9 babysit invocation non-skippable on clean-looking CI

### DIFF
--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -89,7 +89,7 @@ Never pass this object or the removed directive to `ce-plan`, `ce-doc-review`, `
 
    This commits any remaining changes, pushes the branch, and opens a pull request — non-interactively, per the mode token. If it prints a `New concepts:` trailer after the PR URL, record the concept name(s) for step 10. If step 6 already opened a PR (check with `gh pr view --json number,url,state 2>/dev/null`), skip PR creation but still commit and push any uncommitted changes. **Per the shipping precondition, when no remote is configured, do NOT invoke `ce-commit-push-pr` — its commit step pushes unconditionally (`git push -u origin HEAD`), so a literal invocation would still hit the impossible push. Instead commit any remaining changes locally yourself (`git add -A && git commit`) and skip the push and PR creation entirely.**
 
-9. **Drive CI to green via `ce-babysit-pr`** (only when an open PR exists for the current branch)
+9. **Watch the PR to CI-decided via `ce-babysit-pr`** (only when an open PR exists for the current branch)
 
    Detect the PR; if none exists or `gh` is unavailable, skip this step entirely and proceed to step 10.
 
@@ -97,7 +97,7 @@ Never pass this object or the removed directive to `ce-plan`, `ce-doc-review`, `
    gh pr view --json number,url,state
    ```
 
-   Invoke **`ce-babysit-pr mode:pipeline <pr-url>`**. It runs the bounded pipeline loop: watches CI, repairs real (convergent) failures via `ce-debug mode:pipeline` — never weakening, skipping, or mocking an assertion — resolves any review comments that arrived via `ce-resolve-pr-feedback mode:pipeline`, and stops when CI is decided or its budget (default 3 fix rounds) is hit. This replaces LFG's former hand-rolled CI loop; do not reimplement CI-watching here.
+   Invoke **`ce-babysit-pr mode:pipeline <pr-url>`**. It runs the bounded pipeline loop: watches CI, repairs real (convergent) failures via `ce-debug mode:pipeline` — never weakening, skipping, or mocking an assertion — resolves any review comments that arrived via `ce-resolve-pr-feedback mode:pipeline`, and stops when CI is decided or its budget (default 3 fix rounds) is hit. This replaces LFG's former hand-rolled CI loop; do not reimplement CI-watching here. Invoke it unconditionally whenever an open PR exists — a run whose CI looks likely-clean is not a reason to skip babysit and poll `gh pr checks` yourself. Green CI at one instant is not this step's goal: babysit also resolves review comments across the PR's life, so a passing check while advisory checks (e.g. Bugbot) are still pending or comments are unhandled is not "done" and never substitutes for the invocation.
 
    Collect its structured result (`{ status, fixes_applied, residuals }`). It surfaces unfixable CI as a **run-report comment on the PR** and returns residuals — do **NOT** write a `## CI Failures Unresolved` PR-body section. A `needs-human` residual (a fix that would need a product/design decision) is deferred, not applied — that is the autopilot contract, unchanged. Do not block DONE once babysit has surfaced residuals.
 


### PR DESCRIPTION
In an `lfg` autonomous run, `ce-babysit-pr` is meant to be invoked at Step 9 to watch the PR after it opens. But an agent could skip that invocation whenever CI *looked* likely-clean, hand-roll a `gh pr checks` poll instead, and declare the PR "🚢 Shipped" the moment the `test` check went green — leaving advisory checks (e.g. Cursor Bugbot) still pending and any incoming review comments unhandled. Observed on #1216, where the pipeline stopped watching at first green. Step 9 already said "do not reimplement CI-watching here," but that prohibition was read past under a "this run looks clean, skip the ceremony" rationalization.

This reframes the step goal from "drive CI to green" to "watch the PR to CI-decided," and adds a falsifiable counter: babysit is invoked unconditionally whenever an open PR exists; likely-clean CI is not a reason to skip it and poll yourself; and green CI at one instant is not the goal, because babysit also resolves review comments across the PR's life — so a passing check while advisory checks are pending or comments are unhandled is not "done."

This is prose-interpreted runtime behavior, so there is no mechanical regression test for it (consistent with the repo's split — skill-prose behavior is eval-only, not a `bun test` lane). Verified only that `release:validate` stays in sync and the `skill-conventions` + `frontmatter` guards remain green (370 pass / 0 fail).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
