### PR TITLE
fix(review): enumerate valid CROSS_MODEL_FIXED_ROUTE tokens

### DIFF
--- a/skills/ce-code-review/references/cross-model-review.md
+++ b/skills/ce-code-review/references/cross-model-review.md
@@ -33,7 +33,17 @@ Resolve the preference in this order:
 3. A preference already in your **project instructions** (the active instructions in your context) — consumed from context, **never** read from a named file.
 4. **Default:** first available attested-different target in `codex → claude → grok → composer`; Cursor-default participates only when explicitly preferred.
 
-Before egress, resolve the target to one concrete installed route, verify every recipient against `CROSS_MODEL_PEERS`, announce it, and pass it as `CROSS_MODEL_FIXED_ROUTE`. A failed route returns no artifact and never changes provider or intermediary internally. A retry is a new disclosed and sanctioned dispatch. For backward compatibility, either `cursor` or `composer` in `CROSS_MODEL_PEERS` sanctions Cursor as an intermediary, but selecting Cursor-default requires target `cursor`; `grok` alone never sanctions Grok-via-Cursor.
+Before egress, resolve the target to one concrete installed route, verify every recipient against `CROSS_MODEL_PEERS`, announce it, and pass it as `CROSS_MODEL_FIXED_ROUTE`. `CROSS_MODEL_FIXED_ROUTE` accepts exactly these tokens — the worker fail-closes on anything else (including route-shaped guesses like `codex-cli`):
+
+| Target | Route token(s) |
+|--------|----------------|
+| `codex` | `codex` |
+| `claude` | `claude` |
+| `grok` | `grok-cli` (native CLI) or `grok-cursor` (via Cursor intermediary) |
+| `cursor` | `cursor` |
+| `composer` | `composer` |
+
+A failed route returns no artifact and never changes provider or intermediary internally. A retry is a new disclosed and sanctioned dispatch. For backward compatibility, either `cursor` or `composer` in `CROSS_MODEL_PEERS` sanctions Cursor as an intermediary, but selecting Cursor-default requires target `cursor`; `grok` alone never sanctions Grok-via-Cursor.
 
 `CROSS_MODEL_PEERS` is an optional restriction: when unset, it leaves the resolved route unfiltered and this skill invocation plus the concrete pre-egress disclosure sanctions that route; when set, the selected target/intermediary must appear. Use this contract directly. Do not inspect the worker source to rediscover its allowlist behavior.
 
@@ -94,7 +104,7 @@ The nested windows are one budget with one knob, `CROSS_MODEL_HARD_SECS`. Resolv
 
 - `<run-id>` = the Stage 3d run id (the same one that forms `<run-dir>`); job state lives under `<run-dir>/jobs/<job-id>/`.
 - `<host-serving-family>` is `codex`, `claude`, `grok`, `composer`, or `unknown`; `<host-harness>` is `codex`, `claude`, `grok`, `cursor`, or `unknown`.
-- `<target>` is one of `codex`, `claude`, `grok`, `cursor`, or `composer`; `<fixed-route>` is its already-sanctioned concrete route.
+- `<target>` is one of `codex`, `claude`, `grok`, `cursor`, or `composer`; `<fixed-route>` is its already-sanctioned concrete route token from the Step 1 table (`codex`, `claude`, `grok-cli`, `grok-cursor`, `cursor`, or `composer`).
 - `<base-ref>` = the Stage 1 `BASE` (the diff base the peer reviews via `git diff <base-ref>`).
 - `<run-dir>` = the absolute Stage 4 run dir. The script writes `adversarial-<provider>.json` there **only after** forcing `reviewer` to `adversarial-<provider>` and downgrading peer `safe_auto` → `gated_auto`.
 

--- a/skills/ce-doc-review/references/cross-model-review.md
+++ b/skills/ce-doc-review/references/cross-model-review.md
@@ -32,7 +32,17 @@ Resolve the preference in this order:
 3. A preference already in your **project instructions** (the active instructions in your context) — consumed from context, **never** read from a named file.
 4. **Default:** first available attested-different target in `codex → claude → grok → composer`; Cursor-default participates only when explicitly preferred.
 
