### PR TITLE
feat(ticket-scope): add ce-ticket-scope skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ The `compound-engineering` plugin currently ships 31 skills and 0 standalone age
 | [`/ce-work`](docs/skills/ce-work.md) | Execute plans with native or cross-model implementation, durable progress, and transactional host-owned integration |
 | [`/ce-code-review`](docs/skills/ce-code-review.md) | Review code with skill-local reviewer personas |
 | [`/ce-doc-review`](docs/skills/ce-doc-review.md) | Review requirements and plan documents |
+| [`/ce-ticket-scope`](docs/skills/ce-ticket-scope.md) | Interrogate a work ticket until someone who didn't write it could execute it from the ticket alone |
 | [`/ce-debug`](docs/skills/ce-debug.md) | Reproduce failures, trace root cause, fix bugs, and prepare non-trivial fixes for PR |
 | [`/ce-compound`](docs/skills/ce-compound.md) | Document solved problems to compound team knowledge |
 | [`/ce-compound-refresh`](docs/skills/ce-compound-refresh.md) | Refresh stale or drifting learnings |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -68,6 +68,7 @@ Invoked when a specific need arises — not part of any chain.
 | [`/ce-debug`](./ce-debug.md) | Find root causes systematically — causal chain gate, predictions, post-fix polish/review, PR handoff |
 | [`/ce-code-review`](./ce-code-review.md) | Structured code review with skill-local reviewer personas, confidence-gated findings, four modes |
 | [`/ce-doc-review`](./ce-doc-review.md) | Review requirements or plan documents using skill-local reviewer personas — coherence, feasibility, product-lens, design-lens, security-lens, scope-guardian, adversarial |
+| [`/ce-ticket-scope`](./ce-ticket-scope.md) | Interrogate a work ticket until someone who didn't write it could execute it from the ticket alone — seven-field resolution, operator-case routing (author-interactive vs. implementer clarification comment), proportionality, no-fault framing |
 | [`/ce-simplify-code`](./ce-simplify-code.md) | Refine recently changed code — reuse, quality, and efficiency review; behavior preservation verified |
 | [`/ce-optimize`](./ce-optimize.md) | Metric-driven iterative optimization loops — three-tier evaluation, parallel experiments, persistence discipline |
 

