### PR TITLE
feat(fde): add forward-deployed engineering workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ These sit around the loop or get reached for on demand -- not every cycle needs 
 |-------|---------|
 | [`/ce-ideate`](docs/skills/ce-ideate.md) | *Before the loop*, when you don't yet know what to build -- generates and critically ranks grounded ideas, then routes the strongest one into `/ce-brainstorm` |
 | [`/ce-strategy`](docs/skills/ce-strategy.md) | *Upstream anchor* -- creates and maintains `STRATEGY.md`, read as grounding by ideate, brainstorm, and plan so strategy choices flow into every feature |
+| [`/ce-fde`](docs/skills/ce-fde.md) | *Business-outcome outer loop* -- measures one operating workflow, routes approved software into the CE loop, and requires controlled live value before expansion |
 | [`/ce-product-pulse`](docs/skills/ce-product-pulse.md) | *Outer loop* -- a time-windowed report on what users actually experienced (usage, performance, errors), saved to `docs/pulse-reports/`; its follow-ups feed back into ideation and brainstorming |
 | [`/ce-debug`](docs/skills/ce-debug.md) | *Instead of brainstorm -> plan -> work* when the input is a bug rather than a feature -- reproduce, trace root cause, fix, then polish/review before PR handoff when warranted |
 | [`/ce-pov`](docs/skills/ce-pov.md) | *On demand, before you commit* -- a decisive, project-grounded adoption verdict, holistic document take, or position on supplied approaches; optionally cross-checked by named peers or `oracle` through a blind initial round and bounded reconciliation |
@@ -205,13 +206,14 @@ The first pass tightens recent branch changes before review. The targeted pass i
 
 After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
 
-The `compound-engineering` plugin currently ships 31 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+The `compound-engineering` plugin currently ships 32 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
 
 ### Full Skill Inventory
 
 | Skill | Purpose |
 |-------|---------|
 | [`/ce-strategy`](docs/skills/ce-strategy.md) | Create or maintain `STRATEGY.md` |
+| [`/ce-fde`](docs/skills/ce-fde.md) | Improve one operating workflow and prove its value before expansion |
 | [`/ce-ideate`](docs/skills/ce-ideate.md) | Generate and critically evaluate grounded ideas |
 | [`/ce-pov`](docs/skills/ce-pov.md) | Form a decisive, project-grounded POV on an adoption, document, or approach set |
 | [`/ce-explain`](docs/skills/ce-explain.md) | Explain a concept, diff, idea, or window of your own work as a personal learning artifact |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -51,6 +51,7 @@ Skills that anchor, feed, or maintain the loop without being steps inside it.
 | Skill | Description |
 |-------|-------------|
 | [`/ce-strategy`](./ce-strategy.md) | Create or maintain `STRATEGY.md` — the upstream anchor read by `ce-ideate`, `ce-brainstorm`, and `ce-plan` as grounding |
+| [`/ce-fde`](./ce-fde.md) | Forward-deployed engineering outer loop — measure one operating workflow, route approved software into the CE loop, and require real 30-day value before expansion |
 | [`/ce-product-pulse`](./ce-product-pulse.md) | Outer feedback loop — single-page time-windowed report on usage, performance, errors, followups; saved to `docs/pulse-reports/` as a timeline |
 | [`/ce-sweep`](./ce-sweep.md) | Recurring feedback sweep — ingest Slack/GitHub items (email experimental) since per-source cursors, acknowledge at source, analyze recordings, verify fixes merged, and reconcile an `/lfg`-ready rolling plan |
 | [`/ce-compound-refresh`](./ce-compound-refresh.md) | Maintain `docs/solutions/` over time — five outcomes (Keep / Update / Consolidate / Replace / Delete), Interactive + Autofix modes |

