### PR TITLE
fix(release): raise commit-search-depth so release notes stop dropping older commits

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": true,
   "release-search-depth": 20,
-  "commit-search-depth": 50,
+  "commit-search-depth": 500,
   "plugins": [],
   "packages": {
     ".": {


### PR DESCRIPTION
Release PRs were silently dropping older commits from the generated changelog. release-please's `commit-search-depth` was set to `50`, so it only walked the newest 50 commits from `HEAD` when building release notes. Whenever the open release PR accumulated more than that before merging — 113 commits since v3.19.0 in the current one — every `feat`/`fix` past the 50-commit window was omitted. `feat(ce-handoff)` (#1162, depth 53) was the reported casualty; 55 feat/fix/refactor commits were dropped in total.

Raising it to `500` (release-please's own default) captures the full backlog. The fix takes effect on the next release-please run, which will regenerate the open release PR's notes to include the previously dropped commits.

Related: #1084