-Before content egresses, resolve each selected target to one concrete installed route, verify every recipient against `CROSS_MODEL_PEERS`, announce it, and pass it as `CROSS_MODEL_FIXED_ROUTE`. A failed dispatched route returns no artifact; it never changes provider or intermediary internally. A retry is a new host decision and requires disclosure/sanction before dispatch. For backward compatibility, either `cursor` or `composer` in `CROSS_MODEL_PEERS` sanctions Cursor as an intermediary, but selecting a Cursor-default voice itself requires target `cursor`; `grok` alone never sanctions Grok-via-Cursor.
+Before content egresses, resolve each selected target to one concrete installed route, verify every recipient against `CROSS_MODEL_PEERS`, announce it, and pass it as `CROSS_MODEL_FIXED_ROUTE`. `CROSS_MODEL_FIXED_ROUTE` accepts exactly these tokens — the worker fail-closes on anything else (including route-shaped guesses like `codex-cli`):
+
+| Target | Route token(s) |
+|--------|----------------|
+| `codex` | `codex` |
+| `claude` | `claude` |
+| `grok` | `grok-cli` (native CLI) or `grok-cursor` (via Cursor intermediary) |
+| `cursor` | `cursor` |
+| `composer` | `composer` |
+
+A failed dispatched route returns no artifact; it never changes provider or intermediary internally. A retry is a new host decision and requires disclosure/sanction before dispatch. For backward compatibility, either `cursor` or `composer` in `CROSS_MODEL_PEERS` sanctions Cursor as an intermediary, but selecting a Cursor-default voice itself requires target `cursor`; `grok` alone never sanctions Grok-via-Cursor.
 
 Preferred model mappings run first. Only after the preferred ID is observed unavailable, obsolete, or incompatible may the host inspect current CLI capabilities and choose the closest compatible **same-target/same-family** replacement. Bind it with both `CROSS_MODEL_MODEL_OVERRIDE_TARGET=<target>` and `CROSS_MODEL_MODEL_OVERRIDE=<model-id>`. Never substitute across families, apply one target's override to another route, silently change an explicit model, or add a recipient.
 
@@ -92,7 +102,7 @@ The nested windows are one budget with one knob, `CROSS_MODEL_HARD_SECS`. Resolv
 Omit `--result-path`; `done` means only that the worker exited. The fixed target determines the expected `<reviewer-name>-<target>.json` filename.
 
 - `<host-serving-family>` is `codex`, `claude`, `grok`, `composer`, or `unknown`; `<host-harness>` is `codex`, `claude`, `grok`, `cursor`, or `unknown`.
-- `<target>` is exactly one of `codex`, `claude`, `grok`, `cursor`, or `composer`; `<fixed-route>` is its already-sanctioned route (`grok-cli` and `grok-cursor` remain distinct).
+- `<target>` is exactly one of `codex`, `claude`, `grok`, `cursor`, or `composer`; `<fixed-route>` is its already-sanctioned concrete route token from the Step 1 table (`codex`, `claude`, `grok-cli`, `grok-cursor`, `cursor`, or `composer`).
 - `<reviewer-name>` = the activated lens (`security-lens`, `adversarial`, or `product-lens`). The script derives the persona-brief filename and (per provider) model from this allowlisted value — the brief path is never caller-controlled.
 - `<document-path>` = the document under review.
 - `<document-type>` = the Phase 1 classification (`requirements` / `plan` / `unified-requirements` / `unified-plan`).

--- a/skills/ce-pov/references/cross-model-panel.md
+++ b/skills/ce-pov/references/cross-model-panel.md
@@ -134,6 +134,17 @@ For each peer:
    intermediary. Confirm every actual recipient is in the egress allowlist.
 5. Announce the selected target and route in ordinary language before dispatch.
 
+The fixed route passed to the worker accepts exactly these tokens — the worker
+fail-closes on anything else (including route-shaped guesses like `codex-cli`):
+
+| Target | Route token(s) |
+|--------|----------------|
+| `codex` | `codex` |
+| `claude` | `claude` |
+| `grok` | `grok-cli` (native CLI) or `grok-cursor` (via Cursor intermediary) |
+| `cursor` | `cursor` |
+| `composer` | `composer` |
+
 Binary presence proves only that a route is a candidate. Use an available
 non-egressing authentication or capability probe when the harness exposes one,
 and do not call a route usable until it returns a valid artifact. Classify a

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -1121,12 +1121,21 @@ describe("cross-model peer skip legibility", () => {
     },
   ]
 