--- a/docs/skills/ce-fde.md
+++ b/docs/skills/ce-fde.md
@@ -1,0 +1,82 @@
+# `ce-fde`
+
+> Improve one costly operating workflow, choose the simplest reliable fix, introduce it safely, and decide from real results whether to expand, fix once, stop, or wait.
+
+`ce-fde` adds a business-outcome loop around the Compound Engineering code loop. It starts with observed work and a measurable baseline, not a feature request. If the approved fix requires software or an agent, it hands the bounded scope to `ce-brainstorm` -> `ce-plan` -> `ce-work`, then resumes after shipping to control the live test and value decision.
+
+## TL;DR
+
+| Question | Answer |
+|---|---|
+| What does it do? | Runs discovery, fix selection, controlled delivery, and value review for one workflow |
+| When to use it | Workflow improvement, operational automation, AI project selection, or a pilot that must prove payback |
+| What it produces | A durable `docs/fde/<slug>.md` project sheet with evidence, state, owner, controls, and decision |
+| What's next | `ce-brainstorm` for approved software work; `ce-compound` after a terminal decision with reusable technical learning |
+
+## Why it sits around the loop
+
+The core CE loop answers how to define, implement, review, and learn from software work. `ce-fde` answers an earlier and broader question: which operating problem is worth solving, what is the simplest intervention, and did the deployed change create enough real value to expand?
+
+```text
+ce-fde discovery -> ce-fde design
+                         |
+                         +-> non-code fix -> ce-fde delivery
+                         |
+                         +-> ce-brainstorm -> ce-plan -> ce-work
+                                                     |
+                                                     +-> ce-fde delivery
+
+ce-fde delivery -> ce-fde value review -> expand | fix-once | stop | wait
+```
+
+The handoff is optional. Training, checklists, deterministic rules, and process changes do not enter the code loop merely because CE is installed.
+
+## Novel mechanics
+
+### A durable business artifact
+
+Each project writes one `ce-fde-project/v1` sheet under `docs/fde/`. The sheet separates facts, calculations, staff statements, and assumptions; records the current lifecycle state; and lets later sessions resume at the earliest incomplete gate.
+
+### Process before AI
+
+Fixes are considered in an explicit order: remove or simplify work, improve training and data capture, use deterministic rules and ordinary integrations, then use AI only for the remaining judgment or unstructured input. “No AI needed” is a successful result.
+
+### Expansion is a measured gate
+
+Historical cases prove whether a solution can work; they do not prove business value. Expansion requires controlled live results, comparable exposure, non-degraded quality, contained failures, positive monthly value, and payback within 30 days.
+
+### Bounded authority
+
+Invoking `ce-fde` authorizes only the project-sheet write. Production changes, external messages, spending, and customer-impacting actions retain the approval rules of the active harness and any downstream skill.
+
+## Example invocations
+
+```text
+/ce-fde Our support team retypes emailed requests into the CRM
+/ce-fde docs/fde/support-intake.md
+```
+
+The first form creates a new project sheet after establishing the project title. The second resumes an existing project from its recorded state.
+
+## When to reach for it
+
+Use `ce-fde` when:
+
+- A team asks for an AI agent before the current workflow has been measured.
+- An operating process is expensive, slow, error-prone, or fragmented across tools.
+- A pilot needs explicit human approvals, fallback, monitoring, and an off switch.
+- Leadership needs a real payback decision rather than estimated savings.
+
+Skip it when:
+
+- The input is already a bounded feature with approved requirements -> use `ce-brainstorm`.
+- The input is a reproducible software defect -> use `ce-debug`.
+- The only need is a time-windowed product health report -> use `ce-product-pulse`.
+
+## See also
+
+- [`ce-strategy`](./ce-strategy.md) - durable product direction and metrics
+- [`ce-brainstorm`](./ce-brainstorm.md) - requirements for the approved software fix
+- [`ce-work`](./ce-work.md) - implementation and shipping
+- [`ce-product-pulse`](./ce-product-pulse.md) - product telemetry that may support a live test
+- [`ce-compound`](./ce-compound.md) - reusable technical learning after the cycle

