### PR TITLE
fix(codex-content): preserve URLs and mention-like text

### DIFF
--- a/docs/plans/2026-07-24-001-test-codex-content-transform-coverage-plan.md
+++ b/docs/plans/2026-07-24-001-test-codex-content-transform-coverage-plan.md
@@ -1,0 +1,250 @@
+---
+title: Codex content transform coverage - Plan
+type: test
+date: 2026-07-24
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+---
+
+# Codex content transform coverage - Plan
+
+## Goal Capsule
+
+- **Objective:** Add direct unit tests for `src/utils/codex-content.ts` so the Codex content transform is fully covered, including edge cases and misuse surfaces, and fix any bugs the tests expose.
+- **Authority:** The implementer owns test design and minimal source fixes; product scope is limited to `src/utils/codex-content.ts` and one new test file.
+- **Stop conditions:** `src/utils/codex-content.ts` reaches 100% function and line coverage, `bun run test` passes, and any source fixes are minimal.
+- **Execution profile:** Standard feature branch PR, no release version changes.
+
+---
+
+## Product Contract
+
+### Summary
+
+`src/utils/codex-content.ts` exposes `normalizeCodexName()` and `transformContentForCodex()`, which rewrite Claude Code content (Task agent calls, slash commands, `@`-references, `.claude/` paths) into Codex-compatible text. The current suite only exercises this code indirectly through `convertClaudeToCodex()`, leaving function coverage around 71% and line coverage around 81% in a targeted run. This plan adds a focused `tests/codex-content.test.ts` unit file that systematically covers normalization, every transform branch, ordering interactions, and misuse inputs, then fixes any defects surfaced by those tests.
+
+### Problem Frame
+
+Content transformation is fragile and regex-driven. The existing converter tests hit the happy path but miss namespaced Task fallbacks, backticked agent rewrites, prompt/skill slash mappings, `unknownSlashBehavior: "preserve"`, `@`-agent references, and several pathological inputs such as URLs, file paths, markdown links, and quoted strings. Without direct unit tests, these branches can regress when the converter or target writers change, and contributors cannot safely refactor the transform.
+
+### Requirements
+
+- R1. Add a dedicated test file at `tests/codex-content.test.ts` that imports `normalizeCodexName` and `transformContentForCodex` directly.
+- R2. Cover `normalizeCodexName` edge cases: empty/whitespace, mixed case, slashes, colons, repeated separators, leading/trailing separators, non-ASCII, underscores, and the `"item"` fallback.
+- R3. Cover `transformContentForCodex` Task agent calls: with/without args, zero args, namespaced names, prefix preservation, unknown agent fallback, and malformed Task syntax.
+- R4. Cover `transformContentForCodex` slash-command handling: known prompt targets, known skill targets, unknown default vs `unknownSlashBehavior: "preserve"`, reserved path roots, multi-segment paths, URLs, and boundary characters.
+- R5. Cover `transformContentForCodex` backticked agent names and `@`-references: known and unknown targets, case insensitivity, namespaced vs flat forms, and interactions with surrounding text.
+- R6. Cover `.claude/` -> `.codex/` and `~/.claude/` -> `~/.codex/` rewrites, and cases where the path should be left alone.
+- R7. Cover combined bodies to verify ordering and that no transform double-applies.
+- R8. If a new test exposes a real defect, fix the minimal source change and add a focused regression test.
+- R9. Keep `resolveAgentTarget` internal; do not add exports solely for testing.
+
+### Scope Boundaries
+
+- **In scope:** `src/utils/codex-content.ts` and a new `tests/codex-content.test.ts`; direct unit coverage of `normalizeCodexName` and `transformContentForCodex`; minimal source fixes for bugs exposed by the new tests.
+- **Deferred for later:** Refactoring the rest of the Codex converter (`src/converters/claude-to-codex.ts`, `src/targets/codex.ts`), adding integration tests with real plugin fixtures (already covered by `tests/codex-converter.test.ts` and `tests/codex-writer.test.ts`), or changing marketplace/catalog metadata.
+- **Outside this product's identity:** New CI pipelines, documentation site publishing, release automation.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Test through the public API only. `resolveAgentTarget` stays unexported; coverage of its candidate fallback logic is achieved by exercising `transformContentForCodex` with namespaced Task and agent-ref inputs.
+- KTD2. Add the test file at the root of `tests/` (not a new `tests/utils/` directory) to match `tests/slash-command.test.ts`, `tests/frontmatter.test.ts`, and `tests/resolve-output.test.ts`.
+- KTD3. Use `bun:test` `describe`/`test` blocks and explicit `for` loops for table-driven cases, mirroring the existing utility-test style; avoid `test.each` for harness portability.
+- KTD4. Target 100% function and line coverage for `src/utils/codex-content.ts`. The overall suite coverage should not regress.
+- KTD5. Source fixes triggered by the tests stay in the same PR only when the fix is minimal and the failing test is the proof; larger behavioral changes require a separate plan.
+
+### Assumptions
+
+- The `Task` call syntax is intentionally case-sensitive (`Task` not `task`) and agent names must start with a lowercase letter; inputs that violate this are left unchanged.
+- `normalizeCodexName` intentionally preserves underscores and does not collapse them; test expectations match current behavior.
+- The reserved path-root allowlist (`dev`, `tmp`, `etc`, `usr`, `var`, `bin`, `home`) is the source of truth.
+- Misuse cases (URLs, emails, markdown links, quoted strings) document current behavior; fixing them is in scope only when a test identifies an unambiguous bug.
+
+### Sequencing
+
+1. U1: author `tests/codex-content.test.ts` and run targeted coverage to confirm 100% coverage of `src/utils/codex-content.ts`.
+2. U2: if any test fails because of a real bug, make the minimal source fix and add a regression test.
+3. Run the full suite and release validation before opening the PR.
+
+---
+
+## Implementation Units
+
+### U1. Add comprehensive `tests/codex-content.test.ts`
+
+**Goal:** Directly unit-test `normalizeCodexName` and `transformContentForCodex` to 100% coverage, including edge cases and misuse surfaces.
+
+**Requirements:** R1–R7.
+
+**Dependencies:** None.
+
+**Files:**
+- `tests/codex-content.test.ts` (new)
+
+**Approach:**
+Import `normalizeCodexName` and `transformContentForCodex` from `../src/utils/codex-content`. Build small `CodexInvocationTargets` fixtures inline for each scenario rather than full `ClaudePlugin` objects. Group tests by transform stage in `describe` blocks. Use table-driven `for` loops for repetition. Assert exact string output, and include negative assertions that the original syntax is removed when it should be and preserved when it should not.
+
+#### `normalizeCodexName` scenarios
+
+| Input | Expected | Notes |
+|---|---|---|
+| `"Security Reviewer"` | `"security-reviewer"` | basic normalization |
+| `"  spaces  "` | `"spaces"` | trim |
+| `"foo/bar"` | `"foo-bar"` | forward slash |
+| `"foo\\bar"` | `"foo-bar"` | backslash |
+| `"foo:bar"` | `"foo-bar"` | colon |
+| `"foo bar"` | `"foo-bar"` | whitespace |
+| `"foo\nbar"` | `"foo-bar"` | newline |
+| `"a---b"` | `"a-b"` | repeated hyphens collapsed |
+| `"-leading-"` | `"leading"` | leading/trailing separators stripped |
+| `""` | `"item"` | empty fallback |
+| `"   "` | `"item"` | whitespace-only fallback |
+| `"!!!"` | `"item"` | no usable characters fallback |
+| `"UPPER_CASE"` | `"upper_case"` | mixed case and underscores preserved |
+| `"foo.bar"` | `"foo-bar"` | dot replaced |
+| `"foo@bar"` | `"foo-bar"` | at-sign replaced |
+| `"éè"` | `"item"` | non-ASCII becomes empty |
+| `"aéb"` | `"a-b"` | non-ASCII used as separator |
+| `" workflows:plan "` | `"workflows-plan"` | real-world alias |
+
+#### `transformContentForCodex` Task agent-call scenarios
+
+| Body | Targets | Options | Expected output | Notes |
+|---|---|---|---|---|
+| ``Task repo-researcher(find X)`` | `{agentTargets:{"repo-researcher":"repo-researcher"}}` | default | ``Spawn the custom agent `repo-researcher` with task: find X`` | known agent with args |
+| ``Task repo-researcher()`` | same target | default | ``Spawn the custom agent `repo-researcher` `` | zero args |
+| ``- Task repo-researcher(find X)`` | same target | default | ``- Spawn the custom agent `repo-researcher` with task: find X`` | prefix preserved |
+| ``Task repo-researcher(find X)`` | none | default | ``Use the $repo-researcher skill to: find X`` | unknown fallback |
+| ``Task compound-engineering:research:ce-repo-researcher(find X)`` | `{"research-ce-repo-researcher":"research-ce-repo-researcher"}` | default | ``Spawn the custom agent `research-ce-repo-researcher` with task: find X`` | two-segment candidate match |
+| ``Task compound-engineering:research:ce-repo-researcher()`` | `{"ce-repo-researcher":"ce-repo-researcher"}` | default | ``Spawn the custom agent `ce-repo-researcher` `` | last-segment candidate match |
+| ``Task compound-engineering:research:unknown-agent(find X)`` | none | default | ``Use the $unknown-agent skill to: find X`` | namespaced fallback uses final segment |
+| ``Task Repo-Researcher(find X)`` | target | default | unchanged | case-sensitive agent name |
+| ``Task repo researcher(find X)`` | target | default | unchanged | missing `(` |
+| ``Task repo-researcher (find X)`` | target | default | unchanged | space before `(` |
+| ``inline Task repo-researcher(find X)`` | target | default | unchanged | not at start of the only line |
+| ``Task repo-researcher(find X`` | target | default | unchanged | unbalanced `)` |
+| ``Task repo-researcher(a(b))`` | target | default | ``Spawn the custom agent `repo-researcher` with task: a(b))`` | stops at first `)`; trailing `)` remains |
+
+#### `transformContentForCodex` slash-command scenarios
+
+| Body | Targets | Options | Expected output | Notes |
+|---|---|---|---|---|
+| ``Run /todo-resolve`` | `{promptTargets:{"todo-resolve":"todo-resolve"}}` | default | ``Run /prompts:todo-resolve`` | known prompt |
+| ``Run /ce-plan`` | `{skillTargets:{"ce-plan":"ce-plan"}}` | default | ``Run the ce-plan skill`` | known skill |
+| ``Run /unknown-cmd`` | none | default | ``Run /prompts:unknown-cmd`` | unknown default |
+| ``Run /unknown-cmd`` | none | `unknownSlashBehavior: "preserve"` | ``Run /unknown-cmd`` | preserve unknown |
+| ``config lives in /tmp`` | none | default | unchanged | reserved root |
+| ``See /usr/local/bin/tool`` | none | default | unchanged | multi-segment path |
+| ``Run https://example.com/path`` | none | default | unchanged | URL (`:` before slash) |
+| ``paths like a/b`` | none | default | unchanged | word char before slash |
+| ``Run /ce-plan, then /ce-work.`` | skill targets | default | ``Run the ce-plan skill, then the ce-work skill.`` | multiple commands |
+| ``Run /PLAN`` | `{promptTargets:{"plan":"workflows-plan"}}` | default | ``Run /prompts:workflows-plan`` | case-insensitive, normalized key |
+| ``Run /my_command`` | none | default | ``Run /prompts:my_command`` | underscore in name |
+| ``(see /plan)`` | `{promptTargets:{"plan":"plan"}}` | default | ``(see /prompts:plan)`` | inside parentheses |
+| ``href="/plan"`` | `{promptTargets:{"plan":"plan"}}` | default | ``href="/prompts:plan"`` | inside double quotes |
+| ``Run /plan:`` | none | default | ``Run /prompts:plan`` | trailing colon consumed |
+| ``[link](/plan)`` | `{promptTargets:{"plan":"plan"}}` | default | ``[link](/prompts:plan)`` | markdown link |
+| ``Run /workflows:work`` | `{skillTargets:{"workflows-work":"ce-work"}}` | default | ``Run the ce-work skill`` | namespaced slash command |
+
+#### `transformContentForCodex` backticked agent scenarios
+
+| Body | Targets | Expected output | Notes |
+|---|---|---|---|
+| `` `research:ce-repo-researcher` `` | `{agentTargets:{"research-ce-repo-researcher":"research-ce-repo-researcher"}}` | ``custom agent `research-ce-repo-researcher` `` | two-segment match |
+| `` `compound-engineering:research:ce-repo-researcher` `` | `{agentTargets:{"research-ce-repo-researcher":"research-ce-repo-researcher"}}` | ``custom agent `research-ce-repo-researcher` `` | three-segment match |
+| `` `ce-repo-researcher` `` | `{agentTargets:{"ce-repo-researcher":"ce-repo-researcher"}}` | unchanged | single-segment not matched by current pattern |
+| `` `a:b:c:d` `` | `{agentTargets:{"a-b-c":"a-b-c"}}` | ``custom agent `a-b-c`:d` `` | four-segment partial match; document current behavior |
+| `` `Research:Ce-Repo-Researcher` `` | `{agentTargets:{"research-ce-repo-researcher":"research-ce-repo-researcher"}}` | ``custom agent `research-ce-repo-researcher` `` | case-insensitive |
+
+#### `transformContentForCodex` `@`-reference scenarios
+
+| Body | Targets | Expected output | Notes |
+|---|---|---|---|
+| ``@security-reviewer`` | `{agentTargets:{"security-reviewer":"security-reviewer"}}` | ``custom agent `security-reviewer` `` | known |
+| ``@security-reviewer`` | none | ``$security-reviewer skill`` | unknown |
+| ``@Security-Reviewer`` | `{agentTargets:{"security-reviewer":"security-reviewer"}}` | ``custom agent `security-reviewer` `` | case-insensitive |
+| ``user@security-reviewer`` | `{agentTargets:{"security-reviewer":"security-reviewer"}}` | ``usercustom agent `security-reviewer` `` | email-like; no word-boundary lookbehind |
+| ``@user`` | none | unchanged | missing required suffix |
+| ``@compound-engineering:review:ce-security-reviewer`` | target | unchanged | colon not allowed |
+
+#### Path-rewrite and combined scenarios
+
+| Body | Expected output | Notes |
+|---|---|---|
+| ``Read .claude/config.local.md`` | ``Read .codex/config.local.md`` | basic rewrite |
+| ``Read ~/.claude/config.local.md`` | ``Read ~/.codex/config.local.md`` | home rewrite |
+| ``Read .claude-plugin/marketplace.json`` | unchanged | not `.claude/` |
+| ``Read .CLAUDE/config.md`` | unchanged | case-sensitive |
+| ``~/.claude/.claude/file.md`` | ``~/.codex/.codex/file.md`` | both rules apply |
+| ``Task repo-researcher(go) then run /ce-plan from ~/.claude/config.`` | ``Spawn the custom agent `repo-researcher` with task: go then run the ce-plan skill from ~/.codex/config.`` | combined transform ordering |
+
+**Verification:**
+- `bun test --coverage tests/codex-content.test.ts` shows `src/utils/codex-content.ts` at 100% functions and lines.
+- `bun run test` passes before any source fix.
+
+### U2. Fix source defects surfaced by U1
+
+**Goal:** Address any real bugs the new tests expose in `src/utils/codex-content.ts`.
+
+**Requirements:** R8.
+
+**Dependencies:** U1.
+
+**Files:**
+- `src/utils/codex-content.ts` (only if a test fails because of a real bug)
+
+**Approach:**
+For each failing test that indicates incorrect behavior (not just a missing test), make the smallest source change that fixes it without breaking existing tests. Add one focused regression test per fix. If the defect is large or the correct behavior is ambiguous, stop and treat it as a follow-up plan rather than expanding this PR.
+
+**Verification:**
+- The failing test passes.
+- `bun run test` still passes.
+- No public API signatures change.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Applies to |
+|---|---|---|
+| Unit-test iteration | `bun test --coverage tests/codex-content.test.ts` | U1 |
+| Full suite | `bun run test` | U1, U2 |
+| Release metadata | `bun run release:validate` | whole PR, if agent/skill counts change (unlikely for a test-only change) |
+| Coverage target | `src/utils/codex-content.ts` reaches 100% functions and 100% lines in the coverage report | U1 |
+
+Run the full suite after any source fix in U2. Do not bump versions or hand-edit `CHANGELOG.md`.
+
+---
+
+## Definition of Done
+
+- `tests/codex-content.test.ts` exists and all its tests pass.
+- `bun test --coverage tests/codex-content.test.ts` shows `src/utils/codex-content.ts` at 100% functions and 100% lines.
+- `bun run test` passes.
+- Any source change in `src/utils/codex-content.ts` is minimal, includes a regression test, and does not change the public export signatures.
+- The PR uses a conventional-commit title (`test:` or `fix:` if source changes are included) and stays on a feature branch; no direct push to `main`.
+
+---
+
+## Risks & Dependencies
+
+- `normalizeCodexName` is used by `src/converters/claude-to-codex.ts` and `src/data/plugin-legacy-artifacts.ts`. Any source change must be verified with `bun run test`, not only the targeted `codex-content` tests.
+- Some "misuse" tests may document surprising but intentional behavior (for example, single-segment backticked agents are not matched). If a test fails, the implementer must decide whether to fix the source or adjust the expectation; KTD5 and the Scope Boundaries prevent scope creep.
+- The PR is test-first; if a bug is larger than a minimal fix, escalate to a separate plan.
+
+---
+
+## Sources & Research
+
+- `src/utils/codex-content.ts` — the module under test.
+- `src/utils/slash-command.ts` — shared reserved path-root list.
+- `tests/codex-converter.test.ts` — existing converter coverage baseline.
+- `tests/slash-command.test.ts`, `tests/frontmatter.test.ts`, `tests/resolve-output.test.ts` — utility test style conventions.
+- `docs/solutions/adding-converter-target-providers.md` — "Content transformation is fragile — test extensively" and normalize/slash pattern guidance.
+- `docs/solutions/codex-skill-prompt-entrypoints.md` — Codex converter default mode and `transformContentForCodex` role.

--- a/docs/plans/2026-07-24-001-test-codex-content-transform-coverage-plan.md
+++ b/docs/plans/2026-07-24-001-test-codex-content-transform-coverage-plan.md
@@ -129,7 +129,7 @@ Import `normalizeCodexName` and `transformContentForCodex` from `../src/utils/co
 | ``Task repo-researcher (find X)`` | target | default | unchanged | space before `(` |
 | ``inline Task repo-researcher(find X)`` | target | default | unchanged | not at start of the only line |
 | ``Task repo-researcher(find X`` | target | default | unchanged | unbalanced `)` |
-| ``Task repo-researcher(a(b))`` | target | default | ``Spawn the custom agent `repo-researcher` with task: a(b))`` | stops at first `)`; trailing `)` remains |
+| ``Task repo-researcher(a(b))`` | target | default | ``Spawn the custom agent `repo-researcher` with task: a(b)`` | stops at first `)`; trailing `)` remains |
 
 #### `transformContentForCodex` slash-command scenarios
 
