### PR TITLE
fix(ce-work): pin codex worker reasoning effort to high

### DIFF
--- a/skills/ce-work/scripts/cross-model-work.sh
+++ b/skills/ce-work/scripts/cross-model-work.sh
@@ -95,8 +95,11 @@ validate_model_override() {
 adapter_argv() {
   case "$1" in
     codex)
+      # --ignore-user-config drops the user's model_reasoning_effort, so pin the
+      # editorial tier explicitly, matching the claude/grok routes' --effort high.
       printf '%s\0' codex exec --ignore-user-config --ignore-rules --ephemeral \
-        -s workspace-write -C "$WORKSPACE" --json -o "$RAW_RESULT"
+        -s workspace-write -C "$WORKSPACE" --json -o "$RAW_RESULT" \
+        -c model_reasoning_effort=high
       [ "$(route_model codex)" = auto ] || printf '%s\0' -m "$(route_model codex)"
       printf '%s\0' -
       ;;

--- a/tests/skills/ce-work-cross-model-routes.test.ts
+++ b/tests/skills/ce-work-cross-model-routes.test.ts
@@ -206,6 +206,7 @@ describe("ce-work fixed write routes", () => {
     expect(codex).toContain("--ephemeral")
     expect(codex).toContain("-s workspace-write")
     expect(codex).toContain("-C <workspace>")
+    expect(codex).toContain("-c model_reasoning_effort=high")
 
     const claude = emit("claude").stdout
     expect(claude).toContain("--safe-mode")


### PR DESCRIPTION
## Summary

`ce-work`'s codex implementation workers now run at an explicit reasoning-effort tier instead of the CLI's built-in default. The adapter passes `-c model_reasoning_effort=high` on the codex route — the same editorial choice the claude and grok routes already hardcode via `--effort high`.

Fixes EveryInc/compound-engineering-plugin#1289.

## Why the gap existed

`--ignore-user-config` (correctly) drops the user's `~/.codex/config.toml`, taking their `model_reasoning_effort` with it — and the engine-config contract forbids CLI flags in `work_engine_preferences`, so users had no sanctioned way to restore it. Codex was the only route running workers at an unpinned default tier.

## Validation (dogfooded on a real run)

- `--emit-adapter codex` introspection composes cleanly: `codex exec --ignore-user-config --ignore-rules --ephemeral -s workspace-write -C <workspace> --json -o <raw-result> -c model_reasoning_effort=high -`
- Ran a full ce-work cross-model unit through the patched adapter (test-only unit in a real repo, model pin `gpt-5.6-sol`): live worker process argv confirmed `-c model_reasoning_effort=high -m gpt-5.6-sol`; the worker completed, terminalized, and integrated normally with the suite green.
- One behavioral observation worth reviewers' eyes: at high effort the worker produced a ~6-minute silent thinking stretch between output events. It stayed within the documented 600s `CE_PEER_IDLE_SECS` window for `incremental` posture, but repos tuning that window lower may want to know effort lengthens quiet gaps.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