--- a/skills/ce-fde/SKILL.md
+++ b/skills/ce-fde/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ce-fde
+description: "Run a forward-deployed engineering lifecycle for one costly operating workflow: measure the current process, choose the simplest reliable fix, introduce it safely, and decide from real results whether to expand, fix once, stop, or wait. Use for workflow improvement, AI project selection, operational pilots, or proving 30-day payback before scaling."
+---
+
+# Forward-Deployed Engineering
+
+## Outcome
+
+- **Result:** One measured workflow project with a durable project sheet and an evidence-backed next decision.
+- **Next consumer:** The operating owner, or `ce-brainstorm` when the approved fix requires software or an agent.
+- **Done:** The project sheet records one decision: `expand`, `fix-once`, `stop`, or `wait`, plus the owner and next review condition.
+- **Intent:** Improve the process before adding AI and require real-use value before expansion.
+
+Act as a hands-on problem solver beside the operating team. Use plain language. Explain “FDE” once as “a hands-on problem solver who works beside the team.”
+
+## Input and artifact
+
+Treat the invocation input as either a work problem or an existing `docs/fde/<slug>.md` path.
+
+- For an existing path, read the sheet and resume its current `state`.
+- For a new problem, establish a short project title, derive a lowercase hyphenated slug, and create `docs/fde/<slug>.md` from `references/project-sheet.md`.
+- If the target filename already exists for a different project, ask for a different slug. Never overwrite an unrelated sheet.
+- Update the sheet after each accepted fact or decision. Preserve evidence links and distinguish facts, calculations, staff statements, and assumptions.
+- Keep tracked sheets aggregate and anonymized: never copy customer or staff PII, message bodies, credentials, secrets, or private operational data. Prefer owner roles over names and links or redacted summaries over sensitive source content.
+
+Invoking this skill authorizes creating or updating only the selected project sheet. It does not authorize live-system changes, customer or staff messages, spending, production data mutation, or external write-backs. A downstream CE skill receives only the authority granted by its own invocation and the current user instructions.
+
+## Lifecycle router
+
+Read only the reference for the current state. Do not advance until that reference's readiness gate passes.
+
+| State | Load | Advance when |
+|---|---|---|
+| `discovery` | `references/discover.md` | The owner and a frontline employee approve the measured better process |
+| `design` | `references/design.md` | The owner approves the simplest reliable fix, limits, and cautious money case |
+| `delivery` | `references/deliver.md` | A controlled live test produces comparable real-use results with working controls |
+| `value-review` | `references/review-value.md` | The evidence supports `expand`, `fix-once`, `stop`, or `wait` |
+| `fix-once` | `references/deliver.md` | One bounded repair is retested without expanding scope, then returns to `value-review` |
+| `expand`, `stop`, or `wait` | none | Return the recorded decision and next review condition; change state only with new user authority and evidence |
+
+If required evidence is missing, keep the current state and record the exact blocker. Do not skip an earlier gate because the user asks to build or expand.
+
+Ask one question at a time using the harness's blocking user-input capability when available, with plain chat as the fallback. Ask only for the smallest missing fact or decision that can move the current state.
+
+## Compound Engineering handoff
+
+When the approved fix requires software or an agent:
+
+1. Ask whether to hand the chosen-fix scope into `ce-brainstorm`.
+2. Pass the project-sheet path, approved better process, chosen fix, job limits, and success measures as grounding.
+3. Let `ce-brainstorm` -> `ce-plan` -> `ce-work` own requirements, implementation, review, and shipping. Do not duplicate their code workflow inside this skill.
+4. Resume `ce-fde` in `delivery` after the solution is available for controlled testing.
+
+Use `ce-debug` instead when discovery proves the requested work is a reproducible software defect rather than a new solution. Non-code fixes such as training, checklists, or process changes stay in `ce-fde` and do not enter the code loop.
+
+After a terminal value decision, offer `ce-compound` when implementation produced a reusable technical learning. Do not claim estimates or historical-case tests prove payback.
+
+## Invariants
+
+- Solve one tightly bounded workflow problem at a time.
+- Measure the current result before choosing a fix.
+- Prefer removal, simplification, training, forms, rules, reports, and ordinary integrations before AI.
+- Keep human approval for prices, payments, refunds, contracts, financing, schedules, private information, or promises to customers.
+- Never invent organization numbers, rules, or evidence.
+- Never expand before `references/review-value.md` produces `expand` from controlled live results.
+
+## Return
+
+Return the project-sheet path, current state, evidence added, decision or blocker, owner, and exactly one next action.

