### PR TITLE
docs(claude-code): refresh spec for current Claude Code — schemas, skills, hooks

### DIFF
--- a/docs/specs/claude-code.md
+++ b/docs/specs/claude-code.md
@@ -1,67 +1,83 @@
 # Claude Code Plugin Spec
 
-Last verified: 2026-01-21
+Last verified: 2026-07-21
 
 ## Primary sources
 
+`docs.claude.com/en/docs/claude-code/*` now redirects to `code.claude.com/docs/en/*`; the list below uses the current locations.
+
 ```
-https://docs.claude.com/en/docs/claude-code/plugins-reference
-https://docs.claude.com/en/docs/claude-code/hooks
-https://docs.claude.com/en/docs/claude-code/slash-commands
-https://docs.claude.com/en/docs/claude-code/skills
-https://docs.claude.com/en/docs/claude-code/plugin-marketplaces
+https://code.claude.com/docs/en/plugins-reference
+https://code.claude.com/docs/en/skills
+https://code.claude.com/docs/en/sub-agents
+https://code.claude.com/docs/en/hooks
+https://code.claude.com/docs/en/mcp
+https://code.claude.com/docs/en/plugin-marketplaces
 ```
 
 ## Plugin layout and file locations
 
-- A plugin root contains `.claude-plugin/plugin.json` and optional default directories like `commands/`, `agents/`, `skills/`, `hooks/`, plus `.mcp.json` and `.lsp.json` at the plugin root. citeturn2view7
-- The `.claude-plugin/` directory only holds the manifest; component directories (commands/agents/skills/hooks) must be at the plugin root, not inside `.claude-plugin/`. citeturn2view7
-- The reference table lists default locations and notes that `commands/` is the legacy home for skills; new skills should live under `skills/<name>/SKILL.md`. citeturn2view7
+- A plugin is a self-contained directory. Its optional manifest lives at `.claude-plugin/plugin.json`; default component locations at the plugin root include `skills/`, `commands/`, `agents/`, `output-styles/`, `themes/`, `monitors/`, `hooks/`, `bin/`, `settings.json`, `.mcp.json`, and `.lsp.json`.
+- The plugin manifest belongs at `.claude-plugin/plugin.json`; component directories and runtime configuration files belong at the plugin root. A repository that is also a marketplace keeps its catalog at `.claude-plugin/marketplace.json`.
+- `commands/` contains legacy flat Markdown skills. New skills should use `skills/<name>/SKILL.md`; a root `SKILL.md` also loads as a single-skill plugin when no `skills/` directory or manifest field is present.
+- A root `CLAUDE.md` is not loaded as project context. Plugins contribute context through skills, agents, and hooks.
 
 ## Manifest schema (`.claude-plugin/plugin.json`)
 