@@ -159,7 +159,7 @@ Import `normalizeCodexName` and `transformContentForCodex` from `../src/utils/co
 | `` `research:ce-repo-researcher` `` | `{agentTargets:{"research-ce-repo-researcher":"research-ce-repo-researcher"}}` | ``custom agent `research-ce-repo-researcher` `` | two-segment match |
 | `` `compound-engineering:research:ce-repo-researcher` `` | `{agentTargets:{"research-ce-repo-researcher":"research-ce-repo-researcher"}}` | ``custom agent `research-ce-repo-researcher` `` | three-segment match |
 | `` `ce-repo-researcher` `` | `{agentTargets:{"ce-repo-researcher":"ce-repo-researcher"}}` | unchanged | single-segment not matched by current pattern |
-| `` `a:b:c:d` `` | `{agentTargets:{"a-b-c":"a-b-c"}}` | ``custom agent `a-b-c`:d` `` | four-segment partial match; document current behavior |
+| `` `a:b:c:d` `` | `{agentTargets:{"a-b-c":"a-b-c"}}` | unchanged | four-segment form is outside the supported pattern |
 | `` `Research:Ce-Repo-Researcher` `` | `{agentTargets:{"research-ce-repo-researcher":"research-ce-repo-researcher"}}` | ``custom agent `research-ce-repo-researcher` `` | case-insensitive |
 
 #### `transformContentForCodex` `@`-reference scenarios
