### PR TITLE
fix(ce-resolve-pr-feedback): stream GraphQL responses to temp files and fix comment lookup index-0 bug

### DIFF
--- a/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
+++ b/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
@@ -61,7 +61,12 @@ fi
 # limited to structural loop-prevention facts: blank bodies and messages known
 # to come from the PR author. If the PR author is unavailable, fail open.
 
-threads_pages=$(gh api graphql --paginate --slurp \
+tmp_threads=$(mktemp)
+tmp_comments=$(mktemp)
+tmp_reviews=$(mktemp)
+trap 'rm -f "$tmp_threads" "$tmp_comments" "$tmp_reviews"' EXIT
+
+gh api graphql --paginate --slurp \
   -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
   -f query='
 query Threads($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
@@ -92,9 +97,9 @@ query Threads($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
       }
     }
   }
-}')
+}' > "$tmp_threads"
 
-comments_pages=$(gh api graphql --paginate --slurp \
+gh api graphql --paginate --slurp \
   -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
   -f query='
 query Comments($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
@@ -110,9 +115,9 @@ query Comments($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
       }
     }
   }
-}')
+}' > "$tmp_comments"
 
-reviews_pages=$(gh api graphql --paginate --slurp \
+gh api graphql --paginate --slurp \
   -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
   -f query='
 query Reviews($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
@@ -130,7 +135,7 @@ query Reviews($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
       }
     }
   }
-}')
+}' > "$tmp_reviews"
 
 # Resolution semantics: `isOutdated` means the diff hunk around the comment
 # has shifted since the thread was opened -- not that the reviewer concern