-  // The route-token vocabulary lives in the worker's route_target() case, but
-  // the reference forbids inspecting worker source — so the reference must
-  // enumerate every accepted CROSS_MODEL_FIXED_ROUTE token itself (issue
-  // #1282: an orchestrator guessed `codex-cli` and wasted a dispatch cycle).
-  for (const { worker, reference } of pairs) {
-    test(`${reference} enumerates the worker's accepted CROSS_MODEL_FIXED_ROUTE tokens`, async () => {
+  // The route-token vocabulary lives in each worker's route_target() case, but
+  // the references forbid inspecting worker source — so each reference must
+  // enumerate every accepted fixed-route token itself (issue #1282: an
+  // orchestrator guessed `codex-cli` and wasted a dispatch cycle). ce-pov
+  // shares the vocabulary but not the review-worker internals the rest of
+  // this describe pins, so it joins only this parity check.
+  const routeTokenPairs = [
+    ...pairs,
+    {
+      worker: "skills/ce-pov/scripts/cross-model-pov.sh",
+      reference: "skills/ce-pov/references/cross-model-panel.md",
+    },
+  ]
+  for (const { worker, reference } of routeTokenPairs) {
+    test(`${reference} enumerates the worker's accepted fixed-route tokens`, async () => {
       const workerSrc = await readRepoFile(worker)
       const caseBody = workerSrc.match(/route_target\(\) \{\s*case "\$1" in([\s\S]*?)esac/)?.[1]
       expect(caseBody).toBeTruthy()

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -1121,6 +1121,28 @@ describe("cross-model peer skip legibility", () => {
     },
   ]
 
+  // The route-token vocabulary lives in the worker's route_target() case, but
+  // the reference forbids inspecting worker source — so the reference must
+  // enumerate every accepted CROSS_MODEL_FIXED_ROUTE token itself (issue
+  // #1282: an orchestrator guessed `codex-cli` and wasted a dispatch cycle).
+  for (const { worker, reference } of pairs) {
+    test(`${reference} enumerates the worker's accepted CROSS_MODEL_FIXED_ROUTE tokens`, async () => {
+      const workerSrc = await readRepoFile(worker)
+      const caseBody = workerSrc.match(/route_target\(\) \{\s*case "\$1" in([\s\S]*?)esac/)?.[1]
+      expect(caseBody).toBeTruthy()
+      const tokens = [...caseBody!.matchAll(/^\s*([a-z|-]+)\)/gm)]
+        .flatMap((m) => m[1].split("|"))
+      expect(tokens.length).toBeGreaterThanOrEqual(6)
+
+      const ref = await readRepoFile(reference)
+      expect(ref).toContain("accepts exactly these tokens")
+      const tableRows = ref.split("\n").filter((line) => line.startsWith("|"))
+      for (const token of tokens) {
+        expect(tableRows.some((row) => row.includes(`\`${token}\``))).toBe(true)
+      }
+    })
+  }
+
   // A fixed route succeeded only
   // when it returned a reviewer-shaped object with a top-level `findings` array
   // — not merely any valid JSON. Accepting an error/envelope object (e.g. a grok


### PR DESCRIPTION
## Summary

Fixes #1282.

The cross-model references in `ce-code-review`, `ce-doc-review`, and `ce-pov` told the orchestrator to resolve and pass a "concrete route" (as `CROSS_MODEL_FIXED_ROUTE` or the worker's fixed-route argument) without ever listing the valid tokens. The vocabulary exists only in each worker's `route_target()` case (`codex|claude|cursor|composer|grok-cli|grok-cursor`), and the references explicitly forbid inspecting the worker source. In a real run the orchestrating model guessed `codex-cli`; the worker correctly fail-closed ("host must resolve one fixed route before egress; skipping") and a peer dispatch cycle was wasted before retrying with `codex`.

## Changes

- Add a target → route-token table to Step 1 of `ce-code-review`'s `references/cross-model-review.md`, immediately where it instructs passing `CROSS_MODEL_FIXED_ROUTE`, with an explicit note that the worker fail-closes on anything else (including route-shaped guesses like `codex-cli`). Cite the table from the Step 4 `<fixed-route>` variable description.
- Mirror the same table and Step 4 citation into `ce-doc-review`'s `references/cross-model-review.md` — its worker has the identical `route_target()` vocabulary and the same missing enumeration (review follow-up).
- Add the same table to the route-resolution section of `ce-pov`'s `references/cross-model-panel.md` — its panel worker shares the identical six-token vocabulary and fail-closed gate (review follow-up).
- Add a reference↔worker parity test in `tests/review-skill-contract.test.ts` that extracts the accepted tokens from each of the three workers' `route_target()` cases and asserts the paired reference enumerates them, so no reference can drift from its worker's vocabulary again.

The workers' fail-closed behavior is correct and unchanged.

## Validation

`bun run test` green (2843 pass across 105 files). The new parity test fails against the pre-fix `ce-doc-review` and `ce-pov` references and passes after the mirrors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHtLK3iajaiQyr7tX9vYuc

## Security Disclosure

No security-relevant changes — documentation and tests only; the workers' fail-closed route gate is unchanged.

## Agent Disclosure

- **Model:** Claude Code (original PR by @npwalker; specific model not stated) · Claude Code · claude-fable-5 (maintainer follow-up: ce-doc-review/ce-pov mirrors + parity test)
