### PR TITLE
refactor(cli): converge the slash-command path guard into one helper

### DIFF
--- a/src/converters/claude-to-copilot.ts
+++ b/src/converters/claude-to-copilot.ts
@@ -1,5 +1,6 @@
 import { formatFrontmatter } from "../utils/frontmatter"
 import { sanitizePathName } from "../utils/files"
+import { transformSlashCommands } from "../utils/slash-command"
 import { type ClaudeAgent, type ClaudeCommand, type ClaudeMcpServer, type ClaudePlugin, filterSkillsByPlatform } from "../types/claude"
 import type {
   CopilotAgent,
@@ -114,13 +115,7 @@ export function transformContentForCopilot(body: string): string {
   })
 
   // 2. Transform slash command references (replace colons with hyphens)
-  const slashCommandPattern = /(?<![:\w])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
-  result = result.replace(slashCommandPattern, (match, commandName: string) => {
-    if (commandName.includes("/")) return match
-    if (["dev", "tmp", "etc", "usr", "var", "bin", "home"].includes(commandName)) return match
-    const normalized = flattenCommandName(commandName)
-    return `/${normalized}`
-  })
+  result = transformSlashCommands(result, (commandName) => `/${flattenCommandName(commandName)}`)
 
   // 3. Replace plugin colon-namespaced command references (e.g. ce:plan → ce-plan, ce:* → ce-*)
   // Scoped to `ce:` prefix which is the compound-engineering plugin namespace.

--- a/src/converters/claude-to-droid.ts
+++ b/src/converters/claude-to-droid.ts
@@ -2,6 +2,7 @@ import { formatFrontmatter } from "../utils/frontmatter"
 import { type ClaudeAgent, type ClaudeCommand, type ClaudePlugin, filterSkillsByPlatform } from "../types/claude"
 import type { DroidBundle, DroidCommandFile, DroidAgentFile } from "../types/droid"
 import type { ClaudeToOpenCodeOptions } from "./claude-to-opencode"
+import { transformSlashCommands } from "../utils/slash-command"
 
 export type ClaudeToDroidOptions = ClaudeToOpenCodeOptions
 