--- a/skills/ce-fde/references/deliver.md
+++ b/skills/ce-fde/references/deliver.md
@@ -1,0 +1,20 @@
+# Test and introduce the fix
+
+## Controls and evidence
+
+1. Fix the minimum required data, IDs, access, rules, and tool connections.
+2. List likely failures, who could be harmed, detection signals, stop conditions, response owner, reversibility, and manual fallback.
+3. Test historical cases with known answers: normal, missing, confusing, stale, conflicting, adversarial, expensive, retry, failed-tool, and must-go-to-a-person cases.
+4. Test the whole workflow, organization rules, retries, and whether staff can act on the result.
+5. Put the result in the existing system of record as fields, notes, tasks, drafts, checklists, or approvals.
+6. Require human approval, an action log, safe retries that do not repeat effects, a manual fallback, and an immediate off switch.
+
+Each live-system write, production-data change, staff or customer message, or controlled live test requires verified, separately granted user authority. The project-sheet-only authority from invoking `ce-fde` is not enough. If authority is absent, keep `delivery` and record that approval as the exact blocker; do not simulate success or mutate the system.
+
+## Rollout ladder
+
+`historical cases -> silent run -> staff-visible recommendations -> staff approval -> small live group`
+
+Do not expand from this phase. After a small live group, collect baseline-comparable real-use results and advance to `value-review` only when quality is no worse, serious-risk cases pass, failures are detectable and containable, and the owner accepts the test evidence. Otherwise keep `delivery` and record the missing control or evidence.
+
+For `fix-once`, make one bounded repair to the already approved fix without adding users, workflows, or capabilities. Retest the failed cases and controlled live group under the same authority and measures, then return to `value-review`. If the repair would expand scope, stop and request a new design decision instead.

--- a/skills/ce-fde/references/design.md
+++ b/skills/ce-fde/references/design.md
@@ -1,0 +1,21 @@
+# Choose the simplest reliable fix
+
+Evaluate options in this order:
+
+1. Instruction or training
+2. Required field or checklist
+3. Deterministic rule or error check
+4. Report or saved search
+5. Connection between existing tools
+6. Standard prediction tool
+7. AI that reads, sorts, or drafts
+8. AI that uses approved tools
+9. Multiple AI helpers only after one helper is proven insufficient
+
+Choose a first project that happens often, has measurable value, uses trusted information, is easy for a person to check, and can be undone. Require a cautious 30-day payback case before delivery.
+
+For an AI helper, define one problem, trigger, trusted inputs, allowed tools, required output, forbidden actions, human approval, escalation reasons, visible finish, manual fallback, off-switch conditions, and day-to-day owner.
+
+Shrink or stop a proposed fix when it combines unrelated work, lacks trusted facts, can cause costly actions without review, has no clear finish, can repeat actions, creates a separate staff screen, costs more to review than it saves, or hides a process problem.
+
+Advance to `delivery` only after the owner approves the chosen fix, limits, success measures, stop conditions, and cautious money case. Otherwise keep `design` and record the blocker.