@@ -169,7 +169,7 @@ Import `normalizeCodexName` and `transformContentForCodex` from `../src/utils/co
 | ``@security-reviewer`` | `{agentTargets:{"security-reviewer":"security-reviewer"}}` | ``custom agent `security-reviewer` `` | known |
 | ``@security-reviewer`` | none | ``$security-reviewer skill`` | unknown |
 | ``@Security-Reviewer`` | `{agentTargets:{"security-reviewer":"security-reviewer"}}` | ``custom agent `security-reviewer` `` | case-insensitive |
-| ``user@security-reviewer`` | `{agentTargets:{"security-reviewer":"security-reviewer"}}` | ``usercustom agent `security-reviewer` `` | email-like; no word-boundary lookbehind |
+| ``user@security-reviewer`` | `{agentTargets:{"security-reviewer":"security-reviewer"}}` | unchanged | word-character lookbehind preserves email-like text |
 | ``@user`` | none | unchanged | missing required suffix |
 | ``@compound-engineering:review:ce-security-reviewer`` | target | unchanged | colon not allowed |
 

--- a/docs/solutions/integrations/codex-content-transform-greedy-regex.md
+++ b/docs/solutions/integrations/codex-content-transform-greedy-regex.md
@@ -40,13 +40,13 @@ For `@`-references, there was no boundary check at all, so any `@` followed by a
 
 Move both exclusions into the regex patterns themselves instead of the replacement callbacks.
 
-Slash commands now use a negative lookbehind that excludes URL/path contexts, including query and fragment separators:
+Slash commands now use a URL-first alternative that consumes full HTTP(S) URL spans before the command alternative can inspect their embedded routes:
 
 ```typescript
