### PR TITLE
perf(ci): run the test suite in parallel worker processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,7 @@ jobs:
           npm install -g @anthropic-ai/claude-code@2.1.175
           bun run plugin:validate
 
+      # Runs the package `test` script so the flags CI uses and the flags a
+      # contributor gets from `bun run test` cannot drift apart.
       - name: Run tests
-        run: bun test
+        run: bun run test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,10 @@ The `test` script runs `bun test --parallel`, which distributes test *files* acr
 
 That makes cross-file isolation load-bearing rather than incidental: a test file may not depend on another file's leftovers, and any test that writes outside its own `mktemp` directory is a latent flake. `tests/skills/ce-code-review-cross-model-routes.test.ts` is the one deliberate exception — it stages a marker file in the repo root to exercise dirty-tree handling, and cleans it up in `afterAll`.
 
+**Do not pin a worker count.** `--parallel` with no value tracks the runner's core count, which is what you want. Raising it looks free — the suite is idle-bound, so more workers should pack better — but it was measured on CI and it is not: at `--parallel=8` on a 4-core runner, wall time improved ~9% (102s -> 93s) while total test-CPU inflated from 223s to 343s, and five tests crossed the 5000ms default per-test timeout. That converts runner busyness into red builds. A file that legitimately runs for seconds should call `setDefaultTimeout` instead, as the subprocess-heavy suites do.
+
+Wall time is now bounded by the **slowest single file**, since a file never splits across workers. As measured: `tests/skills/ce-work-unit-workspace.test.ts` is 61s of a ~100s run and `tests/ce-babysit-pr-snapshot.test.ts` is 40s. The next real speedup is splitting those two, not more workers.
+
 ### What belongs where
 
 | Kind of check | Where it lives | Notes |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ It also contains:
 
 ```bash
 bun install
-bun test                  # full test suite (also runs in CI)
+bun run test              # full test suite (also runs in CI; `--parallel` across worker processes)
 bun run release:validate  # plugin/marketplace consistency (also runs in CI)
 bun run plugin:validate   # Claude marketplace + plugin schema (also runs in CI; needs `claude` on PATH)
 ```
@@ -35,7 +35,7 @@ bun run codex:dev -- remove   # remove both supported CE installation surfaces
 - **Branching:** Create a feature branch for any non-trivial change. If already on the correct branch for the task, keep using it; do not create additional branches or worktrees unless explicitly requested.
 - **Merge policy:** All changes to `main` go through pull requests. Direct pushes and direct merges are not allowed; branch protection on `main` enforces this by requiring the `test` status check to pass. The direct path bypasses `release:validate`, the test suite, and PR title validation — past direct merges have caused version drift requiring multi-PR recovery (see `docs/solutions/workflow/release-please-version-drift-recovery.md`).
 - **Safety:** Do not delete or overwrite user data. Avoid destructive commands.
-- **Testing:** Run `bun test` after changes that affect parsing, conversion, output, skill conventions, or other mechanical guards. Local `bun test` is the same suite CI runs — there is no separate local-only unit-test lane.
+- **Testing:** Run `bun run test` after changes that affect parsing, conversion, output, skill conventions, or other mechanical guards. Local `bun run test` is the same suite CI runs — there is no separate local-only unit-test lane. Prefer it over bare `bun test`: the package script carries `--parallel`, which is where the suite's speed comes from. Bare `bun test <file>` is still the right tool for iterating on one file.
 - **Release versioning:** Releases are prepared by release automation, not normal feature PRs. The repo has one root plugin/package release component (`compound-engineering`) plus marketplace components (`marketplace`, `cursor-marketplace`). GitHub release PRs and GitHub Releases are the canonical release-notes surface for new releases; root `CHANGELOG.md` is only a pointer to that history. Use conventional titles such as `feat:` and `fix:` so release automation can classify change intent, but do not hand-bump release-owned versions or hand-author release notes in routine PRs.
 - **Output Paths:** Keep OpenCode output at `opencode.json` and `.opencode/{agents,skills,plugins}`. For OpenCode, commands go to `~/.config/opencode/commands/<name>.md`; `opencode.json` is deep-merged (never overwritten wholesale).
 - **Scratch Space:** Default to OS temp. Use `.context/` only when explicitly justified by the rules below.
