### PR TITLE
fix(ce-compound): read and write session logs as UTF-8 in session-history scripts

### DIFF
--- a/skills/ce-compound/scripts/session-history/extract-errors.py
+++ b/skills/ce-compound/scripts/session-history/extract-errors.py
@@ -30,6 +30,11 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+# Session logs are UTF-8; force UTF-8 I/O so Windows' cp1252 default can't crash
+# on non-Latin-1 content like emoji, smart quotes, or box-drawing (#1258).
+sys.stdin.reconfigure(encoding="utf-8", errors="replace")
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 _original_stdout = sys.stdout
 if args.output:
     sys.stdout = io.StringIO()
@@ -248,7 +253,7 @@ print(json.dumps({"_meta": True, **stats}))
 if args.output:
     body = sys.stdout.getvalue()
     sys.stdout = _original_stdout
-    with open(args.output, "w") as f:
+    with open(args.output, "w", encoding="utf-8") as f:
         f.write(body)
     bytes_written = os.path.getsize(args.output)
     print(json.dumps({"_meta": True, "wrote": args.output, "bytes": bytes_written, **stats}))

--- a/skills/ce-compound/scripts/session-history/extract-metadata.py
+++ b/skills/ce-compound/scripts/session-history/extract-metadata.py
@@ -214,7 +214,7 @@ def _extract_user_assistant_text(filepath):
     chunks = []
     try:
         objects = []
-        with open(filepath, "r", errors="replace") as f:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             for line in f:
                 try:
                     objects.append(json.loads(line.strip()))
