### PR TITLE
docs(codex): refresh spec for current Codex — URLs, profiles, skill config

### DIFF
--- a/docs/specs/codex.md
+++ b/docs/specs/codex.md
@@ -1,59 +1,64 @@
 # Codex Spec (Config, Prompts, Skills, Subagents, MCP)
 
-Last verified: 2026-04-19
+Last verified: 2026-07-21
 
 ## Primary sources
 
+`developers.openai.com/codex/*` now 308-redirects to `learn.chatgpt.com/docs/*`; the list below reflects the current locations.
+
 ```
-https://developers.openai.com/codex/config-basic
-https://developers.openai.com/codex/config-advanced
-https://developers.openai.com/codex/custom-prompts
-https://developers.openai.com/codex/skills
-https://developers.openai.com/codex/skills/create-skill
-https://developers.openai.com/codex/subagents
-https://developers.openai.com/codex/guides/agents-md
-https://developers.openai.com/codex/mcp
+https://learn.chatgpt.com/docs/config-file/config-basic
+https://learn.chatgpt.com/docs/config-file/config-advanced
+https://learn.chatgpt.com/docs/custom-prompts
+https://learn.chatgpt.com/docs/build-skills
+https://learn.chatgpt.com/docs/build-skills#create-a-skill
+https://learn.chatgpt.com/docs/agent-configuration/subagents
+https://learn.chatgpt.com/docs/agent-configuration/agents-md
+https://learn.chatgpt.com/docs/extend/mcp?surface=cli
 ```
 
 ## Config location and precedence
 
-- Codex reads local settings from `~/.codex/config.toml`, shared by the CLI and IDE extension. citeturn2view0
-- Configuration precedence is: CLI flags → profile values → root-level values in `config.toml` → built-in defaults. citeturn2view0
-- Codex stores local state under `CODEX_HOME` (defaults to `~/.codex`) and includes `config.toml` there. citeturn4view0
+- Codex reads local settings from `~/.codex/config.toml`, shared by the CLI and IDE extension.
+- Configuration precedence, highest to lowest, is: CLI flags and `--config` overrides → project `.codex/config.toml` (nearest the working directory wins) → the profile file selected by `--profile` → user `~/.codex/config.toml` → system `/etc/codex/config.toml` → built-in defaults.
+- Project-scoped config loads only for projects you have explicitly trusted; untrusted projects skip that layer.
+- Codex stores local state under `CODEX_HOME` (defaults to `~/.codex`) and includes `config.toml` there.
 
 ## Profiles and providers
 
-- Profiles are defined under `[profiles.<name>]` and selected with `codex --profile <name>`. citeturn4view0
-- A top-level `profile = "<name>"` sets the default profile; CLI flags can override it. citeturn4view0
-- Profiles are experimental and not supported in the IDE extension. citeturn4view0
-- Custom model providers can be defined with base URL, wire API, and optional headers, then referenced via `model_provider`. citeturn4view0
+- Profiles are separate files at `$CODEX_HOME/<name>.config.toml` (e.g. `~/.codex/worker.config.toml`), selected with `codex --profile <name>`, and overlaid on top of the base user config. Names may contain letters, numbers, hyphens, and underscores.
+- **Changed in Codex 0.134.0:** "`--profile` no longer reads `[profiles.profile-name]` from `config.toml`, and the top-level `profile = "profile-name"` selector is no longer supported." Both forms are inert on current releases, so a config still using them silently loses its profile settings.
+- Profiles are selected from the CLI; the docs do not describe IDE-extension support either way.
+- Custom model providers can be defined with base URL, wire API, and optional headers, then referenced via `model_provider`.
 
 ## Custom prompts (slash commands)
 