@@ -179,7 +179,11 @@ Behavioral changes to a plugin skill or skill-local persona (anything under `ski
 
 ## CI and Quality Gates
 
-PR CI (`.github/workflows/ci.yml`) is the merge gate. It runs, in order: PR-title lint (PRs only), `bun run release:validate`, `bun run plugin:validate`, and `bun test`. Do not invent a parallel local-only mechanical suite — if a check is deterministic and should block merges, put it in one of those steps (usually `bun test`).
+PR CI (`.github/workflows/ci.yml`) is the merge gate. It runs, in order: PR-title lint (PRs only), `bun run release:validate`, `bun run plugin:validate`, and `bun run test`. Do not invent a parallel local-only mechanical suite — if a check is deterministic and should block merges, put it in one of those steps (usually `bun run test`).
+
+The `test` script runs `bun test --parallel`, which distributes test *files* across worker processes (one file still runs its own tests serially, and `--parallel` implies `--isolate`). This is the single biggest lever on CI wall time, because most of the suite is spent blocked on subprocesses — `python3`, `bash`, `git`, and `bun run src/index.ts` — not on CPU. Keeping it in the package script rather than the workflow means CI and a contributor's local run cannot drift apart.
+
+That makes cross-file isolation load-bearing rather than incidental: a test file may not depend on another file's leftovers, and any test that writes outside its own `mktemp` directory is a latent flake. `tests/skills/ce-code-review-cross-model-routes.test.ts` is the one deliberate exception — it stages a marker file in the repo root to exercise dirty-tree handling, and cleans it up in `afterAll`.
 
 ### What belongs where
 

--- a/docs/solutions/developer-experience/idle-bound-test-suite-parallel-workers.md
+++ b/docs/solutions/developer-experience/idle-bound-test-suite-parallel-workers.md
@@ -1,0 +1,100 @@
+---
+title: "CI test suite was idle-bound, not CPU-bound — parallel workers cut it 54%"
+date: 2026-07-22
+category: developer-experience
+module: ci
+problem_type: performance_issue
+component: testing_framework
+symptoms:
+  - "CI `Run tests` step took 193-237s while every other step in the job totalled ~12s"
+  - "Suite wall time grew with the test count even though no individual test was slow"
+  - "A serial run reports low CPU utilization — `95.24s user 78.62s system 36% cpu`"
+root_cause: config_error
+resolution_type: config_change
+severity: medium
+tags:
+  - ci
+  - test-performance
+  - bun-test
+  - parallelism
+  - flaky-tests
+  - measurement
+---
+
+# CI test suite was idle-bound, not CPU-bound — parallel workers cut it 54%
+
+## Problem
+
+The `Run tests` step in `.github/workflows/ci.yml` effectively *was* the CI job: ~224s median across seven successful runs, against ~12s for checkout, install, `release:validate`, and `plugin:validate` combined. Every PR paid roughly four minutes to learn whether it was green.
+
+## Symptoms
+
+- `Run tests` step durations of 193s, 215s, 218s, 224s, 227s, 228s, 237s on `ubuntu-latest`.
+- No single slow test to blame — the cost was spread across 98 files and 2617 tests.
+- The tell: a serial local run reports `95.24s user 78.62s system 36% cpu`. Bun was consuming about a third of one core while the rest of the runner sat idle.
+
+## What Didn't Work
+
+- **Measuring on a developer laptop.** The first instinct was to time `bun test` locally and A/B it. The machine happened to be at load average ~300 from unrelated concurrent work, so the serial run took 7m56s (vs. 224s on CI) and produced two spurious 5s-timeout failures that had nothing to do with any change. Local wall-clock was not just noisy, it was actively misleading. The A/B had to move to CI, where the runner is a dedicated 4-core VM — see Prevention.
+- **Turning the worker count up.** More workers looks free on an idle-bound suite, so `--parallel=8` on a 4-core runner was measured rather than assumed. It bought ~9% (102s -> 93s) but inflated total test-CPU from 223s to 343s and pushed five tests past bun's 5000ms default per-test timeout. That trades wall time for builds that go red when the runner is busy. Rejected.
+- **Looking for one hot file to fix.** There wasn't a pathological test. The problem was structural — the runner had four cores and the test runner used one.
+
+## Solution
+
+Put `--parallel` on the package `test` script and have CI invoke the script rather than the bare binary:
+
+```json
+// package.json
+"test": "bun test --parallel",
+```
+
+```yaml
+# .github/workflows/ci.yml
+- name: Run tests
+  run: bun run test
+```
+
+Keeping the flag in the package script rather than inline in the workflow is the point: the command CI runs and the command a contributor runs cannot drift apart. Bare `bun test <file>` stays available and is still the right tool for iterating on one file.
+
+Note `--parallel` takes no value. It tracks the runner's core count, which is what you want — see Prevention.
+
+Result, measured on the `Run tests` step (the only step whose duration moves):
+
+| | `Run tests` step | |
+|---|---|---|
+| Before — `main`, two same-hour controlled runs | 207s, 218s | median 212s |
+| Before — last 7 successful runs | 193s, 215s, 218s, 224s, 227s, 228s, 237s | median 224s |
+| After — four runs | 97s, 102s, 103s, 108s | median 103s |
+
+51% against the controlled pair, 54% against the historical median. 2617 pass / 0 fail in every run.
+
+## Why This Works
+
+The suite spends its wall time *blocked*, not computing. It shells out constantly — `python3` script invocations, `bash` sandbox scripts, `git` fixture repos, `bun run src/index.ts` CLI spawns — and several suites contain deliberate real sleeps to exercise timeout, liveness, and detached-process behavior. While a test file waits on a subprocess, the process running it has nothing to do.
+
+`36% cpu` on a serial run is the whole diagnosis in one number: roughly two-thirds of the elapsed time was a single process waiting. Distributing *files* across worker processes fills that idle time with other files' work. Total work was 223 test-CPU-seconds; packed onto 4 cores it lands at ~100s wall.
+
+This is why the fix is a flag and not a rewrite. Nothing was written inefficiently — the runner was just serial.
+
+## Prevention
+
+- **Check CPU utilization before optimizing a slow suite.** `time` on a serial run answers "is this idle-bound or CPU-bound?" in one command, and the two diagnoses lead to completely different fixes. A low `%cpu` means look at concurrency; a high one means look at the work itself. Do not start by hunting for slow tests.
+
+- **Measure CI changes on CI.** A developer laptop is a shared, unmetered machine — background builds, other worktrees, and editor indexing move wall-clock by multiples and can manufacture timeout failures that look like real regressions. `gh workflow run ci.yml --ref <branch>` gives a controlled A/B on identical dedicated runners; `gh run view <id> --json jobs` reads the exact per-step durations. Dispatch the baseline branch and the change branch in the same window so runner-pool conditions match. `gh run view <id> --log` also carries bun's per-test timings, which is how the critical path below was found.
+
+- **Do not pin a worker count.** Bare `--parallel` follows the runner's core count and keeps working if the runner size changes. Raising it looks free on an idle-bound suite and is not — it inflates per-test latency and converts runner busyness into red builds.
+
+- **Parallel workers make cross-file isolation load-bearing.** `--parallel` implies `--isolate`. A test file may no longer depend on another file's leftovers, and a test that writes outside its own `mktemp` directory becomes a latent flake rather than a harmless one. Audit for repo-root and fixed-path writes before enabling it.
+
+- **Give subprocess-heavy suites an explicit timeout.** Parallelism narrows the margin on any test already running near the default. `tests/skills/peer-job-runner.test.ts` drives real detached processes and bounded waits on bun's 5000ms default; its bounded-wait case measured 4653ms on CI — a 347ms margin, meaning whether it passed was a question of runner busyness rather than correctness. A file whose tests legitimately run for seconds should declare `setDefaultTimeout(20_000)` the way the other subprocess-heavy suites do. Scan for near-timeout tests with:
+
+  ```bash
+  gh run view <run-id> --log | grep -oE '\[[0-9]{4}\.[0-9]+ms\]' | sort -rn | head
+  ```
+
+- **After parallelizing, the floor is the slowest single file** — a file never splits across workers. Measure it before assuming more workers will help: here `ce-work-unit-workspace.test.ts` is 61s and `ce-babysit-pr-snapshot.test.ts` is 40s of a ~100s run, so splitting those two is the next real lever and no amount of added concurrency will beat it.
+
+## Related Issues
+
+- PR EveryInc/compound-engineering-plugin#1235 — the change described here.
+- `AGENTS.md` > "CI and Quality Gates" carries the operating rules (unpinned worker count, isolation contract, current critical path).

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cleanup": "bun run src/index.ts cleanup",
     "list": "bun run src/index.ts list",
     "cli:install": "bun run src/index.ts install",
-    "test": "bun test",
+    "test": "bun test --parallel",
     "plugin:validate": "claude plugin validate --strict .claude-plugin/marketplace.json && claude plugin validate --strict .claude-plugin/plugin.json",
     "release:preview": "bun run scripts/release/preview.ts",
     "release:sync-metadata": "bun run scripts/release/sync-metadata.ts --write",

--- a/tests/skills/peer-job-runner.test.ts
+++ b/tests/skills/peer-job-runner.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { spawnSync } from "child_process"
 import {
   chmodSync,
@@ -23,6 +23,13 @@ const SCRIPT = path.join(
   "../../skills/ce-doc-review/scripts/peer-job-runner.py",
 )
 const FIXTURE = path.join(__dirname, "../fixtures/peer-job-runner-unit.py")
+
+// These drive real detached processes and real bounded waits, so several cases
+// legitimately run for seconds. The bounded-wait case measured 4.65s on CI --
+// 347ms under the 5s default -- which makes a timeout flake a matter of how
+// busy the runner is rather than whether the code is correct. Match the headroom
+// the other subprocess-heavy suites already take.
+setDefaultTimeout(20_000)
 
 const tempRoots: string[] = []
 function mkTempRoot(prefix: string): string {


### PR DESCRIPTION
## Summary

CI's `Run tests` step effectively *is* the CI job: ~224s median, against ~12s for checkout, install, `release:validate`, and `plugin:validate` combined. Running the test files across worker processes instead of one cuts it to ~103s — **a 54% reduction**, with the suite green and all 2617 tests still running.

The suite was never CPU-bound. Its 98 files spend most of their wall time *blocked* — `python3` script invocations, `bash` sandbox scripts, `git` fixture repos, `bun run src/index.ts` CLI spawns, and deliberate real sleeps in the peer-job-runner and cross-model route tests. A serial local run reports `95.24s user 78.62s system 36% cpu`: bun was using about a third of one core while a 4-core runner sat idle for four minutes.

`--parallel` (Bun 1.3) distributes test *files* across worker processes. It lives on the package `test` script rather than inline in the workflow, so the command CI runs and the command a contributor runs cannot drift apart; CI now invokes `bun run test`. Bare `bun test <file>` is unchanged and is still the right tool for iterating on one file.

## Before / after

Measured on the `Run tests` step of the `test` job — the only step whose duration moves. The controlled pair was run within the same 15 minutes on identical `ubuntu-latest` runners: two `workflow_dispatch` runs of unmodified `main` against five runs of this branch.

| | `Run tests` step | |
|---|---|---|
| Before — `main`, same-hour controlled runs | 207s, 218s | median **212s** |
| Before — last 7 successful runs prior to this PR | 193s, 215s, 218s, 224s, 227s, 228s, 237s | median **224s** |
| After — this branch | 97s, 102s, 103s, 103s, 108s | median **103s** |

**51% faster against the controlled pair, 54% against the historical median.** All runs green; 2617 pass / 0 fail in each.

## Two findings that changed the change

**Don't pin a worker count.** More workers looks free on an idle-bound suite, so I measured it: `--parallel=8` on a 4-core runner bought ~9% (102s → 93s) but inflated total test-CPU from 223s to 343s and pushed five tests past bun's 5000ms default per-test timeout. That trades wall time for builds that go red when the runner is busy. Left unpinned, `--parallel` tracks the runner's core count. AGENTS.md now records the measurement so the next person doesn't re-derive it.

**One suite was already living on the edge.** `tests/skills/peer-job-runner.test.ts` drives real detached processes and real bounded waits on the 5000ms default; its bounded-wait case measured 4653ms on CI — a 347ms margin. It passes today, but whether it passes was a question of runner busyness rather than correctness, and parallel workers narrow that further. It now takes the same 20s headroom the other subprocess-heavy suites already declare. This is a latent flake fixed, not one introduced.

## What this costs, and what's next

`--parallel` implies `--isolate`, which promotes cross-file isolation from incidental to load-bearing: a test file may no longer depend on another file's leftovers, and any test writing outside its own `mktemp` directory becomes a latent flake rather than a harmless one. AGENTS.md says so now, and names the single deliberate exception — `tests/skills/ce-code-review-cross-model-routes.test.ts` stages a marker file in the repo root to exercise dirty-tree handling and cleans it up in `afterAll`.

Wall time is now bounded by the **slowest single file**, because a file never splits across workers. From the CI log: `ce-work-unit-workspace.test.ts` is 61s of the ~100s run and `ce-babysit-pr-snapshot.test.ts` is 40s, against 223s of total work. Splitting those two is the next real lever and is left to its own PR — it is a restructure of a 4,477-line test file, not a flag.

The diagnosis is captured in `docs/solutions/developer-experience/idle-bound-test-suite-parallel-workers.md`, since the reusable part is the method (a low `%cpu` on a serial run is what points at concurrency rather than at slow tests), not the flag.

## Validation

Five green CI runs on this branch (2617 pass / 0 fail each) are the full-suite check under the new flag; the timings above are read from GitHub's own step durations. Local wall-clock is not usable as evidence on the machine this was developed on (load average ~300 from concurrent unrelated work), which is why the A/B is CI-side rather than local.

Also verified that the merge gate still bites: a deliberately failing test run through `bun run test` exits 1, so routing CI through the package script does not swallow failures. `bun run release:validate` passes, and `bun test tests/skills/peer-job-runner.test.ts` is green after the timeout change.
