### PR TITLE
fix(ce-babysit-pr): run the watcher on native Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,11 +104,14 @@ jobs:
       - name: Run tests
         run: bun run test
 
-  # Focused Windows gate for peer-job-runner (#1243). Not a full-suite matrix:
-  # POSIX lifecycle tests (fork/killpg/ps) stay on ubuntu-latest. This job runs
-  # the cross-platform unit fixture under real win32 plus a smoke that hits
-  # Job Objects / DETACHED_PROCESS / bare-.sh wrap — the paths Mac cannot prove.
-  peer-job-runner-windows:
+  # Focused Windows gate for the skill scripts that reach for POSIX process and
+  # file primitives: peer-job-runner (#1243) and ce-babysit-pr's pr-snapshot
+  # (#1280). Not a full-suite matrix — POSIX lifecycle tests (fork/killpg/ps)
+  # stay on ubuntu-latest. This job runs the cross-platform fixtures under real
+  # win32, which is the only way to execute the msvcrt/ctypes branches at all:
+  # they are imported solely under sys.platform == "win32", so no amount of
+  # patching reaches them from Linux or Mac.
+  windows-native:
     runs-on: windows-latest
 
     steps:
@@ -144,3 +147,6 @@ jobs:
 
       - name: Peer-job-runner parity
         run: bun test tests/peer-job-runner-parity.test.ts
+
+      - name: pr-snapshot platform primitives
+        run: python tests/fixtures/pr-snapshot-platform.py

--- a/docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md
+++ b/docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md
@@ -2,7 +2,7 @@
 title: "Porting POSIX process supervision to native Windows: the primitives that fail silently"
 date: 2026-07-24
 category: architecture-patterns
-module: "skills (peer-job-runner.py, byte-duplicated across ce-doc-review, ce-code-review, ce-pov, ce-work, ce-plan, ce-brainstorm)"
+module: "skills (peer-job-runner.py, byte-duplicated across ce-doc-review, ce-code-review, ce-pov, ce-work, ce-plan, ce-brainstorm; ce-babysit-pr/scripts/pr-snapshot)"
 problem_type: architecture_pattern
 component: tooling
 severity: high
@@ -12,7 +12,10 @@ applies_when:
   - "Reading or writing bytes through os.open on Windows (result artifacts, logs, caches)"
   - "Reimplementing a uid/mode-based file-ownership or privacy check on Windows"
   - "A worker's child processes survive teardown on Windows but not on macOS/Linux"
-tags: [windows, cross-platform, process-supervision, job-objects, taskkill, ctypes, file-ownership, o-binary, detached-jobs]
+  - "Replacing fcntl.flock with a Windows file lock, or relying on a shared/read lock"
+  - "Replacing a `ps`-based process-identity or start-time probe used as a PID-reuse guard"
+  - "os.replace raises PermissionError on Windows but never on macOS/Linux"
+tags: [windows, cross-platform, process-supervision, job-objects, taskkill, ctypes, file-ownership, o-binary, detached-jobs, file-locking, msvcrt, pid-reuse, atomic-rename]
 ---
 
 # Porting POSIX process supervision to native Windows: the primitives that fail silently
@@ -132,6 +135,43 @@ user-supplied root the way an unconditional `chmod 0700` safely would.
 - Resolve `icacls`/`taskkill` by absolute `%SystemRoot%\System32` path: `CreateProcess`
   searches the application and current directories before System32, so bare names are a
   binary-hijack surface.
