### PR TITLE
fix(ce-work): gate simplify on substantive code lines, not total diff lines

### DIFF
--- a/docs/skills/ce-simplify-code.md
+++ b/docs/skills/ce-simplify-code.md
@@ -8,7 +8,7 @@ It's a **utility skill** — point it at whatever you want refined. With no argu
 
 The premise is that simplification preserves exact functionality. The skill enforces this by running typecheck, lint, and scoped tests after fixes. **It refuses to relax assertions, weaken type signatures, or skip tests to make checks pass** — that defeats the guarantee.
 
-The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /ce-plan → /ce-work`. `ce-simplify-code` runs automatically as a quality gate inside `/ce-work` Phase 3 (for diffs ≥30 changed lines) and as step 3 of the autonomous `/lfg` loop (before review, skipped for docs-only or trivial changes), and is directly invocable for refining a feature branch before you open a PR.
+The compound-engineering ideation chain is `/ce-ideate → /ce-brainstorm → /ce-plan → /ce-work`. `ce-simplify-code` runs automatically as a quality gate inside `/ce-work` Phase 3 (for diffs with ≥30 substantive code lines) and as step 3 of the autonomous `/lfg` loop (before review, skipped for docs-only or trivial changes), and is directly invocable for refining a feature branch before you open a PR.
 
 ---
 
@@ -133,7 +133,7 @@ Skip `ce-simplify-code` when:
 
 `ce-simplify-code` is invoked automatically by two workflows, always **before** the review step so reviewers see the simplified diff:
 
-- **`/ce-work` Phase 3** — runs when a diff is ≥30 changed lines, ahead of the harness-native or `/ce-code-review` review tier.
+- **`/ce-work` Phase 3** — runs when a diff has ≥30 substantive code lines, ahead of the harness-native or `/ce-code-review` review tier.
 - **`/lfg` step 3** — the autonomous build loop runs it on the branch diff after the build step and before code review. It's skipped only for docs-only changes (markdown/docs paths) or trivial ones (roughly under 10 changed lines), and it leaves its edits uncommitted so the loop's later commit step sweeps them up with the rest of the work.
 
 It's also commonly invoked manually before `/ce-commit-push-pr`, when you want a refinement pass on a branch you've been building over multiple sessions.
@@ -218,7 +218,7 @@ The skill won't relax assertions, weaken type signatures, or skip tests to paper
 It can be, but in practice the moment to find an existing utility is when you're searching for it, not when you're writing the feature. A separate refinement pass with parallel cross-cutting search catches things the original write didn't.
 
 **Does it run for tiny diffs?**
-By default it runs against whatever code scope it resolves, but the yield on tiny diffs (a couple of lines) is low. The automated callers gate on size for that reason: `ce-work` runs it only for diffs ≥30 changed lines, and `/lfg` skips it for docs-only or trivial (roughly under 10 changed lines) changes. The skill itself does not gate on size — an explicit scope on a small function is authoritative and still runs; the size floor is a cost policy that lives in the callers and in any [standing instruction](#make-it-automatic) you add.
+By default it runs against whatever code scope it resolves, but the yield on tiny diffs (a couple of lines) is low. The automated callers gate on size for that reason: `ce-work` runs it only for diffs with ≥30 substantive code lines, and `/lfg` skips it for docs-only or trivial (roughly under 10 changed lines) changes. The skill itself does not gate on size — an explicit scope on a small function is authoritative and still runs; the size floor is a cost policy that lives in the callers and in any [standing instruction](#make-it-automatic) you add.
 
 **What if I point it at a docs-only or mechanical diff?**
 The skill detects when the resolved scope has no substantive code — documentation/Markdown-only, or only generated, vendored, lockfile, or purely mechanical churn — and stops with a short "nothing to simplify" note instead of dispatching the three reviewers, which would find nothing there. On a mixed diff it narrows to the code files and continues. This self-guard keys on the *kind* of change, not its size.

--- a/skills/ce-work/SKILL.md
+++ b/skills/ce-work/SKILL.md
@@ -282,7 +282,7 @@ Before implementing the first task, you must read `references/implementation-loo
 
    Don't simplify after every single unit — early patterns may look duplicated but diverge intentionally in later units. Wait for a natural phase boundary or when you notice accumulated complexity.
 
