### PR TITLE
fix(codex): use a local marketplace source so /plugins lists CE's skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "compound-engineering",
       "source": {
-        "source": "url",
-        "url": "https://github.com/EveryInc/compound-engineering-plugin.git"
+        "source": "local",
+        "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,11 @@ When testing current skill files in Codex, run the repository workflow from the 
 ```bash
 bun run codex:dev -- local    # link this worktree's skills and remove CE plugin installs
 bun run codex:dev -- status   # show local/remote state and checkout provenance
-bun run codex:dev -- remote   # restore the official Git-backed plugin
+bun run codex:dev -- remote   # restore the official marketplace-backed plugin
 bun run codex:dev -- remove   # remove both supported CE installation surfaces
 ```
 
-`refresh` is an idempotent alias for `local`. Local mode manages only the exact `$CODEX_HOME/skills/compound-engineering-local` symlink and Compound Engineering plugin IDs; it must not alter unrelated user skills. The symlink includes modified and untracked files from the selected worktree. Start a new Codex session after switching installation modes. Current Codex versions detect direct skill edits automatically; restart only if an edit does not appear. Do not use this repository itself as a Codex marketplace for local testing: its committed marketplace source points to the public Git repository.
+`refresh` is an idempotent alias for `local`. Local mode manages only the exact `$CODEX_HOME/skills/compound-engineering-local` symlink and Compound Engineering plugin IDs; it must not alter unrelated user skills. The symlink includes modified and untracked files from the selected worktree. Start a new Codex session after switching installation modes. Current Codex versions detect direct skill edits automatically; restart only if an edit does not appear. For live local testing, use this workflow instead of adding the repository as a marketplace: a marketplace install caches a snapshot, while local mode links the current skill files.
 
 ## Working Agreement
 

--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ bun run codex:dev -- remove
 
 The script derives the repository path, so it works from checkouts in any location, including paths with spaces. It inherits the active `CODEX_HOME`; set `CODEX_HOME` on the command when testing an isolated profile. Run every mode against the same `CODEX_HOME` you use to launch Codex.
 
-Do not use `codex plugin marketplace add "$PWD"` as a local-development shortcut. This repository's committed `.agents/plugins/marketplace.json` intentionally points Compound Engineering back to the public Git repository, so installing from that marketplace can still cache remote content. A matching manifest version also does not prove the cache matches the worktree.
+Do not use `codex plugin marketplace add "$PWD"` for live local development. It installs a cached copy of this checkout, so later edits are not reflected until the plugin is installed again; a matching manifest version also does not prove the cache matches the worktree. The `codex:dev` workflow instead keeps Codex linked to the current skill files.
 
 </details>
 

--- a/docs/solutions/developer-experience/codex-local-skill-development-workflow.md
+++ b/docs/solutions/developer-experience/codex-local-skill-development-workflow.md
@@ -13,7 +13,7 @@ related_components:
   - documentation
 applies_when:
   - "Testing Compound Engineering skill changes from any checkout or linked worktree in Codex"
-  - "Switching quickly between unreleased local skill content and the official Git-backed plugin"
+  - "Switching quickly between unreleased local skill content and the official marketplace-backed plugin"
   - "Verifying which worktree supplies the active Compound Engineering skills"
   - "Using modified or untracked skill files without changing the plugin manifest version"
 tags:
@@ -29,7 +29,7 @@ tags:
 
 ## Context
 
-Compound Engineering development needs two different Codex experiences: a fast loop against the exact files in the current checkout, and a production-like loop against the released Git-backed plugin. Treating a checkout as a marketplace does not provide the first experience. The repository's committed marketplace catalog names Compound Engineering but sets its source to the public Git URL, so `codex plugin marketplace add "$PWD"` followed by `codex plugin add compound-engineering@compound-engineering-plugin` can still install remote content (`.agents/plugins/marketplace.json:8-12`). The Codex manifest also remains at a release-owned version such as `3.19.0` while branch contents change (`.codex-plugin/plugin.json:2-4`), so version equality cannot establish which files were loaded.
+Compound Engineering development needs two different Codex experiences: a fast loop against the exact files in the current checkout, and a production-like loop against the released marketplace plugin. Treating a checkout as a marketplace does not provide the first experience. The repository's marketplace entry points at the co-located plugin root, so `codex plugin marketplace add "$PWD"` followed by `codex plugin add compound-engineering@compound-engineering-plugin` installs a cached copy of that checkout. Later edits are not live, and the Codex manifest remains at a release-owned version such as `3.20.0` while branch contents change, so version equality cannot establish which files were loaded.
 
 There are two distinct contracts to keep straight:
 
@@ -56,7 +56,7 @@ bun run codex:dev -- remote
 bun run codex:dev -- remove
 ```
 
-The package script delegates to the dedicated Bun entrypoint (`package.json:18-20`), and that entrypoint returns the workflow exit code while formatting failures consistently (`scripts/codex-dev.ts:1-7`). `local` and `refresh` take the same reconciliation path; `status` is read-only; `remote` restores the official Git-backed plugin; and `remove` clears both supported Compound Engineering installation surfaces (`src/dev/codex-dev.ts:660-688`).
+The package script delegates to the dedicated Bun entrypoint (`package.json:18-20`), and that entrypoint returns the workflow exit code while formatting failures consistently (`scripts/codex-dev.ts:1-7`). `local` and `refresh` take the same reconciliation path; `status` is read-only; `remote` restores the official marketplace-backed plugin; and `remove` clears both supported Compound Engineering installation surfaces (`src/dev/codex-dev.ts:663-699`).
 
 The workflow derives provenance instead of encoding a developer-specific path. It asks Git for the invoking repository root, resolves that path, validates both the package and Codex plugin identities, and requires the manifest's skills entry to resolve to this repository's `skills/` directory (`src/dev/codex-dev.ts:122-140`, `src/dev/codex-dev.ts:171-183`). It records the Git directory, common Git directory, branch, HEAD, and porcelain status, which allows `status` to distinguish primary and linked worktrees and report modified and untracked files (`src/dev/codex-dev.ts:184-228`). Arguments are passed as arrays to `Bun.spawn`, so paths containing spaces are not reconstructed through shell interpolation (`src/dev/codex-dev.ts:19-32`).
 
@@ -66,19 +66,19 @@ Local mode is intentionally skill-only. Before linking anything, repository vali
 
 Local activation is conservative about user state. It refuses to overwrite a regular file or directory, an unrelated symlink, or a broken symlink at the managed path (`src/dev/codex-dev.ts:232-275`). Link creation is exclusive. Removal and retargeting atomically move the current entry into a unique same-parent recovery directory, validate the stable moved entry, and delete it only when its raw symlink target matches the inspected target. An unexpected entry is restored exclusively or retained at a reported recovery path instead of being overwritten or deleted (`src/dev/codex-dev.ts:278-400`). The workflow never recursively deletes the target or neighboring skills (`src/dev/codex-dev.ts:417-430`).
 
-Avoid mixed installations. Codex plugin discovery filters all installed Compound Engineering IDs, not just the official one (`src/dev/codex-dev.ts:449-458`). `local` first activates the link, removes every detected Compound Engineering plugin through `codex plugin remove`, verifies that the resulting mode is local, and restores the prior link state if plugin removal or verification fails (`src/dev/codex-dev.ts:506-537`). Status explicitly classifies a valid link plus any installed Compound Engineering plugin as `mixed`. Link collisions and broken or unrelated links are `drifted`; without a valid local link, unexpected plugin IDs or source mismatches are also `drifted` (`src/dev/codex-dev.ts:476-503`).
+Avoid mixed installations. Codex plugin discovery filters all installed Compound Engineering IDs, not just the official one (`src/dev/codex-dev.ts:449-458`). `local` first activates the link, removes every detected Compound Engineering plugin through `codex plugin remove`, verifies that the resulting mode is local, and restores the prior link state if plugin removal or verification fails (`src/dev/codex-dev.ts:519-540`). Status explicitly classifies a valid link plus any installed Compound Engineering plugin as `mixed`. Link collisions and broken or unrelated links are `drifted`; without a valid local link, unexpected plugin IDs or source mismatches are also `drifted` (`src/dev/codex-dev.ts:479-506`).
 
-Returning to production-like behavior is verification-first. `remote` confirms that the named official marketplace is either absent or Git-backed by the expected repository, upgrades it, adds the official plugin, and verifies that exactly one enabled plugin reports the expected plugin ID and Git sources before unlinking local skills (`src/dev/codex-dev.ts:464-474`, `src/dev/codex-dev.ts:540-604`). If installation fails before verification, the local symlink remains available. `remove` similarly removes only detected Compound Engineering plugin IDs and the exact managed link, then verifies the `absent` state (`src/dev/codex-dev.ts:606-618`).
+Returning to production-like behavior is verification-first. `remote` confirms that the named official marketplace is either absent or Git-backed by the expected repository, upgrades it, adds the official plugin, and verifies that exactly one enabled plugin reports the expected plugin ID and marketplace provenance before unlinking local skills (`src/dev/codex-dev.ts:464-477`, `src/dev/codex-dev.ts:543-607`). The co-located plugin source is local within that Git-fetched marketplace snapshot; the verifier also accepts the former Git plugin source so existing installations remain classifiable during the transition. If installation fails before verification, the local symlink remains available. `remove` similarly removes only detected Compound Engineering plugin IDs and the exact managed link, then verifies the `absent` state (`src/dev/codex-dev.ts:609-621`).
 
-Start a new Codex session after changing between local, remote, and absent modes. For ordinary edits while already in local mode, Codex CLI 0.144.5 empirically observes the live symlinked files, so no reinstall is normally needed; restart only if a change is not visible. The command prints that distinction after every mutating operation (`src/dev/codex-dev.ts:690-694`).
+Start a new Codex session after changing between local, remote, and absent modes. For ordinary edits while already in local mode, Codex CLI 0.144.5 empirically observes the live symlinked files, so no reinstall is normally needed; restart only if a change is not visible. The command prints that distinction after every mutating operation (`src/dev/codex-dev.ts:693-697`).
 
 ## Why This Matters
 
-A marketplace installation and a live development source solve different problems. A marketplace exercises catalog resolution, plugin installation, cache population, and the released user path. A symlink exercises the exact branch or worktree being edited. Conflating them makes a successful local test ambiguous: the manifest version may match while the cache contains an older branch snapshot or the public repository.
+A marketplace installation and a live development source solve different problems. A marketplace exercises catalog resolution, plugin installation, cache population, and the released user path. A symlink exercises the exact branch or worktree being edited. Conflating them makes a successful local test ambiguous: the manifest version may match while the cache contains an older checkout or released-marketplace snapshot.
 
-The fixed collection name provides a stable ownership boundary without a separate manifest of copied skills. Provenance lives in the symlink target and the Git metadata printed by `status`: Codex home, source checkout, primary or linked worktree, branch, commit, dirty counts, skill inventory, linked target, and whether it matches the invoking checkout (`src/dev/codex-dev.ts:620-647`). This makes uncommitted and untracked experiments visible while still making it obvious which worktree is supplying them.
+The fixed collection name provides a stable ownership boundary without a separate manifest of copied skills. Provenance lives in the symlink target and the Git metadata printed by `status`: Codex home, source checkout, primary or linked worktree, branch, commit, dirty counts, skill inventory, linked target, and whether it matches the invoking checkout (`src/dev/codex-dev.ts:623-650`). This makes uncommitted and untracked experiments visible while still making it obvious which worktree is supplying them.
 
-The explicit local/remote state machine also prevents a subtler failure: both surfaces can be enabled at once. Without reconciliation, duplicate skill names may come from a live directory and a cached plugin simultaneously. Classifying that condition as `mixed`, returning a non-zero exit for mixed or drifted states, and providing deterministic repair commands makes the unsafe state visible rather than relying on a developer to remember which installation they last touched (`src/dev/codex-dev.ts:620-696`).
+The explicit local/remote state machine also prevents a subtler failure: both surfaces can be enabled at once. Without reconciliation, duplicate skill names may come from a live directory and a cached plugin simultaneously. Classifying that condition as `mixed`, returning a non-zero exit for mixed or drifted states, and providing deterministic repair commands makes the unsafe state visible rather than relying on a developer to remember which installation they last touched (`src/dev/codex-dev.ts:623-699`).
 
 Finally, preserving the official marketplace while local mode is active makes switching cheap. Local work does not require editing a personal marketplace catalog, and remote mode can refresh and verify the normal installation when a developer wants to reproduce the released user experience. Unrelated marketplace entries and unrelated user skills stay outside the workflow's ownership boundary.
 
@@ -86,13 +86,13 @@ Finally, preserving the official marketplace while local mode is active makes sw
 
 Use `local` when developing or evaluating Compound Engineering skill content from a checkout, feature branch, detached worktree, or dirty working tree. Run it from anywhere inside the intended repository; repository discovery resolves the top level, and the selected `skills/` directory becomes the link target (`src/dev/codex-dev.ts:171-183`, `src/dev/codex-dev.ts:215-229`).
 
-Use `refresh` when the worktree is already linked but a plugin was installed accidentally or the state otherwise needs reconciliation. It is an idempotent alias for `local`, not a file-copy refresh (`src/dev/codex-dev.ts:674-678`). Ordinary local edits already flow through the live link.
+Use `refresh` when the worktree is already linked but a plugin was installed accidentally or the state otherwise needs reconciliation. It is an idempotent alias for `local`, not a file-copy refresh (`src/dev/codex-dev.ts:677-681`). Ordinary local edits already flow through the live link.
 
-Use `status` before testing when provenance matters, after changing worktrees, or whenever duplicate or stale behavior is suspected. It reads the managed link and Codex plugin list, reports `local`, `remote`, `mixed`, `drifted`, or `absent`, and does not execute an installation transition (`src/dev/codex-dev.ts:476-503`, `src/dev/codex-dev.ts:685-687`).
+Use `status` before testing when provenance matters, after changing worktrees, or whenever duplicate or stale behavior is suspected. It reads the managed link and Codex plugin list, reports `local`, `remote`, `mixed`, `drifted`, or `absent`, and does not execute an installation transition (`src/dev/codex-dev.ts:479-506`, `src/dev/codex-dev.ts:688-690`).
 
-Use `remote` before release validation or any test intended to simulate a normal marketplace user. This path exercises the official marketplace and verifies the Git-backed installed plugin before removing the local development link (`src/dev/codex-dev.ts:573-604`).
+Use `remote` before release validation or any test intended to simulate a normal marketplace user. This path exercises the official Git marketplace and verifies the marketplace-backed installed plugin before removing the local development link (`src/dev/codex-dev.ts:576-607`).
 
-Use `remove` when neither the local collection nor a Compound Engineering plugin should remain in the active profile. It is not a repository cleanup command and does not alter the worktree (`src/dev/codex-dev.ts:606-618`).
+Use `remove` when neither the local collection nor a Compound Engineering plugin should remain in the active profile. It is not a repository cleanup command and does not alter the worktree (`src/dev/codex-dev.ts:609-621`).
 
 Do not use the symlink workflow if the Codex manifest gains apps, hooks, or MCP servers, or if the default hook manifest appears; the built-in guard deliberately stops rather than silently testing an incomplete plugin (`src/dev/codex-dev.ts:132-153`). At that point, extend the development workflow to represent those components or test through a full plugin installation.
 
@@ -152,7 +152,7 @@ Switch to the released-user path, then begin a fresh Codex session:
 bun run codex:dev -- remote
 ```
 
-This upgrades the `compound-engineering-plugin` marketplace, ensures `compound-engineering@compound-engineering-plugin` is the sole enabled Compound Engineering plugin, verifies its Git source, and only then unlinks `compound-engineering-local` (`src/dev/codex-dev.ts:545-604`).
+This upgrades the `compound-engineering-plugin` marketplace, ensures `compound-engineering@compound-engineering-plugin` is the sole enabled Compound Engineering plugin, verifies its official marketplace provenance, and only then unlinks `compound-engineering-local` (`src/dev/codex-dev.ts:548-607`).
 
 Remove either supported installation without touching other skills:
 

--- a/src/dev/codex-dev.ts
+++ b/src/dev/codex-dev.ts
@@ -461,15 +461,18 @@ function normalizedGitUrl(value: string | undefined): string | undefined {
   return value?.replace(/\.git\/?$/, "").replace(/\/$/, "").toLowerCase()
 }
 
-function isOfficialRemotePlugin(plugin: InstalledPlugin): boolean {
+function isOfficialMarketplacePlugin(plugin: InstalledPlugin): boolean {
+  const pluginSourceIsOfficial =
+    plugin.source?.source === "local" ||
+    (plugin.source?.source === "git" &&
+      normalizedGitUrl(plugin.source.url) === normalizedGitUrl(OFFICIAL_REPOSITORY))
   return (
     plugin.pluginId === OFFICIAL_PLUGIN_ID &&
     plugin.installed === true &&
     plugin.enabled === true &&
     plugin.marketplaceSource?.sourceType === "git" &&
     normalizedGitUrl(plugin.marketplaceSource.source) === normalizedGitUrl(OFFICIAL_REPOSITORY) &&
-    plugin.source?.source === "git" &&
-    normalizedGitUrl(plugin.source.url) === normalizedGitUrl(OFFICIAL_REPOSITORY)
+    pluginSourceIsOfficial
   )
 }
 
@@ -494,7 +497,7 @@ export async function inspectCodexDevStatus(
     mode = localMatchesCheckout ? "local" : "drifted"
   } else if (plugins.length === 0) {
     mode = "absent"
-  } else if (plugins.length === 1 && isOfficialRemotePlugin(plugins[0]!)) {
+  } else if (plugins.length === 1 && isOfficialMarketplacePlugin(plugins[0]!)) {
     mode = "remote"
   } else {
     mode = "drifted"
@@ -591,8 +594,8 @@ export async function switchToRemote(
   await runCodex(context, runner, ["plugin", "add", OFFICIAL_PLUGIN_ID, "--json"])
 
   const installed = await listCompoundEngineeringPlugins(context, runner)
-  if (installed.length !== 1 || !isOfficialRemotePlugin(installed[0]!)) {
-    throw new Error("Could not verify the official Git-backed Compound Engineering plugin")
+  if (installed.length !== 1 || !isOfficialMarketplacePlugin(installed[0]!)) {
+    throw new Error("Could not verify the official marketplace-backed Compound Engineering plugin")
   }
 
   await removeLocalCollection(context)

--- a/src/release/metadata.ts
+++ b/src/release/metadata.ts
@@ -424,10 +424,14 @@ export async function syncReleaseMetadata(options: SyncOptions = {}): Promise<Me
         `${marketplaceCodexPath}: plugin list [${codexNames.join(", ")}] does not match ${marketplaceClaudePath} [${claudeNames.join(", ")}]`,
       )
     }
+    // Codex materialises non-local ("url"/"git"/"npm") sources only on install, so
+    // it blanks the plugin's skills/hooks/apps/MCP in the `/plugins` preview (#1226).
+    // The plugin is co-located in this repo, so its source must be local.
     for (const plugin of marketplaceCodex.plugins) {
-      if (plugin.source?.source === "local" && plugin.source.path === "./") {
+      const codexSourceType = plugin.source?.source
+      if (codexSourceType !== undefined && codexSourceType !== "local") {
         errors.push(
-          `${marketplaceCodexPath}: plugin "${plugin.name}" uses source.path "./"; Codex does not enumerate marketplace entries that point back at the marketplace root. Use a plugin subdirectory path or a Git URL source.`,
+          `${marketplaceCodexPath}: plugin "${plugin.name}" uses a "${codexSourceType}" source; Codex materialises non-local sources only on install, so the /plugins preview lists no skills, hooks, apps, or MCP servers (issue #1226). Use a co-located "local" source.`,
         )
       }
     }

--- a/tests/codex-dev.test.ts
+++ b/tests/codex-dev.test.ts
@@ -95,7 +95,7 @@ function plugin(pluginId: string, options: Partial<InstalledPlugin> = {}): Insta
     version: "3.19.0",
     installed: true,
     enabled: true,
-    source: { source: "git", url: "https://github.com/EveryInc/compound-engineering-plugin.git" },
+    source: { source: "local", path: "/tmp/compound-engineering-plugin" },
     marketplaceSource: {
       sourceType: "git",
       source: "https://github.com/EveryInc/compound-engineering-plugin.git",
@@ -460,7 +460,7 @@ describe("Codex development installation transitions", () => {
     ])
   })
 
-  test("remote mode installs and verifies the official Git plugin before unlinking local skills", async () => {
+  test("remote mode installs and verifies the official marketplace plugin before unlinking local skills", async () => {
     const context = await makeContext()
     await activateLocalCollection(context)
     const runner = new StatefulCodexRunner([], [officialMarketplace])
@@ -480,6 +480,20 @@ describe("Codex development installation transitions", () => {
       "compound-engineering-plugin",
       "--json",
     ])
+  })
+
+  test("status accepts an existing Git-source install during the marketplace migration", async () => {
+    const context = await makeContext()
+    const runner = new StatefulCodexRunner([
+      plugin("compound-engineering@compound-engineering-plugin", {
+        source: {
+          source: "git",
+          url: "https://github.com/EveryInc/compound-engineering-plugin.git",
+        },
+      }),
+    ])
+
+    expect((await inspectCodexDevStatus(context, runner)).mode).toBe("remote")
   })
 
   test("keeps local skills active if the remote install fails", async () => {
@@ -595,6 +609,8 @@ describe("Codex developer workflow contracts", () => {
     }
     expect(agents).toContain("bun run codex:dev -- local")
     expect(agents).toContain("$CODEX_HOME/skills/compound-engineering-local")
+    expect(readme).toContain("cached copy of this checkout")
+    expect(readme).not.toContain("points Compound Engineering back to the public Git repository")
   })
 
   test("refuses an unrelated symlink at the managed collection path", async () => {

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -338,6 +338,60 @@ describe("release metadata", () => {
     ).toBe(true)
   })
 
+  test("reports a materialized (non-local) Codex marketplace source as a structural error", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".agents", "plugins", "marketplace.json"),
+      JSON.stringify(
+        {
+          name: "compound-engineering-plugin",
+          plugins: [
+            {
+              name: "compound-engineering",
+              source: {
+                source: "url",
+                url: "https://github.com/EveryInc/compound-engineering-plugin.git",
+              },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some(
+        (err) => err.includes(".agents/plugins/marketplace.json") && err.includes("#1226"),
+      ),
+    ).toBe(true)
+  })
+
+  test("accepts a co-located local Codex marketplace source", async () => {
+    const root = await makeFixtureRoot()
+    await writeFile(
+      path.join(root, ".agents", "plugins", "marketplace.json"),
+      JSON.stringify(
+        {
+          name: "compound-engineering-plugin",
+          plugins: [
+            { name: "compound-engineering", source: { source: "local", path: "./" } },
+          ],
+        },
+        null,
+        2,
+      ),
+    )
+
+    const result = await syncReleaseMetadata({ root, write: false })
+
+    expect(
+      result.errors.some((err) => err.includes(".agents/plugins/marketplace.json")),
+    ).toBe(false)
+  })
+
   test("reports package.json version drift without auto-correcting", async () => {
     const root = await makeFixtureRoot()
     await writeFile(
@@ -618,39 +672,6 @@ describe("release metadata", () => {
     expect(
       result.errors.some(
         (err) => err.includes(".agents/plugins/marketplace.json") && err.includes("does not match"),
-      ),
-    ).toBe(true)
-  })
-
-  test("reports Codex marketplace root-local plugin source as structural error", async () => {
-    const root = await makeFixtureRoot()
-    await writeFile(
-      path.join(root, ".agents", "plugins", "marketplace.json"),
-      JSON.stringify(
-        {
-          name: "compound-engineering-plugin",
-          plugins: [
-            {
-              name: "compound-engineering",
-              source: {
-                source: "local",
-                path: "./",
-              },
-            },
-          ],
-        },
-        null,
-        2,
-      ),
-    )
-    const result = await syncReleaseMetadata({ root, write: false })
-
-    expect(
-      result.errors.some(
-        (err) =>
-          err.includes(".agents/plugins/marketplace.json") &&
-          err.includes("compound-engineering") &&
-          err.includes('source.path "./"'),
       ),
     ).toBe(true)
   })


### PR DESCRIPTION
## Summary

Codex now shows Compound Engineering's 31 skills in `/plugins` before installation instead of presenting an empty plugin. The marketplace resolves the plugin from the root of its Git-fetched snapshot, where Codex can read the manifest immediately, rather than treating the same repository as a second Git source that exists only after installation.

Fixes #1226.

## Why the old configuration existed

The Git source was a compatibility workaround, not an arbitrary indirection. When the plugin moved to the repository root in #967, the stable Codex release available at the time rejected `source.path: "./"` and registered the marketplace without enumerating its root plugin. #973 therefore switched the entry to a Git URL and added a guard against the failing configuration.

Codex fixed root-local marketplace sources in openai/codex#28771. That support first reached stable Codex 0.142, released about four and a half hours after #973 merged. On current Codex versions the trade-off has reversed: the root-local source works, while the extra Git source hides path-backed components from the pre-install listing.

Users on Codex 0.141 or earlier need to update Codex before using this marketplace configuration.

## Compatibility

Existing installations are not removed or disabled. They continue loading from the versioned plugin cache; after the marketplace snapshot refreshes, the catalog uses the new co-located source, and installing the plugin again refreshes that cache normally.

The repository's `codex:dev` workflow now recognizes both states during the transition: the new local plugin source inside the official Git marketplace, and the former Git plugin source reported by an existing installation. Local-development documentation now distinguishes a cached marketplace install from the live worktree link supplied by `bun run codex:dev -- local`.

The root plugin still materializes the repository into the plugin cache. Slimming the package layout remains separate work.

## Validation

- Codex CLI 0.145 listed version `3.20.0` from the root-local source and installed all 31 of 31 skills.
- A disposable source transition kept an existing Git-source installation enabled before reinstallation, then refreshed normally through `codex plugin add`.
- `bun test tests/codex-dev.test.ts tests/release-metadata.test.ts` — 57 passed.
- `bun run test` — 2,678 passed.
- `bunx tsc --noEmit`
- `bun run release:validate`
- `bun run plugin:validate`

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model / reasoning — bulk of the work:** GPT-5 · unknown
- **Model / reasoning — opening this PR:** unknown · unknown
