### PR TITLE
fix(parser): deduplicate component dirs when manifest declares the default

### DIFF
--- a/src/parsers/claude.ts
+++ b/src/parsers/claude.ts
@@ -193,7 +193,15 @@ function resolveComponentDirs(
   for (const entry of toPathList(custom)) {
     dirs.push(resolveWithinRoot(root, entry, `${defaultDir} path`))
   }
-  return dirs
+  // Deduplicate by resolved path so a manifest that declares the default
+  // directory explicitly (e.g. `"skills": "./skills/"`) does not scan it twice.
+  const seen = new Set<string>()
+  return dirs.filter((dir) => {
+    const resolved = path.resolve(dir)
+    if (seen.has(resolved)) return false
+    seen.add(resolved)
+    return true
+  })
 }
 
 function toPathList(value?: string | string[]): string[] {

--- a/tests/claude-parser.test.ts
+++ b/tests/claude-parser.test.ts
@@ -14,6 +14,7 @@ const fixtureNames = [
   "invalid-command-path",
   "invalid-hooks-path",
   "invalid-mcp-path",
+  "default-dir-declared",
 ] as const
 const fixtures = fixtureNames.map((name) =>
   materializeClaudePluginFixture(path.join(import.meta.dir, "fixtures", name)),
@@ -25,6 +26,7 @@ const [
   invalidCommandPathRoot,
   invalidHooksPathRoot,
   invalidMcpPathRoot,
+  defaultDirDeclaredRoot,
 ] = fixtures.map((fixture) => fixture.root)
 const tempRoots: string[] = []
 
@@ -188,6 +190,11 @@ describe("loadClaudePlugin", () => {
     expect(plugin.skills.map((skill) => skill.name).sort()).toEqual(["custom-skill", "default-skill"])
     expect(plugin.hooks?.hooks.PreToolUse?.[0]?.hooks[0]?.command).toBe("echo default")
     expect(plugin.hooks?.hooks.PostToolUse?.[0]?.hooks[0]?.command).toBe("echo custom")
+  })
+
+  test("does not double-count skills when the manifest declares the default dir", async () => {
+    const plugin = await loadClaudePlugin(defaultDirDeclaredRoot)
+    expect(plugin.skills.map((skill) => skill.name).sort()).toEqual(["skill-a", "skill-b"])
   })
 
   test("rejects custom component paths that escape the plugin root", async () => {

--- a/tests/fixtures/default-dir-declared/claude-plugin/plugin.json
+++ b/tests/fixtures/default-dir-declared/claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "default-dir-declared",
+  "version": "1.0.0",
+  "skills": "./skills/"
+}

--- a/tests/fixtures/default-dir-declared/skills/skill-a/SKILL.md
+++ b/tests/fixtures/default-dir-declared/skills/skill-a/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: skill-a
+description: Skill A
+---
+
+Skill A body.

--- a/tests/fixtures/default-dir-declared/skills/skill-b/SKILL.md
+++ b/tests/fixtures/default-dir-declared/skills/skill-b/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: skill-b
+description: Skill B
+---
+
+Skill B body.


### PR DESCRIPTION
## Summary

- Deduplicate by resolved path in `resolveComponentDirs` so a manifest that declares the default directory explicitly (e.g. `"skills": "./skills/"`) does not scan it twice and double-count skills
- Add a regression fixture (`default-dir-declared`) with a manifest declaring `"skills": "./skills/"` and two skills, asserting the parser returns 2 skills, not 4

## Context

`resolveComponentDirs` always included the default dir (`root/skills`) AND any manifest-declared dir. When a manifest declares the default dir explicitly, the default dir ended up in the array twice, producing 2N skills in conversion output. This was latent on `main` because the Claude manifest did not declare the `skills` field, but it is reachable for any plugin that does.

The original version of this PR also added `"skills": "./skills/"` to `.claude-plugin/plugin.json` based on a claim that the Claude Code loader recursively scanned the entire repo tree without it. That claim was wrong — the loader scans `skills/<name>/SKILL.md` one level deep and does not pick up fixtures under `tests/fixtures/`. The manifest change has been dropped. Thanks to @tmchow for the thorough review that caught this.

## Test plan

- [x] `bun run test` — 2747 pass, 0 fail
- [x] `bun run plugin:validate` — both manifests pass `--strict`
- [x] `bun run release:validate` — in sync, 32 skills
- [x] Regression test fails without the fix (returns 4 skills), passes with it (returns 2)

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

Claude Code · claude-sonnet-4-5 (verification and code changes); review and reframing informed by prior sessions on Claude Code 2.1.220.