--- a/docs/skills/ce-ticket-scope.md
+++ b/docs/skills/ce-ticket-scope.md
@@ -1,0 +1,68 @@
+# `ce-ticket-scope`
+
+> Interrogate a work ticket until someone who didn't write it — human or agent — could produce the **intended** result from the ticket alone, then emit the fully specified ticket or a batched clarification comment for its author.
+
+`ce-ticket-scope` covers the artifact most day-to-day work actually arrives as: a tracker ticket someone else wrote. The rest of the core loop specifies work the team *authors* (`ce-brainstorm` → `ce-plan`); this skill raises the floor on work that arrives pre-scoped from outside that loop — which makes it usable, and useful, even when only one person on the team runs the plugin.
+
+It is pure prose with **no bundled script**, so it works verbatim on every supported target.
+
+---
+
+## TL;DR
+
+| Question | Answer |
+|----------|--------|
+| What does it do? | Resolves seven fields — baseline, observable acceptance criteria, approach, out-of-scope, tagged assumptions, unwritten context, existing runbooks — until a new-to-the-codebase engineer or agent could execute from the ticket alone |
+| When to use it | Writing or refining a ticket before assigning it; picking up an under-specified ticket someone else wrote |
+| What it produces | Author-operated: the filled, paste-ready ticket. Implementer-operated: proposed readings with evidence + a paste-ready clarification comment for the author |
+| Skip when | The ticket is small, reversible, and single-file — the skill's own proportionality rule short-circuits to a single baseline question |
+
+---
+
+## Example invocations
+
+```text
+# Pressure-test a ticket you are about to assign
+/ce-ticket-scope is this ready to assign? <paste ticket>
+
+# Scope a ticket you received from someone else
+/ce-ticket-scope I was assigned issue #482 — what's missing before I start?
+
+# Refine while writing
+/ce-ticket-scope scope this ticket with me
+```
+
+---
+
+## The Problem
+
+"Go read the codebase and figure it out" now works — an agent (or a senior engineer with time) excavates successfully. But excavation fails in two distinct ways:
+
+- **Unwritten intent.** The codebase contains what *is*, never what's *wanted*: which of several valid end states was intended, the constraint living in someone's head, the assumption nobody validated. Excavation converges *confidently* on **a** reading — and agents inverted the cost curve, so plausible-but-wrong work now appears fast and at scale, discovered in review after it exists.
+- **Written-but-undiscovered knowledge.** A maintained skill or runbook that already executes the work — with its preflights and failure patterns — exists in the repo, but the ticket never named it. A hand-derived procedure can be parameter-perfect and still fail on exactly the step the runbook encodes.
+
+Both failure classes trace to specific unresolved fields, and the fix at authoring time is usually one sentence someone already knew.
+
+## Novel Mechanics
+
+- **The bar as a termination condition.** Interrogation stops when a named test passes — "could someone new to this codebase produce the intended result from the ticket alone?" — not when a template looks full. A filled checklist can still fail the bar (an either/or inside a criterion is an unresolved decision deferred into review).
+- **Operator-case routing.** Questions must reach the person who holds the answers. Author-operated runs interrogate interactively, one question at a time. Implementer-operated runs — the common case — never block on questions the session user can't answer: self-answered fields become evidence-cited "proposed readings," and the residue becomes a batched, paste-ready clarification comment addressed to the ticket's author. The skill never writes to the tracker itself.
+- **Explore-before-asking.** Everything the codebase, links, and history can answer is self-answered and marked "proposed — confirm"; only what genuinely lives in the author's head becomes a question.
+- **Proportionality.** Blast radius is sized before interrogating: small reversible tickets get one question (usually the baseline), and full seven-field treatment is reserved for work where misreading is expensive.
+- **The seventh field.** "Does a skill/runbook already execute this?" treats existing executable knowledge as a first-class ticket field — a guide link is documentation; a runbook reference is operator knowledge.
+- **No-fault framing.** Findings attribute to the artifact, never the author. The output is always the improved ticket, not a critique.
+
+## Chain Position
+
+`ce-ticket-scope` sits at the **intake boundary** of the core loop:
+
+- **Upstream of `ce-plan` / `ce-work`:** a ticket that passes the bar is ready to plan or execute without a clarification round-trip mid-implementation.
+- **Complementary to `ce-brainstorm`:** brainstorm defines what the team should build; ticket-scope repairs the specification of work that arrived already defined by someone else.
+- **Distinct from `ce-doc-review`:** doc-review runs persona analysis over authored planning documents; ticket-scope is an interrogation/emission workflow that terminates in an improved ticket (or a postable comment) in the tracker.
+
+## When to Reach for It
+
+- You're about to assign a ticket and want it to survive contact with an implementer who has none of your context.
+- You've been assigned a ticket that states a goal and little else, and you want the gaps named before work starts instead of in review.
+- A ticket offers multiple sanctioned options and you need the acceptable one designated — or your documented choice protected — before building.
+- The work smells like something a runbook already does.