@@ -335,7 +335,7 @@ def process_file(filepath):
     content scan cost."""
     try:
         size = os.path.getsize(filepath)
-        with open(filepath, "r") as f:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
             lines = []
             for i, line in enumerate(f):
                 if i >= MAX_LINES:

--- a/skills/ce-compound/scripts/session-history/extract-skeleton.py
+++ b/skills/ce-compound/scripts/session-history/extract-skeleton.py
@@ -37,6 +37,11 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
+# Session logs are UTF-8; force UTF-8 I/O so Windows' cp1252 default can't crash
+# on non-Latin-1 content like emoji, smart quotes, or box-drawing (#1258).
+sys.stdin.reconfigure(encoding="utf-8", errors="replace")
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 # Capture-and-redirect when --output is set: prints in the rest of the script
 # go to the buffer; at the end the buffer is written to PATH and a status
 # line is emitted to the real stdout.
@@ -569,7 +574,7 @@ print(json.dumps({"_meta": True, **stats}))
 if args.output:
     body = sys.stdout.getvalue()
     sys.stdout = _original_stdout
-    with open(args.output, "w") as f:
+    with open(args.output, "w", encoding="utf-8") as f:
         f.write(body)
     bytes_written = os.path.getsize(args.output)
     print(json.dumps({"_meta": True, "wrote": args.output, "bytes": bytes_written, **stats}))

--- a/tests/session-history-scripts.test.ts
+++ b/tests/session-history-scripts.test.ts
@@ -12,13 +12,15 @@ const FIXTURES_DIR = path.join(__dirname, "fixtures/session-history")
 async function runScript(
   scriptName: string,
   args: string[] = [],
-  stdin?: string
+  stdin?: string,
+  env?: Record<string, string>
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const scriptPath = path.join(SCRIPTS_DIR, scriptName)
   const proc = Bun.spawn(["python3", scriptPath, ...args], {
     stdin: stdin ? new TextEncoder().encode(stdin) : undefined,
     stdout: "pipe",
     stderr: "pipe",
+    ...(env ? { env: { ...process.env, ...env } } : {}),
   })
   const stdout = await new Response(proc.stdout).text()
   const stderr = await new Response(proc.stderr).text()
@@ -1436,6 +1438,118 @@ describe("extract-errors", () => {
     expect(meta._meta).toBe(true)
     expect(meta.errors_found).toBeGreaterThan(0)
     expect(meta.parse_errors).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// UTF-8 session content under a non-UTF-8 locale (issue #1258)
+//
+// Session JSONL is UTF-8, but the scripts opened files and stdio in text mode
+// without an explicit encoding, so they fell back to the platform default
+// (cp1252 on Windows, ascii under a C locale) and crashed on emoji, smart
+// quotes, or box-drawing characters. Forcing a C locale reproduces the Windows
+// failure deterministically on Linux CI: file open() defaults to ascii/strict
+// (read and write both raise), while stdio uses surrogateescape.
+// ---------------------------------------------------------------------------
+describe("UTF-8 session content under a non-UTF-8 locale (#1258)", () => {
+  // PYTHONCOERCECLOCALE=0 stops Python promoting C -> C.UTF-8; PYTHONUTF8=0
+  // keeps UTF-8 mode off, so the interpreter actually honors the C locale.
+  const NON_UTF8_LOCALE = {
+    LC_ALL: "C",
+    LANG: "C",
+    LC_CTYPE: "C",
+    PYTHONUTF8: "0",
+    PYTHONCOERCECLOCALE: "0",
+  }
+  const NON_ASCII = 'rocket 🚀 “smart” ─ box'
+
+  test("extract-metadata.py reads a UTF-8 session file without crashing", async () => {
+    const base = await Bun.file(
+      path.join(FIXTURES_DIR, "claude-session.jsonl")
+    ).text()
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ce-utf8-meta-"))
+    const file = path.join(dir, "session.jsonl")
+    fs.writeFileSync(file, base.replace("auth bug", `auth bug ${NON_ASCII}`))
+    try {
+      const { stdout, stderr, exitCode } = await runScript(
+        "extract-metadata.py",
+        [file],
+        undefined,
+        NON_UTF8_LOCALE
+      )
+      expect(stderr).not.toContain("UnicodeDecodeError")
+      expect(exitCode).toBe(0)
+      const meta = parseJsonLines(stdout).find((l) => l._meta)
+      expect(meta.files_processed).toBe(1)
+      expect(meta.parse_errors).toBe(0)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("extract-skeleton.py --output round-trips UTF-8 content without crashing", async () => {
+    const base = await Bun.file(
+      path.join(FIXTURES_DIR, "claude-session.jsonl")
+    ).text()
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ce-utf8-skel-"))
+    const out = path.join(dir, "out.txt")
+    try {
+      const { stderr, exitCode } = await runScript(
+        "extract-skeleton.py",
+        ["--output", out],
+        base.replace("auth bug", `auth bug ${NON_ASCII}`),
+        NON_UTF8_LOCALE
+      )
+      expect(stderr).not.toContain("UnicodeEncodeError")
+      expect(exitCode).toBe(0)
+      // Written as real UTF-8, not surrogate-escaped mojibake.
+      expect(fs.readFileSync(out, "utf-8")).toContain(NON_ASCII)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("extract-errors.py --output round-trips UTF-8 content without crashing", async () => {
+    const session =
+      JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "utf8-err",
+        timestamp: "2026-04-07T09:00:00.000Z",
+        cwd: "/Users/test/Code/my-repo",
+      }) +
+      "\n" +
+      JSON.stringify({
+        type: "message",
+        id: "b1",
+        parentId: null,
+        timestamp: "2026-04-07T09:02:00.000Z",
+        message: {
+          role: "bashExecution",
+          command: `bun test ${NON_ASCII}`,
+          output: "1 test failed",
+          exitCode: 1,
+          cancelled: false,
+          truncated: false,
+          timestamp: 1775542920000,
+        },
+      }) +
+      "\n"
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ce-utf8-err-"))
+    const out = path.join(dir, "out.txt")
+    try {
+      const { stderr, exitCode } = await runScript(
+        "extract-errors.py",
+        ["--output", out],
+        session,
+        NON_UTF8_LOCALE
+      )
+      expect(stderr).not.toContain("UnicodeEncodeError")
+      expect(exitCode).toBe(0)
+      expect(fs.readFileSync(out, "utf-8")).toContain(NON_ASCII)
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Problem

On Windows, `/ce-compound`'s session-history flow crashes when it reads session logs. `extract-metadata.py` opens files in text mode without an explicit encoding, so Python uses the platform default (cp1252 on Windows) and fails on the UTF-8 bytes (emoji, smart quotes) that Claude Code session JSONL regularly contains. This is issue #1258.

```
File ".../extract-metadata.py", line 340, in process_file
    for i, line in enumerate(f):
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 4838: character maps to <undefined>
```

## Root cause

The three session-history scripts assume the platform default encoding instead of UTF-8. Reproducing on native Windows (Python 3.13, cp1252 default) shows the defect has three parts that interact:

- `extract-metadata.py` reads session files with `open(filepath, "r")`. File text mode is cp1252 strict, so a non-Latin-1 byte raises `UnicodeDecodeError` (the crash above, line 338). The keyword-scan read at line 217 already has `errors="replace"`, so it doesn't crash but silently misdecodes.
- `extract-skeleton.py` and `extract-errors.py` read the session from `sys.stdin` and, in `--output` mode, write the extracted body with `open(path, "w")`. `sys.stdin` uses cp1252 with `surrogateescape`, so the read doesn't crash but yields surrogate characters; the file write is cp1252 strict, so writing those surrogates raises `UnicodeEncodeError`.

The real flow reaches both entry points. From `skills/ce-compound/SKILL.md`:

```
python3 .../extract-skeleton.py --output "$SCRATCH/<session-id>.skeleton.txt" < <session-file>
```

That one invocation both pipes the session file into stdin and writes with `--output`, so fixing only `extract-metadata.py` would leave `/ce-compound` still crashing at `extract-skeleton.py` on the same machine and content.

## Fix

- `extract-metadata.py`: read session files as `encoding="utf-8", errors="replace"` (lines 217 and 338).
- `extract-skeleton.py` / `extract-errors.py`: reconfigure `sys.stdin` and `sys.stdout` to UTF-8, and write `--output` files as UTF-8.

`sys.stdout` needs the same treatment as `sys.stdin`: once stdin decodes real characters, a stdout-mode `print()` of an emoji would otherwise crash on a cp1252 stdout. On Linux the `reconfigure` calls are a no-op. `extract-metadata.py`'s stdout is left alone because it only emits `json.dumps` output, which is ASCII.

## Tests

Adds a `#1258` block to `tests/session-history-scripts.test.ts` covering all three scripts. The tests force a C locale (`LC_ALL=C`, `PYTHONUTF8=0`, `PYTHONCOERCECLOCALE=0`) so the failure reproduces on Linux CI, where file `open()` defaults to ascii/strict and stdio uses surrogateescape, mirroring the Windows behaviour.

Each test fails on the current scripts with the `UnicodeDecodeError` / `UnicodeEncodeError` above and passes with the fix, and the extracted content round-trips as real UTF-8 rather than surrogate escaped mojibake. `runScript` gains an optional `env` argument while the existing callers are unchanged.

## Notes

- `discover-sessions.sh` is a shell script and isn't affected by this encoding class.
- `errors="replace"` on the reads matches the reporter's suggestion and the existing `extract-metadata.py:217` pattern, so a genuinely malformed byte degrades to a replacement character instead of crashing again.