@@ -138,15 +143,15 @@ query Reviews($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
 # threads are still surfaced (with their isOutdated flag intact) so the
 # resolver can factor in that the referenced line may have moved.
 jq -n \
-  --argjson threads "$threads_pages" \
-  --argjson comments "$comments_pages" \
-  --argjson reviews "$reviews_pages" '
-  ($threads[0].data.repository.pullRequest.author) as $author |
-  [$threads[].data.repository.pullRequest.reviewThreads.nodes[]] as $all_threads |
-  [$comments[].data.repository.pullRequest.comments.nodes[]] as $all_comments |
-  [$reviews[].data.repository.pullRequest.reviews.nodes[]] as $all_reviews |
+  --slurpfile threads "$tmp_threads" \
+  --slurpfile comments "$tmp_comments" \
+  --slurpfile reviews "$tmp_reviews" '
+  ($threads[0][0].data.repository.pullRequest.author) as $author |
+  [$threads[0][].data.repository.pullRequest.reviewThreads.nodes[]] as $all_threads |
+  [$comments[0][].data.repository.pullRequest.comments.nodes[]] as $all_comments |
+  [$reviews[0][].data.repository.pullRequest.reviews.nodes[]] as $all_reviews |
   [$all_threads[] | select(.isResolved == false)] as $unresolved |
-  ($reviews[0].data.viewer.login) as $viewer |
+  ($reviews[0][0].data.viewer.login) as $viewer |
   {
     pending_review: (first($all_reviews[]
       | select(.state == "PENDING")

--- a/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
+++ b/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
@@ -37,7 +37,10 @@ fi
 # more than one page of threads can still resolve a comment to its parent
 # thread. Per-thread comments are still capped at 100 -- threads exceeding
 # that depth are not paginated here.
-threads_pages=$(gh api graphql --paginate --slurp \
+tmp_threads=$(mktemp)
+trap 'rm -f "$tmp_threads"' EXIT
+
+gh api graphql --paginate --slurp \
   -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
   -f query='
 query Threads($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
@@ -67,10 +70,10 @@ query Threads($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
       }
     }
   }
-}')
+}' > "$tmp_threads"
 
-echo "$threads_pages" | jq -e --arg cid "$COMMENT_NODE_ID" '
-  [.[].data.repository.pullRequest.reviewThreads.nodes[]
-   | select(.comments.nodes | map(.id) | index($cid))]
-  | if length == 0 then error("No thread found for comment \($cid)") else .[0] end
+jq -r --slurpfile pages "$tmp_threads" --arg cid "$COMMENT_NODE_ID" '
+  [$pages[0][].data.repository.pullRequest.reviewThreads.nodes[]
+   | select(any(.comments.nodes[]; .id == $cid))]
+  | if length == 0 then error("No thread found for comment \($cid)") else .[0].id end
 '

--- a/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
+++ b/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
@@ -72,8 +72,8 @@ query Threads($owner: String!, $repo: String!, $pr: Int!, $endCursor: String) {
   }
 }' > "$tmp_threads"
 
-jq -r --slurpfile pages "$tmp_threads" --arg cid "$COMMENT_NODE_ID" '
+jq -e -n --slurpfile pages "$tmp_threads" --arg cid "$COMMENT_NODE_ID" '
   [$pages[0][].data.repository.pullRequest.reviewThreads.nodes[]
    | select(any(.comments.nodes[]; .id == $cid))]
-  | if length == 0 then error("No thread found for comment \($cid)") else .[0].id end
+  | if length == 0 then error("No thread found for comment \($cid)") else .[0] end
 '

--- a/tests/resolve-pr-feedback-pagination.test.ts
+++ b/tests/resolve-pr-feedback-pagination.test.ts
@@ -131,4 +131,159 @@ describe("ce-resolve-pr-feedback scripts paginate GraphQL connections (issue #79
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  test("get-pr-comments merges slurpfile pages without --argjson", () => {
+    // Pins the ARG_MAX fix: payloads go through temp files + --slurpfile, so
+    // jq must unwrap the extra slurp layer ($threads[0][]) correctly. A nesting
+    // typo here silently empties Full Mode's feedback lists.
+    const body = read("get-pr-comments")
+    expect(body).toContain("--slurpfile")
+    expect(body).not.toContain("--argjson")
+
+    const dir = mkdtempSync(path.join(tmpdir(), "ce-pr-comments-"))
+    const fakeGh = path.join(dir, "gh")
+    const unresolved = {
+      id: "thread-open",
+      isResolved: false,
+      isOutdated: false,
+      path: "a.ts",
+      line: 1,
+      originalLine: 1,
+      startLine: null,
+      originalStartLine: null,
+      comments: {
+        nodes: [{
+          id: "c1",
+          author: { login: "reviewer" },
+          body: "open finding",
+          createdAt: "2026-07-23T00:00:00Z",
+          url: "https://github.com/o/r/pull/1#discussion_r1",
+        }],
+      },
+    }
+    const resolved = {
+      ...unresolved,
+      id: "thread-done",
+      isResolved: true,
+      comments: {
+        nodes: [{
+          id: "c2",
+          author: { login: "reviewer" },
+          body: "resolved finding",
+          createdAt: "2026-07-23T00:00:00Z",
+          url: "https://github.com/o/r/pull/1#discussion_r2",
+        }],
+      },
+    }
+
+    const threadsPage = [{
+      data: {
+        repository: {
+          pullRequest: {
+            author: { login: "author" },
+            reviewThreads: {
+              nodes: [unresolved, resolved],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    }]
+    const commentsPage = [{
+      data: {
+        repository: {
+          pullRequest: {
+            comments: {
+              nodes: [
+                { id: "pc1", author: { login: "reviewer" }, body: "top-level note" },
+                { id: "pc2", author: { login: "author" }, body: "author reply" },
+                { id: "pc3", author: { login: "bot" }, body: "   " },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    }]
+    const reviewsPage = [{
+      data: {
+        viewer: { login: "resolver" },
+        repository: {
+          pullRequest: {
+            reviews: {
+              nodes: [
+                {
+                  id: "pending-1",
+                  author: { login: "resolver" },
+                  body: "",
+                  state: "PENDING",
+                },
+                {
+                  id: "submitted-1",
+                  author: { login: "reviewer" },
+                  body: "LGTM with nits",
+                  state: "COMMENTED",
+                },
+              ],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          },
+        },
+      },
+    }]
+
+    writeFileSync(
+      fakeGh,
+      `#!/usr/bin/env bash
+args="$*"
+if [[ "$args" == *"query Threads"* ]]; then
+  cat <<'JSON'
+${JSON.stringify(threadsPage)}
+JSON
+elif [[ "$args" == *"query Comments"* ]]; then
+  cat <<'JSON'
+${JSON.stringify(commentsPage)}
+JSON
+elif [[ "$args" == *"query Reviews"* ]]; then
+  cat <<'JSON'
+${JSON.stringify(reviewsPage)}
+JSON
+else
+  echo "unexpected gh invocation: $args" >&2
+  exit 1
+fi
+`,
+    )
+    chmodSync(fakeGh, 0o755)
+
+    try {
+      const result = spawnSync(
+        "bash",
+        [path.join(SCRIPTS_DIR, "get-pr-comments"), "1", "o/r"],
+        {
+          encoding: "utf8",
+          env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+        },
+      )
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(JSON.parse(result.stdout)).toEqual({
+        pending_review: "pending-1",
+        review_threads: [{ node: unresolved }],
+        pr_comments: [
+          { id: "pc1", author: { login: "reviewer" }, body: "top-level note" },
+        ],
+        review_bodies: [
+          {
+            id: "submitted-1",
+            author: { login: "reviewer" },
+            body: "LGTM with nits",
+            state: "COMMENTED",
+          },
+        ],
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/tests/resolve-pr-feedback-pagination.test.ts
+++ b/tests/resolve-pr-feedback-pagination.test.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from "fs"
+import { spawnSync } from "node:child_process"
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
+import { tmpdir } from "os"
 import path from "path"
 import { describe, expect, test } from "bun:test"
 
@@ -71,5 +73,62 @@ describe("ce-resolve-pr-feedback scripts paginate GraphQL connections (issue #79
     ).toMatch(/gh api graphql --paginate\b/)
     expect(body).toMatch(/reviewThreads\(first:\s*\d+,\s*after:\s*\$endCursor\)/)
     expect(body).toMatch(PAGE_INFO_SELECTION)
+  })
+
+  test("get-thread-for-comment emits the matched thread context from a slurpfile", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "ce-thread-lookup-"))
+    const fakeGh = path.join(dir, "gh")
+    const thread = {
+      id: "thread-1",
+      isResolved: false,
+      isOutdated: true,
+      path: "example.ts",
+      line: null,
+      originalLine: 42,
+      startLine: null,
+      originalStartLine: 40,
+      comments: {
+        nodes: [{
+          id: "comment-1",
+          author: { login: "reviewer" },
+          body: "Please fix this.",
+          createdAt: "2026-07-23T00:00:00Z",
+          url: "https://github.com/o/r/pull/1#discussion_r1",
+        }],
+      },
+    }
+
+    writeFileSync(
+      fakeGh,
+      `#!/usr/bin/env bash\ncat <<'JSON'\n${JSON.stringify([{
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [thread],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          },
+        },
+      }])}\nJSON\n`,
+    )
+    chmodSync(fakeGh, 0o755)
+
+    try {
+      const result = spawnSync(
+        "bash",
+        [path.join(SCRIPTS_DIR, "get-thread-for-comment"), "1", "comment-1", "o/r"],
+        {
+          encoding: "utf8",
+          env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+        },
+      )
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(JSON.parse(result.stdout)).toEqual(thread)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary
Fixes bugs in `ce-resolve-pr-feedback` helper scripts (`get-pr-comments` and `get-thread-for-comment`):

1. **Prevent `ARG_MAX` / `E2BIG` argument list overflow on large PRs**:
   Capturing GraphQL responses into bash variables and ~~piping/expanding `$threads_pages` via command-line arguments~~ expanding them via `--argjson` ~~to `jq`~~ puts multi-page payloads on the `jq` argv, which raises `Argument list too long` ~~(exit code 126)~~ on PRs with extensive comment/thread history.
   **Fix**: Stream GraphQL query output directly to temporary files using `mktemp` and pass them into `jq` via `--slurpfile`, with automatic cleanup registered via a shell `trap`.

2. ~~**Fix index-0 false negative bug in thread lookup**:~~ **Clarify thread comment matching in `get-thread-for-comment`**:
   ~~In `get-thread-for-comment`, `.comments.nodes | map(.id) | index($cid)` returns `0` when the target comment is the root comment of a thread. In `jq`, `select(0)` treats `0` as falsy, causing `get-thread-for-comment` to falsely report `"No thread found for comment ..."` for valid root comments.~~
   ~~**Fix**:~~ Replace index matching with boolean `any(.comments.nodes[]; .id == $cid)` ~~predicate matching~~.
   **Correction:** In jq, only `false`/`null` are falsy — `0` is truthy — so the old `index($cid)` filter already matched root comments. Kept `any(...)` as a readability improvement alongside the streaming change, not as a functional bugfix.

## Test Plan
- Run `bun run release:validate` and `bun run test` (all tests passing).
- Verified against active PR #4 on `gh-pr-workbench` (containing 96+ review thread nodes and large GraphQL response payloads).
- ~~Tested root-comment ID lookup (`PRRC_...`) and confirmed correct thread ID (`PRRT_...`) resolution.~~
- Fake-`gh` regression coverage for:
  - `get-thread-for-comment` slurpfile lookup returning the full matched thread object
  - `get-pr-comments` `--slurpfile` merge / `$threads[0][]` nesting (no `--argjson`)

Generated with [Devin](https://devin.ai)