### PR TITLE
fix(skills): force LF line endings on bundled shell and python scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 # or Linux bash. See #1251.
 *.sh text eol=lf
 *.py text eol=lf
+
+# Bundled scripts with no extension (shebang bash/python) need the same pin.
+skills/ce-babysit-pr/scripts/pr-snapshot text eol=lf
+skills/ce-resolve-pr-feedback/scripts/* text eol=lf
+skills/ce-setup/scripts/check-health text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Bundled skill scripts run under POSIX bash/python; force LF so a CRLF
+# checkout (e.g. core.autocrlf=true on Windows) can't break them under WSL
+# or Linux bash. See #1251.
+*.sh text eol=lf
+*.py text eol=lf

--- a/tests/bundled-script-line-endings.test.ts
+++ b/tests/bundled-script-line-endings.test.ts
@@ -1,34 +1,61 @@
 import { describe, expect, test } from "bun:test"
+import fs from "fs"
 import path from "path"
 
 const REPO_ROOT = path.join(__dirname, "..")
 
-// Bundled .sh/.py scripts are executed by POSIX bash/python. A CRLF-committed
-// script fails under WSL/Linux bash before its own logic runs ($'\r': command
-// not found), and the file-existence guards skills use don't catch it because
-// the file exists — it just doesn't parse (issue #1251). .gitattributes pins
-// these to eol=lf; this guards the invariant against a future CRLF commit.
-//
-// The check reads the git index eol (i/...), not the working tree (w/...): the
-// index is what ships and is identical on every platform, whereas the working
-// tree eol depends on the checkout's core.autocrlf.
-describe("bundled script line endings (#1251)", () => {
-  test("no tracked .sh/.py script has CRLF line endings in the index", async () => {
-    const proc = Bun.spawn(
-      ["git", "ls-files", "--eol", "--", "*.sh", "*.py"],
-      { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" }
-    )
-    const stdout = await new Response(proc.stdout).text()
-    expect(await proc.exited).toBe(0)
+async function git(args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd: REPO_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const stdout = await new Response(proc.stdout).text()
+  expect(await proc.exited).toBe(0)
+  return stdout
+}
 
+// A bundled bash/python script: .sh/.py by extension, or extensionless with a
+// bash/python shebang. Other-runtime scripts (e.g. a #!/usr/bin/env node file
+// run via `node`) are excluded: bash never parses them and node tolerates CRLF.
+function isBundledPosixScript(relPath: string): boolean {
+  if (relPath.endsWith(".sh") || relPath.endsWith(".py")) return true
+  const base = relPath.split("/").pop() || ""
+  if (base.includes(".")) return false
+  try {
+    const firstLine = fs
+      .readFileSync(path.join(REPO_ROOT, relPath), "latin1")
+      .split("\n", 1)[0]
+    return /^#!.*\b(sh|bash|dash|python[0-9.]*)\b/.test(firstLine)
+  } catch {
+    return false
+  }
+}
+
+// Bundled scripts are executed by POSIX bash/python; a CRLF checkout breaks
+// them before their own logic runs (issue #1251). The fix is .gitattributes
+// eol=lf, which governs checkout, so this asserts the resolved eol attribute
+// (git check-attr) rather than the current index bytes. That way it fails if
+// .gitattributes is removed or a script (including extensionless ones) is left
+// uncovered, which a raw byte scan would not catch.
+describe("bundled script line endings (#1251)", () => {
+  test("every bundled bash/python script resolves to eol=lf", async () => {
+    const scripts = (await git(["ls-files", "--", "skills"]))
+      .split("\n")
+      .filter(Boolean)
+      .filter(isBundledPosixScript)
+
+    // Enumeration sanity: the bundled scripts were actually found.
+    expect(scripts.length).toBeGreaterThan(30)
+
+    // check-attr -z emits NUL-separated (path, "eol", value) triples.
+    const fields = (
+      await git(["check-attr", "-z", "eol", "--", ...scripts])
+    ).split("\0")
     const offenders: string[] = []
-    for (const line of stdout.split("\n")) {
-      if (!line.trim()) continue
-      // Format: "i/<eol>\tw/<eol>\tattr/<attr>\t<path>"
-      const [attrs, filePath] = line.split("\t")
-      const indexEol = attrs.trim().split(/\s+/)[0] // e.g. "i/lf", "i/crlf", "i/none"
-      if (indexEol === "i/crlf" || indexEol === "i/mixed") {
-        offenders.push(`${filePath} (${indexEol})`)
+    for (let i = 0; i + 2 < fields.length; i += 3) {
+      if (fields[i + 2] !== "lf") {
+        offenders.push(`${fields[i]} (eol=${fields[i + 2]})`)
       }
     }
 

--- a/tests/bundled-script-line-endings.test.ts
+++ b/tests/bundled-script-line-endings.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+
+const REPO_ROOT = path.join(__dirname, "..")
+
+// Bundled .sh/.py scripts are executed by POSIX bash/python. A CRLF-committed
+// script fails under WSL/Linux bash before its own logic runs ($'\r': command
+// not found), and the file-existence guards skills use don't catch it because
+// the file exists — it just doesn't parse (issue #1251). .gitattributes pins
+// these to eol=lf; this guards the invariant against a future CRLF commit.
+//
+// The check reads the git index eol (i/...), not the working tree (w/...): the
+// index is what ships and is identical on every platform, whereas the working
+// tree eol depends on the checkout's core.autocrlf.
+describe("bundled script line endings (#1251)", () => {
+  test("no tracked .sh/.py script has CRLF line endings in the index", async () => {
+    const proc = Bun.spawn(
+      ["git", "ls-files", "--eol", "--", "*.sh", "*.py"],
+      { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" }
+    )
+    const stdout = await new Response(proc.stdout).text()
+    expect(await proc.exited).toBe(0)
+
+    const offenders: string[] = []
+    for (const line of stdout.split("\n")) {
+      if (!line.trim()) continue
+      // Format: "i/<eol>\tw/<eol>\tattr/<attr>\t<path>"
+      const [attrs, filePath] = line.split("\t")
+      const indexEol = attrs.trim().split(/\s+/)[0] // e.g. "i/lf", "i/crlf", "i/none"
+      if (indexEol === "i/crlf" || indexEol === "i/mixed") {
+        offenders.push(`${filePath} (${indexEol})`)
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

Every bundled `.sh` / `.py` script under `skills/**/scripts/` can end up with CRLF line endings on a Windows checkout, and the repo has no `.gitattributes` to prevent it. When such a script runs under a POSIX (non-MSYS) `bash`, which on Windows is what `bash` resolves to when WSL is installed and Git Bash isn't on PATH, the trailing `\r` breaks it before its own logic runs. This is issue #1251.

```
discover-sessions.sh: line 15: $'\r': command not found
discover-sessions.sh: line 16: set: pipefail: invalid option name
```

The file-existence guards these skills use don't help here: the script exists, it just doesn't parse.

## Root cause

The committed source is already LF (`git ls-files --eol` reports `i/lf` for every script), but nothing pins it there. With no `.gitattributes`, a contributor's `core.autocrlf=true`, or a checkout that applies it, can turn these executable scripts into CRLF, and the shipped copy then breaks under WSL/Linux bash.

## Fix

Add a `.gitattributes` that pins the bundled bash/python scripts to LF. That means `*.sh` and `*.py`, plus the extensionless shebang scripts under `ce-setup`, `ce-resolve-pr-feedback`, and `ce-babysit-pr` that the extension globs would miss:

```
*.sh text eol=lf
*.py text eol=lf
skills/ce-babysit-pr/scripts/pr-snapshot text eol=lf
skills/ce-resolve-pr-feedback/scripts/* text eol=lf
skills/ce-setup/scripts/check-health text eol=lf
```

Because the index is already LF, this adds no renormalization churn; it just guarantees LF survives any checkout config from here on. `git check-attr` confirms the rule now applies (`eol: lf`), and a fresh checkout writes LF even under `core.autocrlf=true`.

## Test

Adds `tests/bundled-script-line-endings.test.ts`, a guard that asserts the resolved `eol` attribute (`git check-attr`) for every bundled bash/python script, enumerating them by extension and by shebang so extensionless scripts are covered. It checks the checkout behaviour the fix controls rather than the current index bytes, so it fails if `.gitattributes` is removed or a script is left uncovered. Green now; verified red when a script is uncovered.

## Notes

- The issue also flags a second trap: workflow instructions that build a `bash scripts/...` invocation with the host's native path separator break under a WSL-backed `bash` (which needs a `/mnt/<drive>/...` path). That is a separate docs/invocation change and overlaps #944, so I have left it out of this PR to keep the fix focused.
- Scope covers bundled bash/python scripts. `visual-probe-server.js` is left out: it is run via `node`, which tolerates CRLF, and it isn't executed directly. A broader `* text=auto` default could be a follow-up if you want repo-wide normalization.