+
+### 5. State files: locking, identity, and rename
+
+`ce-babysit-pr`'s `pr-snapshot` watcher hit the same family from a different angle (issue
+#1280). It needed no fork or job object at all — only a lock, a start-time probe, and a
+rename — and all three still differ.
+
+**`fcntl.flock` -> `msvcrt.locking`, with three semantic changes.** It locks a byte range
+**from the current file offset**, not the whole file, so the offset must be pinned (seek to
+0, lock 1 byte) or an unlock at a different offset silently leaves the range held. It has
+**no shared mode** — every holder is exclusive, so a POSIX `LOCK_SH` reader has to become a
+writer, which is free only if critical sections are short. And its blocking mode `LK_LOCK`
+**gives up after ~10 seconds** (1s × 10 retries) rather than waiting, so the faithful
+translation of "block until the holder releases" is a retry loop around the *non-blocking*
+`LK_NBLCK`, not `LK_LOCK`. Also: do not acquire the lock through a truncating `open(path,
+"w")` — on Windows, truncating a file another process holds a byte-range lock on fails, so
+lock acquisition becomes the race it was meant to prevent. Use `os.open(..., O_RDWR |
+O_CREAT)`.
+
+**`ps -o lstart=` -> `GetProcessTimes`.** A PID-reuse guard needs process *creation time*;
+Windows recycles PIDs aggressively, so this matters more there, not less. `OpenProcess`
+with `PROCESS_QUERY_LIMITED_INFORMATION` plus `GetProcessTimes` is the analog, with
+`QueryFullProcessImageNameW` standing in for `command=`. Two asymmetries: Windows keeps an
+exited process openable while any handle to it remains, so a "dead" pid can still yield an
+identity (harmless if you compare identities rather than test existence); and
+`QueryFullProcessImageNameW` fails on an exited process, so the image half goes empty while
+the creation-time half stays valid. Guard the POSIX branch too — a missing `ps` raises
+`FileNotFoundError`, it does not return nonzero.
+
+**`os.replace` is not unconditional.** POSIX rename succeeds over an open destination;
+Windows refuses with `PermissionError` while any other handle to the destination is open.
+Any unlocked best-effort reader — or a virus scanner — turns a routine concurrent read into
+a *crashed writer*, and it is timing-dependent, so it passes every local test. Retry the
+rename briefly instead of treating the sharing violation as failure.
+
+Note that a lock file used only for locking moves no bytes, so item 2's `O_BINARY` does not
+apply to it. Apply that rule by whether the descriptor carries data, not by platform.
 
 ## Why This Matters
 

--- a/skills/ce-babysit-pr/scripts/pr-snapshot
+++ b/skills/ce-babysit-pr/scripts/pr-snapshot
@@ -36,12 +36,21 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
+import time
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from urllib.parse import quote, urlsplit
+
+IS_WINDOWS = sys.platform == "win32"
+
+if IS_WINDOWS:
+    import msvcrt
+else:
+    import fcntl
 
 # Conclusions that mean "this check needs attention" (failing states).
 FAILING = {"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"}
@@ -95,6 +104,142 @@ DEFAULT_INVOCATION_BUDGET_SECONDS = 8 * 60 * 60
 DEAD_TIME_THRESHOLD_SECONDS = 15 * 60
 DEFAULT_INVOCATION_BACKSTOP_SECONDS = 3 * 24 * 60 * 60
 CURRENCY_RETRY_BACKOFF_SECONDS = 30