--- a/skills/ce-fde/references/discover.md
+++ b/skills/ce-fde/references/discover.md
@@ -1,0 +1,22 @@
+# Discover the workflow
+
+## Required work
+
+1. Define one measurable business result and the measures that must not get worse.
+2. Name the operating owner, frontline employees, recipients of the work, and anyone harmed by a mistake.
+3. Compare written rules with 10-20 real cases, including workarounds and unusual cases.
+4. Measure the baseline period and exposure: volume, elapsed time, staff minutes, completed work, mistakes, rework, returns, and profit or preventable loss.
+5. Test the primary cause among demand, information, process, rules, disconnected tools, training, capacity, difficult judgment, and staff adoption.
+6. For each major step ask in order: remove it, change it, simplify it, use a deterministic rule, use an AI helper, or keep it with a person.
+7. Draw the better process with its start, owners, tools, approvals, exceptions, manual fallback, and visible finish.
+
+## Evidence rules
+
+- Separate facts, calculations, staff statements, and assumptions.
+- Written instructions do not prove the actual workflow.
+- Prefer organization data to industry averages.
+- Treat “no AI needed” as a valid result.
+
+## Readiness gate
+
+Advance to `design` only when the operating owner and at least one frontline employee approve the better process and the evidence supports the primary cause. Otherwise keep `discovery` and record the smallest missing evidence or decision.

--- a/skills/ce-fde/references/project-sheet.md
+++ b/skills/ce-fde/references/project-sheet.md
@@ -1,0 +1,66 @@
+# FDE project sheet
+
+Create `docs/fde/<slug>.md` with this shape. Preserve the field names and state enum across updates.
+
+```markdown
+---
+artifact_contract: ce-fde-project/v1
+title: <short project title>
+state: discovery
+decision: pending
+owner: <role, or unknown>
+updated: YYYY-MM-DD
+---
+
+# <Project title>
+
+## Problem and baseline
+
+- Result to improve:
+- Measures that must not get worse:
+- Baseline period and exposure:
+- Facts:
+- Staff statements:
+- Assumptions:
+
+## Better process
+
+- Main cause:
+- Steps and owners:
+- Exceptions and approvals:
+- Manual fallback:
+- Approval evidence:
+
+## Chosen fix
+
+- Fix:
+- Why simpler choices were insufficient:
+- 30-day money case:
+- Limits and forbidden actions:
+- Success and stop conditions:
+
+## Delivery evidence
+
+- Historical-case results:
+- Controlled-live-test period and exposure:
+- Monitoring, approval, fallback, and off switch:
+- Staff corrections and failures:
+
+## Value review
+
+- Observed and normalized value:
+- Payback days or no payback:
+- Quality and safety status:
+- Decision and evidence:
+
+## Blockers and next action
+
+- Blockers:
+- Owner:
+- Next action:
+- Next review condition:
+```
+
+Allowed `state` values are `discovery`, `design`, `delivery`, `value-review`, `expand`, `fix-once`, `stop`, and `wait`. Allowed `decision` values are `pending`, `expand`, `fix-once`, `stop`, and `wait`. Set `updated` to the current ISO date whenever the sheet changes.
+
+Tracked sheets must contain only aggregate, anonymized evidence. Use roles instead of personal names. Never copy customer or staff PII, message bodies, credentials, secrets, or private operational data; use a link to the authorized source or a redacted summary.

--- a/skills/ce-fde/references/review-value.md
+++ b/skills/ce-fde/references/review-value.md
@@ -1,0 +1,22 @@
+# Review value and decide
+
+## Comparable evidence
+
+Record baseline and live-test dates, number and mix of items, completed work, staff minutes, quality, mistakes, successful outcomes, customer problems, staff corrections, extra profit or prevented loss, recurring costs, and one-time project cost.
+
+Compare like periods or exposure units. Convert recurring benefits and costs to the same 30-day basis only when volume and work mix are comparable; otherwise choose `wait` and name the evidence required.
+
+`Monthly value = monthly extra profit + monthly losses prevented + monthly useful work from freed time - monthly software cost - monthly integration cost - monthly review cost - monthly support cost`
+
+`Payback days = one-time project cost / positive monthly value * 30`
+
+Count freed time only when it reduces spending, avoids hiring, completes more valuable work, or creates another measured result. Do not count a benefit twice. If monthly value is zero or negative, report `no payback` and do not expand.
+
+## Decision
+
+- **`expand`:** Quality holds, controlled live results show payback within 30 days, value safely exceeds ongoing cost, failures stay contained, and the owner accepts responsibility.
+- **`fix-once`:** One small understood repair can plausibly make the same bounded project pass without adding scope.
+- **`stop`:** Payback is too slow or absent, value or volume is too low, trusted information is missing, staff will not use it, review consumes the benefit, or risk cannot be contained.
+- **`wait`:** The live test is too small, too short, or not comparable. Record the exact additional group, period, or evidence required.
+
+Set both `state` and `decision` to the chosen value. Record observed results, normalization method, assumptions, owner, and next review condition. Keep estimates separate from real results.