-const slashCommandPattern = /(?<![:\w>}\]\)\/#?=])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+const slashCommandPattern = /https?:\/\/\S+|(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
 ```
 
-The `commandName.includes("/")` guard in the callback was then unreachable and was removed.
+When the URL alternative matches, `commandName` is absent and the callback returns the full span unchanged. This handles ordinary paths as well as query and fragment variants without enumerating every punctuation character that may precede an embedded route.
 
 `@`-agent references now require token boundaries before the `@` and after the recognized name:
 
@@ -56,7 +56,7 @@ const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|a
 
 ## Why This Works
 
-A slash that follows another slash or a URL query/fragment separator is part of a URL, not a leading command slash. The lookbehind rejects those positions before the match is consumed, so the replacement callback never sees an embedded URL route.
+The URL alternative appears first, so the regex engine consumes each complete non-whitespace HTTP(S) token before it can find a slash-command candidate inside that token. Slash commands elsewhere in the same string still reach the command alternative and transform normally.
 
 A `@` that follows a word character is part of an email handle, username, or other compound token, not a stand-alone agent mention. The `(?<!\w)` lookbehind ensures only boundary `@` symbols are considered, while `(?![\w-])` prevents partial matches inside longer identifiers.
 

--- a/docs/solutions/integrations/codex-content-transform-greedy-regex.md
+++ b/docs/solutions/integrations/codex-content-transform-greedy-regex.md
@@ -1,13 +1,15 @@
 ---
 title: Codex content transform regexes greedily matched URLs and email-like strings
 date: 2026-07-24
-category: logic-errors
+category: integrations
 module: src/utils/codex-content.ts
 problem_type: logic_error
 component: tooling
 symptoms:
   - "Slash-command rewrite corrupted URLs such as `https://example.com/path` by matching the second `/`"
+  - "Slash-command rewrite corrupted route-like values inside URL queries and fragments"
   - "@-agent rewrite corrupted email-like strings such as `user@security-reviewer` by matching the `@` inside a word"
+  - "@-agent rewrite partially transformed longer mention-like identifiers"
 root_cause: logic_error
 resolution_type: code_fix
 severity: medium
@@ -24,7 +26,9 @@ related_components: [codex converter, transformContentForCodex]
 ## Symptoms
 
 - URLs such as `https://example.com/path` were rewritten as `https:prompts:example.com/path` because the slash-command regex matched the second `/`.
+- URL queries and fragments such as `https://example.com?next=/unknown-cmd` and `https://example.com/#/ce-plan` had their embedded routes rewritten as commands.
 - Email-like strings such as `user@security-reviewer` were rewritten as `usercustom agent \`security-reviewer\`` because the `@`-agent regex matched the `@` inside a word.
+- Longer handles such as `@security-reviewer_helper` were partially rewritten because `_` was not treated as a continuation character.
 
 ## What Didn't Work
 
@@ -36,25 +40,25 @@ For `@`-references, there was no boundary check at all, so any `@` followed by a
 
 Move both exclusions into the regex patterns themselves instead of the replacement callbacks.
 
-Slash commands now use a negative lookbehind that excludes another `/`:
+Slash commands now use a negative lookbehind that excludes URL/path contexts, including query and fragment separators:
 
 ```typescript
-const slashCommandPattern = /(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+const slashCommandPattern = /(?<![:\w>}\]\)\/#?=])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
 ```
 
 The `commandName.includes("/")` guard in the callback was then unreachable and was removed.
 
-`@`-agent references now require a word boundary before the `@`:
+`@`-agent references now require token boundaries before the `@` and after the recognized name:
 
 ```typescript
-const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))/gi
+const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))(?![\w-])/gi
 ```
 
 ## Why This Works
 
-A slash that follows another slash is part of a URL path or protocol separator, not a leading command slash. The lookbehind rejects those positions before the match is consumed, so the replacement callback never sees a URL path segment.
+A slash that follows another slash or a URL query/fragment separator is part of a URL, not a leading command slash. The lookbehind rejects those positions before the match is consumed, so the replacement callback never sees an embedded URL route.
 
-A `@` that follows a word character is part of an email handle, username, or other compound token, not a stand-alone agent mention. The `(?<!\w)` lookbehind ensures only boundary `@` symbols are considered.
+A `@` that follows a word character is part of an email handle, username, or other compound token, not a stand-alone agent mention. The `(?<!\w)` lookbehind ensures only boundary `@` symbols are considered, while `(?![\w-])` prevents partial matches inside longer identifiers.
 
 ## Prevention
 

--- a/docs/solutions/integrations/codex-content-transform-greedy-regex.md
+++ b/docs/solutions/integrations/codex-content-transform-greedy-regex.md
@@ -38,15 +38,18 @@ For `@`-references, there was no boundary check at all, so any `@` followed by a
 
 ## Solution
 
-Move both exclusions into the regex patterns themselves instead of the replacement callbacks.
+Handle each exclusion at its owning layer: preserve HTTP(S) spans once around all free-form rewrites, and keep mention-token boundaries in the `@` regex.
 
-Slash commands now use a URL-first alternative that consumes full HTTP(S) URL spans before the command alternative can inspect their embedded routes:
+`transformOutsideHttpUrls()` splits the content into URL and non-URL spans. Backticked-agent, slash-command, path, and `@`-agent rewrites run only on the non-URL spans:
 
 ```typescript
-const slashCommandPattern = /https?:\/\/\S+|(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+result = transformOutsideHttpUrls(result, (segment) => {
+  // Apply the free-form Codex rewrites to segment.
+  return transformed
+})
 ```
 
-When the URL alternative matches, `commandName` is absent and the callback returns the full span unchanged. This handles ordinary paths as well as query and fragment variants without enumerating every punctuation character that may precede an embedded route.
+This handles ordinary paths, query/fragment variants, and agent-like URL tokens without enumerating every punctuation character that may precede an embedded route or mention.
 
 `@`-agent references now require token boundaries before the `@` and after the recognized name:
 
@@ -56,15 +59,15 @@ const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|a
 
 ## Why This Works
 
-The URL alternative appears first, so the regex engine consumes each complete non-whitespace HTTP(S) token before it can find a slash-command candidate inside that token. Slash commands elsewhere in the same string still reach the command alternative and transform normally.
+The shared wrapper copies each complete non-whitespace HTTP(S) token unchanged and applies every free-form rewrite only to the text between URLs. Commands, paths, and agent mentions elsewhere in the same string still transform normally.
 
 A `@` that follows a word character is part of an email handle, username, or other compound token, not a stand-alone agent mention. The `(?<!\w)` lookbehind ensures only boundary `@` symbols are considered, while `(?![\w-])` prevents partial matches inside longer identifiers.
 
 ## Prevention
 
-- When writing regexes for command or mention syntax that will run against free-form text, put the contextual exclusions in the pattern (lookbehind/lookahead) rather than in post-match guards.
+- Put token-local exclusions in the pattern, but protect shared lexical regions such as URLs once at the layer that owns all affected rewrites.
 - Test common embedding cases early: URLs, markdown links, HTML attributes, quoted strings, email addresses, and parentheses.
-- Keep the negative lookbehind character class up to date with every character that can legitimately precede the same token (`/`, word chars, closing brackets, punctuation).
+- When one protected context affects multiple sequential transforms, test that every stage preserves it and that equivalent syntax outside the context still transforms.
 
 ## Related
 