-- Custom prompts are Markdown files stored under `~/.codex/prompts/`. citeturn3view0
-- Custom prompts require explicit invocation and aren’t shared through the repository; use skills to share or auto-invoke. citeturn3view0
-- Prompts are invoked as `/prompts:<name>` in the slash command UI. citeturn3view0
-- Prompt front matter supports `description:` and `argument-hint:`. citeturn3view0turn2view3
-- Prompt arguments support `$1`–`$9`, `$ARGUMENTS`, and named placeholders like `$FILE` provided as `KEY=value`. citeturn2view3
-- Codex ignores non-Markdown files in the prompts directory. citeturn2view3
+- Custom prompts are Markdown files stored under `~/.codex/prompts/`.
+- Custom prompts require explicit invocation and aren’t shared through the repository; use skills to share or auto-invoke.
+- Prompts are invoked as `/prompts:<name>` in the slash command UI.
+- Prompt front matter supports `description:` and `argument-hint:`.
+- Prompt arguments support `$1`–`$9`, `$ARGUMENTS`, and named placeholders like `$FILE` provided as `KEY=value`.
+- Codex ignores non-Markdown files in the prompts directory.
 
 ## AGENTS.md instructions
 
-- Codex reads `AGENTS.md` files before doing any work and builds a combined instruction chain. citeturn3view1
-- Discovery order: global (`~/.codex`, using `AGENTS.override.md` then `AGENTS.md`) then project directory traversal from repo root to CWD, with override > AGENTS > fallback names. citeturn3view1
-- Codex concatenates files from root down; files closer to the working directory appear later and override earlier guidance. citeturn3view1
+- Codex reads `AGENTS.md` files before doing any work and builds a combined instruction chain.
+- Discovery order: global (`~/.codex`, using `AGENTS.override.md` then `AGENTS.md`) then project directory traversal from repo root to CWD, with override > AGENTS > fallback names.
+- Codex concatenates files from root down; files closer to the working directory appear later and override earlier guidance.
 
 ## Skills (Agent Skills)
 
-- A skill is a folder containing `SKILL.md` plus optional `scripts/`, `references/`, and `assets/`. citeturn3view3turn3view4
-- `SKILL.md` uses YAML front matter and requires `name` and `description`. citeturn3view3turn3view4
-- Required fields are single-line with length limits (name ≤ 100 chars, description ≤ 500 chars). citeturn3view4
-- At startup, Codex loads only each skill’s name/description; full content is injected when invoked. citeturn3view3turn3view4
-- Skills can be repo-scoped in `.agents/skills/` and are discovered from the current working directory up to the repository root. User-scoped skills live in `~/.agents/skills/`. citeturn1view1turn1view4
+- A skill is a folder containing `SKILL.md` plus optional `scripts/`, `references/`, `assets/`, and an `agents/openai.yaml` config file.
+- `SKILL.md` uses YAML front matter and requires `name` and `description`.
+- Required fields are single-line with length limits (name ≤ 100 chars, description ≤ 500 chars).
+- At startup, Codex loads only each skill’s name, description, and file path; full content is injected when invoked.
+- An optional `agents/openai.yaml` inside the skill directory carries Codex-specific presentation and invocation config: an `interface` block (`display_name`, `short_description`, `icon_small`, `icon_large`, `brand_color`, `default_prompt`), a `policy.allow_implicit_invocation` flag, and a `dependencies.tools` list declaring MCP tool dependencies (`type`, `value`, `description`, `transport`, `url`).
+- `policy.allow_implicit_invocation` defaults to `true`. Setting it `false` makes the skill reachable only by explicit `/skills` or `$skill-name` invocation, opting it out of task-matching auto-selection — the Codex counterpart to Claude Code’s `disable-model-invocation: true` frontmatter.
+- Skills can be repo-scoped in `.agents/skills/` and are discovered from the current working directory up to the repository root. User-scoped skills live in `~/.agents/skills/`.
 - Inference: some existing tooling and user setups still use `.codex/skills/` and `~/.codex/skills/` as compatibility paths, but those locations are not documented in the current OpenAI Codex skills docs linked above.
 - Compound Engineering should avoid `~/.agents/skills` for managed installs because that shared root can shadow Copilot's native plugin skills. Use the Codex-specific compatibility root `~/.codex/skills/compound-engineering/<skill-name>/SKILL.md` for CE Codex skills, and track generated files with a CE manifest.