--- a/tests/ce-fde-contract.test.ts
+++ b/tests/ce-fde-contract.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { readFile } from "fs/promises"
+import path from "path"
+
+const root = process.cwd()
+const skillPath = path.join(root, "skills", "ce-fde")
+
+describe("ce-fde skill contract", () => {
+  test("keeps the lifecycle and CE handoff gates explicit", async () => {
+    const skill = await readFile(path.join(skillPath, "SKILL.md"), "utf8")
+
+    expect(skill).toContain("Do not advance until that reference's readiness gate passes")
+    expect(skill).toContain("Do not skip an earlier gate")
+    expect(skill).toContain("Never expand before `references/review-value.md` produces `expand`")
+    expect(skill).toContain("`ce-brainstorm` -> `ce-plan` -> `ce-work`")
+    expect(skill).toContain("Keep tracked sheets aggregate and anonymized")
+    expect(skill).toContain("Return the recorded decision and next review condition")
+  })
+
+  test("defines stable project state and non-positive value behavior", async () => {
+    const sheet = await readFile(path.join(skillPath, "references", "project-sheet.md"), "utf8")
+    const review = await readFile(path.join(skillPath, "references", "review-value.md"), "utf8")
+
+    for (const state of ["discovery", "design", "delivery", "value-review", "expand", "fix-once", "stop", "wait"]) {
+      expect(sheet).toContain(state)
+    }
+
+    expect(review).toContain("If monthly value is zero or negative, report `no payback` and do not expand")
+    expect(review).toContain("Convert recurring benefits and costs to the same 30-day basis")
+    expect(sheet).toContain("Tracked sheets must contain only aggregate, anonymized evidence")
+  })
+
+  test("requires separate authority for live mutations and bounds fix-once", async () => {
+    const delivery = await readFile(path.join(skillPath, "references", "deliver.md"), "utf8")
+
+    expect(delivery).toContain("requires verified, separately granted user authority")
+    expect(delivery).toContain("keep `delivery` and record that approval as the exact blocker")
+    expect(delivery).toContain("without adding users, workflows, or capabilities")
+    expect(delivery).toContain("then return to `value-review`")
+  })
+})

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -194,7 +194,7 @@ describe("release metadata", () => {
 
     expect(counts).toEqual({
       agents: 0,
-      skills: 31,
+      skills: 32,
       mcpServers: 0,
     })
   })


### PR DESCRIPTION
## Summary

- add a portable `ce-fde` skill that moves one costly operating workflow through discovery, design, delivery, and value review
- route approved software work into `ce-brainstorm` → `ce-plan` → `ce-work`, with `ce-debug` and `ce-compound` at the appropriate boundaries
- require controlled live evidence and positive normalized 30-day value before expansion
- keep durable project sheets anonymized and require separate authority for live-system mutations
- document the skill, update the 32-skill inventory, and add focused contract tests

Standalone Claude Code and AGENTS.md-compatible suite: https://github.com/inbusiness23/fde-skill

## Verification

- `python3 ~/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/ce-fde`
- `bun test` — 2,638 pass, 0 fail
- `bun run release:validate`
- `bun run plugin:validate`
- fresh-context behavior evaluation refused a discovery bypass and organization-wide rollout
- independent review completed; privacy, mutation-authority, and terminal-state routing findings were fixed and revalidated
- staged-content privacy scan passed

## Post-deploy monitoring and validation

No runtime or production mutation is introduced. After a release containing this skill, validate discovery and routing on one fresh install. Owner: maintainers. Window: first release/canary.

This is an illustrative outside contribution, consistent with the repository contribution policy.