--- a/docs/solutions/logic-errors/codex-content-transform-greedy-regex.md
+++ b/docs/solutions/logic-errors/codex-content-transform-greedy-regex.md
@@ -1,0 +1,67 @@
+---
+title: Codex content transform regexes greedily matched URLs and email-like strings
+date: 2026-07-24
+category: logic-errors
+module: src/utils/codex-content.ts
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "Slash-command rewrite corrupted URLs such as `https://example.com/path` by matching the second `/`"
+  - "@-agent rewrite corrupted email-like strings such as `user@security-reviewer` by matching the `@` inside a word"
+root_cause: logic_error
+resolution_type: code_fix
+severity: medium
+tags: [codex, converter, regex, slash-commands, agent-mentions, url-handling, word-boundary]
+related_components: [codex converter, transformContentForCodex]
+---
+
+# Codex content transform regexes greedily matched URLs and email-like strings
+
+## Problem
+
+`transformContentForCodex()` in `src/utils/codex-content.ts` rewrites Claude-style `Task` calls, slash commands, backticked agent names, and `@`-references into Codex-style phrasing. Two of its regexes were too greedy and matched the command/mention markers when they appeared inside unrelated text, producing incorrect output.
+
+## Symptoms
+
+- URLs such as `https://example.com/path` were rewritten as `https:prompts:example.com/path` because the slash-command regex matched the second `/`.
+- Email-like strings such as `user@security-reviewer` were rewritten as `usercustom agent \`security-reviewer\`` because the `@`-agent regex matched the `@` inside a word.
+
+## What Didn't Work
+
+Guarding inside the slash-command replacement callback with `commandName.includes("/")` did not prevent the match; the URL's second slash still entered the callback. Removing the guard alone would not fix the underlying match, and adding a second post-match filter would still have rewritten the URL before the guard could reject it.
+
+For `@`-references, there was no boundary check at all, so any `@` followed by a recognized suffix was transformed regardless of context.
+
+## Solution
+
+Move both exclusions into the regex patterns themselves instead of the replacement callbacks.
+
+Slash commands now use a negative lookbehind that excludes another `/`:
+
+```typescript
+const slashCommandPattern = /(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+```
+
+The `commandName.includes("/")` guard in the callback was then unreachable and was removed.
+
+`@`-agent references now require a word boundary before the `@`:
+
+```typescript
+const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))/gi
+```
+
+## Why This Works
+
+A slash that follows another slash is part of a URL path or protocol separator, not a leading command slash. The lookbehind rejects those positions before the match is consumed, so the replacement callback never sees a URL path segment.
+
+A `@` that follows a word character is part of an email handle, username, or other compound token, not a stand-alone agent mention. The `(?<!\w)` lookbehind ensures only boundary `@` symbols are considered.
+
+## Prevention
+
+- When writing regexes for command or mention syntax that will run against free-form text, put the contextual exclusions in the pattern (lookbehind/lookahead) rather than in post-match guards.
+- Test common embedding cases early: URLs, markdown links, HTML attributes, quoted strings, email addresses, and parentheses.
+- Keep the negative lookbehind character class up to date with every character that can legitimately precede the same token (`/`, word chars, closing brackets, punctuation).
+
+## Related
+
+- `docs/solutions/codex-skill-prompt-entrypoints.md` — broader Codex converter architecture and the rule to preserve unknown slash references.

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -58,9 +58,8 @@ export function transformContentForCodex(
     return agentTarget ? `custom agent \`${agentTarget}\`` : match
   })
 