-- Codex also supports admin-scoped skills in `/etc/codex/skills` plus built-in system skills bundled with Codex. citeturn1view4
-- Skills can be invoked explicitly using `/skills` or `$skill-name`. citeturn3view3
+- Codex also supports admin-scoped skills in `/etc/codex/skills` plus built-in system skills bundled with Codex.
+- Skills can be invoked explicitly using `/skills` or `$skill-name`.
 
 ## Subagents and custom agents
 
@@ -65,6 +70,9 @@ https://developers.openai.com/codex/mcp
   - `description`
   - `developer_instructions`
 - Optional fields can include `nickname_candidates`, `model`, `model_reasoning_effort`, `sandbox_mode`, `mcp_servers`, and `skills.config`.
+- `model_reasoning_effort` accepts `ultra`, `max`, `xhigh`, `high`, `medium`, `low`, `minimal`, or `none`.
+- When `model` or `model_reasoning_effort` is omitted, the subagent inherits the parent session’s value — but the docs also state that Codex "can choose a setup that balances intelligence, speed, and price for the task", so do not treat inheritance as guaranteed.
+- Global caps live under `[agents]` in `config.toml`: `max_threads` (default `6`) caps concurrent agent threads, and `max_depth` (default `1`) caps nesting, so by default a spawned subagent cannot itself spawn one.
 - The TOML `name` field is the source of truth; matching the filename to the agent name is only a convention.
 - The generic converter can convert Claude Markdown agents into Codex custom-agent TOML files under `~/.codex/agents/<plugin>/` for plugins that still ship standalone agents.
 - Generated agents should live under `~/.codex/agents`, not `~/.agents/skills`, because `~/.agents` is shared across harnesses and can shadow native plugin installs.
@@ -74,7 +82,7 @@ https://developers.openai.com/codex/mcp
 
 ## MCP (Model Context Protocol)
 
-- MCP configuration lives in `~/.codex/config.toml` and is shared by the CLI and IDE extension. citeturn3view2turn3view5
-- Each server is configured under `[mcp_servers.<server-name>]`. citeturn3view5
-- STDIO servers support `command` (required), `args`, `env`, `env_vars`, and `cwd`. citeturn3view5
-- Streamable HTTP servers support `url` (required), `bearer_token_env_var`, `http_headers`, and `env_http_headers`. citeturn3view5
+- MCP configuration lives in `~/.codex/config.toml` and is shared by the CLI and IDE extension.
+- Each server is configured under `[mcp_servers.<server-name>]`.
+- STDIO servers support `command` (required), `args`, `env`, `env_vars`, and `cwd`.
+- Streamable HTTP servers support `url` (required), `bearer_token_env_var`, `http_headers`, and `env_http_headers`.


### PR DESCRIPTION
## Summary

`docs/specs/codex.md` was last verified 2026-04-19 and has drifted. Most of it is merely stale, but the profiles section is actively misleading: it documents a mechanism Codex removed, and the failure mode is silent.

**Codex 0.134.0 discontinued `[profiles.<name>]` in `config.toml` and the top-level `profile = "<name>"` selector.** From the current docs, verbatim:

> `--profile` no longer reads `[profiles.profile-name]` from `config.toml`, and the top-level `profile = "profile-name"` selector is no longer supported.

A config written against the spec as it stands today doesn't error — it's simply inert, and the profile's settings are silently dropped. Profiles are now separate files at `$CODEX_HOME/<name>.config.toml`, overlaid on the base user config.

Since this repo's converters and tooling are built against these documented facts, a wrong claim here propagates into code.

## What changed