-- `name` is required and must be kebab-case with no spaces. citeturn2view8
-- Metadata fields include `version`, `description`, `author`, `homepage`, `repository`, `license`, and `keywords`. citeturn2view8
-- Component path fields include `commands`, `agents`, `skills`, `hooks`, `mcpServers`, `outputStyles`, and `lspServers`. These can be strings or arrays, or inline objects for hooks/MCP/LSP. citeturn2view8turn2view9
-- Custom paths supplement defaults; they do not replace them, and all paths must be relative to the plugin root and start with `./`. citeturn2view9
+- The manifest is optional. When present, `name` is its only required field and must be a kebab-case identifier with no spaces.
+- Metadata fields are `$schema`, `displayName`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`, and `defaultEnabled`.
+- Component fields are `skills`, `commands`, `agents`, `hooks`, `mcpServers`, `outputStyles`, `lspServers`, `experimental.themes`, and `experimental.monitors`. Skills, commands, agents, output styles, and themes accept paths; hooks, MCP, and LSP also accept inline objects, while monitors accept a path or inline entries. `userConfig`, `channels`, and `dependencies` configure plugin options, message channels, and plugin dependencies.
+- Custom `skills` paths add to the default `skills/` scan. Custom `commands`, `agents`, `outputStyles`, `experimental.themes`, and `experimental.monitors` paths replace their defaults. Hooks, MCP, and LSP use component-specific merge rules.
+- All component paths are relative to the plugin root and start with `./`; arrays can specify multiple paths.
+- `version` is optional but pins update detection when set. `plugin.json` wins over a marketplace entry's version; when neither declares one, git-backed sources use their commit SHA, while npm sources and local directories outside a git repository resolve to `unknown`.
+- Unknown top-level fields are ignored at runtime and reported as validation warnings; wrong field types are load errors. `claude plugin validate --strict` promotes warnings to errors.
 
-## Commands (slash commands)
+## Commands (legacy flat skills)
 
-- Command files are Markdown with frontmatter. Supported frontmatter includes `allowed-tools`, `argument-hint`, `description`, `model`, and `disable-model-invocation`, each with documented defaults. citeturn6search0
+- Custom commands have been merged into skills. Flat Markdown files under `commands/` remain supported and use the same frontmatter as `SKILL.md`; `skills/` is preferred because a skill directory can carry supporting files.
 
 ## Skills (`skills/<name>/SKILL.md`)
 
-- Skills are directories containing `SKILL.md` (plus optional support files). Skills and commands are auto-discovered when the plugin is installed. citeturn2view7
-- Skills can be invoked with `/<skill-name>` and are stored in `~/.claude/skills` or `.claude/skills` (project-level); plugins can also ship skills. citeturn12view0
-- Skill frontmatter examples include `name`, `description`, and optional `allowed-tools`. citeturn12view0
+- A skill is a directory containing `SKILL.md` plus optional supporting files. Plugin skills and commands are discovered when the plugin is installed.
+- Personal skills live in `~/.claude/skills/`, project skills in `.claude/skills/`, and plugin skills in `<plugin>/skills/`. Users invoke personal and project skills as `/<skill-name>`; plugin skills are namespaced as `/<plugin-name>:<skill-name>`. For plugin skills, frontmatter `name` replaces the final command segment, and the bare `/<skill-name>` alias also works unless another command already uses it.
+- Every frontmatter field is optional; `description` is recommended for automatic matching. Current fields are `name`, `description`, `when_to_use`, `argument-hint`, `arguments`, `disable-model-invocation`, `user-invocable`, `allowed-tools`, `disallowed-tools`, `model`, `effort`, `context`, `agent`, `hooks`, `paths`, and `shell`.
+- By default both the user and Claude can invoke a skill. `disable-model-invocation: true` makes it manual-only and removes its description from Claude's context; `user-invocable: false` hides it from the `/` menu but does not block Claude. `allowed-tools` grants permission only for the invoking turn, while `disallowed-tools` removes tools for that turn.
 
 ## Agents (`agents/*.md`)
 
-- Agents are markdown files with frontmatter such as `description` and `capabilities`, plus descriptive content for when to invoke the agent. citeturn2view7
+- Agents are Markdown files with YAML frontmatter followed by the agent's system prompt. `name` and `description` are required.
+- Plugin agents support `name`, `description`, `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `skills`, `memory`, `background`, and `isolation`; the only valid isolation value is `worktree`. For security, plugin agents do not support `hooks`, `mcpServers`, or `permissionMode`.
+- Enabled plugin agents are available for automatic delegation and manual invocation under scoped names such as `plugin-name:agent-name`.
 
 ## Hooks (`hooks/hooks.json` or inline)
 
-- Hooks can be provided in `hooks/hooks.json` or inline via the manifest. Hooks are organized by event → matcher → hook list. citeturn2view7
-- Plugin hooks are merged with user and project hooks when the plugin is enabled, and matching hooks run in parallel. citeturn1search0
-- Supported events include `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `UserPromptSubmit`, `Notification`, `Stop`, `SubagentStart`, `SubagentStop`, `Setup`, `SessionStart`, `SessionEnd`, and `PreCompact`. citeturn2view7
-- Hook types include `command`, `prompt`, and `agent`. citeturn2view7
-- Hooks can use `${CLAUDE_PLUGIN_ROOT}` to reference plugin files. citeturn1search0
+- Plugins provide hooks in `hooks/hooks.json` or inline through `plugin.json`. Configuration is organized as event -> matcher -> handler list.
+- Enabled plugin hooks merge with user and project hooks. All matching handlers run in parallel, with identical handlers deduplicated.
+- Supported events are `SessionStart`, `Setup`, `InstructionsLoaded`, `UserPromptSubmit`, `UserPromptExpansion`, `MessageDisplay`, `PreToolUse`, `PermissionRequest`, `PermissionDenied`, `PostToolUse`, `PostToolUseFailure`, `PostToolBatch`, `Notification`, `SubagentStart`, `SubagentStop`, `TaskCreated`, `TaskCompleted`, `Stop`, `StopFailure`, `TeammateIdle`, `ConfigChange`, `CwdChanged`, `FileChanged`, `WorktreeCreate`, `WorktreeRemove`, `PreCompact`, `PostCompact`, `Elicitation`, `ElicitationResult`, and `SessionEnd`.
+- Hook handler types are `command`, `http`, `mcp_tool`, `prompt`, and `agent`.
+- Plugins can reference `${CLAUDE_PLUGIN_ROOT}` for the installed version, `${CLAUDE_PLUGIN_DATA}` for persistent state, and `${CLAUDE_PROJECT_DIR}` for the project root. Substitution fields vary by component.
 
 ## MCP servers
 
-- Plugins can define MCP servers in `.mcp.json` or inline under `mcpServers` in the manifest. Configuration includes `command`, `args`, `env`, and `cwd`. citeturn2view7turn2view10
-- Plugin MCP servers start automatically when enabled and appear as standard MCP tools. citeturn2view10
+- Plugins define MCP servers in `.mcp.json` or inline under `mcpServers` in the manifest. Supported transports are stdio, HTTP, SSE, and WebSocket; SSE is deprecated in favor of HTTP.
+- Stdio configurations use `command` with optional `args` and `env`. Remote configurations specify a `type` (`http`, `sse`, or `ws`) and `url`, with transport-specific fields such as `headers` and `headersHelper`.
+- Plugin MCP servers start automatically when enabled and expose standard MCP tools under scoped names that include the plugin and server names.
 
 ## LSP servers
 
-- LSP servers can be defined in `.lsp.json` or inline in the manifest. Required fields include `command` and `extensionToLanguage`, with optional settings for transport, args, env, and timeouts. citeturn2view7turn2view10
+- LSP servers are defined in `.lsp.json` or inline under `lspServers`. Each server requires `command` and `extensionToLanguage`.
+- Optional fields are `args`, `transport`, `env`, `initializationOptions`, `settings`, `workspaceFolder`, `startupTimeout`, `shutdownTimeout`, `restartOnCrash`, `maxRestarts`, and `diagnostics`.
+- LSP plugins configure the connection but do not bundle the language-server binary; the binary must be installed separately and available on `PATH`.
 
 ## Plugin caching and path limits
 
-- Claude Code copies plugin files into a cache directory instead of using them in place. Plugins cannot access paths outside the copied root (for example, `../shared-utils`). citeturn2view12
-- To access external files, use symlinks inside the plugin directory or restructure your marketplace so the plugin root contains shared files. citeturn2view12
+- Marketplace-installed plugins are copied into versioned directories under `~/.claude/plugins/cache` rather than used in place. Each installed version is separate; orphaned versions remain for 14 days so running sessions can finish.
+- Installed plugins cannot reference paths outside their copied root, so traversal such as `../shared-utils` fails after installation.
+- A symlink whose target stays inside the plugin is preserved. A link to another location inside the same marketplace is dereferenced and copied into the cache; a link outside the marketplace is skipped. Local-path and `--plugin-dir` installs preserve only links whose targets remain inside the plugin.
 
 ## Marketplace schema (`.claude-plugin/marketplace.json`)
 
-- A marketplace JSON file lists plugins and includes fields for marketplace metadata and a `plugins` array. citeturn8view2
-- Each plugin entry includes at least a `name` and `source` and can include additional manifest fields. citeturn8view2
+- A marketplace requires `name`, `owner`, and `plugins`; `owner.name` is required and `owner.email` is optional. Optional top-level fields include `$schema`, `description`, `version`, `metadata.pluginRoot`, `allowCrossMarketplaceDependenciesOn`, and `renames`.
+- Every plugin entry requires a kebab-case `name` and a `source`. Sources can be a relative path or `github`, `url`, `git-subdir`, or `npm` objects. Relative sources normally start with `./` and resolve from the marketplace root; `metadata.pluginRoot` supplies a base directory and allows entries such as `"source": "formatter"` without that prefix.
+- Plugin entries can include manifest fields plus marketplace-only `category`, `tags`, `strict`, and `relevance`; `defaultEnabled` in the marketplace takes precedence over the same manifest field.
+- `strict` defaults to `true`: `plugin.json` is authoritative and the marketplace entry can add components. With `strict: false`, the marketplace entry is the whole definition, and component declarations in a present `plugin.json` are a load conflict.


### PR DESCRIPTION
## Summary

`docs/specs/claude-code.md` was last verified 2026-01-21, making it the oldest spec in the repository by roughly five months. It had drifted across nearly every fast-moving Claude Code surface: the manifest is now optional, commands have merged into skills, plugin agents have a different field contract than documented, hooks have expanded to 30 events and five handler types, and marketplace installation semantics are substantially more precise than the existing text suggested.

This is the source-format spec every converter in `src/converters/` reads from. A wrong claim here does not stay isolated to one target; it can propagate into every conversion path.

## What changed

**Primary sources.** `docs.claude.com/en/docs/claude-code/*` now redirects to `code.claude.com/docs/en/*`. The list uses the current URLs and adds the missing sub-agent and MCP references.

**Plugin layout and manifest.** Documents that `.claude-plugin/plugin.json` is optional, expands the current metadata and component inventories, and distinguishes which custom paths add to defaults, replace defaults, or use component-specific merge rules. It also records validation behavior and version precedence/fallback semantics.

**Commands and skills.** Recasts `commands/` as the legacy flat-skill format, documents the current `SKILL.md` frontmatter inventory, and adds plugin namespacing, frontmatter-name overrides, aliases, invocation visibility, and per-turn tool restrictions.

**Agents.** Replaces the obsolete `capabilities` claim with the current plugin-agent fields and records that plugin agents do not support `hooks`, `mcpServers`, or `permissionMode`.

**Hooks.** Expands the event inventory from 13 to the current 30, adds the `http` and `mcp_tool` handler types, and documents deduplication plus the current plugin/project/data path variables.

**MCP and LSP.** Documents current MCP transports, remote configuration, scoped tool exposure, the full LSP field inventory, and the requirement that language-server binaries be installed separately. The previous MCP `cwd` claim could not be verified in current official docs and was removed.

**Caching and marketplaces.** Narrows cache-copy behavior to marketplace-installed plugins, documents version retention and exact symlink handling, and expands the marketplace schema, source forms, `metadata.pluginRoot`, `defaultEnabled` precedence, and `strict` behavior.

**Citation markers.** Removes 24 leaked browsing-tool artifacts — 75 private-use codepoints (U+E200–U+E202) wrapping tokens like `cite…turn2view0`. Three markers contained multiple source references separated by U+E202, so the cleanup matched complete marker spans rather than assuming a single turn token. No prose was changed in the mechanical stripping pass.

## Verification

Every claim was checked against the live official documentation rather than carried over.

| Claim group | Source |
|---|---|
| Plugin layout, manifest fields, merge rules, validation, versioning, LSP, caching, and symlinks | `plugins-reference` |
| Skill layout, invocation, frontmatter, visibility, and tool restrictions | `skills` |
| Plugin-agent fields, isolation, restrictions, and scoped invocation | `sub-agents` |
| Hook configuration, all 30 events, five handler types, parallelism, and deduplication | `hooks` |
| MCP transports and stdio/remote configuration | `mcp` |
| Marketplace requirements, sources, plugin root, precedence, and strict mode | `plugin-marketplaces` |

All six current primary-source URLs return 200. Legacy `docs.claude.com` locations redirect to their `code.claude.com` equivalents.

An independent reviewer checked the refreshed file against live official documentation without receiving the implementation conclusions. It found four issues — version-fallback scope, marketplace catalog placement, plugin skill alias behavior, and `metadata.pluginRoot` source resolution. All four were corrected, and its second pass was all-clear.

The original contained 75 private-use codepoints across 24 citation markers. The refreshed file contains zero. Stripping the markers from the original into an independent baseline and comparing that baseline with the result leaves only the intended content edits.

## Not verified

- **Docs, not behavior.** This is doc-vs-doc throughout; I did not construct fixtures against a Claude Code binary or inspect its source. If the official documentation is wrong, this spec inherits that.
- The current documentation pages carry no release-wide version stamp, so the verification date records when these claims were checked, not a single Claude Code version they all describe.

## Noted, not fixed

- The refreshed skill and agent field inventories describe Claude Code's source contract. Existing parser and target-converter support for every field was not audited or expanded in this documentation-only change.

## Test plan

Documentation-only — no source, tests, generated artifacts, or release metadata changed.

- `bun test` — 2610 pass, 0 fail across 97 files
- `bun run release:validate` — “Release metadata is in sync”
- `git diff --check` — clean
- PUA scan — 0 codepoints remain