-  const slashCommandPattern = /(?<![:\w>}\]\)])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+  const slashCommandPattern = /(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
   result = result.replace(slashCommandPattern, (match, commandName: string) => {
-    if (commandName.includes("/")) return match
     if (isReservedPathRoot(commandName)) return match
 
     const normalizedName = normalizeCodexName(commandName)

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -58,7 +58,7 @@ export function transformContentForCodex(
     return agentTarget ? `custom agent \`${agentTarget}\`` : match
   })
 
-  const slashCommandPattern = /(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+  const slashCommandPattern = /(?<![:\w>}\]\)\/#?=])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
   result = result.replace(slashCommandPattern, (match, commandName: string) => {
     if (isReservedPathRoot(commandName)) return match
 
@@ -79,7 +79,7 @@ export function transformContentForCodex(
     .replace(/~\/\.claude\//g, "~/.codex/")
     .replace(/\.claude\//g, ".codex/")
 
-  const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))(?![a-z0-9-])/gi
+  const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))(?![\w-])/gi
   result = result.replace(agentRefPattern, (_match, agentName: string) => {
     const agentTarget = resolveAgentTarget(agentName, agentTargets)
     if (agentTarget) return `custom agent \`${agentTarget}\``

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -45,7 +45,7 @@ export function transformContentForCodex(
 
     // For namespaced calls like "compound-engineering:research:repo-research-analyst",
     // use only the final segment as the skill name when no custom agent target exists.
-    const finalSegment = agentName.includes(":") ? agentName.split(":").pop()! : agentName
+    const finalSegment = agentName.split(":").pop()!
     const skillName = normalizeCodexName(finalSegment)
     return trimmedArgs
       ? `${prefix}Use the $${skillName} skill to: ${trimmedArgs}`

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -79,7 +79,7 @@ export function transformContentForCodex(
     .replace(/~\/\.claude\//g, "~/.codex/")
     .replace(/\.claude\//g, ".codex/")
 
-  const agentRefPattern = /@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))/gi
+  const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))/gi
   result = result.replace(agentRefPattern, (_match, agentName: string) => {
     const agentTarget = resolveAgentTarget(agentName, agentTargets)
     if (agentTarget) return `custom agent \`${agentTarget}\``

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -53,42 +53,60 @@ export function transformContentForCodex(
   })
 
   const backtickedAgentPattern = /`([a-z][a-z0-9-]*(?::[a-z][a-z0-9-]*){1,2})`/gi
-  result = result.replace(backtickedAgentPattern, (match, agentName: string) => {
-    const agentTarget = resolveAgentTarget(agentName, agentTargets)
-    return agentTarget ? `custom agent \`${agentTarget}\`` : match
-  })
-
-  const slashCommandPattern = /https?:\/\/\S+|(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
-  result = result.replace(slashCommandPattern, (match, commandName: string) => {
-    if (!commandName) return match
-    if (isReservedPathRoot(commandName)) return match
-
-    const normalizedName = normalizeCodexName(commandName)
-    if (promptTargets[normalizedName]) {
-      return `/prompts:${promptTargets[normalizedName]}`
-    }
-    if (skillTargets[normalizedName]) {
-      return `the ${skillTargets[normalizedName]} skill`
-    }
-    if (unknownSlashBehavior === "preserve") {
-      return match
-    }
-    return `/prompts:${normalizedName}`
-  })
-
-  result = result
-    .replace(/~\/\.claude\//g, "~/.codex/")
-    .replace(/\.claude\//g, ".codex/")
-
+  const slashCommandPattern = /(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
   const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))(?![\w-])/gi
-  result = result.replace(agentRefPattern, (_match, agentName: string) => {
-    const agentTarget = resolveAgentTarget(agentName, agentTargets)
-    if (agentTarget) return `custom agent \`${agentTarget}\``
-    const skillName = normalizeCodexName(agentName)
-    return `$${skillName} skill`
+  result = transformOutsideHttpUrls(result, (segment) => {
+    let transformed = segment
+    transformed = transformed.replace(backtickedAgentPattern, (match, agentName: string) => {
+      const agentTarget = resolveAgentTarget(agentName, agentTargets)
+      return agentTarget ? `custom agent \`${agentTarget}\`` : match
+    })
+    transformed = transformed.replace(slashCommandPattern, (match, commandName: string) => {
+      if (isReservedPathRoot(commandName)) return match
+
+      const normalizedName = normalizeCodexName(commandName)
+      if (promptTargets[normalizedName]) {
+        return `/prompts:${promptTargets[normalizedName]}`
+      }
+      if (skillTargets[normalizedName]) {
+        return `the ${skillTargets[normalizedName]} skill`
+      }
+      if (unknownSlashBehavior === "preserve") {
+        return match
+      }
+      return `/prompts:${normalizedName}`
+    })
+    transformed = transformed
+      .replace(/~\/\.claude\//g, "~/.codex/")
+      .replace(/\.claude\//g, ".codex/")
+    transformed = transformed.replace(agentRefPattern, (_match, agentName: string) => {
+      const agentTarget = resolveAgentTarget(agentName, agentTargets)
+      if (agentTarget) return `custom agent \`${agentTarget}\``
+      const skillName = normalizeCodexName(agentName)
+      return `$${skillName} skill`
+    })
+    return transformed
   })
 
   return result
+}
+
+function transformOutsideHttpUrls(
+  value: string,
+  transform: (segment: string) => string,
+): string {
+  const urlPattern = /https?:\/\/\S+/gi
+  let output = ""
+  let cursor = 0
+  let match: RegExpExecArray | null
+
+  while ((match = urlPattern.exec(value))) {
+    output += transform(value.slice(cursor, match.index))
+    output += match[0]
+    cursor = match.index + match[0].length
+  }
+
+  return output + transform(value.slice(cursor))
 }
 
 function resolveAgentTarget(value: string, agentTargets: Record<string, string>): string | null {

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -79,7 +79,7 @@ export function transformContentForCodex(
     .replace(/~\/\.claude\//g, "~/.codex/")
     .replace(/\.claude\//g, ".codex/")
 
-  const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))/gi
+  const agentRefPattern = /(?<!\w)@([a-z][a-z0-9-]*-(?:agent|reviewer|researcher|analyst|specialist|oracle|sentinel|guardian|strategist))(?![a-z0-9-])/gi
   result = result.replace(agentRefPattern, (_match, agentName: string) => {
     const agentTarget = resolveAgentTarget(agentName, agentTargets)
     if (agentTarget) return `custom agent \`${agentTarget}\``

--- a/src/utils/codex-content.ts
+++ b/src/utils/codex-content.ts
@@ -58,8 +58,9 @@ export function transformContentForCodex(
     return agentTarget ? `custom agent \`${agentTarget}\`` : match
   })
 
-  const slashCommandPattern = /(?<![:\w>}\]\)\/#?=])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
+  const slashCommandPattern = /https?:\/\/\S+|(?<![:\w>}\]\)\/])\/([a-z][a-z0-9_:-]*?)(?=[\s,."')\]}`]|$)/gi
   result = result.replace(slashCommandPattern, (match, commandName: string) => {
+    if (!commandName) return match
     if (isReservedPathRoot(commandName)) return match
 
     const normalizedName = normalizeCodexName(commandName)

--- a/tests/codex-content.test.ts
+++ b/tests/codex-content.test.ts
@@ -249,6 +249,21 @@ describe("transformContentForCodex", () => {
       expect(transformContentForCodex(line, emptyTargets)).toBe(line)
     })
 
+    test("preserves full URL spans while transforming commands outside them", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: { "ce-work": "ce-work" },
+      }
+      expect(
+        transformContentForCodex(
+          "See https://example.com/#!/ce-plan or https://example.com?next=(/unknown-cmd, then /ce-work",
+          targets,
+        ),
+      ).toBe(
+        "See https://example.com/#!/ce-plan or https://example.com?next=(/unknown-cmd, then the ce-work skill",
+      )
+    })
+
     test("ignores slashes preceded by a word character", () => {
       expect(
         transformContentForCodex("paths like a/b and foo/bar", emptyTargets),

--- a/tests/codex-content.test.ts
+++ b/tests/codex-content.test.ts
@@ -437,6 +437,22 @@ describe("transformContentForCodex", () => {
       )
     })
 
+    test("preserves agent-like references inside URLs while transforming outside mentions", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(
+        transformContentForCodex(
+          "See https://example.com/@security-reviewer or https://example.com?assignee=@security-reviewer, then @security-reviewer",
+          targets,
+        ),
+      ).toBe(
+        "See https://example.com/@security-reviewer or https://example.com?assignee=@security-reviewer, then custom agent `security-reviewer`",
+      )
+    })
+
     test("leaves longer hyphenated agent-like tokens unchanged", () => {
       const targets: CodexInvocationTargets = {
         promptTargets: {},

--- a/tests/codex-content.test.ts
+++ b/tests/codex-content.test.ts
@@ -1,0 +1,506 @@
+import { describe, expect, test } from "bun:test"
+import {
+  normalizeCodexName,
+  transformContentForCodex,
+  type CodexInvocationTargets,
+} from "../src/utils/codex-content"
+
+describe("normalizeCodexName", () => {
+  const cases = [
+    { input: "Security Reviewer", expected: "security-reviewer" },
+    { input: "  spaces  ", expected: "spaces" },
+    { input: "foo/bar", expected: "foo-bar" },
+    { input: "foo\\bar", expected: "foo-bar" },
+    { input: "foo:bar", expected: "foo-bar" },
+    { input: "foo bar", expected: "foo-bar" },
+    { input: "foo\nbar", expected: "foo-bar" },
+    { input: "a---b", expected: "a-b" },
+    { input: "-leading-", expected: "leading" },
+    { input: "", expected: "item" },
+    { input: "   ", expected: "item" },
+    { input: "!!!", expected: "item" },
+    { input: "UPPER_CASE", expected: "upper_case" },
+    { input: "foo.bar", expected: "foo-bar" },
+    { input: "foo@bar", expected: "foo-bar" },
+    { input: "éè", expected: "item" },
+    { input: "aéb", expected: "a-b" },
+    { input: " workflows:plan ", expected: "workflows-plan" },
+  ]
+
+  for (const { input, expected } of cases) {
+    test(`normalizes ${JSON.stringify(input)} to ${JSON.stringify(expected)}`, () => {
+      expect(normalizeCodexName(input)).toBe(expected)
+    })
+  }
+})
+
+describe("transformContentForCodex", () => {
+  const emptyTargets: CodexInvocationTargets = {
+    promptTargets: {},
+    skillTargets: {},
+  }
+
+  describe("Task agent calls", () => {
+    test("known agent with args becomes a custom-agent spawn", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("Task repo-researcher(find X)", targets)).toBe(
+        "Spawn the custom agent `repo-researcher` with task: find X",
+      )
+    })
+
+    test("known agent with zero args omits the task clause", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("Task repo-researcher()", targets)).toBe(
+        "Spawn the custom agent `repo-researcher`",
+      )
+    })
+
+    test("preserves leading list prefix", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("- Task repo-researcher(find X)", targets)).toBe(
+        "- Spawn the custom agent `repo-researcher` with task: find X",
+      )
+    })
+
+    test("unknown agent falls back to a skill invocation", () => {
+      expect(transformContentForCodex("Task repo-researcher(find X)", emptyTargets)).toBe(
+        "Use the $repo-researcher skill to: find X",
+      )
+    })
+
+    test("namespaced agent matches on the last two segments", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "research-ce-repo-researcher": "research-ce-repo-researcher" },
+      }
+      expect(
+        transformContentForCodex(
+          "Task compound-engineering:research:ce-repo-researcher(find X)",
+          targets,
+        ),
+      ).toBe("Spawn the custom agent `research-ce-repo-researcher` with task: find X")
+    })
+
+    test("namespaced agent matches on the final segment when no longer key exists", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "ce-repo-researcher": "ce-repo-researcher" },
+      }
+      expect(
+        transformContentForCodex(
+          "Task compound-engineering:research:ce-repo-researcher()",
+          targets,
+        ),
+      ).toBe("Spawn the custom agent `ce-repo-researcher`")
+    })
+
+    test("namespaced unknown agent uses the final segment as the skill name", () => {
+      expect(
+        transformContentForCodex(
+          "Task compound-engineering:research:unknown-agent(find X)",
+          emptyTargets,
+        ),
+      ).toBe("Use the $unknown-agent skill to: find X")
+    })
+
+    test("unknown agent with zero args omits the task clause", () => {
+      expect(transformContentForCodex("Task unknown-agent()", emptyTargets)).toBe(
+        "Use the $unknown-agent skill",
+      )
+    })
+
+    test("leaves uppercase agent names unchanged", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("Task Repo-Researcher(find X)", targets)).toBe(
+        "Task Repo-Researcher(find X)",
+      )
+    })
+
+    test("leaves calls missing the opening parenthesis", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("Task repo researcher(find X)", targets)).toBe(
+        "Task repo researcher(find X)",
+      )
+    })
+
+    test("leaves calls with a space before the parenthesis", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("Task repo-researcher (find X)", targets)).toBe(
+        "Task repo-researcher (find X)",
+      )
+    })
+
+    test("does not match Task calls that are not at the start of a line", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("inline Task repo-researcher(find X)", targets)).toBe(
+        "inline Task repo-researcher(find X)",
+      )
+    })
+
+    test("leaves calls with an unbalanced closing parenthesis", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("Task repo-researcher(find X", targets)).toBe(
+        "Task repo-researcher(find X",
+      )
+    })
+
+    test("stops args at the first closing parenthesis and leaves the rest intact", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(transformContentForCodex("Task repo-researcher(a(b))", targets)).toBe(
+        "Spawn the custom agent `repo-researcher` with task: a(b)",
+      )
+    })
+  })
+
+  describe("slash commands", () => {
+    test("known prompt target becomes /prompts:<target>", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: { "todo-resolve": "todo-resolve" },
+        skillTargets: {},
+      }
+      expect(transformContentForCodex("Run /todo-resolve", targets)).toBe(
+        "Run /prompts:todo-resolve",
+      )
+    })
+
+    test("known skill target becomes a skill reference", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: { "ce-plan": "ce-plan" },
+      }
+      expect(transformContentForCodex("Run /ce-plan", targets)).toBe("Run the ce-plan skill")
+    })
+
+    test("unknown slash command defaults to /prompts:<normalized>", () => {
+      expect(transformContentForCodex("Run /unknown-cmd", emptyTargets)).toBe(
+        "Run /prompts:unknown-cmd",
+      )
+    })
+
+    test("unknown slash commands are preserved when requested", () => {
+      expect(
+        transformContentForCodex("Run /unknown-cmd", emptyTargets, {
+          unknownSlashBehavior: "preserve",
+        }),
+      ).toBe("Run /unknown-cmd")
+    })
+
+    test("leaves bare reserved path roots untouched", () => {
+      const roots = ["dev", "tmp", "etc", "usr", "var", "bin", "home"]
+      for (const root of roots) {
+        const line = `config lives in /${root}.`
+        expect(transformContentForCodex(line, emptyTargets)).toBe(line)
+      }
+    })
+
+    test("leaves multi-segment absolute paths untouched", () => {
+      expect(transformContentForCodex("See /usr/local/bin/tool", emptyTargets)).toBe(
+        "See /usr/local/bin/tool",
+      )
+    })
+
+    test("leaves URL paths untouched", () => {
+      expect(
+        transformContentForCodex("Run https://example.com/path", emptyTargets),
+      ).toBe("Run https://example.com/path")
+    })
+
+    test("ignores slashes preceded by a word character", () => {
+      expect(
+        transformContentForCodex("paths like a/b and foo/bar", emptyTargets),
+      ).toBe("paths like a/b and foo/bar")
+    })
+
+    test("handles multiple slash commands in one line", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: { "ce-plan": "ce-plan", "ce-work": "ce-work" },
+      }
+      expect(transformContentForCodex("Run /ce-plan, then /ce-work.", targets)).toBe(
+        "Run the ce-plan skill, then the ce-work skill.",
+      )
+    })
+
+    test("matches slash commands case-insensitively using normalized keys", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: { plan: "workflows-plan" },
+        skillTargets: {},
+      }
+      expect(transformContentForCodex("Run /PLAN", targets)).toBe(
+        "Run /prompts:workflows-plan",
+      )
+    })
+
+    test("preserves underscores in command names", () => {
+      expect(transformContentForCodex("Run /my_command", emptyTargets)).toBe(
+        "Run /prompts:my_command",
+      )
+    })
+
+    test("transforms slash commands inside parentheses", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: { plan: "plan" },
+        skillTargets: {},
+      }
+      expect(transformContentForCodex("(see /plan)", targets)).toBe("(see /prompts:plan)")
+    })
+
+    test("transforms slash commands inside double quotes", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: { plan: "plan" },
+        skillTargets: {},
+      }
+      expect(transformContentForCodex('href="/plan"', targets)).toBe('href="/prompts:plan"')
+    })
+
+    test("consumes a trailing colon with the command name", () => {
+      expect(transformContentForCodex("Run /plan:", emptyTargets)).toBe(
+        "Run /prompts:plan",
+      )
+    })
+
+    test("transforms slash commands inside markdown links", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: { plan: "plan" },
+        skillTargets: {},
+      }
+      expect(transformContentForCodex("[link](/plan)", targets)).toBe(
+        "[link](/prompts:plan)",
+      )
+    })
+
+    test("handles namespaced slash commands that map to skills", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: { "workflows-work": "ce-work" },
+      }
+      expect(transformContentForCodex("Run /workflows:work", targets)).toBe(
+        "Run the ce-work skill",
+      )
+    })
+  })
+
+  describe("backticked agent names", () => {
+    test("matches two-segment namespaced agents", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "research-ce-repo-researcher": "research-ce-repo-researcher" },
+      }
+      expect(transformContentForCodex("`research:ce-repo-researcher`", targets)).toBe(
+        "custom agent `research-ce-repo-researcher`",
+      )
+    })
+
+    test("matches three-segment namespaced agents", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "research-ce-repo-researcher": "research-ce-repo-researcher" },
+      }
+      expect(
+        transformContentForCodex(
+          "`compound-engineering:research:ce-repo-researcher`",
+          targets,
+        ),
+      ).toBe("custom agent `research-ce-repo-researcher`")
+    })
+
+    test("does not match single-segment backticked agents", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "ce-repo-researcher": "ce-repo-researcher" },
+      }
+      expect(transformContentForCodex("`ce-repo-researcher`", targets)).toBe(
+        "`ce-repo-researcher`",
+      )
+    })
+
+    test("leaves four-segment backticked names unchanged", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "a-b-c": "a-b-c" },
+      }
+      expect(transformContentForCodex("`a:b:c:d`", targets)).toBe("`a:b:c:d`")
+    })
+
+    test("matches case-insensitively", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "research-ce-repo-researcher": "research-ce-repo-researcher" },
+      }
+      expect(transformContentForCodex("`Research:Ce-Repo-Researcher`", targets)).toBe(
+        "custom agent `research-ce-repo-researcher`",
+      )
+    })
+  })
+
+  describe("@ agent references", () => {
+    test("known @-references become custom agent mentions", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(transformContentForCodex("@security-reviewer", targets)).toBe(
+        "custom agent `security-reviewer`",
+      )
+    })
+
+    test("unknown @-references become $skill skill", () => {
+      expect(transformContentForCodex("@security-reviewer", emptyTargets)).toBe(
+        "$security-reviewer skill",
+      )
+    })
+
+    test("matches @-references case-insensitively", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(transformContentForCodex("@Security-Reviewer", targets)).toBe(
+        "custom agent `security-reviewer`",
+      )
+    })
+
+    test("transforms @-references even when preceded by a word", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(transformContentForCodex("user@security-reviewer", targets)).toBe(
+        "usercustom agent `security-reviewer`",
+      )
+    })
+
+    test("leaves @-mentions that lack the required suffix", () => {
+      expect(transformContentForCodex("@user", emptyTargets)).toBe("@user")
+    })
+
+    test("leaves namespaced @-mentions", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "ce-security-reviewer": "ce-security-reviewer" },
+      }
+      expect(
+        transformContentForCodex(
+          "@compound-engineering:review:ce-security-reviewer",
+          targets,
+        ),
+      ).toBe("@compound-engineering:review:ce-security-reviewer")
+    })
+  })
+
+  describe("path rewrites", () => {
+    test("rewrites .claude/ to .codex/", () => {
+      expect(transformContentForCodex("Read .claude/config.local.md", emptyTargets)).toBe(
+        "Read .codex/config.local.md",
+      )
+    })
+
+    test("rewrites ~/.claude/ to ~/.codex/", () => {
+      expect(
+        transformContentForCodex("Read ~/.claude/config.local.md", emptyTargets),
+      ).toBe("Read ~/.codex/config.local.md")
+    })
+
+    test("leaves .claude without a trailing slash", () => {
+      expect(transformContentForCodex("Read .claude", emptyTargets)).toBe("Read .claude")
+    })
+
+    test("leaves .claude-plugin paths alone", () => {
+      expect(
+        transformContentForCodex(
+          "Read .claude-plugin/marketplace.json",
+          emptyTargets,
+        ),
+      ).toBe("Read .claude-plugin/marketplace.json")
+    })
+
+    test("leaves uppercase .CLAUDE/ alone", () => {
+      expect(transformContentForCodex("Read .CLAUDE/config.md", emptyTargets)).toBe(
+        "Read .CLAUDE/config.md",
+      )
+    })
+
+    test("applies both home and general rewrite rules", () => {
+      expect(
+        transformContentForCodex("~/.claude/.claude/file.md", emptyTargets),
+      ).toBe("~/.codex/.codex/file.md")
+    })
+  })
+
+  describe("combined and edge-case behavior", () => {
+    test("applies Task, slash, and path transforms in order", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: { "ce-plan": "ce-plan" },
+        agentTargets: { "repo-researcher": "repo-researcher" },
+      }
+      expect(
+        transformContentForCodex(
+          "Task repo-researcher(go) then run /ce-plan from ~/.claude/config.",
+          targets,
+        ),
+      ).toBe(
+        "Spawn the custom agent `repo-researcher` with task: go then run the ce-plan skill from ~/.codex/config.",
+      )
+    })
+
+    test("degrades gracefully when targets are omitted", () => {
+      expect(transformContentForCodex("Task repo-researcher(find X)")).toBe(
+        "Use the $repo-researcher skill to: find X",
+      )
+      expect(transformContentForCodex("Run /unknown")).toBe("Run /prompts:unknown")
+    })
+
+    test("returns empty and whitespace-only bodies unchanged", () => {
+      expect(transformContentForCodex("", emptyTargets)).toBe("")
+      expect(transformContentForCodex("   ", emptyTargets)).toBe("   ")
+    })
+  })
+})