@@ -139,13 +140,7 @@ export function transformContentForDroid(body: string): string {
 
   // 2. Transform slash command references
   // /workflows:plan → /plan, /command-name stays as-is
-  const slashCommandPattern = /(?<![:\w])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
-  result = result.replace(slashCommandPattern, (match, commandName: string) => {
-    if (commandName.includes('/')) return match
-    if (['dev', 'tmp', 'etc', 'usr', 'var', 'bin', 'home'].includes(commandName)) return match
-    const flattened = flattenCommandName(commandName)
-    return `/${flattened}`
-  })
+  result = transformSlashCommands(result, (commandName) => `/${flattenCommandName(commandName)}`)
 
   // 3. Transform @agent-name references to droid references
   const agentRefPattern = /@agent-([a-z][a-z0-9-]*)/gi

--- a/src/converters/claude-to-kiro.ts
+++ b/src/converters/claude-to-kiro.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from "fs"
 import path from "path"
 import { formatFrontmatter } from "../utils/frontmatter"
+import { isReservedPathRoot } from "../utils/slash-command"
 import { type ClaudeAgent, type ClaudeCommand, type ClaudeMcpServer, type ClaudePlugin, filterSkillsByPlatform } from "../types/claude"
 import type {
   KiroAgent,
@@ -164,7 +165,7 @@ export function transformContentForKiro(body: string, knownAgentNames: string[] 
       if (nextChar === "/" && !match.endsWith("`")) {
         return match
       }
-      if (["dev", "tmp", "etc", "usr", "var", "bin", "home"].includes(cmdName)) {
+      if (isReservedPathRoot(cmdName)) {
         return match
       }
       return `the ${normalizeName(cmdName)} skill`

--- a/src/converters/claude-to-pi.ts
+++ b/src/converters/claude-to-pi.ts
@@ -7,6 +7,7 @@ import type {
   PiMcporterServer,
 } from "../types/pi"
 import type { ClaudeToOpenCodeOptions } from "./claude-to-opencode"
+import { transformSlashCommands } from "../utils/slash-command"
 
 export type ClaudeToPiOptions = ClaudeToOpenCodeOptions
 
@@ -137,13 +138,7 @@ export function transformContentForPi(body: string): string {
   result = result.replace(/\bTodoRead\b/g, "the platform's task-tracking primitive")
 
   // /command-name or /workflows:command-name -> /workflows-command-name
-  const slashCommandPattern = /(?<![:\w])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
-  result = result.replace(slashCommandPattern, (match, commandName: string) => {
-    if (commandName.includes("/")) return match
-    if (["dev", "tmp", "etc", "usr", "var", "bin", "home"].includes(commandName)) {
-      return match
-    }
-
+  result = transformSlashCommands(result, (commandName) => {
     if (commandName.startsWith("skill:")) {
       const skillName = commandName.slice("skill:".length)
       return `/skill:${normalizeName(skillName)}`

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -1,3 +1,5 @@
+import { isReservedPathRoot } from "./slash-command"
+
 export type CodexInvocationTargets = {
   promptTargets: Record<string, string>
   skillTargets: Record<string, string>
@@ -59,7 +61,7 @@ export function transformContentForCodex(
   const slashCommandPattern = /(?<![:\w>}\]\)])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
   result = result.replace(slashCommandPattern, (match, commandName: string) => {
     if (commandName.includes("/")) return match
-    if (["dev", "tmp", "etc", "usr", "var", "bin", "home"].includes(commandName)) return match
+    if (isReservedPathRoot(commandName)) return match
 
     const normalizedName = normalizeCodexName(commandName)
     if (promptTargets[normalizedName]) {

--- a/src/utils/slash-command.ts
+++ b/src/utils/slash-command.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared slash-command detection for the plugin converters.
+ *
+ * kiro rewrote `/etc/hosts` into `the etc skill/hosts` (#1171) because the path
+ * allowlist below was byte-copied into every converter and kiro's copy was the
+ * one that never got it. Centralising it here stops the next converter from
+ * drifting the same way.
+ */
+
+/** Single-segment roots that read as `/word` but are filesystem paths, not commands. */
+export const SLASH_COMMAND_PATH_ALLOWLIST = [
+  "dev",
+  "tmp",
+  "etc",
+  "usr",
+  "var",
+  "bin",
+  "home",
+] as const
+
+export function isReservedPathRoot(commandName: string): boolean {
+  return (SLASH_COMMAND_PATH_ALLOWLIST as readonly string[]).includes(commandName)
+}
+
+/**
+ * Detect `/command` references and hand each name to `format` for target-specific
+ * rewriting. Reserved path roots and multi-segment paths are left verbatim.
+ * copilot, droid and pi share this detector byte for byte; codex and kiro keep
+ * their own (a target-map lookup and #1171's callback path-check respectively)
+ * and call isReservedPathRoot directly.
+ */
+export function transformSlashCommands(
+  body: string,
+  format: (commandName: string) => string,
+): string {
+  const slashCommandPattern = /(?<![:\w])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+  return body.replace(slashCommandPattern, (match, commandName: string) => {
+    if (commandName.includes("/")) return match
+    if (isReservedPathRoot(commandName)) return match
+    return format(commandName)
+  })
+}

--- a/tests/slash-command.test.ts
+++ b/tests/slash-command.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+import {
+  SLASH_COMMAND_PATH_ALLOWLIST,
+  isReservedPathRoot,
+  transformSlashCommands,
+} from "../src/utils/slash-command"
+
+describe("isReservedPathRoot", () => {
+  test("matches every reserved single-segment path root", () => {
+    for (const root of SLASH_COMMAND_PATH_ALLOWLIST) {
+      expect(isReservedPathRoot(root)).toBe(true)
+    }
+  })
+
+  test("does not match real command names", () => {
+    expect(isReservedPathRoot("plan")).toBe(false)
+    expect(isReservedPathRoot("workflows:plan")).toBe(false)
+    expect(isReservedPathRoot("etcetera")).toBe(false)
+  })
+})
+
+describe("transformSlashCommands", () => {
+  const upcase = (body: string) => transformSlashCommands(body, (name) => `/${name.toUpperCase()}`)
+
+  test("hands the matched command name to the formatter", () => {
+    expect(upcase("Run /plan then stop")).toBe("Run /PLAN then stop")
+  })
+
+  test("passes namespaced names through verbatim", () => {
+    expect(upcase("Run /workflows:plan")).toBe("Run /WORKFLOWS:PLAN")
+  })
+
+  test("leaves bare reserved path roots untouched", () => {
+    for (const root of SLASH_COMMAND_PATH_ALLOWLIST) {
+      const line = `config lives in /${root}.`
+      expect(transformSlashCommands(line, (name) => `/CMD-${name}`)).toBe(line)
+    }
+  })
+
+  test("leaves multi-segment absolute paths untouched", () => {
+    const line = "See /usr/local/bin/tool for details"
+    expect(transformSlashCommands(line, () => "/FIRED")).toBe(line)
+  })
+
+  test("ignores slashes preceded by a word character", () => {
+    const line = "paths like a/b and foo/bar stay put"
+    expect(transformSlashCommands(line, () => "/FIRED")).toBe(line)
+  })
+})


### PR DESCRIPTION
## What

Extracts the slash-command path allowlist that all five plugin converters carry into a single `src/utils/slash-command.ts`, so the copies can't drift apart.

## Why

The allowlist `["dev","tmp","etc","usr","var","bin","home"]` keeps absolute paths like `/etc/hosts` from being rewritten as slash-command references. It was byte-copied into copilot, droid, pi, codex and kiro. kiro's copy is the one that drifted (it had no allowlist at all), which is the corruption #1171 fixed. Centralizing the list removes the way that bug happened.

## What's shared, and what isn't

Only the genuinely identical parts are converged:

- All five converters now call `isReservedPathRoot()` for the allowlist.
- copilot, droid and pi share `transformSlashCommands()`. Their detector regex and the two guards were byte-identical, so each converter keeps only its own output formatting.
- codex and kiro keep their own detection. codex has a variant lookbehind and target-map early-returns; kiro decides path-vs-command in the #1171 callback. Pushing either through a shared detector would change behavior, so they use the shared allowlist only.

## Behavior

No behavior change. main already carries kiro's guard via #1171, so this only moves code. The existing converter suites stay green, and `tests/slash-command.test.ts` covers the helper directly.

## Verification

- `tsc --noEmit`: clean.
- `tests/slash-command.test.ts`: 7/7.
- The five converter suites: 112 tests, green except the codex `dead-code fallback` case, which fails identically on main and sits in the Task-agent-call path, unrelated to this change.
- Full `bun test` baseline-diff (main vs this branch, same Windows machine): identical failing set, 0 new failures, 0 disappearing. The failing set itself is pre-existing local environment noise; the suite is green in CI on main.
