### PR TITLE
ci(plugin-validate): validate on claude-code 2.1.220 with a cached binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       # --strict stays green; see AGENTS.md "CI and Quality Gates".
       - name: Validate plugin schema (claude plugin validate)
         run: |
-          npm install -g @anthropic-ai/claude-code@2.1.175
+          npm install -g @anthropic-ai/claude-code@2.1.220
           bun run plugin:validate
 
       # Runs the package `test` script so the flags CI uses and the flags a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    env:
+      # Single source of truth for the pinned `claude plugin validate` version:
+      # both the install and its cache key read this, so a bump cannot bump one
+      # and leave the other serving a stale cached binary.
+      CLAUDE_CODE_VERSION: 2.1.220
+
     steps:
       - uses: actions/checkout@v6
         # Full history so release:validate can read the base-branch (origin/main)
@@ -68,9 +74,29 @@ jobs:
       # plugin:validate must hit .claude-plugin/plugin.json — `validate .` only
       # checks the marketplace. Root CLAUDE.md is a symlink to AGENTS.md so
       # --strict stays green; see AGENTS.md "CI and Quality Gates".
+      #
+      # The install is cached because the npm package is a 165KB wrapper whose
+      # postinstall pulls a platform binary (`@anthropic-ai/claude-code-linux-x64`,
+      # ~275MB unpacked). Registry throughput for that payload is the whole cost
+      # of this step — validation itself is under a second. Observed range on
+      # ubuntu-latest: 3-10s typical, 5m worst case. Caching buys predictability,
+      # not average speed: it caps the tail rather than beating the fast path.
+      # Keying on the pinned version means a hit on every run between bumps.
+      - name: Cache claude-code validator
+        id: cache-claude-code
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm-global
+          key: claude-code-${{ runner.os }}-${{ env.CLAUDE_CODE_VERSION }}
+
+      - name: Install claude-code validator
+        if: steps.cache-claude-code.outputs.cache-hit != 'true'
+        run: npm install -g --prefix ~/.npm-global @anthropic-ai/claude-code@${{ env.CLAUDE_CODE_VERSION }}
+
       - name: Validate plugin schema (claude plugin validate)
         run: |
-          npm install -g @anthropic-ai/claude-code@2.1.220
+          export PATH="$HOME/.npm-global/bin:$PATH"
+          claude --version
           bun run plugin:validate
 
       # Runs the package `test` script so the flags CI uses and the flags a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       # Keying on the pinned version means a hit on every run between bumps.
       - name: Cache claude-code validator
         id: cache-claude-code
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.npm-global
           key: claude-code-${{ runner.os }}-${{ env.CLAUDE_CODE_VERSION }}


### PR DESCRIPTION
## Summary

CI's plugin-schema gate now runs on Claude Code 2.1.220 instead of 2.1.175, so `--strict` rules added upstream over that range are enforced on merge rather than discovered later. Both `claude plugin validate --strict` calls pass clean on 2.1.220 with no compensating repo change needed, so this is a pure adoption of the newer validator.

The validator install is also no longer unbounded. The npm package is a 165KB wrapper whose postinstall pulls a platform binary (`@anthropic-ai/claude-code-linux-x64`, ~275MB unpacked), so registry throughput was the entire cost of the step — the validation itself finishes in under a second. Measured on `ubuntu-latest`: 3-10s across 19 consecutive runs, then 5m21s on one. Caching keyed on the pinned version hits on every run between deliberate bumps.

Worth being clear about what this does and doesn't buy: it caps the tail rather than beating the fast path. A ~275MB cache restore is roughly comparable to the 4s happy-path download, so the win is predictability, not average CI time. The pin moves into a job-level `CLAUDE_CODE_VERSION` so a future bump cannot update the install while leaving the cache key serving a stale binary.

## Validation

Ran locally against 2.1.220 before bumping: `claude plugin validate --strict` passes on both `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json`.

Exercised the prefixed install path the cache depends on (`npm install -g --prefix ~/.npm-global`): `bin/claude` lands as a relative symlink into `../lib/node_modules/...`, so the tree is self-contained and survives being tarred and restored by `actions/cache`. `bun run plugin:validate` passes with only that prefix on `PATH`. CI on this PR is the real proof of the cold-miss then warm-hit sequence.

`actions/cache@v6` was checked against its `action.yml` at `v6`: same `path`/`key` inputs and `cache-hit` output as v4, and v6.0.0's only change was an ESM migration.

## Security Disclosure

No security-relevant changes. No new shell/exec, path, or credential handling; the validator is still installed from the same pinned npm package, now into a user-local prefix instead of the system global prefix.

## Agent Disclosure
- **Model:** `Claude Code · claude-opus-5[1m]`