+
+
+# --- cross-platform state primitives ------------------------------------------
+#
+# The watcher needs three POSIX facilities that native Windows Python does not
+# have: an advisory file lock (fcntl.flock), a process-identity probe for the
+# PID-reuse guard (`ps -o lstart=`), and an unconditional rename. Each Windows
+# analog differs in a way that matters here, so each is named rather than
+# translated literally. See
+# docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md.
+
+# Poll spacing while waiting on a Windows lock or a blocked rename.
+_WIN_RETRY_SECONDS = 0.05
+# Bound only the rename retry. A lock wait is unbounded, matching flock.
+_WIN_REPLACE_TIMEOUT_SECONDS = 10.0
+
+if IS_WINDOWS:
+    import ctypes
+    from ctypes import wintypes
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+    # Declare argtypes/restype explicitly: without them ctypes truncates HANDLEs
+    # to 32-bit ints on Win64, so a valid handle silently becomes a bad one.
+    _kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+    _kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE, ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME), ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME)]
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
+    _kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
+
+    def _win_process_identity(pid):
+        """Creation time plus image path — the Windows analog of `ps -o lstart= -o command=`.
+
+        Creation time is the part that makes this a PID-reuse guard: Windows recycles PIDs
+        aggressively, and a recycled PID always carries a later creation time than the watcher
+        we recorded. Returns None when the process is gone or unopenable, which the caller
+        treats as "identity not proven" and declines to act on."""
+        handle = _kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            if not started:
+                return None
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = (buf.value if _kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size)) else "")
+        finally:
+            _kernel32.CloseHandle(handle)
+        return "{} {}".format(started, image)
+
+
+def _lock_acquire(fd, exclusive):
+    """Block until this process owns the lock file.
+
+    msvcrt.locking is the Windows analog of flock, with three differences. It locks a byte range
+    from the current offset rather than the whole file, so the offset is pinned to 0. It has no
+    shared mode, so a reader takes the same exclusive lock a writer does — free here, because every
+    critical section is a small local read/write with the network fetch already completed outside
+    the lock. And its blocking mode (LK_LOCK) gives up after roughly ten seconds instead of waiting,
+    so retrying the non-blocking mode is what actually reproduces flock's wait-for-the-holder
+    behavior. As on POSIX, the OS releases the lock if a holder dies, so a crash cannot wedge this."""
+    if not IS_WINDOWS:
+        fcntl.flock(fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+        return
+    os.lseek(fd, 0, os.SEEK_SET)
+    while True:
+        try:
+            msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+            return
+        except OSError:
+            time.sleep(_WIN_RETRY_SECONDS)
+
+
+def _lock_release(fd):
+    if not IS_WINDOWS:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        return
+    os.lseek(fd, 0, os.SEEK_SET)
+    try:
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+    except OSError:
+        pass
+
+
+@contextmanager
+def _state_lock(state_dir, exclusive=True):
+    """Serialize access to the state dir for the duration of the body."""
+    os.makedirs(state_dir, exist_ok=True)
+    # O_RDWR|O_CREAT rather than a truncating open("w"): on Windows, truncating a file another
+    # process holds a byte-range lock on fails, which would make lock acquisition itself the race.
+    fd = os.open(os.path.join(state_dir, "lock"), os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        _lock_acquire(fd, exclusive)
+        try:
+            yield
+        finally:
+            _lock_release(fd)
+    finally:
+        os.close(fd)
+
+
+def _replace_atomic(src, dst):
+    """Atomically move `src` onto `dst`.
+
+    POSIX rename always succeeds over an open destination. Windows refuses while any other handle
+    to `dst` is open, so an unlocked best-effort reader — or a virus scanner that opened the file
+    behind us — would otherwise turn a routine concurrent read into a crashed writer. Retry briefly
+    rather than treating that transient sharing violation as a failure."""
+    if not IS_WINDOWS:
+        os.replace(src, dst)
+        return
+    deadline = time.monotonic() + _WIN_REPLACE_TIMEOUT_SECONDS
+    while True:
+        try:
+            os.replace(src, dst)
+            return
+        except PermissionError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(_WIN_RETRY_SECONDS)
 
 
 class _WatchSuperseded(Exception):
@@ -1420,12 +1565,8 @@ def _session_started_at(value):
 
 @contextmanager
 def locked_state(state_dir, pr, repo, now):
-    import fcntl
-    os.makedirs(state_dir, exist_ok=True)
-    lock_path = os.path.join(state_dir, "lock")
     state_path = os.path.join(state_dir, "state.json")
-    with open(lock_path, "w") as lf:
-        fcntl.flock(lf, fcntl.LOCK_EX)
+    with _state_lock(state_dir):
         if os.path.exists(state_path):
             with open(state_path) as f:
                 state = json.load(f)
@@ -1449,8 +1590,7 @@ def locked_state(state_dir, pr, repo, now):
         tmp.flush()
         os.fsync(tmp.fileno())
         tmp.close()
-        os.replace(tmp.name, state_path)
-        fcntl.flock(lf, fcntl.LOCK_UN)
+        _replace_atomic(tmp.name, state_path)
 
 
 def _fetch_snapshot(args):
@@ -1689,23 +1829,16 @@ def _blocker_sig(a):
 def _process_identity(pid):
     """Best-effort PID-reuse guard for replacing a prior watcher. If process identity cannot be
     proven, generation invalidation still suppresses its wake and we leave OS cleanup alone."""
-    r = subprocess.run(["ps", "-p", str(pid), "-o", "lstart=", "-o", "command="],
-                       capture_output=True, text=True)
+    if IS_WINDOWS:
+        return _win_process_identity(pid)
+    try:
+        r = subprocess.run(["ps", "-p", str(pid), "-o", "lstart=", "-o", "command="],
+                           capture_output=True, text=True)
+    except OSError:
+        return None   # no ps on PATH: unproven identity, same as a failed lookup
     if r.returncode != 0:
         return None
     return (r.stdout or "").strip() or None
-
-
-@contextmanager
-def _watch_lock(state_dir, exclusive):
-    import fcntl
-    os.makedirs(state_dir, exist_ok=True)
-    with open(os.path.join(state_dir, "lock"), "w") as lf:
-        fcntl.flock(lf, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
-        try:
-            yield
-        finally:
-            fcntl.flock(lf, fcntl.LOCK_UN)
 
 
 def _watch_candidate_path(args):
@@ -1728,19 +1861,19 @@ def _reserve_watch_candidate(args, generation):
         "pid": os.getpid(),
         "process_identity": _process_identity(os.getpid()),
     }
-    with _watch_lock(args.state_dir, exclusive=True):
+    with _state_lock(args.state_dir, exclusive=True):
         previous = _read_watch_candidate(args)
         tmp = tempfile.NamedTemporaryFile("w", dir=args.state_dir, delete=False)
         json.dump(candidate, tmp)
         tmp.flush()
         os.fsync(tmp.fileno())
         tmp.close()
-        os.replace(tmp.name, _watch_candidate_path(args))
+        _replace_atomic(tmp.name, _watch_candidate_path(args))
     return previous
 
 
 def _clear_watch_candidate(args, generation):
-    with _watch_lock(args.state_dir, exclusive=True):
+    with _state_lock(args.state_dir, exclusive=True):
         if _read_watch_candidate(args).get("generation") != generation:
             return
         try:
@@ -1778,7 +1911,7 @@ def _activate_watch(args, generation, now, cur):
 def _watch_is_current(args, generation):
     """Read the ownership generation under the state lock without rewriting state.json."""
     state_path = os.path.join(args.state_dir, "state.json")
-    with _watch_lock(args.state_dir, exclusive=False):
+    with _state_lock(args.state_dir, exclusive=False):
         if not os.path.exists(state_path):
             return False
         with open(state_path) as f:
@@ -1790,7 +1923,7 @@ def _emit_wake_if_current(args, generation, reason, **fields):
     the new generation has become current. Invocation replacement also supersedes every ordinary
     wake from the old budget, even when the replacement kept the same watch generation."""
     state_path = os.path.join(args.state_dir, "state.json")
-    with _watch_lock(args.state_dir, exclusive=False):
+    with _state_lock(args.state_dir, exclusive=False):
         if not os.path.exists(state_path):
             return False
         with open(state_path) as f:
@@ -1811,7 +1944,13 @@ def _emit_wake_if_current(args, generation, reason, **fields):
 
 
 def _terminate_replaced_watch(previous):
-    """Promptly stop the replaced process, but never signal a PID whose identity no longer matches."""
+    """Promptly stop the replaced process, but never signal a PID whose identity no longer matches.
+
+    On Windows os.kill maps to TerminateProcess, so the replaced watcher dies abruptly instead of
+    unwinding a SIGTERM handler: it cannot clear its own watch candidate, nor finish terminating a
+    predecessor it was mid-handoff with. Neither leaks. The replacement has already written its own
+    candidate before calling this, and any watcher left running reads a foreign watch_generation on
+    its next poll and exits on its own — so the abrupt path costs at most one poll interval."""
     pid = previous.get("pid")
     identity = previous.get("process_identity")
     if not isinstance(pid, int) or pid == os.getpid() or not identity:
@@ -1820,8 +1959,8 @@ def _terminate_replaced_watch(previous):
         return
     try:
         os.kill(pid, signal.SIGTERM)
-    except ProcessLookupError:
-        pass
+    except OSError:
+        pass   # exited between the identity check and here (Windows reports this as a plain OSError)
 
 
 def cmd_watch(args):
@@ -1850,6 +1989,9 @@ def cmd_watch(args):
         if interrupt_immediately:
             raise _WatchSuperseded()
 
+    # Cooperative supersession. Windows accepts this handler but never delivers SIGTERM across
+    # processes, so there it is inert and the loop's own watch_generation checks are what retire a
+    # replaced watcher — the handler is the fast path, not the correctness guarantee.
     prior_sigterm = signal.getsignal(signal.SIGTERM)
     signal.signal(signal.SIGTERM, request_stop)
     try:

--- a/tests/fixtures/pr-snapshot-platform.py
+++ b/tests/fixtures/pr-snapshot-platform.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Platform-primitive checks for ce-babysit-pr's pr-snapshot (issue #1280).
+
+pr-snapshot needs three facilities that native Windows Python does not provide:
+an advisory file lock, a process-identity probe for the PID-reuse guard, and a
+rename that survives a concurrent reader. Each has a Windows analog with
+different semantics, so this fixture exercises the *observable* contract each
+one exists to uphold, and asserts the same thing on every platform:
+
+  - a lock actually serializes concurrent writers (state.json is never a torn
+    read, and no writer crashes)
+  - process identity distinguishes this process from a dead/foreign pid, which
+    is what makes replacing a watcher safe against pid reuse
+  - a replaced watcher is retired and only the new owner wakes
+
+Cross-platform on purpose. The POSIX run is the regression guard for the
+Windows branches' *contract*; the windows-latest CI job is what proves the
+Windows implementations satisfy it. Run directly:  python <this file>
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import importlib.util
+from importlib.machinery import SourceFileLoader
+
+IS_WINDOWS = sys.platform == "win32"
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+SCRIPT = os.path.join(REPO_ROOT, "skills", "ce-babysit-pr", "scripts", "pr-snapshot")
+BUDGET = "28800"
+
+# One failing check plus one unresolved thread: a stable "there is work" fetch.
+ACTIONABLE = {
+    "pr_state": "OPEN",
+    "mergeable": "MERGEABLE",
+    "merge_state_status": "BLOCKED",
+    "review_decision": "REVIEW_REQUIRED",
+    "head_sha": "s1",
+    "base": {
+        "host": "github.com", "repository": "o/r", "ref": "main",
+        "oid": "base-1", "pr_oid": "base-1", "freshness": "current",
+    },
+    "url": "http://x/1",
+    "checks": [{"key": "CI/test", "name": "test", "status": "COMPLETED",
+                "conclusion": "FAILURE", "details_url": "u"}],
+    "threads": [{"thread_id": "T1", "last_comment_id": "C1", "last_comment_at": "t1"}],
+}
+
+# Same PR with nothing to act on, so a watcher keeps polling instead of waking.
+QUIET = dict(
+    ACTIONABLE,
+    checks=[{"key": "CI/test", "name": "test", "status": "IN_PROGRESS",
+             "conclusion": None, "details_url": "u"}],
+    threads=[],
+)
+
+
+def load_script():
+    """Import pr-snapshot as a module for direct helper calls.
+
+    It ships without a .py suffix, so the loader has to be named explicitly —
+    spec_from_file_location infers nothing from an extensionless path."""
+    spec = importlib.util.spec_from_loader(
+        "pr_snapshot", SourceFileLoader("pr_snapshot", SCRIPT))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PlatformPrimitives(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="pr-snapshot-platform-")
+        self.state = os.path.join(self.dir, "state")
+
+    def write_fetch(self, name, payload):
+        path = os.path.join(self.dir, name)
+        with open(path, "w") as f:
+            json.dump(payload, f)
+        return path
+
+    def snapshot_argv(self, fetch, extra):
+        return [sys.executable, SCRIPT, "snapshot", "--pr", "1", "--repo", "o/r",
+                "--state-dir", self.state, "--fetch-file", fetch] + extra
+
+    def start_invocation(self, fetch):
+        r = subprocess.run(
+            self.snapshot_argv(fetch, ["--start-invocation", "--invocation-budget-seconds", BUDGET]),
+            capture_output=True, text=True)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        return json.loads(r.stdout)
+
+    def invocation_args(self, started):
+        return ["--invocation-id", started["invocation_id"],
+                "--session-started-at", started["invocation_started_at"],
+                "--invocation-budget-seconds", str(started["invocation_budget_seconds"])]
+
+    def read_state(self):
+        with open(os.path.join(self.state, "state.json")) as f:
+            return json.load(f)
+
+    # --- the lock -------------------------------------------------------------
+
+    def test_concurrent_snapshots_serialize_without_tearing_state(self):
+        """Every writer must complete and state.json must never be a partial read.
+
+        Without a working lock this fails loudly on Windows in two different ways: the
+        import of fcntl raises, and (once imported) concurrent os.replace onto an open
+        state.json raises PermissionError in whichever writer loses the race."""
+        fetch = self.write_fetch("actionable.json", ACTIONABLE)
+        started = self.start_invocation(fetch)
+        argv = self.snapshot_argv(fetch, self.invocation_args(started))
+
+        procs = [subprocess.Popen(argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                  text=True) for _ in range(6)]
+        for p in procs:
+            out, err = p.communicate(timeout=60)
+            self.assertEqual(p.returncode, 0, err)
+            json.loads(out)   # each writer emitted complete JSON
+
+        state = self.read_state()
+        self.assertEqual(state["invocation_id"], started["invocation_id"])
+        self.assertTrue(os.path.exists(os.path.join(self.state, "lock")))
+
+    def test_lock_can_be_reacquired_after_release(self):
+        """Release must actually release: a second acquisition in the same process must not hang.
+
+        This is the msvcrt trap — its lock is a byte range from the current file offset, so an
+        unlock at a different offset than the lock silently leaves the range held."""
+        module = load_script()
+        with module._state_lock(self.state):
+            pass
+        with module._state_lock(self.state, exclusive=False):
+            pass
+        # Re-acquire after full release, exclusive this time.
+        with module._state_lock(self.state):
+            self.assertTrue(os.path.exists(os.path.join(self.state, "lock")))
+
+    def test_replace_atomic_overwrites_an_existing_file(self):
+        module = load_script()
+        dst = os.path.join(self.dir, "dst.json")
+        with open(dst, "w") as f:
+            f.write('{"v": 1}')
+        src = os.path.join(self.dir, "src.json")
+        with open(src, "w") as f:
+            f.write('{"v": 2}')
+        module._replace_atomic(src, dst)
+        with open(dst) as f:
+            self.assertEqual(json.load(f)["v"], 2)
+        self.assertFalse(os.path.exists(src))
+
+    # --- process identity -----------------------------------------------------
+
+    def test_process_identity_is_stable_for_a_live_process(self):
+        module = load_script()
+        mine = module._process_identity(os.getpid())
+        self.assertIsInstance(mine, str)
+        self.assertTrue(mine.strip())
+        self.assertEqual(mine, module._process_identity(os.getpid()))
+
+    def test_process_identity_distinguishes_a_different_process(self):
+        """The guard exists to refuse killing a pid that is no longer the watcher we recorded."""
+        module = load_script()
+        child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+        try:
+            other = module._process_identity(child.pid)
+            self.assertIsInstance(other, str)
+            self.assertNotEqual(other, module._process_identity(os.getpid()))
+        finally:
+            child.kill()
+            child.wait(timeout=30)
+
+    def test_process_identity_is_unproven_for_a_dead_process(self):
+        module = load_script()
+        child = subprocess.Popen([sys.executable, "-c", "pass"])
+        child.wait(timeout=30)
+        # A reaped pid is either gone (None) or, if the pid was recycled, a different
+        # identity than the process we are checking against. Either outcome declines the kill.
+        self.assertNotEqual(module._process_identity(child.pid),
+                            module._process_identity(os.getpid()))
+
+    # --- watcher replacement --------------------------------------------------
+
+    def test_replaced_watcher_is_retired_and_only_the_new_owner_wakes(self):
+        """End-to-end proof that supersession works without POSIX signal delivery."""
+        quiet = self.write_fetch("quiet.json", QUIET)
+        started = self.start_invocation(quiet)
+        watch_argv = [sys.executable, SCRIPT, "watch", "--pr", "1", "--repo", "o/r",
+                      "--state-dir", self.state, "--fetch-file", quiet,
+                      "--interval", "0.2"] + self.invocation_args(started)
+
+        old = subprocess.Popen(watch_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        first = self.wait_for_generation(None)
+        new = subprocess.Popen(watch_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        self.wait_for_generation(first)
+
+        # The superseded watcher must go away without claiming the wake, whichever
+        # mechanism retires it.
+        old_out, old_err = old.communicate(timeout=60)
+        self.assertEqual(old_out.strip(), "", "a superseded watcher must not emit a wake")
+        # POSIX retires it with a SIGTERM its handler unwinds, so it exits 0. Windows never
+        # delivers that signal across processes: os.kill is TerminateProcess, and the exit
+        # code is the signal number it was handed — unless the watcher happened to notice the
+        # new generation first and returned 0 on its own.
+        self.assertIn(old.returncode, (0, int(signal.SIGTERM)) if IS_WINDOWS else (0,), old_err)
+
+        # Give the surviving owner something to wake on.
+        with open(quiet, "w") as f:
+            json.dump(ACTIONABLE, f)
+        new_out, new_err = new.communicate(timeout=60)
+        self.assertEqual(new.returncode, 0, new_err)
+        wakes = [json.loads(line) for line in new_out.strip().splitlines() if line.strip()]
+        self.assertEqual(len(wakes), 1, new_out)
+        self.assertEqual(wakes[0]["event"], "BABYSIT_WAKE")
+        self.assertEqual(wakes[0]["watch_generation"], self.read_state()["watch_generation"])
+
+    def wait_for_generation(self, previous, timeout=30.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                generation = self.read_state().get("watch_generation")
+            except (OSError, ValueError):
+                generation = None   # the first watcher may still be creating state.json
+            if isinstance(generation, str) and generation and generation != previous:
+                return generation
+            time.sleep(0.05)
+        raise AssertionError("watch generation did not advance from %r" % (previous,))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/skills/ce-babysit-pr-platform.test.ts
+++ b/tests/skills/ce-babysit-pr-platform.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import path from "node:path"
+
+// Drives tests/fixtures/pr-snapshot-platform.py, which pins the observable contract of
+// pr-snapshot's three platform primitives: the state lock, the process-identity probe
+// behind the PID-reuse guard, and the atomic rename (issue #1280).
+//
+// This run is the POSIX half. The windows-latest CI job runs the same fixture against
+// real Win32 msvcrt/ctypes, which is the half that proves the Windows branches — those
+// cannot execute here at all, because the module imports msvcrt only under win32.
+const FIXTURE = path.join(__dirname, "../fixtures/pr-snapshot-platform.py")
+
+// The fixture spawns real watchers and waits on real poll intervals.
+setDefaultTimeout(90_000)
+
+describe("ce-babysit-pr platform primitives", () => {
+  test("state lock, process identity, and watcher replacement (python fixture — must run, never skip)", () => {
+    const r = spawnSync("python3", [FIXTURE], { encoding: "utf8" })
+    // Hard-assert the fixture's own result: an import error or a missing script must
+    // fail here rather than silently skip.
+    expect(r.stderr).toContain("OK")
+    expect(r.status).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

On native Windows, asking `ce-babysit-pr` to watch a PR reported that continuous babysitting was unavailable and left monitoring paused — the user got no CI or review reaction at all unless they re-invoked the skill by hand. The watcher now runs there.

`pr-snapshot` imported `fcntl` lazily inside `locked_state` and `_watch_lock`, so under native Windows Python the script started and parsed arguments normally, then died with `ModuleNotFoundError: No module named 'fcntl'` at the first state-lock acquisition — i.e. on the first command that touched state, which is every real one. Three POSIX facilities are now platform-branched. Each Windows analog differs in a way that fails *silently* if translated literally, so each is named rather than swapped:

| POSIX | Windows analog | The trap |
|---|---|---|
| `fcntl.flock` | `msvcrt.locking` | Locks a byte range from the **current file offset**, not the whole file — an unlock at a different offset silently leaves the range held. Has no shared mode. Its blocking mode gives up after ~10s, so the faithful translation of "wait for the holder" is a retry loop around the *non-blocking* mode, not `LK_LOCK`. |
| `ps -o lstart=` | `GetProcessTimes` | The PID-reuse guard needs process creation time, which matters *more* on Windows because it recycles PIDs aggressively. |
| `os.replace` | `os.replace` + retry | POSIX rename succeeds over an open destination; Windows refuses while any other handle is open, so an unlocked best-effort reader could crash a writer. Timing-dependent, so it passes every local test. |

Acquiring the lock also moved from a truncating `open(path, "w")` to `os.open(..., O_RDWR | O_CREAT)` — on Windows, truncating a file another process holds a byte-range lock on fails, which would make lock acquisition itself the race it exists to prevent.

**Watcher supersession no longer depends on cross-process signal delivery**, which Windows does not provide. `os.kill` is `TerminateProcess` there, so a replaced watcher dies abruptly instead of unwinding its `SIGTERM` handler. Nothing leaks: the replacement writes its own candidate before terminating anyone, and any watcher left running reads a foreign `watch_generation` on its next poll and retires itself. The signal handler is now the fast path, not the correctness guarantee.

The POSIX path is unchanged.

Fixes #1280

## Validation

**The Windows branches have never executed locally — this was developed on macOS, where `msvcrt`/`ctypes` cannot be imported at all.** That gap is the reason for the CI change rather than something the CI change papers over:

- `tests/fixtures/pr-snapshot-platform.py` is a new cross-platform fixture pinning the observable contract of all three primitives: that concurrent writers serialize without tearing `state.json`, that a released lock can be re-acquired (the msvcrt offset trap), that process identity separates this process from a dead or foreign pid, and that a superseded watcher is retired without claiming the wake.
- The existing `windows-latest` job (renamed `peer-job-runner-windows` → `windows-native`, since it now gates two scripts) runs that fixture under real win32. **This is the only way to execute the Windows code at all** — those branches are imported solely under `sys.platform == "win32"`, so no amount of patching reaches them from Linux or macOS.
- The four `msvcrt.locking` semantics the port depends on were verified against the official Python docs, not assumed.

Local (macOS): full suite 2841 pass / 0 fail, plus `release:validate` and `plugin:validate` clean. The 113 existing `ce-babysit-pr` snapshot tests pass unchanged, which is the POSIX no-regression guard.

Treat the windows-native job as the merge gate for the Windows half.

## Security Disclosure

Three security-relevant changes, all in `skills/ce-babysit-pr/scripts/pr-snapshot`:

- **Process termination.** `_terminate_replaced_watch` broadened `except ProcessLookupError` to `except OSError`, because Windows' `os.kill`→`TerminateProcess` mapping does not raise `ProcessLookupError`. On POSIX this now also swallows `EPERM`. The guard that actually matters is unchanged: it still refuses to signal any pid whose recorded process identity does not match exactly, so a recycled pid is never killed.
- **New Win32 calls via ctypes.** `OpenProcess` is requested with `PROCESS_QUERY_LIMITED_INFORMATION` — read-only, least privilege — never `PROCESS_ALL_ACCESS`. `argtypes`/`restype` are declared explicitly, which is required to avoid ctypes truncating handles to 32 bits on Win64.
- **Lock file creation.** The lock is now opened via `os.open(..., O_RDWR | O_CREAT, 0o600)` rather than `open(path, "w")`, so it is created owner-only. It carries no data and is never read.

No changes to credential handling, network calls, or the `gh` command surface. No new dependencies (`msvcrt` and `ctypes` are stdlib).

## Agent Disclosure
- **Model:** `Claude Code · claude-fable-5`