--- a/skills/ce-ticket-scope/SKILL.md
+++ b/skills/ce-ticket-scope/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ce-ticket-scope
+description: Interrogate a work ticket until someone who did not write it — human or agent — could produce the intended result from the ticket alone. Resolves the baseline/starting context, observable acceptance criteria, which of several valid approaches is wanted, explicit out-of-scope boundaries, assumptions that must be validated before work starts, and any existing skill or runbook that already executes the work. Use when writing or refining a ticket before assigning it, when the user says "scope this ticket", "is this ready to assign", or "pressure-test this ticket", or when the user has been assigned a ticket someone else wrote and wants the gaps surfaced. Use it even for tickets that look complete — a filled-in checklist can still carry an unresolved either/or inside it.
+---
+
+# Ticket Scope
+
+Make a ticket executable by a competent engineer — or agent — who is new to this codebase, using only what the ticket says. The skill closes the gap between what the author *meant* and what they *wrote*, then emits a fully specified ticket or a batched clarification comment.
+
+## The bar
+
+Keep going until this is true:
+
+> Could an engineer (or agent) skilled in the relevant technology, but new to this codebase and its history, produce the **intended** result from this ticket alone — without asking anyone?
+
+If not, name the exact unwritten thing and get it written. "It was unclear" is not a finding; the specific missing criterion or context item is.
+
+## Phase 0: Operator case and proportionality
+
+**Identify the operator case first — it changes where questions go:**
+
+- **Author-operated** — the session user wrote (or is writing) the ticket. Unresolved fields become interactive questions to them.
+- **Implementer-operated** — the session user received a ticket someone else wrote. The answers live in the author's head; the session user cannot confirm them. Unresolved fields become a batched clarification comment addressed to the author (see Output). Do not run a blocking question loop against someone who cannot answer, and do not treat the session user's guess as confirmation of another author's intent.
+
+When the ticket's author is ambiguous, ask the session user which case applies before interrogating.
+
+**Proportionality:** size the blast radius before interrogating — what rework costs if the ticket is misread. A small, reversible, single-file change gets a single question (usually the baseline); interrogate all fields only when misreading is expensive (multi-day work, release-bound work, shared infrastructure, more than one plausible end state). State which depth you chose.
+
+**Read everything the ticket links** — related tickets, PRs, referenced docs — before asking anything. Treat "N/A" in a field that plausibly needs content as missing, not resolved.
+
+## The fields
+
+Resolve each field. The parenthetical names the failure mode leaving it blank produces.
+
+1. **Baseline / starting context** *(starting-context gap)* — which branch, release line, environment, or precondition the work targets. Most often left blank and most expensive: an acceptance check can pass trivially against the wrong baseline (the end state already true on the default branch, when the work is only coherent against a release branch never named). In a sub-ticket, "see parent" is not a baseline — the sub-ticket states its own slice.
+2. **Acceptance criteria / observable end state** — what is true and testable when the work is done. Signals to test the result against, never implementation steps. Three sub-checks:
+   - Name what the check runs against — shipped/published artifact vs. working tree, and which environment.
+   - An either/or inside a criterion ("backport X, *or* add Y") is an unresolved decision deferred into review, not a resolved field.
+   - Mark must-have vs. severable-if-blocked, with the fallback stated.
+3. **Approach resolution** *(end-state gap)* — if more than one valid path exists: is one required, or is the implementer's documented choice acceptable? Name who adjudicates if review disagrees with a sanctioned choice, and record any later redirect as a scope change rather than a miss.
+4. **Out of scope** — explicit boundaries; what this ticket does *not* include.
+5. **Assumptions + validity** *(goalpost-moved)* — what the ticket assumes, each tagged `confirmed` (with source) or `validate-before-building`. A blanket disclaimer ("may not be 100% accurate", an AI-generated note) flags that assumptions exist while tagging none of them.
+6. **Unwritten context / prior decisions** — anything the author knows that the implementer cannot derive. A decision recorded as a bare link to a chat thread or doc is unresolved: put the decision's content inline in one sentence; keep the link as provenance.
+7. **Existing executable knowledge** *(reinvented-runbook gap)* — does a skill, runbook, script, or CI workflow already execute this work? Search the project's skills/runbooks locations and ask before deriving the procedure by hand: a hand-derived command can be parameter-perfect and still miss the preflights and failure patterns the existing runbook encodes. A guide link is documentation; a runbook reference is operator knowledge — the ticket needs the second.
+
+Cross-cutting: information in the wrong field counts as a gap. Baseline data filed under acceptance criteria while the assumptions field reads "N/A" means the next reader checks the field, sees content, and moves on.
+
+## Author-operated flow
+
+1. Self-answer whatever the codebase, the ticket's links, version-control history, or existing docs can answer; mark each "proposed — confirm." Only what genuinely lives in the author's head becomes a question.
+2. Ask one question at a time, in dependency order (target release before environment-specific behavior; approach before approach-specific criteria). Provide 2–4 concrete options plus a custom answer; skip generic Yes/No unless the question is genuinely binary.
+3. Use the platform's blocking question tool for every question. In Claude Code, `AskUserQuestion` is a deferred tool: call `ToolSearch` with query `select:AskUserQuestion` once, before the first question, to load its schema. Fall back to a numbered list and wait for the reply only when the harness genuinely lacks a blocking question tool — never silently skip a question.
+4. After each answer, acknowledge the decision in 1–2 sentences, then ask the next.
+5. Re-run **The bar** against the result. Stop when it passes at the chosen proportionality depth.
+
+## Implementer-operated flow
+
+1. Self-answer whatever the codebase and history can answer; mark each "proposed" and cite the evidence (file, commit, linked PR). These are proposals for the author to confirm, not confirmed facts.
+2. Convert each remaining gap into one specific question naming the field it resolves.
+3. Emit the batched clarification comment (see Output). Do not post it: writing to the tracker is the user's action, taken with whatever interface the project's issue tracker exposes (connector/MCP, documented API, or a documented CLI).
+
+## Output
+
+**Author-operated:** emit the ticket with every field populated, paste-ready in the project's ticket format (use its existing template when the tracker or project defines one; otherwise use the field list above as sections). End with a one-line summary of the decisions made and a short list of what was surfaced that had not previously been written down.
+
+**Implementer-operated:** emit two blocks —
+
+1. **Proposed readings** — the self-answered fields with evidence, framed for confirmation ("Reading the linked PR, this targets `release/1.2` — please confirm").
+2. **Clarification comment** — a single paste-ready comment addressed to the ticket's author: batched questions, each tied to the field it resolves, ordered by how much the answer changes the work. No preamble beyond one sentence of context.
+
+## Framing
+
+Attribute findings to the artifact, never the author. Do not moralize or imply the author did something wrong by leaving a field blank. The output is always the improved artifact, not a critique of the person who wrote it.

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -194,7 +194,7 @@ describe("release metadata", () => {
 
     expect(counts).toEqual({
       agents: 0,
-      skills: 31,
+      skills: 32,
       mcpServers: 0,
     })
   })