-   If **`ce-simplify-code`** is available, invoke it at phase boundaries (especially before Phase 3 when the diff is >=30 lines). Otherwise, review the changed files yourself for reuse and consolidation opportunities.
+   If **`ce-simplify-code`** is available, invoke it at phase boundaries (especially before Phase 3 when the accumulated cluster has >=30 substantive changed code lines — count human-authored code, not total diff lines, so a mostly test-fixture/config/generated/mechanical cluster does not trip the gate). Otherwise, review the changed files yourself for reuse and consolidation opportunities.
 
    When the plan carries `session-settled:`-labeled KTDs, pass the plan path as structure-pin context, not as the simplification scope, with the one-line constraint that labeled KTDs are structure pins the simplification must preserve (e.g., deliberate duplication stays duplicated).
 

--- a/skills/ce-work/references/shipping-workflow.md
+++ b/skills/ce-work/references/shipping-workflow.md
@@ -18,7 +18,7 @@ This file contains the shipping workflow (Phase 3-4). It is loaded when all Phas
 
 2. **Simplify** (conditional — separate from code review)
 
-   Before code review, invoke **`ce-simplify-code`** when the diff is non-mechanical and large enough to benefit (default: **>=30 changed lines**). Skip when the diff is purely mechanical (formatting, dependency bumps, lint-only fixes, generated artifacts).
+   Before code review, invoke **`ce-simplify-code`** when the diff has enough substantive code to benefit (default: **>=30 substantive changed code lines** — count human-authored code, not total diff lines). Skip when the diff is purely mechanical (formatting, dependency bumps, lint-only fixes, generated artifacts) or when substantive code stays under the floor even though the total diff is larger.
 
    This step refines reuse, quality, and efficiency on the **current diff** so any later review sees cleaner code. It is not a substitute for code review.
 
@@ -121,7 +121,7 @@ Before creating PR, verify:
 - [ ] Validation/evidence context passed to `ce-commit-push-pr` when the change has observable behavior
 - [ ] Commit messages follow conventional format
 - [ ] PR description includes Post-Deploy Monitoring & Validation section (or explicit no-impact rationale)
-- [ ] Simplify: `ce-simplify-code` when diff >=30 lines (or skipped with reason)
+- [ ] Simplify: `ce-simplify-code` when the diff has >=30 substantive changed code lines (or skipped with reason)
 - [ ] Code review: `ce-code-review` ran (self-sized), or skipped (mechanical diff / unavailable — noted in summary); residuals handled via the Residual Work Gate
 - [ ] PR description includes summary, testing notes, and evidence when captured
 - [ ] `ce-commit-push-pr` received `branding:on` from the Compound Engineering workflow


### PR DESCRIPTION
`ce-work`'s Simplify-as-You-Go and pre-review simplify passes triggered on `>=30` *total* changed lines, so a cluster that was mostly test fixtures, config, or generated/mechanical churn could clear the gate on non-code lines and dispatch `ce-simplify-code` against only a few real code lines — a near-empty pass its own kind-of-change preflight then had to absorb. The gate now counts substantive human-authored code lines, aligning `ce-work`'s caller-owned size floor with the "substantive code" basis already documented for `ce-simplify-code` (skill owns the kind-of-change floor; caller owns the size floor).

Scoped deliberately: an oracle cross-check (Codex + Grok, independent, read-only) confirmed code review should stay end-of-run over the whole branch diff and that `ce-code-review` is already right-sized by its own lite/full roster — so this touches only the simplify trigger's counting basis, nothing about review altitude. `bun test` green (2617/2617).