--- a/tests/codex-content.test.ts
+++ b/tests/codex-content.test.ts
@@ -405,14 +405,25 @@ describe("transformContentForCodex", () => {
       )
     })
 
-    test("transforms @-references even when preceded by a word", () => {
+    test("leaves @-mentions that are preceded by a word character", () => {
       const targets: CodexInvocationTargets = {
         promptTargets: {},
         skillTargets: {},
         agentTargets: { "security-reviewer": "security-reviewer" },
       }
       expect(transformContentForCodex("user@security-reviewer", targets)).toBe(
-        "usercustom agent `security-reviewer`",
+        "user@security-reviewer",
+      )
+    })
+
+    test("still transforms @-mentions after a non-word character", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(transformContentForCodex("(see @security-reviewer)", targets)).toBe(
+        "(see custom agent `security-reviewer`)",
       )
     })
 

--- a/tests/codex-content.test.ts
+++ b/tests/codex-content.test.ts
@@ -416,6 +416,28 @@ describe("transformContentForCodex", () => {
       )
     })
 
+    test("leaves longer hyphenated agent-like tokens unchanged", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(transformContentForCodex("@security-reviewer-helper", targets)).toBe(
+        "@security-reviewer-helper",
+      )
+    })
+
+    test("leaves agent-like tokens with a trailing digit unchanged", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(transformContentForCodex("@security-reviewer2", targets)).toBe(
+        "@security-reviewer2",
+      )
+    })
+
     test("still transforms @-mentions after a non-word character", () => {
       const targets: CodexInvocationTargets = {
         promptTargets: {},

--- a/tests/codex-content.test.ts
+++ b/tests/codex-content.test.ts
@@ -243,6 +243,12 @@ describe("transformContentForCodex", () => {
       ).toBe("Run https://example.com/path")
     })
 
+    test("leaves slash-prefixed routes inside URL queries and fragments untouched", () => {
+      const line =
+        "See https://example.com/#/ce-plan or https://example.com?next=/unknown-cmd"
+      expect(transformContentForCodex(line, emptyTargets)).toBe(line)
+    })
+
     test("ignores slashes preceded by a word character", () => {
       expect(
         transformContentForCodex("paths like a/b and foo/bar", emptyTargets),
@@ -435,6 +441,17 @@ describe("transformContentForCodex", () => {
       }
       expect(transformContentForCodex("@security-reviewer2", targets)).toBe(
         "@security-reviewer2",
+      )
+    })
+
+    test("leaves agent-like tokens with a trailing underscore unchanged", () => {
+      const targets: CodexInvocationTargets = {
+        promptTargets: {},
+        skillTargets: {},
+        agentTargets: { "security-reviewer": "security-reviewer" },
+      }
+      expect(transformContentForCodex("@security-reviewer_helper", targets)).toBe(
+        "@security-reviewer_helper",
       )
     })
 


### PR DESCRIPTION
## Summary

Codex conversion now preserves complete HTTP(S) URLs, email-like text, and longer mention-like tokens instead of partially rewriting them as commands or agents. All free-form rewrite stages share one URL-span boundary, while direct unit coverage locks down normalization and every content-transform stage.

The boundary fixes stay inside `transformContentForCodex` and preserve its public API. The resulting focused coverage reaches 100% of `src/utils/codex-content.ts` functions and lines.

## Validation

- `bun test --coverage tests/codex-content.test.ts` - 75 passed, 0 failed; `src/utils/codex-content.ts` at 100% functions and lines
- `bun run test` - 2,727 passed, 0 failed across 100 files
- `bun run release:validate` - release metadata is in sync

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this behavior runs locally during plugin conversion and is covered by deterministic focused and full-suite tests.