### PR DESCRIPTION
Closes #1237 (phase 1).

Adds `ce-ticket-scope`: interrogate a work ticket until someone who didn't write it — human or agent — could produce the **intended** result from the ticket alone.

**What's in phase 1 (forward mode only, per the issue):**
- Seven-field resolution: baseline/starting context, observable acceptance criteria (with the either/or-inside-a-criterion rule and must-have vs. severable), approach resolution with a named decider, out-of-scope, assumptions tagged `confirmed`/`validate-before-building`, unwritten context (decision-by-reference is unresolved), and existing executable knowledge (does a runbook already do this?).
- Operator-case routing: author-operated runs interrogate interactively one question at a time; implementer-operated runs (the common case) never block on questions the session user can't answer — they emit evidence-cited proposed readings plus a paste-ready clarification comment addressed to the ticket's author. The skill never writes to the tracker.
- Proportionality triage: blast radius is sized first; small reversible tickets get one question, not seven fields.
- No-fault framing: findings attribute to the artifact, never the author.

**Explicitly not in this PR (phase 2, per the issue):** retro/audit mode, pattern tags, batch summaries, and the `learned-gaps.md` compounding loop.

**Surfaces touched:** `skills/ce-ticket-scope/SKILL.md`, `docs/skills/ce-ticket-scope.md`, catalog row in `docs/skills/README.md`, root `README.md` inventory row, skill count in `tests/release-metadata.test.ts`.

**Validation:** `bun run test` (2653 pass), `bun run release:validate` (32 skills), `bun run plugin:validate` (strict, both manifests). No bundled scripts; prose follows the admission rules and capability-not-tool tracker references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