**Primary sources.** `developers.openai.com/codex/*` now 308-redirects to `learn.chatgpt.com/docs/*`. All eight URLs updated to their redirect targets; one mention of the old host is kept so the move stays discoverable.

**Config precedence.** The documented order was `CLI → profile → config.toml → defaults`, omitting the project and system layers entirely. Replaced with the full chain, plus the condition that project-scoped config loads only for trusted projects.

**Profiles.** Rewritten for the file-based mechanism, with the 0.134.0 change called out. Also drops "Profiles are experimental and not supported in the IDE extension" — current docs make neither claim.

**Skills.** Documents the optional `agents/openai.yaml` inside a skill directory: the `interface` block, `dependencies.tools`, and `policy.allow_implicit_invocation`. That last one is worth noting for converter work — it's the Codex counterpart to Claude Code's `disable-model-invocation` frontmatter, and there was previously no documented way to express "explicit invocation only" on the Codex side. Startup context is also name, description, **and file path**, not just name/description.

**Subagents.** Adds the `model_reasoning_effort` value set and the `[agents]` `max_threads` / `max_depth` caps. Omitted `model`/`model_reasoning_effort` inherit from the parent session, but the docs also allow Codex to select them, so the spec no longer presents inheritance as guaranteed.

**Citation markers.** Removes 27 leaked browsing-tool artifacts — private-use codepoints (U+E200–U+E202) wrapping tokens like `cite…turn2view0`. They resolve to nothing outside the tool that produced them and are invisible in most editors, so they survived earlier review. No prose was changed: stripping them from the previous revision and diffing against this one yields only the intended content edits.

## Verification

Every claim was checked against the live docs rather than carried over.

| Claim | Source |
|---|---|
| Precedence: CLI/`--config` → project `.codex/config.toml` (closest wins) → `--profile` file → user → `/etc/codex/config.toml` → defaults | `config-file/config-basic` |
| Project config loads only for trusted projects | `config-file/config-basic` |
| Profiles are `$CODEX_HOME/<name>.config.toml`, overlaid on base user config | `config-file/config-advanced` |
| 0.134.0 discontinued `[profiles.<name>]` and top-level `profile =` | `config-file/config-advanced` |
| `agents/openai.yaml` keys (`interface`, `dependencies.tools`) | `build-skills` |
| `policy.allow_implicit_invocation` defaults to `true` | `build-skills` |
| Startup loads name, description, and file path | `build-skills` |
| `model_reasoning_effort` ∈ {ultra, max, xhigh, high, medium, low, minimal, none} | `agent-configuration/subagents` |
| `[agents] max_threads` default 6, `max_depth` default 1 | `agent-configuration/subagents` |

All 8 new URLs return 200. All 8 old ones return 308, and each redirect target matches the URL chosen here byte-for-byte — including the `#create-a-skill` anchor and the `?surface=cli` query string.

Unchanged bullets in the prompts, AGENTS.md, and MCP sections were spot-checked and still hold, which is what makes the `Last verified` bump defensible. The MCP field lists remain non-exhaustive (the docs also document `experimental_environment`, `auth`, and `enabled_tools`) — left as-is, since narrowing scope wasn't the goal here.

## Not verified

- **Docs, not behavior.** This is doc-vs-doc throughout; I did not run a Codex binary or read its source. If the docs are wrong, this spec inherits that.
- The `learn.chatgpt.com` pages carry no version stamp, so I can't tell whether a newer Codex release has already moved past them.

## Noted, not fixed

- Line 59 refers to "Copilot's native plugin skills" in a Codex spec — looks like a typo, but it predates this change and I've left it alone.
- `docs/specs/claude-code.md` still contains roughly 25 of the same citation markers. Every other file in `docs/specs/` is already clean, so that's a natural follow-up; happy to send it separately.

## Test plan

Documentation-only — no source, tests, or generated artifacts touched.

- `bun test` — 2610 pass, 0 fail across 97 files
- `bun run release:validate` — "Release metadata is in sync"
