### PR TITLE
fix(peer-job-runner): prefer Git Bash over WSL on native Windows

### DIFF
--- a/docs/plans/2026-07-31-002-fix-prefer-git-bash-over-wsl-plan.md
+++ b/docs/plans/2026-07-31-002-fix-prefer-git-bash-over-wsl-plan.md
@@ -1,0 +1,258 @@
+---
+title: "fix: Prefer Git Bash over WSL on native Windows"
+type: fix
+status: active
+date: 2026-07-31
+origin: "https://github.com/EveryInc/compound-engineering-plugin/issues/1268"
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# fix: Prefer Git Bash over WSL on native Windows - Plan
+
+## Goal Capsule
+
+- **Objective:** On native Windows, cross-model peer workers run under Git for Windows Bash (not WSL System32 `bash`), so `jq` and the Windows Claude CLI remain visible and independent review does not skip.
+- **Product authority:** Issue #1268 + session brainstorm (own only #1268; fail closed; rewrite bare `bash`/`sh`). Related Windows issues (#1251, #944, #1258, closed #1243/#1184/#1247) are context only.
+- **Open blockers:** None.
+- **Stop conditions:** Stop if preferring Git Bash requires weakening `authorize-dispatch` argv contracts or forcing peer-job-runner off native Windows Python.
+
+---
+
+## Product Contract
+
+### Summary
+
+Native Windows cross-model review already works when workers are launched through an explicit Git Bash path. Bare `bash` still resolves to WSL (`C:\Windows\System32\bash.exe`), which lacks Windows `jq`/`claude`, so the worker skips. Prefer Git Bash via configured path, `CLAUDE_CODE_GIT_BASH_PATH`, and standard install detection; rewrite bare `bash`/`sh` argv0; reject System32 WSL bash with an actionable error; keep the runner on native Windows Python; record the selected shell in diagnostics.
+
+Product Contract preservation: authored in this enrichment from the confirmed brainstorm (no prior requirements-only file on disk).
+
+### Problem Frame
+
+After #1243/#1248, `peer-job-runner.py` detaches correctly on native Windows Python. Shell selection still uses `shutil.which("bash")`, which prefers System32 WSL. Review skills launch as `bash script.sh`; `cmd_start` resolves that bare name before spawn, so WSL is baked into argv. Explicit `C:\Program Files\Git\bin\bash.exe` succeeds end-to-end.
+
+### Requirements
+
+- R1. On native Windows, resolve a POSIX shell for peer workers in this order: `CE_PEER_BASH` (if set and valid), then `CLAUDE_CODE_GIT_BASH_PATH` (if set and valid), then well-known Git for Windows paths (`Git\bin\bash.exe`, `Git\usr\bin\bash.exe` under Program Files), then non-System32 `bash`/`sh` on PATH.
+- R2. Never select `C:\Windows\System32\bash.exe` (or equivalent System32 WSL launcher) for native-Windows peer workers.
+- R3. When only System32 bash is available (or no usable Git Bash), fail closed at `start` with an actionable error naming install Git Bash or set `CE_PEER_BASH` / `CLAUDE_CODE_GIT_BASH_PATH` — do not detach into WSL and skip.
+- R4. Rewrite bare `bash` / `bash.exe` / `sh` / `sh.exe` argv0 to the preferred absolute path at start and at spawn wrap time (covers review-skill `bash script.sh` and bare `.sh` wrapping).
+- R5. Keep `peer-job-runner.py` on native Windows Python; do not move detach into Git Bash or WSL.
+- R6. Record the selected Bash absolute path in job diagnostics (meta and/or start/error messages) so operators can see which shell ran.
+- R7. Prefer Git Bash so tools visible in that environment (`jq`, Windows Claude CLI) are what the worker's existing `command -v` checks see inside that shell; the runner does not add a separate tool probe beyond shell selection and diagnostics.
+- R8. All six byte-identical `peer-job-runner.py` copies stay in lockstep after the change.
+
+### Key Decisions
+
+- KD1. Fail closed — no WSL fallback or opt-in. `(session-settled: user-directed — chosen over WSL opt-in or last-resort System32: silent WSL skips are the bug)` Governs R2, R3.
+- KD2. Rewrite bare `bash`/`sh` argv0 to preferred absolute path. `(session-settled: user-directed — chosen over wrap-bare-.sh-only: review skills already launch as bash script.sh)` Governs R4.
+- KD3. Own only #1268. `(session-settled: user-directed — chosen over including #1251/#944/#1258: coherent shell-selection slice)` Governs scope.
+- KD4. Resolve shell inside the runner, not by rewriting every skill's launch prose. Governs R1, R4, R8.
+
+### Scope Boundaries
+
+**In scope**
+
+- Windows shell selection in `peer-job-runner.py` (`_popen_argv`, `cmd_start` preflight/resolution)
+- Env overrides `CE_PEER_BASH` and `CLAUDE_CODE_GIT_BASH_PATH`
+- Unit/fixture regression with System32-before-Git-Bash PATH ordering; Windows smoke updates as needed
+- Parity across the six runner copies
+
+**Out of scope**
+
+- CRLF packaging / #1251 residual path translation / #944 invocation audit / #1258 encoding
+- Installing tools inside WSL; treating WSL as a supported native-Windows host
+- Changing peer worker `.sh` review logic beyond shell selection and diagnostics
+- Weakening `authorize-dispatch` contracts
+
+### Deferred to Follow-Up Work
+
+- Closing or residual-doc work on #1251 / #944 after shell selection lands
+- Optional compound-config YAML key mirroring `CE_PEER_BASH` if product later wants non-env config
+
+### Acceptance Examples
+
+- AE1. Covers R1, R4, R7. Given System32 `bash.exe` precedes Git Bash on PATH, when `start` launches `bash cross-model-….sh …`, then the worker process argv0 is Git Bash and the run does not WSL-skip for missing `jq` solely due to shell choice.
+- AE2. Covers R2, R3. Given only System32 bash on PATH and no env override / Git install, when `start` is invoked with a `.sh` worker or bare `bash` prefix, then start fails closed with an actionable message (no detach).
+- AE3. Covers R1. Given `CLAUDE_CODE_GIT_BASH_PATH` or `CE_PEER_BASH` pointing at a valid Git Bash, when PATH would otherwise prefer System32, then that configured path is selected and named in diagnostics.
+- AE4. Covers R5, R8. Given the fix, when parity and Windows unit/smoke gates run, then all runner copies match and native Windows Python detach path remains unchanged.
+
+---
+
+## Planning Contract
+
+### Assumptions
+
+- "Configured Bash path" for this repo is `CE_PEER_BASH` (new, peer-runner-local) plus Claude Code's existing `CLAUDE_CODE_GIT_BASH_PATH`; no compound YAML key in this slice.
+- Valid override paths must exist as files; invalid overrides fall through to the next candidate rather than silently using System32.
+- `authorize-dispatch` for ce-work stores bare adapter `.sh` in meta (no bash prefix); spawn-time wrap stays invisible to that contract. Review skills may store rewritten absolute bash in `worker_argv` after start resolution — acceptable.
+- Thorough testing means unit/fixture PATH-order cases are mandatory; live Windows smoke extends only where it can assert selection without requiring a fake System32 binary on CI.
+
+### Key Technical Decisions
+
+- KTD1. Centralize Windows POSIX-shell resolution in one helper used by `cmd_start` and `_popen_argv`. Reject normalized paths under `%SystemRoot%\System32\` (case-insensitive) for bash/sh. Precedence per R1.
+- KTD2. In `cmd_start`, when argv0 basename is bash/sh (or which/abspath lands on System32 bash), replace with the preferred absolute path before writing `meta.json` and before detach — so CreateProcess never inherits WSL from PATH.
+- KTD3. In `_popen_argv`, when wrapping bare `.sh` or when head is bare bash/sh, use the same helper; do not trust raw `shutil.which("bash")`.
+- KTD4. Edit canonical `skills/ce-doc-review/scripts/peer-job-runner.py`, then copy byte-identical to the other five consumers; parity test remains the gate.
+- KTD5. Extend `tests/fixtures/peer-job-runner-unit.py` with mocked PATH/which ordering (System32 before Git Bash); keep smoke on real Win32 without depending on installing a fake System32 bash.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TD
+  start[cmd_start argv] --> resolve{Windows?}
+  resolve -->|no| posix[POSIX passthrough]
+  resolve -->|yes| helper[_resolve_windows_posix_shell]
+  helper --> env1{CE_PEER_BASH valid?}
+  env1 -->|yes| use[Use absolute path]
+  env1 -->|no| env2{CLAUDE_CODE_GIT_BASH_PATH valid?}
+  env2 -->|yes| use
+  env2 -->|no| known{Git Program Files bash exists?}
+  known -->|yes| use
+  known -->|no| pathScan[PATH bash/sh excluding System32]
+  pathScan -->|found| use
+  pathScan -->|none| fail[RunnerError actionable]
+  use --> meta[Write meta + diagnostics]
+  meta --> spawn[_popen_argv / Popen]
+```
+
+Resolution order (directional):
+
+1. `CE_PEER_BASH` if set and is an existing file
+2. `CLAUDE_CODE_GIT_BASH_PATH` if set and is an existing file
+3. Well-known Git Bash locations
+4. `which`/`PATH` candidates whose resolved path is not System32 WSL launcher
+5. Else fail closed
+
+### System-Wide Impact
+
+- **End users (native Windows Codex/PowerShell):** cross-model independent pass can run when Git Bash is installed.
+- **Implementers:** must keep six runner copies identical.
+- **CI:** `windows-native` job already runs unit + smoke + parity; extend unit fixture assertions.
+
+### Risks & Dependencies
+
+- Risk: absolute bash in meta changes observability for review skills — mitigate by documenting diagnostics field.
+- Risk: well-known path list misses portable Git installs — mitigate with env overrides first.
+- Dependency: Git for Windows installed for happy path; fail-closed otherwise (KD1).
+
+---
+
+## Implementation Units
+
+### U1. Windows POSIX shell resolver + start/spawn wiring
+
+**Goal:** Prefer Git Bash, reject System32 WSL bash, rewrite bare bash/sh, fail closed with diagnostics.
+
+**Requirements:** R1–R7
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `skills/ce-doc-review/scripts/peer-job-runner.py` (canonical)
+- Modify: `skills/ce-code-review/scripts/peer-job-runner.py`
+- Modify: `skills/ce-pov/scripts/peer-job-runner.py`
+- Modify: `skills/ce-work/scripts/peer-job-runner.py`
+- Modify: `skills/ce-plan/scripts/peer-job-runner.py`
+- Modify: `skills/ce-brainstorm/scripts/peer-job-runner.py`
+- Test: `tests/fixtures/peer-job-runner-unit.py`
+- Test: `tests/skills/peer-job-runner.test.ts` (only if the driver needs new case names)
+
+**Approach:**
+
+1. Add a single Windows-only resolver helper implementing KTD1 / R1 order; classify System32 bash as unusable (R2).
+2. Wire `cmd_start` preflight and argv0 rewrite per KTD2 (R3, R4, R6).
+3. Wire `_popen_argv` wrap/prefix rewrite per KTD3 (R4).
+4. Document `CE_PEER_BASH` and `CLAUDE_CODE_GIT_BASH_PATH` in the runner module docstring env list.
+5. Copy the canonical file to all consumers (KTD4 / R8).
+
+**Execution note:** Implement resolver behavior test-first in the unit fixture (failing cases for System32-first PATH and bare `bash` rewrite) before changing production code.
+
+**Patterns to follow:**
+
+- `tests/scratch-root-preamble-executes.test.ts` `posixShell()` candidate list for Git path fallbacks
+- Existing `_popen_argv` / `PopenArgvBranch` tests
+- `docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md` (keep native Windows Python)
+- `docs/solutions/workflow/reviewing-byte-duplicated-shared-assets.md` (parity)
+
+**Test scenarios:**
+
+- Happy path: mocked which returns System32 bash first and Git Bash second; resolver returns Git Bash path.
+- Happy path: `CE_PEER_BASH` set to a fake Git Bash path that exists; selected over PATH System32.
+- Happy path: `CLAUDE_CODE_GIT_BASH_PATH` set when `CE_PEER_BASH` unset; selected over PATH System32.
+- Happy path: `_popen_argv` bare `.sh` wraps with preferred Git Bash, not System32.
+- Happy path: `_popen_argv` / `cmd_start` rewrite `["bash", "script.sh", …]` so argv0 is preferred absolute Git Bash.
+- Edge: override path set but missing file — fall through to next candidate, never System32.
+- Edge: non-Windows — resolver unused; argv passthrough unchanged.
+- Error: only System32 bash available — `RunnerError` with actionable text mentioning Git Bash / `CE_PEER_BASH` / `CLAUDE_CODE_GIT_BASH_PATH`.
+- Integration: `cmd_start` preflight fails closed before detach when no usable shell (no job left running).
+- Covers AE3: diagnostics/meta include selected bash absolute path when resolution succeeds.
+
+**Verification:** Unit fixture cases above green; module docstring lists the new env knobs; six files still byte-identical after copy.
+
+---
+
+### U2. Thorough regression harness + Windows smoke alignment
+
+**Goal:** Lock the System32-before-Git-Bash regression and keep CI Windows gates honest.
+
+**Requirements:** R2, R3, R4, R8; AE1, AE2, AE4
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `tests/fixtures/peer-job-runner-unit.py`
+- Modify: `tests/fixtures/peer-job-runner-windows-smoke.py` (only if current `which("bash")` assumptions break or a safe selection assertion can be added)
+- Test: `tests/peer-job-runner-parity.test.ts` (must remain green; no logic change expected)
+- Reference: `.github/workflows/ci.yml` `windows-native` job (no change unless a new test file must be invoked)
+
+**Approach:**
+
+1. Expand unit fixture with dedicated tests for precedence, System32 rejection, bare-prefix rewrite, and fail-closed messaging (complete any gaps left from U1).
+2. Update Windows smoke bare-`.sh` wrap assertion to tolerate/prefer Git Bash absolute path without requiring WSL.
+3. Confirm parity test still asserts byte-identity across consumers.
+
+**Execution note:** Prefer deterministic mocks in the unit fixture for PATH ordering; do not require CI to plant a fake System32 `bash.exe`.
+
+**Patterns to follow:** Existing `PopenArgvBranch` mock style; CI `windows-native` steps.
+
+**Test scenarios:**
+
+- Covers AE1: System32 appears before Git Bash in mocked which order; wrap/rewrite selects Git Bash.
+- Covers AE2: only System32 candidate; start/`_popen_argv` raises actionable `RunnerError`.
+- Covers AE4: after copying U1, `bun test tests/peer-job-runner-parity.test.ts` passes.
+- Smoke (when bash present on windows-latest): bare `.sh` worker still starts successfully through resolved Git Bash (or skip only if no Git Bash — should be rare on `windows-latest`).
+- Edge: explicit absolute non-System32 bash prefix left as-is (already preferred).
+- Error: empty `CE_PEER_BASH` / whitespace treated as unset.
+
+**Verification:** Local/CI unit fixture + parity green; Windows smoke green on `windows-native`.
+
+---
+
+## Verification Contract
+
+- Unit: `python tests/fixtures/peer-job-runner-unit.py` (use `python`, not `python3`, on Windows).
+- Parity: `bun test tests/peer-job-runner-parity.test.ts`
+- Skills driver (if touched): `bun test tests/skills/peer-job-runner.test.ts`
+- Windows CI job `windows-native`: unit fixture + Windows smoke + parity (existing workflow).
+
+## Definition of Done
+
+- [ ] R1–R8 satisfied; KD1–KD4 honored
+- [ ] U1–U2 complete with listed test scenarios
+- [ ] Six `peer-job-runner.py` copies byte-identical
+- [ ] No WSL System32 bash selected on native Windows; fail closed when Git Bash unavailable
+- [ ] AE1–AE4 demonstrable via unit/parity (and smoke where applicable)
+- [ ] Issue #1268 addressable by the PR description
+
+## Sources & Research
+
+- Origin: https://github.com/EveryInc/compound-engineering-plugin/issues/1268
+- Context (not in scope): #1251 (LF pin #1263), #944, #1258; closed #1243/#1248, #1184, #1247; #1285 Git Bash scratch-root
+- Prior plan: `docs/plans/2026-07-23-001-feat-peer-job-runner-windows-native-plan.md`
+- Learnings: `docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md`, `docs/solutions/conventions/resolve-python-interpreter-not-python3.md`, `docs/solutions/conventions/shell-primitives-must-be-executed-not-shape-checked.md`, `docs/solutions/workflow/reviewing-byte-duplicated-shared-assets.md`
+- Precedent: `tests/scratch-root-preamble-executes.test.ts` Git Bash candidate fallback

--- a/docs/plans/2026-07-31-003-fix-portable-windows-path-unit-tests-plan.md
+++ b/docs/plans/2026-07-31-003-fix-portable-windows-path-unit-tests-plan.md
@@ -1,0 +1,123 @@
+---
+title: "fix: Make Windows path unit tests portable on Linux CI"
+type: fix
+status: active
+date: 2026-07-31
+origin: "PR #1292 Codex review (discussion_r3689928630); follow-up to docs/plans/2026-07-31-002-fix-prefer-git-bash-over-wsl-plan.md"
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# fix: Make Windows path unit tests portable on Linux CI
+
+## Goal Capsule
+
+- **Objective:** `WindowsPosixShellResolve` (and any sibling cases that exercise real Windows path ops under patched `IS_WINDOWS`) pass on Ubuntu `bun run test` / CI without changing production shell-selection behavior.
+- **Authority:** Codex P1 on PR #1292; AGENTS.md CI gate (`bun run test` must pass); institutional note that `IS_WINDOWS` patches must not reach `_win_*` helpers.
+- **Stop when:** Unit fixture exits 0 on Linux semantics (or verified equivalent), Bun driver assertion still sees `OK`, production runners unchanged, smoke tests remain win32-only.
+
+---
+
+## Product Contract
+
+### Summary
+
+PR #1292's new resolver unit tests patch `IS_WINDOWS=True` but leave `MOD.os.path` as host `posixpath`. On Ubuntu, Windows drive strings are not split on `\`, so `abspath` / `dirname` / `basename` / `normcase` / `isfile` mocks disagree and the mandatory fixture run fails CI. Fix the fixture so Linux CI exercises the same resolver logic with `ntpath` semantics.
+
+Product Contract preservation: N/A (ce-plan-bootstrap; no upstream brainstorm). Does not reopen #1268 product decisions (fail closed, rewrite bare bash/sh, no WSL fallback).
+
+### Requirements
+
+- R1. Unit tests that call production `_resolve_windows_posix_shell` / `_is_system32_wsl_bash` (and path ops they use) must behave the same whether the host is Linux or Windows when `IS_WINDOWS` is patched True.
+- R2. Production `peer-job-runner.py` shell-selection behavior remains unchanged (fixture-only fix).
+- R3. The Bun driver test that hard-asserts the fixture prints `OK` and exits 0 continues to pass on Ubuntu CI.
+- R4. Prefer keeping Linux CI coverage of resolver precedence over skipping the class on non-Windows.
+
+### Scope Boundaries
+
+- In: `tests/fixtures/peer-job-runner-unit.py` helper + case updates.
+- Out: production resolver changes; WindowsApps/Sysnative residual; skipping the whole class on Linux; changing `peer-job-runner-windows-smoke.py` skip policy.
+
+### Key Decisions
+
+- KD1. Use an `ntpath`-backed context manager around patched `IS_WINDOWS` cases rather than `@unittest.skipUnless(win32)` — preserves Ubuntu CI coverage of #1268 resolver logic (Codex offered both; skip loses Linux proof).
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Add a fixture-local context manager (e.g. `windows_ntpath` / `windows_platform`) that patches `MOD.os.path.abspath`, `normcase`, `dirname`, `basename`, and `join` to the matching `ntpath` callables while tests simulate Windows. Patch `isfile` per-test as today, but compare with `ntpath.normcase`. (Governs R1, R4)
+- KTD2. Assert expected paths with `ntpath.normcase`, not host `os.path.normcase` (on POSIX, `normcase` does not case-fold). (Governs R1)
+- KTD3. Do not change production code or byte-copy runners for this fix. (Governs R2)
+- KTD4. `PopenArgvBranch` cases that fully mock `_resolve_windows_posix_shell` may already pass on Linux; still wrap any path that exercises real `abspath`/`normcase` under the helper for consistency. (Governs R1)
+
+### Assumptions
+
+- Codex's Ubuntu reproduction is accurate; local Windows hosts already green for these cases.
+- Shell-resolver branches do not call `_win_*` helpers, so `IS_WINDOWS` + `ntpath` patching remains within the safe cross-platform test envelope documented in `docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md`.
+
+### Patterns to Follow
+
+- `DetachSupportBranch` comment in `tests/fixtures/peer-job-runner-unit.py` — only patch `IS_WINDOWS` for branches that never touch `_win_*`.
+- Existing `WindowsPosixShellResolve` structure — env dict + candidate/`isfile` mocks; replace host path ops with the helper.
+
+---
+
+## Implementation Units
+
+### U1. Add ntpath platform helper and rewire Windows path cases
+
+**Goal:** Fixture runs green under POSIX host path semantics with Windows logic under test.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `tests/fixtures/peer-job-runner-unit.py`
+- Test: same fixture (driven by `tests/skills/peer-job-runner.test.ts`)
+
+**Approach:**
+1. Import `ntpath` and add a small context manager that patches the five `MOD.os.path` methods listed in KTD1.
+2. Optionally compose `IS_WINDOWS=True` + ntpath + optional `isfile` side_effect in one helper to reduce boilerplate.
+3. Wrap every `WindowsPosixShellResolve` case (and `test_is_system32_wsl_bash`) so production path ops see Windows semantics; use `ntpath.normcase` in assertions and in `isfile` lambdas.
+4. Spot-check `PopenArgvBranch` for any remaining real path ops; wrap only if needed.
+
+**Execution note:** Prefer proof-first — temporarily run the fixture under Linux path semantics (WSL or a quick `posixpath`-forcing sanity check) if available; otherwise implement helper and rely on CI/Ubuntu for the red→green confirmation.
+
+**Patterns to follow:** Existing mock nesting in `WindowsPosixShellResolve`; DetachSupportBranch safety comment.
+
+**Test scenarios:**
+- Happy path: with System32 first in mocked PATH candidates and Program Files Git present via `isfile`, resolver still returns Git Bash under ntpath semantics.
+- Happy path: `_is_system32_wsl_bash(System32 bash)` is True and Git Bash is False when path ops are ntpath.
+- Edge: whitespace-only env overrides still fall through; LocalAppData well-known path still wins.
+- Error: System32-only candidates still raise `RunnerError` with actionable message.
+- Integration: full fixture subprocess exits 0 and stderr contains `OK` (Bun driver contract).
+
+**Verification:** `python tests/fixtures/peer-job-runner-unit.py` exits 0; Bun `peer-job-runner.test.ts` fixture assertion passes; no production file diffs.
+
+---
+
+## Verification Contract
+
+- Primary: `python tests/fixtures/peer-job-runner-unit.py` (or `python3` as CI uses) must print `OK` / exit 0.
+- Gate: `bun test tests/skills/peer-job-runner.test.ts` — fixture case must not fail.
+- Regression: do not weaken smoke skipUnless; production peer-job-runner copies unchanged (parity still green).
+
+---
+
+## Definition of Done
+
+- Codex P1 addressed: Windows path unit cases portable on Linux CI.
+- No production behavior change for #1268 shell selection.
+- PR #1292 can proceed once this lands on the same branch (or a follow-up commit).
+
+## Sources & Research
+
+- PR #1292 review: https://github.com/EveryInc/compound-engineering-plugin/pull/1292#discussion_r3689928630
+- `docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md` (IS_WINDOWS patch limits)
+- Origin plan: `docs/plans/2026-07-31-002-fix-prefer-git-bash-over-wsl-plan.md`

--- a/docs/plans/2026-07-31-004-fix-preserve-explicit-windows-bash-plan.md
+++ b/docs/plans/2026-07-31-004-fix-preserve-explicit-windows-bash-plan.md
@@ -1,0 +1,137 @@
+---
+title: "fix: Preserve explicit absolute non-WSL bash on Windows"
+type: fix
+status: active
+date: 2026-07-31
+origin: "PR #1292 Codex P2 (discussion_r3690011704); follow-up to docs/plans/2026-07-31-002-fix-prefer-git-bash-over-wsl-plan.md"
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# fix: Preserve explicit absolute non-WSL bash on Windows
+
+## Goal Capsule
+
+- **Objective:** When a Windows peer worker argv already names an absolute non-System32 bash/sh (e.g. portable Git), keep that path — do not substitute the preferred resolver result or fail closed because the portable path is undiscoverable.
+- **Authority:** Codex P2 on PR #1292; origin plan edge case “explicit absolute non-System32 bash prefix left as-is”; session-settled KD2 from #1268 applies to **bare** bash/sh only.
+- **Stop when:** Absolute non-WSL bash is kept at `cmd_start` and spawn; System32 absolute bash still rewritten/fail-closed; bare names still resolve; six runners stay byte-identical; unit coverage proves both behaviors.
+
+---
+
+## Debug Summary (carried into planning)
+
+**Problem:** `start -- C:\PortableGit\bin\bash.exe script.sh …` (or any absolute non-WSL bash) is treated like bare `bash`.
+
+**Root cause:** `cmd_start` keys only on `basename(argv0) in {bash,sh,…}` and always calls `_resolve_windows_posix_shell()`, so the absolute-path branch never runs for `…\bash.exe`. Same basename gate in `_popen_argv` and `_rewrite_windows_env_bash_argv` substitutes preferred Git Bash or raises if the portable path is not in env/well-known/PATH.
+
+**Evidence:** Origin plan U2 edge: “explicit absolute non-System32 bash prefix left as-is (already preferred).” Goal capsule of #1268: explicit Git Bash path already worked before this PR.
+
+**Fix direction:** Treat absolute (drive/sep) bash/sh as caller-supplied: accept if file exists and not System32 WSL; reject System32; resolve only bare names.
+
+---
+
+## Product Contract
+
+### Summary
+
+Keep #1268 Git-Bash preference for **bare** `bash`/`sh` and System32 WSL rewrites, but honor an explicitly supplied absolute non-WSL shell so portable Git and other installs are not silently replaced or spuriously fail-closed.
+
+Product Contract preservation: N/A (bootstrap). Does not reopen fail-closed / no-WSL-fallback / bare-rewrite product decisions — it restores the absolute-path exception already implied by those decisions and the #1268 plan’s edge case.
+
+### Requirements
+
+- R1. On Windows, if worker argv0 (or env-prefixed bash token) is an absolute path to an existing non-System32 bash/sh, use that path unchanged for meta and spawn.
+- R2. If that absolute path is System32 WSL bash/sh, do not use it — rewrite via the existing resolver or fail closed (same as bare System32).
+- R3. Bare `bash`/`sh`/`bash.exe`/`sh.exe` continue to resolve via `_resolve_windows_posix_shell()` (env → well-known → PATH walk).
+- R4. Production change is in canonical `peer-job-runner.py` then byte-copied to all consumer skills; no product change outside shell selection.
+
+### Scope Boundaries
+
+- In: `cmd_start` bash/sh branch, `_popen_argv` bash/sh head, `_rewrite_windows_env_bash_argv`; unit tests; parity copy.
+- Out: WindowsApps/Sysnative alias residual; changing resolver precedence; skipping Linux path tests; unrelated PR hygiene.
+
+### Key Decisions
+
+- KD1. Absolute path detection uses the same Windows absolute rule already used elsewhere in `cmd_start` (`os.sep in path` or drive-letter `X:`), not “looks like bash basename only.”
+- KD2. Prefer a small shared helper (e.g. resolve-or-keep argv0 / token) used by start + spawn + env-rewrite so the three sites cannot drift.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Introduce a helper along the lines of “given a bash/sh token, return the absolute shell to use”: if absolute → require `isfile`, reject System32 via `_is_system32_wsl_bash`, else return abspath; if bare → `_resolve_windows_posix_shell()`. (Governs R1–R3)
+- KTD2. Wire that helper in `cmd_start`’s basename-bash branch (so absolute `…\bash.exe` no longer always resolves), in `_popen_argv`’s bash/sh head branch, and in `_rewrite_windows_env_bash_argv` for the bash token. (Governs R1, R4)
+- KTD3. Fixture-only tests under existing `windows_platform` / `ntpath` helpers: absolute portable kept; absolute System32 rewritten/fail path; bare still resolves. No production behavior change for bare `bash`. (Governs R1–R3)
+
+### Assumptions
+
+- Codex P1 (Linux path semantics in unit fixture) remains addressed by `97ff131`; this plan does not reopen it.
+- Callers that pass absolute bash intend that binary; `CE_PEER_BASH` remains the override for bare-name launches, not a silent override of an explicit argv0.
+
+### Patterns to Follow
+
+- Existing `_is_system32_wsl_bash` and absolute-path preflight in `cmd_start`.
+- Byte-copy + `tests/peer-job-runner-parity.test.ts`.
+- Unit fixture `windows_platform` for portable Windows path mocks.
+
+---
+
+## Implementation Units
+
+### U1. Keep absolute non-WSL bash; resolve only bare names
+
+**Goal:** Explicit absolute shells are preserved; bare and System32 paths still go through preference / fail-closed.
+
+**Requirements:** R1, R2, R3, R4
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `skills/ce-doc-review/scripts/peer-job-runner.py` (canonical), then copy to `skills/ce-code-review|ce-pov|ce-work|ce-plan|ce-brainstorm/scripts/peer-job-runner.py`
+- Modify: `tests/fixtures/peer-job-runner-unit.py`
+
+**Approach:**
+1. Add shared helper per KTD1.
+2. Replace unconditional resolve in `cmd_start` bash basename branch with the helper; set `windows_posix_shell` from the kept/resolved path.
+3. Same for `_popen_argv` bash/sh head and env-token rewrite.
+4. Tests: absolute portable kept; absolute System32 not kept; bare `bash` still rewritten to preferred; env `… absolute_bash …` kept when non-WSL.
+
+**Execution note:** Test-first in the unit fixture (absolute-keep must fail on current code), then implement helper + wire sites, then parity copy.
+
+**Patterns to follow:** `#1268` resolver and System32 helper; `windows_platform` fixture.
+
+**Test scenarios:**
+- Happy: `cmd_start` / `_popen_argv` with absolute portable bash → argv0 unchanged; meta `windows_posix_shell` equals that path when recorded.
+- Happy: bare `bash` still becomes preferred absolute Git Bash.
+- Edge: absolute System32 bash → not used; resolver preferred or fail-closed with actionable message.
+- Edge: env-prefixed argv with absolute non-WSL bash token → token kept.
+- Error: absolute path that does not exist → preflight failure, no detach.
+- Integration: six skill copies byte-identical after copy.
+
+**Verification:** Unit fixture green under Windows and under `windows_platform` on Linux semantics; parity test green; no smoke policy change required.
+
+---
+
+## Verification Contract
+
+- `python tests/fixtures/peer-job-runner-unit.py` exits 0 / prints OK.
+- `bun test tests/peer-job-runner-parity.test.ts` passes.
+- Manual or fixture assertion covering absolute-keep vs bare-rewrite.
+
+---
+
+## Definition of Done
+
+- Codex P2 resolved on PR #1292 head.
+- Origin plan absolute-prefix edge case restored without weakening bare-name Git Bash preference.
+- Parity intact across six runners.
+
+## Sources & Research
+
+- https://github.com/EveryInc/compound-engineering-plugin/pull/1292#discussion_r3690011704
+- `docs/plans/2026-07-31-002-fix-prefer-git-bash-over-wsl-plan.md` (U2 edge: absolute non-System32 left as-is)
+- Prior residual: WindowsApps/Sysnative still out of scope

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1150,8 +1150,7 @@ def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
         or "=" not in token
     ):
         return False
-    name = token.split("=", 1)[0]
-    return bool(name)
+    return True
 
 
 def _env_option_advance(tok: str) -> int:

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1157,14 +1157,17 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
-    cluster; -u/-C consume the rest of the token as an attached operand or the
-    next argv slot. Unsupported clusters fail closed before worker detach.
+    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    attached operand or the next argv slot. Unsupported options fail closed
+    before worker detach.
     (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
+        return 1
+    if tok in ("--ignore-environment", "--null", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1139,11 +1139,30 @@ def _env_assignment_token(token: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
+def _env_option_advance(tok: str) -> int:
+    """How many argv slots an env(1) option occupies (incl. the option itself).
+
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
+    -S/--split-string. Attached `--name=value` forms are a single slot.
+    Unknown flags advance one slot. (#1292 Codex P2)
+    """
+    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+        return 2
+    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+        return 1
+    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+        return 1
+    return 1
+
+
 def _env_bash_index(argv) -> int:
     """Index of bare bash/sh after `env` [options] [assignments], or -1.
 
     Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268).
+    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
+    and long forms) consume their arguments before the command token is
+    sought (#1292).
     """
     if not argv:
         return -1
@@ -1159,11 +1178,10 @@ def _env_bash_index(argv) -> int:
             i += 1
             continue
         if tok.startswith("-"):
-            # env -u NAME / --unset NAME consume the following argument.
-            if tok in ("-u", "--unset"):
-                i += 2
-                continue
-            i += 1
+            span = _env_option_advance(tok)
+            if span > 1 and i + 1 >= len(argv):
+                return -1
+            i += span
             continue
         return -1
     return -1

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -70,6 +70,10 @@ Environment overrides (defaults in parentheses):
   CE_PEER_RESULT_MAX_BYTES  result byte cap, supervise + read (5242880)
   CE_PEER_POLL_SECS         supervisor poll interval (2)
   CE_PEER_GRACE_SECS        TERM-to-KILL grace during reap (5)
+  CE_PEER_BASH              Windows: absolute bash.exe for peer workers
+                            (preferred over PATH / WSL System32 bash)
+  CLAUDE_CODE_GIT_BASH_PATH Claude Code Git Bash path; used on Windows when
+                            CE_PEER_BASH is unset (#1268)
 
 Security posture: the job root is a predictable, owner-private directory under
 world-shared /tmp. Every read of job state opens the file first (no-follow) and
@@ -1067,30 +1071,103 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
         time.sleep(min(0.1, max(0.01, end - time.monotonic())))
 
 
+def _is_system32_wsl_bash(path: str) -> bool:
+    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    if not path:
+        return False
+    base = os.path.basename(path).lower()
+    if base not in ("bash", "bash.exe", "sh", "sh.exe"):
+        return False
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    system32 = os.path.normcase(
+        os.path.join(os.path.abspath(system_root), "System32")
+    )
+    parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
+    return parent == system32
+
+
+def _git_bash_well_known_paths():
+    """Standard Git for Windows bash.exe locations."""
+    pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
+    pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
+    local = os.environ.get("LOCALAPPDATA") or ""
+    paths = [
+        os.path.join(pf, "Git", "bin", "bash.exe"),
+        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
+    ]
+    if local:
+        paths.extend([
+            os.path.join(local, "Programs", "Git", "bin", "bash.exe"),
+            os.path.join(local, "Programs", "Git", "usr", "bin", "bash.exe"),
+        ])
+    return paths
+
+
+def _resolve_windows_posix_shell() -> str:
+    """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
+
+    Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
+    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    nothing usable remains — never select System32\\bash.exe (#1268).
+    """
+    candidates = []
+    for key in ("CE_PEER_BASH", "CLAUDE_CODE_GIT_BASH_PATH"):
+        val = (os.environ.get(key) or "").strip()
+        if val:
+            candidates.append(val)
+    candidates.extend(_git_bash_well_known_paths())
+    for name in ("bash", "sh"):
+        found = shutil.which(name)
+        if found:
+            candidates.append(found)
+
+    seen = set()
+    for raw in candidates:
+        path = os.path.abspath(raw)
+        key = os.path.normcase(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not os.path.isfile(path):
+            continue
+        if _is_system32_wsl_bash(path):
+            continue
+        return path
+
+    raise RunnerError(
+        "no usable Git Bash (or other non-WSL POSIX shell) for native Windows "
+        "peer workers; install Git for Windows or set CE_PEER_BASH / "
+        "CLAUDE_CODE_GIT_BASH_PATH to an absolute bash.exe path "
+        "(System32\\bash.exe / WSL is not used)"
+    )
+
+
 def _popen_argv(argv):
     """Argv for subprocess.Popen.
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
-    worker must be launched through bash/sh. meta.json still records the
-    caller argv so authorize-dispatch contracts that forbid a shell prefix
-    stay exact. Already-prefixed workers (review skills use `bash script.sh`)
-    are left alone.
+    worker must be launched through bash/sh. Prefer Git Bash over System32
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
+    to that absolute path. meta.json still records the caller argv for
+    authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
     head = argv[0]
     base = os.path.basename(head).lower()
-    if base in ("bash", "bash.exe", "sh", "sh.exe", "env", "env.exe"):
+    if base in ("env", "env.exe"):
         return list(argv)
+    if base in ("bash", "bash.exe", "sh", "sh.exe"):
+        shell = _resolve_windows_posix_shell()
+        if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
+            return list(argv)
+        return [shell] + list(argv[1:])
     lower = head.lower()
     if not (lower.endswith(".sh") or lower.endswith(".bash")):
         return list(argv)
-    shell = shutil.which("bash") or shutil.which("sh")
-    if shell is None:
-        raise RunnerError(
-            "worker is a shell script but neither bash nor sh is on PATH; "
-            "install Git Bash or another POSIX shell to run it on Windows"
-        )
+    shell = _resolve_windows_posix_shell()
     return [shell, head] + list(argv[1:])
 
 
@@ -1484,18 +1561,28 @@ def cmd_start(args, worker_argv) -> int:
 
     argv0 = worker_argv[0]
     problem = None
-    if os.sep in argv0:
+    windows_posix_shell = None
+    base0 = os.path.basename(argv0).lower()
+    if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
+        # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        try:
+            resolved = _resolve_windows_posix_shell()
+            windows_posix_shell = resolved
+        except RunnerError as exc:
+            problem = str(exc)
+            resolved = argv0
+    elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):
             problem = "does not exist or is not a regular file"
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
             # CreateProcess cannot run shebang scripts; _popen_argv wraps with
-            # bash/sh. Require that shell now so start fails closed, not after
+            # Git Bash. Require that shell now so start fails closed, not after
             # detach. Skip the X_OK check — Windows often marks .sh non-exec.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
         elif not os.access(resolved, os.X_OK):
             problem = "is not executable"
     else:
@@ -1504,12 +1591,19 @@ def cmd_start(args, worker_argv) -> int:
             problem = "was not found on PATH"
             resolved = argv0
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
-            # Same shell requirement as the path-separator branch: a PATH hit
-            # on a bare `foo.sh` must not detach when bash/sh is missing.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
+        elif IS_WINDOWS and os.path.basename(resolved).lower() in (
+            "bash", "bash.exe", "sh", "sh.exe",
+        ):
+            # which() may have returned System32 WSL — rewrite now.
+            try:
+                resolved = _resolve_windows_posix_shell()
+                windows_posix_shell = resolved
+            except RunnerError as exc:
+                problem = str(exc)
     argv = [resolved] + list(worker_argv[1:])
 
     conf = cfg(args.skill)
@@ -1525,6 +1619,8 @@ def cmd_start(args, worker_argv) -> int:
         "sweep_enabled": not args.no_sweep,
         "supervision": conf,
     }
+    if windows_posix_shell:
+        meta["windows_posix_shell"] = windows_posix_shell
     try:
         create_exclusive(
             os.path.join(job_dir, "meta.json"),

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1167,7 +1167,7 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if tok in ("--ignore-environment", "--null", "--debug"):
+    if tok in ("--ignore-environment", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -119,7 +119,6 @@ import glob
 import json
 import os
 import re
-import shlex
 import shutil
 import signal
 import stat
@@ -1130,125 +1129,75 @@ def _windows_path_shell_candidates():
     return found
 
 
-def _env_assignment_token(token: str) -> bool:
+def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
     """True for env(1) NAME=value operands (not options or the command)."""
-    if not token or token.startswith("-") or "=" not in token:
+    if (
+        not token
+        or (token.startswith("-") and not allow_option_like)
+        or "=" not in token
+    ):
         return False
     name = token.split("=", 1)[0]
-    if not name or name[0].isdigit():
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
+    return bool(name)
 
 
 def _env_option_advance(tok: str) -> int:
     """How many argv slots an env(1) option occupies (incl. the option itself).
 
-    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
-    -S/--split-string. Attached `--name=value` forms are a single slot.
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir.
+    Attached `--name=value` forms are a single slot.
     Unknown flags advance one slot. (#1292 Codex P2)
     """
-    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+    if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
-    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+    if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+    # Short -uNAME (no space) and -CDIR are one slot.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
         return 1
     return 1
-
-
-def _parse_env_split_string(value):
-    """Split an env(1) -S/--split-string operand into words, or None.
-
-    Approximates GNU env's own word-splitting (backslash escapes, single/
-    double quotes) via shlex.split(posix=True) closely enough to detect a
-    bash/sh command inside it. Returns None when the value cannot be parsed
-    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
-    """
-    try:
-        return shlex.split(value, posix=True)
-    except ValueError:
-        return None
-
-
-def _bash_index_in_env_tokens(tokens) -> int:
-    """Index of a bash/sh command among env-style tokens, or -1.
-
-    Tokens are NAME=value assignments followed by a command, the same shape
-    `env` itself parses — used both for top-level env argv and for the words
-    produced by splitting a -S/--split-string operand (#1292).
-    """
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
-        if _env_assignment_token(tok):
-            i += 1
-            continue
-        return -1
-    return -1
 
 
 def _env_bash_index(argv):
     """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
 
     Matches the production cross-model shape `env VAR=… bash script.sh …`
-    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
-    arguments before the command token is sought (#1292).
+    (#1268). Operand-taking options (-u/-C and long forms) consume their
+    arguments before the command token is sought (#1292). Split-string forms
+    fail closed because Python shlex does not match Git env.exe semantics.
 
-    Returns (argv_index, split_prefix). split_prefix is None when
-    argv[argv_index] is itself the bare bash/sh token. It is a string
-    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
-    operand with that literal prefix (e.g. "--split-string=") still attached
-    and the bash/sh command lives inside it after word-splitting — callers
-    must reparse and rewrite the operand's command word, not the whole token
-    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
-    because the split string's contents were never inspected). Returns
-    (-1, None) when no bash/sh command is present.
+    Returns (argv_index, None), or (-1, None) when no bash/sh command is
+    present.
     """
     if not argv:
         return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
         return -1, None
     i = 1
+    options_done = False
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
             return i, None
-        if _env_assignment_token(tok):
+        if tok == "--" and not options_done:
+            options_done = True
             i += 1
             continue
-        prefix = None
-        value = None
-        idx = i
-        advance = 1
-        if tok in ("-S", "--split-string"):
-            if i + 1 >= len(argv):
-                return -1, None
-            idx = i + 1
-            prefix = ""
-            value = argv[idx]
-            advance = 2
-        elif tok.startswith("--split-string="):
-            prefix = "--split-string="
-            value = tok[len(prefix):]
-        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
-            prefix = tok[:2]
-            value = tok[2:]
-        if prefix is not None:
-            tokens = _parse_env_split_string(value)
-            if tokens is None:
-                raise RunnerError(
-                    "cannot parse env -S/--split-string operand for peer "
-                    f"worker shell selection: {value!r}"
-                )
-            if _bash_index_in_env_tokens(tokens) >= 0:
-                return idx, prefix
-            i += advance
+        if _env_assignment_token(tok, allow_option_like=options_done):
+            i += 1
             continue
-        if tok.startswith("-"):
+        if not options_done and (
+            tok in ("-S", "--split-string") or tok.startswith(
+                ("-S", "--split-string=")
+            )
+        ):
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if not options_done and tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
                 return -1, None
@@ -1282,45 +1231,20 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
-def _rewrite_env_split_string_value(value):
-    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
-
-    Returns (new_value, resolved_shell). Assumes `value` already contains a
-    resolvable bash/sh command, as checked by `_env_bash_index` via
-    `_bash_index_in_env_tokens` before this is called (#1292).
-    """
-    tokens = _parse_env_split_string(value)
-    if tokens is None:
-        raise RunnerError(
-            "cannot parse env -S/--split-string operand for peer worker "
-            f"shell selection: {value!r}"
-        )
-    idx = _bash_index_in_env_tokens(tokens)
-    shell = _prefer_windows_posix_shell(tokens[idx])
-    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
-        tokens[idx] = shell
-    return " ".join(shlex.quote(t) for t in tokens), shell
-
-
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
-    inside a -S/--split-string operand is rewritten in place within that
-    operand's word-split contents, preserving any `-S`/`--split-string=`
-    prefix still attached to the argv slot (#1292).
+    non-WSL bash tokens are kept unchanged (#1292 P2). Split-string options
+    are rejected before detach because their parser semantics are not safely
+    reproduced here (#1292).
     """
     idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
     out = list(argv)
-    if split_prefix is not None:
-        value = out[idx][len(split_prefix):]
-        new_value, shell = _rewrite_env_split_string_value(value)
-        out[idx] = split_prefix + new_value
-        return out, shell
+    assert split_prefix is None
     shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1169,16 +1169,41 @@ def _env_bash_index(argv) -> int:
     return -1
 
 
+def _windows_path_is_absolute(path: str) -> bool:
+    """True for Windows absolute paths (drive letter or path separator)."""
+    return os.sep in path or (len(path) >= 2 and path[1] == ":")
+
+
+def _prefer_windows_posix_shell(token: str) -> str:
+    """Absolute non-WSL bash/sh kept; bare names and System32 go through resolve.
+
+    Explicit absolute paths (portable Git, custom installs) must not be
+    substituted by the preferred resolver (#1292 Codex P2). Bare `bash`/`sh`
+    and System32 WSL launchers still use `_resolve_windows_posix_shell()`.
+    """
+    if _windows_path_is_absolute(token):
+        path = os.path.abspath(token)
+        if not os.path.isfile(path):
+            raise RunnerError(
+                f"peer worker shell does not exist or is not a regular file: {token}"
+            )
+        if _is_system32_wsl_bash(path):
+            return _resolve_windows_posix_shell()
+        return path
+    return _resolve_windows_posix_shell()
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
-    token is present but no usable non-WSL shell can be resolved.
+    token is present but no usable non-WSL shell can be resolved. Absolute
+    non-WSL bash tokens are kept unchanged (#1292 P2).
     """
     idx = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _resolve_windows_posix_shell()
+    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
@@ -1228,8 +1253,9 @@ def _popen_argv(argv):
     worker must be launched through bash/sh. Prefer Git Bash over System32
     WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
     `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
-    absolute path. meta.json still records the caller argv for
-    authorize-dispatch contracts that forbid a shell prefix on ce-work.
+    absolute path. Explicit absolute non-WSL bash/sh paths are kept (#1292 P2).
+    meta.json still records the caller argv for authorize-dispatch contracts
+    that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
@@ -1239,7 +1265,7 @@ def _popen_argv(argv):
         rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
         return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
-        shell = _resolve_windows_posix_shell()
+        shell = _prefer_windows_posix_shell(head)
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
             return list(argv)
         return [shell] + list(argv[1:])
@@ -1644,8 +1670,9 @@ def cmd_start(args, worker_argv) -> int:
     base0 = os.path.basename(argv0).lower()
     if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
         # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        # Keep an explicit absolute non-WSL bash (portable Git) (#1292 P2).
         try:
-            resolved = _resolve_windows_posix_shell()
+            resolved = _prefer_windows_posix_shell(argv0)
             windows_posix_shell = resolved
         except RunnerError as exc:
             problem = str(exc)

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1157,15 +1157,34 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Unknown flags advance one slot. (#1292 Codex P2)
+    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
+    cluster; -u/-C consume the rest of the token as an attached operand or the
+    next argv slot. Unsupported clusters fail closed before worker detach.
+    (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) and -CDIR are one slot.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
+    if not tok.startswith("-") or tok.startswith("--"):
         return 1
+
+    cluster = tok[1:]
+    for index, option in enumerate(cluster):
+        if option in "i0v":
+            continue
+        if option == "S":
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if option in "uC":
+            return 1 if index + 1 < len(cluster) else 2
+        raise RunnerError(
+            f"unsupported env short-option cluster {tok!r} for native "
+            "Windows peer workers; pass env options separately"
+        )
     return 1
 
 

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1160,7 +1160,8 @@ def _env_option_advance(tok: str) -> int:
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
     Short options may be clustered. No-operand flags (-i/-v and their exact
-    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    long aliases and signal-handling options) advance one slot; -u/-C consume
+    the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
     (#1292 Codex P2)
@@ -1170,6 +1171,16 @@ def _env_option_advance(tok: str) -> int:
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
     if tok in ("--ignore-environment", "--debug"):
+        return 1
+    if tok == "--list-signal-handling" or tok in (
+        "--block-signal",
+        "--default-signal",
+        "--ignore-signal",
+    ) or tok.startswith((
+        "--block-signal=",
+        "--default-signal=",
+        "--ignore-signal=",
+    )):
         return 1
     if tok == "--null":
         raise RunnerError(

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1072,18 +1072,20 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
 
 
 def _is_system32_wsl_bash(path: str) -> bool:
-    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    """True for Windows System32 WSL launchers, including Sysnative aliases."""
     if not path:
         return False
     base = os.path.basename(path).lower()
     if base not in ("bash", "bash.exe", "sh", "sh.exe"):
         return False
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    system32 = os.path.normcase(
-        os.path.join(os.path.abspath(system_root), "System32")
-    )
+    windows_root = os.path.abspath(system_root)
+    blocked_parents = {
+        os.path.normcase(os.path.join(windows_root, name))
+        for name in ("System32", "Sysnative")
+    }
     parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
-    return parent == system32
+    return parent in blocked_parents
 
 
 def _git_bash_well_known_paths():

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1216,9 +1216,6 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if tok == "--" and not options_done:
             options_done = True
             i += 1
@@ -1226,6 +1223,9 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1088,15 +1088,26 @@ def _is_system32_wsl_bash(path: str) -> bool:
 
 def _git_bash_well_known_paths():
     """Standard Git for Windows bash.exe locations."""
+    pf64 = os.environ.get("ProgramW6432") or ""
     pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
     pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
     local = os.environ.get("LOCALAPPDATA") or ""
-    paths = [
-        os.path.join(pf, "Git", "bin", "bash.exe"),
-        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
-    ]
+    roots = []
+    seen = set()
+    for root in (pf64, pf, pf86):
+        if not root:
+            continue
+        key = os.path.normcase(os.path.abspath(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(root)
+    paths = []
+    for root in roots:
+        paths.extend([
+            os.path.join(root, "Git", "bin", "bash.exe"),
+            os.path.join(root, "Git", "usr", "bin", "bash.exe"),
+        ])
     if local:
         paths.extend([
             os.path.join(local, "Programs", "Git", "bin", "bash.exe"),

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -119,6 +119,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -1156,35 +1157,105 @@ def _env_option_advance(tok: str) -> int:
     return 1
 
 
-def _env_bash_index(argv) -> int:
-    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+def _parse_env_split_string(value):
+    """Split an env(1) -S/--split-string operand into words, or None.
 
-    Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
-    and long forms) consume their arguments before the command token is
-    sought (#1292).
+    Approximates GNU env's own word-splitting (backslash escapes, single/
+    double quotes) via shlex.split(posix=True) closely enough to detect a
+    bash/sh command inside it. Returns None when the value cannot be parsed
+    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
+    """
+    try:
+        return shlex.split(value, posix=True)
+    except ValueError:
+        return None
+
+
+def _bash_index_in_env_tokens(tokens) -> int:
+    """Index of a bash/sh command among env-style tokens, or -1.
+
+    Tokens are NAME=value assignments followed by a command, the same shape
+    `env` itself parses — used both for top-level env argv and for the words
+    produced by splitting a -S/--split-string operand (#1292).
+    """
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _env_bash_index(argv):
+    """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
+
+    Matches the production cross-model shape `env VAR=… bash script.sh …`
+    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
+    arguments before the command token is sought (#1292).
+
+    Returns (argv_index, split_prefix). split_prefix is None when
+    argv[argv_index] is itself the bare bash/sh token. It is a string
+    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
+    operand with that literal prefix (e.g. "--split-string=") still attached
+    and the bash/sh command lives inside it after word-splitting — callers
+    must reparse and rewrite the operand's command word, not the whole token
+    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
+    because the split string's contents were never inspected). Returns
+    (-1, None) when no bash/sh command is present.
     """
     if not argv:
-        return -1
+        return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
-        return -1
+        return -1, None
     i = 1
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
+            return i, None
         if _env_assignment_token(tok):
             i += 1
+            continue
+        prefix = None
+        value = None
+        idx = i
+        advance = 1
+        if tok in ("-S", "--split-string"):
+            if i + 1 >= len(argv):
+                return -1, None
+            idx = i + 1
+            prefix = ""
+            value = argv[idx]
+            advance = 2
+        elif tok.startswith("--split-string="):
+            prefix = "--split-string="
+            value = tok[len(prefix):]
+        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
+            prefix = tok[:2]
+            value = tok[2:]
+        if prefix is not None:
+            tokens = _parse_env_split_string(value)
+            if tokens is None:
+                raise RunnerError(
+                    "cannot parse env -S/--split-string operand for peer "
+                    f"worker shell selection: {value!r}"
+                )
+            if _bash_index_in_env_tokens(tokens) >= 0:
+                return idx, prefix
+            i += advance
             continue
         if tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
-                return -1
+                return -1, None
             i += span
             continue
-        return -1
-    return -1
+        return -1, None
+    return -1, None
 
 
 def _windows_path_is_absolute(path: str) -> bool:
@@ -1211,18 +1282,46 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
+def _rewrite_env_split_string_value(value):
+    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
+
+    Returns (new_value, resolved_shell). Assumes `value` already contains a
+    resolvable bash/sh command, as checked by `_env_bash_index` via
+    `_bash_index_in_env_tokens` before this is called (#1292).
+    """
+    tokens = _parse_env_split_string(value)
+    if tokens is None:
+        raise RunnerError(
+            "cannot parse env -S/--split-string operand for peer worker "
+            f"shell selection: {value!r}"
+        )
+    idx = _bash_index_in_env_tokens(tokens)
+    shell = _prefer_windows_posix_shell(tokens[idx])
+    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
+        tokens[idx] = shell
+    return " ".join(shlex.quote(t) for t in tokens), shell
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2).
+    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
+    inside a -S/--split-string operand is rewritten in place within that
+    operand's word-split contents, preserving any `-S`/`--split-string=`
+    prefix still attached to the argv slot (#1292).
     """
-    idx = _env_bash_index(argv)
+    idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
+    if split_prefix is not None:
+        value = out[idx][len(split_prefix):]
+        new_value, shell = _rewrite_env_split_string_value(value)
+        out[idx] = split_prefix + new_value
+        return out, shell
+    shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
     return out, shell

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1228,7 +1228,7 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        if tok == "--" and not options_done:
+        if tok in ("-", "--") and not options_done:
             options_done = True
             i += 1
             continue

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1105,11 +1105,91 @@ def _git_bash_well_known_paths():
     return paths
 
 
+def _windows_path_shell_candidates():
+    """Every bash/sh on PATH in PATH order (not only shutil.which's first hit)."""
+    path_env = os.environ.get("PATH") or ""
+    names = ("bash.exe", "bash", "sh.exe", "sh")
+    found = []
+    seen = set()
+    for directory in path_env.split(os.pathsep):
+        if not directory:
+            continue
+        for name in names:
+            candidate = os.path.join(directory, name)
+            try:
+                if not os.path.isfile(candidate):
+                    continue
+            except OSError:
+                continue
+            key = os.path.normcase(os.path.abspath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(candidate)
+    return found
+
+
+def _env_assignment_token(token: str) -> bool:
+    """True for env(1) NAME=value operands (not options or the command)."""
+    if not token or token.startswith("-") or "=" not in token:
+        return False
+    name = token.split("=", 1)[0]
+    if not name or name[0].isdigit():
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _env_bash_index(argv) -> int:
+    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+
+    Matches the production cross-model shape:
+    `env VAR=… bash script.sh …` (#1268).
+    """
+    if not argv:
+        return -1
+    if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
+        return -1
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            # env -u NAME / --unset NAME consume the following argument.
+            if tok in ("-u", "--unset"):
+                i += 2
+                continue
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _rewrite_windows_env_bash_argv(argv):
+    """Rewrite bare bash/sh inside an env-prefixed argv.
+
+    Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
+    token is present but no usable non-WSL shell can be resolved.
+    """
+    idx = _env_bash_index(argv)
+    if idx < 0:
+        return list(argv), None
+    shell = _resolve_windows_posix_shell()
+    out = list(argv)
+    if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
+        out[idx] = shell
+    return out, shell
+
+
 def _resolve_windows_posix_shell() -> str:
     """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
 
     Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
-    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    installs, then every PATH bash/sh excluding System32 WSL. Fail closed when
     nothing usable remains — never select System32\\bash.exe (#1268).
     """
     candidates = []
@@ -1118,10 +1198,7 @@ def _resolve_windows_posix_shell() -> str:
         if val:
             candidates.append(val)
     candidates.extend(_git_bash_well_known_paths())
-    for name in ("bash", "sh"):
-        found = shutil.which(name)
-        if found:
-            candidates.append(found)
+    candidates.extend(_windows_path_shell_candidates())
 
     seen = set()
     for raw in candidates:
@@ -1149,8 +1226,9 @@ def _popen_argv(argv):
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
     worker must be launched through bash/sh. Prefer Git Bash over System32
-    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
-    to that absolute path. meta.json still records the caller argv for
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
+    `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
+    absolute path. meta.json still records the caller argv for
     authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
@@ -1158,7 +1236,8 @@ def _popen_argv(argv):
     head = argv[0]
     base = os.path.basename(head).lower()
     if base in ("env", "env.exe"):
-        return list(argv)
+        rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
+        return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
         shell = _resolve_windows_posix_shell()
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
@@ -1571,6 +1650,25 @@ def cmd_start(args, worker_argv) -> int:
         except RunnerError as exc:
             problem = str(exc)
             resolved = argv0
+    elif IS_WINDOWS and base0 in ("env", "env.exe"):
+        # Production cross-model: env VAR=… bash script.sh — rewrite bash
+        # before detach so env cannot PATH-resolve System32 WSL (#1268).
+        if os.sep in argv0 or (len(argv0) >= 2 and argv0[1] == ":"):
+            resolved = os.path.abspath(argv0)
+            if not os.path.isfile(resolved):
+                problem = "does not exist or is not a regular file"
+        else:
+            resolved = shutil.which(argv0)
+            if resolved is None:
+                problem = "was not found on PATH"
+                resolved = argv0
+        try:
+            rewritten, shell = _rewrite_windows_env_bash_argv(list(worker_argv))
+            if shell is not None:
+                windows_posix_shell = shell
+                worker_argv = rewritten
+        except RunnerError as exc:
+            problem = str(exc) if problem is None else f"{problem}; {exc}"
     elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1166,8 +1166,14 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if not tok.startswith("-") or tok.startswith("--"):
+    if not tok.startswith("-"):
         return 1
+    if tok.startswith("--"):
+        raise RunnerError(
+            f"unsupported env long option {tok!r} for native Windows peer "
+            "workers; use an exact supported option or pass -- before "
+            "option-like assignments"
+        )
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1233,6 +1233,7 @@ def _env_bash_index(argv):
             i += 1
             continue
         if _env_assignment_token(tok, allow_option_like=options_done):
+            options_done = True
             i += 1
             continue
         if not options_done and (

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -1159,7 +1159,7 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    Short options may be clustered. No-operand flags (-i/-v and their exact
     long aliases) advance one slot; -u/-C consume the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
@@ -1171,6 +1171,11 @@ def _env_option_advance(tok: str) -> int:
         return 1
     if tok in ("--ignore-environment", "--debug"):
         return 1
+    if tok == "--null":
+        raise RunnerError(
+            "env -0/--null cannot be used with a command by native Windows "
+            "peer workers; remove the null-output option"
+        )
     if not tok.startswith("-"):
         return 1
     if tok.startswith("--"):
@@ -1182,8 +1187,13 @@ def _env_option_advance(tok: str) -> int:
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):
-        if option in "i0v":
+        if option in "iv":
             continue
+        if option == "0":
+            raise RunnerError(
+                "env -0/--null cannot be used with a command by native "
+                "Windows peer workers; remove the null-output option"
+            )
         if option == "S":
             raise RunnerError(
                 "env -S/--split-string is unsupported for native Windows "
@@ -1225,9 +1235,6 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")
@@ -1244,6 +1251,9 @@ def _env_bash_index(argv):
                 return -1, None
             i += span
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         return -1, None
     return -1, None
 

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1150,8 +1150,7 @@ def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
         or "=" not in token
     ):
         return False
-    name = token.split("=", 1)[0]
-    return bool(name)
+    return True
 
 
 def _env_option_advance(tok: str) -> int:

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1157,14 +1157,17 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
-    cluster; -u/-C consume the rest of the token as an attached operand or the
-    next argv slot. Unsupported clusters fail closed before worker detach.
+    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    attached operand or the next argv slot. Unsupported options fail closed
+    before worker detach.
     (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
+        return 1
+    if tok in ("--ignore-environment", "--null", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1139,11 +1139,30 @@ def _env_assignment_token(token: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
+def _env_option_advance(tok: str) -> int:
+    """How many argv slots an env(1) option occupies (incl. the option itself).
+
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
+    -S/--split-string. Attached `--name=value` forms are a single slot.
+    Unknown flags advance one slot. (#1292 Codex P2)
+    """
+    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+        return 2
+    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+        return 1
+    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+        return 1
+    return 1
+
+
 def _env_bash_index(argv) -> int:
     """Index of bare bash/sh after `env` [options] [assignments], or -1.
 
     Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268).
+    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
+    and long forms) consume their arguments before the command token is
+    sought (#1292).
     """
     if not argv:
         return -1
@@ -1159,11 +1178,10 @@ def _env_bash_index(argv) -> int:
             i += 1
             continue
         if tok.startswith("-"):
-            # env -u NAME / --unset NAME consume the following argument.
-            if tok in ("-u", "--unset"):
-                i += 2
-                continue
-            i += 1
+            span = _env_option_advance(tok)
+            if span > 1 and i + 1 >= len(argv):
+                return -1
+            i += span
             continue
         return -1
     return -1

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -70,6 +70,10 @@ Environment overrides (defaults in parentheses):
   CE_PEER_RESULT_MAX_BYTES  result byte cap, supervise + read (5242880)
   CE_PEER_POLL_SECS         supervisor poll interval (2)
   CE_PEER_GRACE_SECS        TERM-to-KILL grace during reap (5)
+  CE_PEER_BASH              Windows: absolute bash.exe for peer workers
+                            (preferred over PATH / WSL System32 bash)
+  CLAUDE_CODE_GIT_BASH_PATH Claude Code Git Bash path; used on Windows when
+                            CE_PEER_BASH is unset (#1268)
 
 Security posture: the job root is a predictable, owner-private directory under
 world-shared /tmp. Every read of job state opens the file first (no-follow) and
@@ -1067,30 +1071,103 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
         time.sleep(min(0.1, max(0.01, end - time.monotonic())))
 
 
+def _is_system32_wsl_bash(path: str) -> bool:
+    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    if not path:
+        return False
+    base = os.path.basename(path).lower()
+    if base not in ("bash", "bash.exe", "sh", "sh.exe"):
+        return False
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    system32 = os.path.normcase(
+        os.path.join(os.path.abspath(system_root), "System32")
+    )
+    parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
+    return parent == system32
+
+
+def _git_bash_well_known_paths():
+    """Standard Git for Windows bash.exe locations."""
+    pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
+    pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
+    local = os.environ.get("LOCALAPPDATA") or ""
+    paths = [
+        os.path.join(pf, "Git", "bin", "bash.exe"),
+        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
+    ]
+    if local:
+        paths.extend([
+            os.path.join(local, "Programs", "Git", "bin", "bash.exe"),
+            os.path.join(local, "Programs", "Git", "usr", "bin", "bash.exe"),
+        ])
+    return paths
+
+
+def _resolve_windows_posix_shell() -> str:
+    """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
+
+    Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
+    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    nothing usable remains — never select System32\\bash.exe (#1268).
+    """
+    candidates = []
+    for key in ("CE_PEER_BASH", "CLAUDE_CODE_GIT_BASH_PATH"):
+        val = (os.environ.get(key) or "").strip()
+        if val:
+            candidates.append(val)
+    candidates.extend(_git_bash_well_known_paths())
+    for name in ("bash", "sh"):
+        found = shutil.which(name)
+        if found:
+            candidates.append(found)
+
+    seen = set()
+    for raw in candidates:
+        path = os.path.abspath(raw)
+        key = os.path.normcase(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not os.path.isfile(path):
+            continue
+        if _is_system32_wsl_bash(path):
+            continue
+        return path
+
+    raise RunnerError(
+        "no usable Git Bash (or other non-WSL POSIX shell) for native Windows "
+        "peer workers; install Git for Windows or set CE_PEER_BASH / "
+        "CLAUDE_CODE_GIT_BASH_PATH to an absolute bash.exe path "
+        "(System32\\bash.exe / WSL is not used)"
+    )
+
+
 def _popen_argv(argv):
     """Argv for subprocess.Popen.
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
-    worker must be launched through bash/sh. meta.json still records the
-    caller argv so authorize-dispatch contracts that forbid a shell prefix
-    stay exact. Already-prefixed workers (review skills use `bash script.sh`)
-    are left alone.
+    worker must be launched through bash/sh. Prefer Git Bash over System32
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
+    to that absolute path. meta.json still records the caller argv for
+    authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
     head = argv[0]
     base = os.path.basename(head).lower()
-    if base in ("bash", "bash.exe", "sh", "sh.exe", "env", "env.exe"):
+    if base in ("env", "env.exe"):
         return list(argv)
+    if base in ("bash", "bash.exe", "sh", "sh.exe"):
+        shell = _resolve_windows_posix_shell()
+        if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
+            return list(argv)
+        return [shell] + list(argv[1:])
     lower = head.lower()
     if not (lower.endswith(".sh") or lower.endswith(".bash")):
         return list(argv)
-    shell = shutil.which("bash") or shutil.which("sh")
-    if shell is None:
-        raise RunnerError(
-            "worker is a shell script but neither bash nor sh is on PATH; "
-            "install Git Bash or another POSIX shell to run it on Windows"
-        )
+    shell = _resolve_windows_posix_shell()
     return [shell, head] + list(argv[1:])
 
 
@@ -1484,18 +1561,28 @@ def cmd_start(args, worker_argv) -> int:
 
     argv0 = worker_argv[0]
     problem = None
-    if os.sep in argv0:
+    windows_posix_shell = None
+    base0 = os.path.basename(argv0).lower()
+    if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
+        # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        try:
+            resolved = _resolve_windows_posix_shell()
+            windows_posix_shell = resolved
+        except RunnerError as exc:
+            problem = str(exc)
+            resolved = argv0
+    elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):
             problem = "does not exist or is not a regular file"
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
             # CreateProcess cannot run shebang scripts; _popen_argv wraps with
-            # bash/sh. Require that shell now so start fails closed, not after
+            # Git Bash. Require that shell now so start fails closed, not after
             # detach. Skip the X_OK check — Windows often marks .sh non-exec.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
         elif not os.access(resolved, os.X_OK):
             problem = "is not executable"
     else:
@@ -1504,12 +1591,19 @@ def cmd_start(args, worker_argv) -> int:
             problem = "was not found on PATH"
             resolved = argv0
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
-            # Same shell requirement as the path-separator branch: a PATH hit
-            # on a bare `foo.sh` must not detach when bash/sh is missing.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
+        elif IS_WINDOWS and os.path.basename(resolved).lower() in (
+            "bash", "bash.exe", "sh", "sh.exe",
+        ):
+            # which() may have returned System32 WSL — rewrite now.
+            try:
+                resolved = _resolve_windows_posix_shell()
+                windows_posix_shell = resolved
+            except RunnerError as exc:
+                problem = str(exc)
     argv = [resolved] + list(worker_argv[1:])
 
     conf = cfg(args.skill)
@@ -1525,6 +1619,8 @@ def cmd_start(args, worker_argv) -> int:
         "sweep_enabled": not args.no_sweep,
         "supervision": conf,
     }
+    if windows_posix_shell:
+        meta["windows_posix_shell"] = windows_posix_shell
     try:
         create_exclusive(
             os.path.join(job_dir, "meta.json"),

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1167,7 +1167,7 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if tok in ("--ignore-environment", "--null", "--debug"):
+    if tok in ("--ignore-environment", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -119,7 +119,6 @@ import glob
 import json
 import os
 import re
-import shlex
 import shutil
 import signal
 import stat
@@ -1130,125 +1129,75 @@ def _windows_path_shell_candidates():
     return found
 
 
-def _env_assignment_token(token: str) -> bool:
+def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
     """True for env(1) NAME=value operands (not options or the command)."""
-    if not token or token.startswith("-") or "=" not in token:
+    if (
+        not token
+        or (token.startswith("-") and not allow_option_like)
+        or "=" not in token
+    ):
         return False
     name = token.split("=", 1)[0]
-    if not name or name[0].isdigit():
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
+    return bool(name)
 
 
 def _env_option_advance(tok: str) -> int:
     """How many argv slots an env(1) option occupies (incl. the option itself).
 
-    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
-    -S/--split-string. Attached `--name=value` forms are a single slot.
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir.
+    Attached `--name=value` forms are a single slot.
     Unknown flags advance one slot. (#1292 Codex P2)
     """
-    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+    if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
-    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+    if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+    # Short -uNAME (no space) and -CDIR are one slot.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
         return 1
     return 1
-
-
-def _parse_env_split_string(value):
-    """Split an env(1) -S/--split-string operand into words, or None.
-
-    Approximates GNU env's own word-splitting (backslash escapes, single/
-    double quotes) via shlex.split(posix=True) closely enough to detect a
-    bash/sh command inside it. Returns None when the value cannot be parsed
-    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
-    """
-    try:
-        return shlex.split(value, posix=True)
-    except ValueError:
-        return None
-
-
-def _bash_index_in_env_tokens(tokens) -> int:
-    """Index of a bash/sh command among env-style tokens, or -1.
-
-    Tokens are NAME=value assignments followed by a command, the same shape
-    `env` itself parses — used both for top-level env argv and for the words
-    produced by splitting a -S/--split-string operand (#1292).
-    """
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
-        if _env_assignment_token(tok):
-            i += 1
-            continue
-        return -1
-    return -1
 
 
 def _env_bash_index(argv):
     """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
 
     Matches the production cross-model shape `env VAR=… bash script.sh …`
-    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
-    arguments before the command token is sought (#1292).
+    (#1268). Operand-taking options (-u/-C and long forms) consume their
+    arguments before the command token is sought (#1292). Split-string forms
+    fail closed because Python shlex does not match Git env.exe semantics.
 
-    Returns (argv_index, split_prefix). split_prefix is None when
-    argv[argv_index] is itself the bare bash/sh token. It is a string
-    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
-    operand with that literal prefix (e.g. "--split-string=") still attached
-    and the bash/sh command lives inside it after word-splitting — callers
-    must reparse and rewrite the operand's command word, not the whole token
-    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
-    because the split string's contents were never inspected). Returns
-    (-1, None) when no bash/sh command is present.
+    Returns (argv_index, None), or (-1, None) when no bash/sh command is
+    present.
     """
     if not argv:
         return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
         return -1, None
     i = 1
+    options_done = False
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
             return i, None
-        if _env_assignment_token(tok):
+        if tok == "--" and not options_done:
+            options_done = True
             i += 1
             continue
-        prefix = None
-        value = None
-        idx = i
-        advance = 1
-        if tok in ("-S", "--split-string"):
-            if i + 1 >= len(argv):
-                return -1, None
-            idx = i + 1
-            prefix = ""
-            value = argv[idx]
-            advance = 2
-        elif tok.startswith("--split-string="):
-            prefix = "--split-string="
-            value = tok[len(prefix):]
-        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
-            prefix = tok[:2]
-            value = tok[2:]
-        if prefix is not None:
-            tokens = _parse_env_split_string(value)
-            if tokens is None:
-                raise RunnerError(
-                    "cannot parse env -S/--split-string operand for peer "
-                    f"worker shell selection: {value!r}"
-                )
-            if _bash_index_in_env_tokens(tokens) >= 0:
-                return idx, prefix
-            i += advance
+        if _env_assignment_token(tok, allow_option_like=options_done):
+            i += 1
             continue
-        if tok.startswith("-"):
+        if not options_done and (
+            tok in ("-S", "--split-string") or tok.startswith(
+                ("-S", "--split-string=")
+            )
+        ):
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if not options_done and tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
                 return -1, None
@@ -1282,45 +1231,20 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
-def _rewrite_env_split_string_value(value):
-    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
-
-    Returns (new_value, resolved_shell). Assumes `value` already contains a
-    resolvable bash/sh command, as checked by `_env_bash_index` via
-    `_bash_index_in_env_tokens` before this is called (#1292).
-    """
-    tokens = _parse_env_split_string(value)
-    if tokens is None:
-        raise RunnerError(
-            "cannot parse env -S/--split-string operand for peer worker "
-            f"shell selection: {value!r}"
-        )
-    idx = _bash_index_in_env_tokens(tokens)
-    shell = _prefer_windows_posix_shell(tokens[idx])
-    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
-        tokens[idx] = shell
-    return " ".join(shlex.quote(t) for t in tokens), shell
-
-
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
-    inside a -S/--split-string operand is rewritten in place within that
-    operand's word-split contents, preserving any `-S`/`--split-string=`
-    prefix still attached to the argv slot (#1292).
+    non-WSL bash tokens are kept unchanged (#1292 P2). Split-string options
+    are rejected before detach because their parser semantics are not safely
+    reproduced here (#1292).
     """
     idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
     out = list(argv)
-    if split_prefix is not None:
-        value = out[idx][len(split_prefix):]
-        new_value, shell = _rewrite_env_split_string_value(value)
-        out[idx] = split_prefix + new_value
-        return out, shell
+    assert split_prefix is None
     shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1169,16 +1169,41 @@ def _env_bash_index(argv) -> int:
     return -1
 
 
+def _windows_path_is_absolute(path: str) -> bool:
+    """True for Windows absolute paths (drive letter or path separator)."""
+    return os.sep in path or (len(path) >= 2 and path[1] == ":")
+
+
+def _prefer_windows_posix_shell(token: str) -> str:
+    """Absolute non-WSL bash/sh kept; bare names and System32 go through resolve.
+
+    Explicit absolute paths (portable Git, custom installs) must not be
+    substituted by the preferred resolver (#1292 Codex P2). Bare `bash`/`sh`
+    and System32 WSL launchers still use `_resolve_windows_posix_shell()`.
+    """
+    if _windows_path_is_absolute(token):
+        path = os.path.abspath(token)
+        if not os.path.isfile(path):
+            raise RunnerError(
+                f"peer worker shell does not exist or is not a regular file: {token}"
+            )
+        if _is_system32_wsl_bash(path):
+            return _resolve_windows_posix_shell()
+        return path
+    return _resolve_windows_posix_shell()
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
-    token is present but no usable non-WSL shell can be resolved.
+    token is present but no usable non-WSL shell can be resolved. Absolute
+    non-WSL bash tokens are kept unchanged (#1292 P2).
     """
     idx = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _resolve_windows_posix_shell()
+    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
@@ -1228,8 +1253,9 @@ def _popen_argv(argv):
     worker must be launched through bash/sh. Prefer Git Bash over System32
     WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
     `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
-    absolute path. meta.json still records the caller argv for
-    authorize-dispatch contracts that forbid a shell prefix on ce-work.
+    absolute path. Explicit absolute non-WSL bash/sh paths are kept (#1292 P2).
+    meta.json still records the caller argv for authorize-dispatch contracts
+    that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
@@ -1239,7 +1265,7 @@ def _popen_argv(argv):
         rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
         return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
-        shell = _resolve_windows_posix_shell()
+        shell = _prefer_windows_posix_shell(head)
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
             return list(argv)
         return [shell] + list(argv[1:])
@@ -1644,8 +1670,9 @@ def cmd_start(args, worker_argv) -> int:
     base0 = os.path.basename(argv0).lower()
     if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
         # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        # Keep an explicit absolute non-WSL bash (portable Git) (#1292 P2).
         try:
-            resolved = _resolve_windows_posix_shell()
+            resolved = _prefer_windows_posix_shell(argv0)
             windows_posix_shell = resolved
         except RunnerError as exc:
             problem = str(exc)

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1157,15 +1157,34 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Unknown flags advance one slot. (#1292 Codex P2)
+    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
+    cluster; -u/-C consume the rest of the token as an attached operand or the
+    next argv slot. Unsupported clusters fail closed before worker detach.
+    (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) and -CDIR are one slot.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
+    if not tok.startswith("-") or tok.startswith("--"):
         return 1
+
+    cluster = tok[1:]
+    for index, option in enumerate(cluster):
+        if option in "i0v":
+            continue
+        if option == "S":
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if option in "uC":
+            return 1 if index + 1 < len(cluster) else 2
+        raise RunnerError(
+            f"unsupported env short-option cluster {tok!r} for native "
+            "Windows peer workers; pass env options separately"
+        )
     return 1
 
 

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1160,7 +1160,8 @@ def _env_option_advance(tok: str) -> int:
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
     Short options may be clustered. No-operand flags (-i/-v and their exact
-    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    long aliases and signal-handling options) advance one slot; -u/-C consume
+    the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
     (#1292 Codex P2)
@@ -1170,6 +1171,16 @@ def _env_option_advance(tok: str) -> int:
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
     if tok in ("--ignore-environment", "--debug"):
+        return 1
+    if tok == "--list-signal-handling" or tok in (
+        "--block-signal",
+        "--default-signal",
+        "--ignore-signal",
+    ) or tok.startswith((
+        "--block-signal=",
+        "--default-signal=",
+        "--ignore-signal=",
+    )):
         return 1
     if tok == "--null":
         raise RunnerError(

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1072,18 +1072,20 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
 
 
 def _is_system32_wsl_bash(path: str) -> bool:
-    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    """True for Windows System32 WSL launchers, including Sysnative aliases."""
     if not path:
         return False
     base = os.path.basename(path).lower()
     if base not in ("bash", "bash.exe", "sh", "sh.exe"):
         return False
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    system32 = os.path.normcase(
-        os.path.join(os.path.abspath(system_root), "System32")
-    )
+    windows_root = os.path.abspath(system_root)
+    blocked_parents = {
+        os.path.normcase(os.path.join(windows_root, name))
+        for name in ("System32", "Sysnative")
+    }
     parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
-    return parent == system32
+    return parent in blocked_parents
 
 
 def _git_bash_well_known_paths():

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1216,9 +1216,6 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if tok == "--" and not options_done:
             options_done = True
             i += 1
@@ -1226,6 +1223,9 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1088,15 +1088,26 @@ def _is_system32_wsl_bash(path: str) -> bool:
 
 def _git_bash_well_known_paths():
     """Standard Git for Windows bash.exe locations."""
+    pf64 = os.environ.get("ProgramW6432") or ""
     pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
     pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
     local = os.environ.get("LOCALAPPDATA") or ""
-    paths = [
-        os.path.join(pf, "Git", "bin", "bash.exe"),
-        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
-    ]
+    roots = []
+    seen = set()
+    for root in (pf64, pf, pf86):
+        if not root:
+            continue
+        key = os.path.normcase(os.path.abspath(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(root)
+    paths = []
+    for root in roots:
+        paths.extend([
+            os.path.join(root, "Git", "bin", "bash.exe"),
+            os.path.join(root, "Git", "usr", "bin", "bash.exe"),
+        ])
     if local:
         paths.extend([
             os.path.join(local, "Programs", "Git", "bin", "bash.exe"),

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -119,6 +119,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -1156,35 +1157,105 @@ def _env_option_advance(tok: str) -> int:
     return 1
 
 
-def _env_bash_index(argv) -> int:
-    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+def _parse_env_split_string(value):
+    """Split an env(1) -S/--split-string operand into words, or None.
 
-    Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
-    and long forms) consume their arguments before the command token is
-    sought (#1292).
+    Approximates GNU env's own word-splitting (backslash escapes, single/
+    double quotes) via shlex.split(posix=True) closely enough to detect a
+    bash/sh command inside it. Returns None when the value cannot be parsed
+    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
+    """
+    try:
+        return shlex.split(value, posix=True)
+    except ValueError:
+        return None
+
+
+def _bash_index_in_env_tokens(tokens) -> int:
+    """Index of a bash/sh command among env-style tokens, or -1.
+
+    Tokens are NAME=value assignments followed by a command, the same shape
+    `env` itself parses — used both for top-level env argv and for the words
+    produced by splitting a -S/--split-string operand (#1292).
+    """
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _env_bash_index(argv):
+    """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
+
+    Matches the production cross-model shape `env VAR=… bash script.sh …`
+    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
+    arguments before the command token is sought (#1292).
+
+    Returns (argv_index, split_prefix). split_prefix is None when
+    argv[argv_index] is itself the bare bash/sh token. It is a string
+    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
+    operand with that literal prefix (e.g. "--split-string=") still attached
+    and the bash/sh command lives inside it after word-splitting — callers
+    must reparse and rewrite the operand's command word, not the whole token
+    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
+    because the split string's contents were never inspected). Returns
+    (-1, None) when no bash/sh command is present.
     """
     if not argv:
-        return -1
+        return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
-        return -1
+        return -1, None
     i = 1
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
+            return i, None
         if _env_assignment_token(tok):
             i += 1
+            continue
+        prefix = None
+        value = None
+        idx = i
+        advance = 1
+        if tok in ("-S", "--split-string"):
+            if i + 1 >= len(argv):
+                return -1, None
+            idx = i + 1
+            prefix = ""
+            value = argv[idx]
+            advance = 2
+        elif tok.startswith("--split-string="):
+            prefix = "--split-string="
+            value = tok[len(prefix):]
+        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
+            prefix = tok[:2]
+            value = tok[2:]
+        if prefix is not None:
+            tokens = _parse_env_split_string(value)
+            if tokens is None:
+                raise RunnerError(
+                    "cannot parse env -S/--split-string operand for peer "
+                    f"worker shell selection: {value!r}"
+                )
+            if _bash_index_in_env_tokens(tokens) >= 0:
+                return idx, prefix
+            i += advance
             continue
         if tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
-                return -1
+                return -1, None
             i += span
             continue
-        return -1
-    return -1
+        return -1, None
+    return -1, None
 
 
 def _windows_path_is_absolute(path: str) -> bool:
@@ -1211,18 +1282,46 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
+def _rewrite_env_split_string_value(value):
+    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
+
+    Returns (new_value, resolved_shell). Assumes `value` already contains a
+    resolvable bash/sh command, as checked by `_env_bash_index` via
+    `_bash_index_in_env_tokens` before this is called (#1292).
+    """
+    tokens = _parse_env_split_string(value)
+    if tokens is None:
+        raise RunnerError(
+            "cannot parse env -S/--split-string operand for peer worker "
+            f"shell selection: {value!r}"
+        )
+    idx = _bash_index_in_env_tokens(tokens)
+    shell = _prefer_windows_posix_shell(tokens[idx])
+    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
+        tokens[idx] = shell
+    return " ".join(shlex.quote(t) for t in tokens), shell
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2).
+    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
+    inside a -S/--split-string operand is rewritten in place within that
+    operand's word-split contents, preserving any `-S`/`--split-string=`
+    prefix still attached to the argv slot (#1292).
     """
-    idx = _env_bash_index(argv)
+    idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
+    if split_prefix is not None:
+        value = out[idx][len(split_prefix):]
+        new_value, shell = _rewrite_env_split_string_value(value)
+        out[idx] = split_prefix + new_value
+        return out, shell
+    shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
     return out, shell

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1228,7 +1228,7 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        if tok == "--" and not options_done:
+        if tok in ("-", "--") and not options_done:
             options_done = True
             i += 1
             continue

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1105,11 +1105,91 @@ def _git_bash_well_known_paths():
     return paths
 
 
+def _windows_path_shell_candidates():
+    """Every bash/sh on PATH in PATH order (not only shutil.which's first hit)."""
+    path_env = os.environ.get("PATH") or ""
+    names = ("bash.exe", "bash", "sh.exe", "sh")
+    found = []
+    seen = set()
+    for directory in path_env.split(os.pathsep):
+        if not directory:
+            continue
+        for name in names:
+            candidate = os.path.join(directory, name)
+            try:
+                if not os.path.isfile(candidate):
+                    continue
+            except OSError:
+                continue
+            key = os.path.normcase(os.path.abspath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(candidate)
+    return found
+
+
+def _env_assignment_token(token: str) -> bool:
+    """True for env(1) NAME=value operands (not options or the command)."""
+    if not token or token.startswith("-") or "=" not in token:
+        return False
+    name = token.split("=", 1)[0]
+    if not name or name[0].isdigit():
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _env_bash_index(argv) -> int:
+    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+
+    Matches the production cross-model shape:
+    `env VAR=… bash script.sh …` (#1268).
+    """
+    if not argv:
+        return -1
+    if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
+        return -1
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            # env -u NAME / --unset NAME consume the following argument.
+            if tok in ("-u", "--unset"):
+                i += 2
+                continue
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _rewrite_windows_env_bash_argv(argv):
+    """Rewrite bare bash/sh inside an env-prefixed argv.
+
+    Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
+    token is present but no usable non-WSL shell can be resolved.
+    """
+    idx = _env_bash_index(argv)
+    if idx < 0:
+        return list(argv), None
+    shell = _resolve_windows_posix_shell()
+    out = list(argv)
+    if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
+        out[idx] = shell
+    return out, shell
+
+
 def _resolve_windows_posix_shell() -> str:
     """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
 
     Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
-    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    installs, then every PATH bash/sh excluding System32 WSL. Fail closed when
     nothing usable remains — never select System32\\bash.exe (#1268).
     """
     candidates = []
@@ -1118,10 +1198,7 @@ def _resolve_windows_posix_shell() -> str:
         if val:
             candidates.append(val)
     candidates.extend(_git_bash_well_known_paths())
-    for name in ("bash", "sh"):
-        found = shutil.which(name)
-        if found:
-            candidates.append(found)
+    candidates.extend(_windows_path_shell_candidates())
 
     seen = set()
     for raw in candidates:
@@ -1149,8 +1226,9 @@ def _popen_argv(argv):
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
     worker must be launched through bash/sh. Prefer Git Bash over System32
-    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
-    to that absolute path. meta.json still records the caller argv for
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
+    `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
+    absolute path. meta.json still records the caller argv for
     authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
@@ -1158,7 +1236,8 @@ def _popen_argv(argv):
     head = argv[0]
     base = os.path.basename(head).lower()
     if base in ("env", "env.exe"):
-        return list(argv)
+        rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
+        return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
         shell = _resolve_windows_posix_shell()
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
@@ -1571,6 +1650,25 @@ def cmd_start(args, worker_argv) -> int:
         except RunnerError as exc:
             problem = str(exc)
             resolved = argv0
+    elif IS_WINDOWS and base0 in ("env", "env.exe"):
+        # Production cross-model: env VAR=… bash script.sh — rewrite bash
+        # before detach so env cannot PATH-resolve System32 WSL (#1268).
+        if os.sep in argv0 or (len(argv0) >= 2 and argv0[1] == ":"):
+            resolved = os.path.abspath(argv0)
+            if not os.path.isfile(resolved):
+                problem = "does not exist or is not a regular file"
+        else:
+            resolved = shutil.which(argv0)
+            if resolved is None:
+                problem = "was not found on PATH"
+                resolved = argv0
+        try:
+            rewritten, shell = _rewrite_windows_env_bash_argv(list(worker_argv))
+            if shell is not None:
+                windows_posix_shell = shell
+                worker_argv = rewritten
+        except RunnerError as exc:
+            problem = str(exc) if problem is None else f"{problem}; {exc}"
     elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1166,8 +1166,14 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if not tok.startswith("-") or tok.startswith("--"):
+    if not tok.startswith("-"):
         return 1
+    if tok.startswith("--"):
+        raise RunnerError(
+            f"unsupported env long option {tok!r} for native Windows peer "
+            "workers; use an exact supported option or pass -- before "
+            "option-like assignments"
+        )
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1233,6 +1233,7 @@ def _env_bash_index(argv):
             i += 1
             continue
         if _env_assignment_token(tok, allow_option_like=options_done):
+            options_done = True
             i += 1
             continue
         if not options_done and (

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -1159,7 +1159,7 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    Short options may be clustered. No-operand flags (-i/-v and their exact
     long aliases) advance one slot; -u/-C consume the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
@@ -1171,6 +1171,11 @@ def _env_option_advance(tok: str) -> int:
         return 1
     if tok in ("--ignore-environment", "--debug"):
         return 1
+    if tok == "--null":
+        raise RunnerError(
+            "env -0/--null cannot be used with a command by native Windows "
+            "peer workers; remove the null-output option"
+        )
     if not tok.startswith("-"):
         return 1
     if tok.startswith("--"):
@@ -1182,8 +1187,13 @@ def _env_option_advance(tok: str) -> int:
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):
-        if option in "i0v":
+        if option in "iv":
             continue
+        if option == "0":
+            raise RunnerError(
+                "env -0/--null cannot be used with a command by native "
+                "Windows peer workers; remove the null-output option"
+            )
         if option == "S":
             raise RunnerError(
                 "env -S/--split-string is unsupported for native Windows "
@@ -1225,9 +1235,6 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")
@@ -1244,6 +1251,9 @@ def _env_bash_index(argv):
                 return -1, None
             i += span
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         return -1, None
     return -1, None
 

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1150,8 +1150,7 @@ def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
         or "=" not in token
     ):
         return False
-    name = token.split("=", 1)[0]
-    return bool(name)
+    return True
 
 
 def _env_option_advance(tok: str) -> int:

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1157,14 +1157,17 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
-    cluster; -u/-C consume the rest of the token as an attached operand or the
-    next argv slot. Unsupported clusters fail closed before worker detach.
+    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    attached operand or the next argv slot. Unsupported options fail closed
+    before worker detach.
     (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
+        return 1
+    if tok in ("--ignore-environment", "--null", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1139,11 +1139,30 @@ def _env_assignment_token(token: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
+def _env_option_advance(tok: str) -> int:
+    """How many argv slots an env(1) option occupies (incl. the option itself).
+
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
+    -S/--split-string. Attached `--name=value` forms are a single slot.
+    Unknown flags advance one slot. (#1292 Codex P2)
+    """
+    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+        return 2
+    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+        return 1
+    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+        return 1
+    return 1
+
+
 def _env_bash_index(argv) -> int:
     """Index of bare bash/sh after `env` [options] [assignments], or -1.
 
     Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268).
+    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
+    and long forms) consume their arguments before the command token is
+    sought (#1292).
     """
     if not argv:
         return -1
@@ -1159,11 +1178,10 @@ def _env_bash_index(argv) -> int:
             i += 1
             continue
         if tok.startswith("-"):
-            # env -u NAME / --unset NAME consume the following argument.
-            if tok in ("-u", "--unset"):
-                i += 2
-                continue
-            i += 1
+            span = _env_option_advance(tok)
+            if span > 1 and i + 1 >= len(argv):
+                return -1
+            i += span
             continue
         return -1
     return -1

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -70,6 +70,10 @@ Environment overrides (defaults in parentheses):
   CE_PEER_RESULT_MAX_BYTES  result byte cap, supervise + read (5242880)
   CE_PEER_POLL_SECS         supervisor poll interval (2)
   CE_PEER_GRACE_SECS        TERM-to-KILL grace during reap (5)
+  CE_PEER_BASH              Windows: absolute bash.exe for peer workers
+                            (preferred over PATH / WSL System32 bash)
+  CLAUDE_CODE_GIT_BASH_PATH Claude Code Git Bash path; used on Windows when
+                            CE_PEER_BASH is unset (#1268)
 
 Security posture: the job root is a predictable, owner-private directory under
 world-shared /tmp. Every read of job state opens the file first (no-follow) and
@@ -1067,30 +1071,103 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
         time.sleep(min(0.1, max(0.01, end - time.monotonic())))
 
 
+def _is_system32_wsl_bash(path: str) -> bool:
+    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    if not path:
+        return False
+    base = os.path.basename(path).lower()
+    if base not in ("bash", "bash.exe", "sh", "sh.exe"):
+        return False
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    system32 = os.path.normcase(
+        os.path.join(os.path.abspath(system_root), "System32")
+    )
+    parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
+    return parent == system32
+
+
+def _git_bash_well_known_paths():
+    """Standard Git for Windows bash.exe locations."""
+    pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
+    pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
+    local = os.environ.get("LOCALAPPDATA") or ""
+    paths = [
+        os.path.join(pf, "Git", "bin", "bash.exe"),
+        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
+    ]
+    if local:
+        paths.extend([
+            os.path.join(local, "Programs", "Git", "bin", "bash.exe"),
+            os.path.join(local, "Programs", "Git", "usr", "bin", "bash.exe"),
+        ])
+    return paths
+
+
+def _resolve_windows_posix_shell() -> str:
+    """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
+
+    Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
+    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    nothing usable remains — never select System32\\bash.exe (#1268).
+    """
+    candidates = []
+    for key in ("CE_PEER_BASH", "CLAUDE_CODE_GIT_BASH_PATH"):
+        val = (os.environ.get(key) or "").strip()
+        if val:
+            candidates.append(val)
+    candidates.extend(_git_bash_well_known_paths())
+    for name in ("bash", "sh"):
+        found = shutil.which(name)
+        if found:
+            candidates.append(found)
+
+    seen = set()
+    for raw in candidates:
+        path = os.path.abspath(raw)
+        key = os.path.normcase(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not os.path.isfile(path):
+            continue
+        if _is_system32_wsl_bash(path):
+            continue
+        return path
+
+    raise RunnerError(
+        "no usable Git Bash (or other non-WSL POSIX shell) for native Windows "
+        "peer workers; install Git for Windows or set CE_PEER_BASH / "
+        "CLAUDE_CODE_GIT_BASH_PATH to an absolute bash.exe path "
+        "(System32\\bash.exe / WSL is not used)"
+    )
+
+
 def _popen_argv(argv):
     """Argv for subprocess.Popen.
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
-    worker must be launched through bash/sh. meta.json still records the
-    caller argv so authorize-dispatch contracts that forbid a shell prefix
-    stay exact. Already-prefixed workers (review skills use `bash script.sh`)
-    are left alone.
+    worker must be launched through bash/sh. Prefer Git Bash over System32
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
+    to that absolute path. meta.json still records the caller argv for
+    authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
     head = argv[0]
     base = os.path.basename(head).lower()
-    if base in ("bash", "bash.exe", "sh", "sh.exe", "env", "env.exe"):
+    if base in ("env", "env.exe"):
         return list(argv)
+    if base in ("bash", "bash.exe", "sh", "sh.exe"):
+        shell = _resolve_windows_posix_shell()
+        if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
+            return list(argv)
+        return [shell] + list(argv[1:])
     lower = head.lower()
     if not (lower.endswith(".sh") or lower.endswith(".bash")):
         return list(argv)
-    shell = shutil.which("bash") or shutil.which("sh")
-    if shell is None:
-        raise RunnerError(
-            "worker is a shell script but neither bash nor sh is on PATH; "
-            "install Git Bash or another POSIX shell to run it on Windows"
-        )
+    shell = _resolve_windows_posix_shell()
     return [shell, head] + list(argv[1:])
 
 
@@ -1484,18 +1561,28 @@ def cmd_start(args, worker_argv) -> int:
 
     argv0 = worker_argv[0]
     problem = None
-    if os.sep in argv0:
+    windows_posix_shell = None
+    base0 = os.path.basename(argv0).lower()
+    if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
+        # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        try:
+            resolved = _resolve_windows_posix_shell()
+            windows_posix_shell = resolved
+        except RunnerError as exc:
+            problem = str(exc)
+            resolved = argv0
+    elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):
             problem = "does not exist or is not a regular file"
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
             # CreateProcess cannot run shebang scripts; _popen_argv wraps with
-            # bash/sh. Require that shell now so start fails closed, not after
+            # Git Bash. Require that shell now so start fails closed, not after
             # detach. Skip the X_OK check — Windows often marks .sh non-exec.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
         elif not os.access(resolved, os.X_OK):
             problem = "is not executable"
     else:
@@ -1504,12 +1591,19 @@ def cmd_start(args, worker_argv) -> int:
             problem = "was not found on PATH"
             resolved = argv0
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
-            # Same shell requirement as the path-separator branch: a PATH hit
-            # on a bare `foo.sh` must not detach when bash/sh is missing.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
+        elif IS_WINDOWS and os.path.basename(resolved).lower() in (
+            "bash", "bash.exe", "sh", "sh.exe",
+        ):
+            # which() may have returned System32 WSL — rewrite now.
+            try:
+                resolved = _resolve_windows_posix_shell()
+                windows_posix_shell = resolved
+            except RunnerError as exc:
+                problem = str(exc)
     argv = [resolved] + list(worker_argv[1:])
 
     conf = cfg(args.skill)
@@ -1525,6 +1619,8 @@ def cmd_start(args, worker_argv) -> int:
         "sweep_enabled": not args.no_sweep,
         "supervision": conf,
     }
+    if windows_posix_shell:
+        meta["windows_posix_shell"] = windows_posix_shell
     try:
         create_exclusive(
             os.path.join(job_dir, "meta.json"),

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1167,7 +1167,7 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if tok in ("--ignore-environment", "--null", "--debug"):
+    if tok in ("--ignore-environment", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -119,7 +119,6 @@ import glob
 import json
 import os
 import re
-import shlex
 import shutil
 import signal
 import stat
@@ -1130,125 +1129,75 @@ def _windows_path_shell_candidates():
     return found
 
 
-def _env_assignment_token(token: str) -> bool:
+def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
     """True for env(1) NAME=value operands (not options or the command)."""
-    if not token or token.startswith("-") or "=" not in token:
+    if (
+        not token
+        or (token.startswith("-") and not allow_option_like)
+        or "=" not in token
+    ):
         return False
     name = token.split("=", 1)[0]
-    if not name or name[0].isdigit():
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
+    return bool(name)
 
 
 def _env_option_advance(tok: str) -> int:
     """How many argv slots an env(1) option occupies (incl. the option itself).
 
-    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
-    -S/--split-string. Attached `--name=value` forms are a single slot.
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir.
+    Attached `--name=value` forms are a single slot.
     Unknown flags advance one slot. (#1292 Codex P2)
     """
-    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+    if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
-    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+    if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+    # Short -uNAME (no space) and -CDIR are one slot.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
         return 1
     return 1
-
-
-def _parse_env_split_string(value):
-    """Split an env(1) -S/--split-string operand into words, or None.
-
-    Approximates GNU env's own word-splitting (backslash escapes, single/
-    double quotes) via shlex.split(posix=True) closely enough to detect a
-    bash/sh command inside it. Returns None when the value cannot be parsed
-    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
-    """
-    try:
-        return shlex.split(value, posix=True)
-    except ValueError:
-        return None
-
-
-def _bash_index_in_env_tokens(tokens) -> int:
-    """Index of a bash/sh command among env-style tokens, or -1.
-
-    Tokens are NAME=value assignments followed by a command, the same shape
-    `env` itself parses — used both for top-level env argv and for the words
-    produced by splitting a -S/--split-string operand (#1292).
-    """
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
-        if _env_assignment_token(tok):
-            i += 1
-            continue
-        return -1
-    return -1
 
 
 def _env_bash_index(argv):
     """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
 
     Matches the production cross-model shape `env VAR=… bash script.sh …`
-    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
-    arguments before the command token is sought (#1292).
+    (#1268). Operand-taking options (-u/-C and long forms) consume their
+    arguments before the command token is sought (#1292). Split-string forms
+    fail closed because Python shlex does not match Git env.exe semantics.
 
-    Returns (argv_index, split_prefix). split_prefix is None when
-    argv[argv_index] is itself the bare bash/sh token. It is a string
-    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
-    operand with that literal prefix (e.g. "--split-string=") still attached
-    and the bash/sh command lives inside it after word-splitting — callers
-    must reparse and rewrite the operand's command word, not the whole token
-    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
-    because the split string's contents were never inspected). Returns
-    (-1, None) when no bash/sh command is present.
+    Returns (argv_index, None), or (-1, None) when no bash/sh command is
+    present.
     """
     if not argv:
         return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
         return -1, None
     i = 1
+    options_done = False
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
             return i, None
-        if _env_assignment_token(tok):
+        if tok == "--" and not options_done:
+            options_done = True
             i += 1
             continue
-        prefix = None
-        value = None
-        idx = i
-        advance = 1
-        if tok in ("-S", "--split-string"):
-            if i + 1 >= len(argv):
-                return -1, None
-            idx = i + 1
-            prefix = ""
-            value = argv[idx]
-            advance = 2
-        elif tok.startswith("--split-string="):
-            prefix = "--split-string="
-            value = tok[len(prefix):]
-        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
-            prefix = tok[:2]
-            value = tok[2:]
-        if prefix is not None:
-            tokens = _parse_env_split_string(value)
-            if tokens is None:
-                raise RunnerError(
-                    "cannot parse env -S/--split-string operand for peer "
-                    f"worker shell selection: {value!r}"
-                )
-            if _bash_index_in_env_tokens(tokens) >= 0:
-                return idx, prefix
-            i += advance
+        if _env_assignment_token(tok, allow_option_like=options_done):
+            i += 1
             continue
-        if tok.startswith("-"):
+        if not options_done and (
+            tok in ("-S", "--split-string") or tok.startswith(
+                ("-S", "--split-string=")
+            )
+        ):
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if not options_done and tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
                 return -1, None
@@ -1282,45 +1231,20 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
-def _rewrite_env_split_string_value(value):
-    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
-
-    Returns (new_value, resolved_shell). Assumes `value` already contains a
-    resolvable bash/sh command, as checked by `_env_bash_index` via
-    `_bash_index_in_env_tokens` before this is called (#1292).
-    """
-    tokens = _parse_env_split_string(value)
-    if tokens is None:
-        raise RunnerError(
-            "cannot parse env -S/--split-string operand for peer worker "
-            f"shell selection: {value!r}"
-        )
-    idx = _bash_index_in_env_tokens(tokens)
-    shell = _prefer_windows_posix_shell(tokens[idx])
-    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
-        tokens[idx] = shell
-    return " ".join(shlex.quote(t) for t in tokens), shell
-
-
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
-    inside a -S/--split-string operand is rewritten in place within that
-    operand's word-split contents, preserving any `-S`/`--split-string=`
-    prefix still attached to the argv slot (#1292).
+    non-WSL bash tokens are kept unchanged (#1292 P2). Split-string options
+    are rejected before detach because their parser semantics are not safely
+    reproduced here (#1292).
     """
     idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
     out = list(argv)
-    if split_prefix is not None:
-        value = out[idx][len(split_prefix):]
-        new_value, shell = _rewrite_env_split_string_value(value)
-        out[idx] = split_prefix + new_value
-        return out, shell
+    assert split_prefix is None
     shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1169,16 +1169,41 @@ def _env_bash_index(argv) -> int:
     return -1
 
 
+def _windows_path_is_absolute(path: str) -> bool:
+    """True for Windows absolute paths (drive letter or path separator)."""
+    return os.sep in path or (len(path) >= 2 and path[1] == ":")
+
+
+def _prefer_windows_posix_shell(token: str) -> str:
+    """Absolute non-WSL bash/sh kept; bare names and System32 go through resolve.
+
+    Explicit absolute paths (portable Git, custom installs) must not be
+    substituted by the preferred resolver (#1292 Codex P2). Bare `bash`/`sh`
+    and System32 WSL launchers still use `_resolve_windows_posix_shell()`.
+    """
+    if _windows_path_is_absolute(token):
+        path = os.path.abspath(token)
+        if not os.path.isfile(path):
+            raise RunnerError(
+                f"peer worker shell does not exist or is not a regular file: {token}"
+            )
+        if _is_system32_wsl_bash(path):
+            return _resolve_windows_posix_shell()
+        return path
+    return _resolve_windows_posix_shell()
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
-    token is present but no usable non-WSL shell can be resolved.
+    token is present but no usable non-WSL shell can be resolved. Absolute
+    non-WSL bash tokens are kept unchanged (#1292 P2).
     """
     idx = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _resolve_windows_posix_shell()
+    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
@@ -1228,8 +1253,9 @@ def _popen_argv(argv):
     worker must be launched through bash/sh. Prefer Git Bash over System32
     WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
     `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
-    absolute path. meta.json still records the caller argv for
-    authorize-dispatch contracts that forbid a shell prefix on ce-work.
+    absolute path. Explicit absolute non-WSL bash/sh paths are kept (#1292 P2).
+    meta.json still records the caller argv for authorize-dispatch contracts
+    that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
@@ -1239,7 +1265,7 @@ def _popen_argv(argv):
         rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
         return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
-        shell = _resolve_windows_posix_shell()
+        shell = _prefer_windows_posix_shell(head)
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
             return list(argv)
         return [shell] + list(argv[1:])
@@ -1644,8 +1670,9 @@ def cmd_start(args, worker_argv) -> int:
     base0 = os.path.basename(argv0).lower()
     if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
         # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        # Keep an explicit absolute non-WSL bash (portable Git) (#1292 P2).
         try:
-            resolved = _resolve_windows_posix_shell()
+            resolved = _prefer_windows_posix_shell(argv0)
             windows_posix_shell = resolved
         except RunnerError as exc:
             problem = str(exc)

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1157,15 +1157,34 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Unknown flags advance one slot. (#1292 Codex P2)
+    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
+    cluster; -u/-C consume the rest of the token as an attached operand or the
+    next argv slot. Unsupported clusters fail closed before worker detach.
+    (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) and -CDIR are one slot.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
+    if not tok.startswith("-") or tok.startswith("--"):
         return 1
+
+    cluster = tok[1:]
+    for index, option in enumerate(cluster):
+        if option in "i0v":
+            continue
+        if option == "S":
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if option in "uC":
+            return 1 if index + 1 < len(cluster) else 2
+        raise RunnerError(
+            f"unsupported env short-option cluster {tok!r} for native "
+            "Windows peer workers; pass env options separately"
+        )
     return 1
 
 

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1160,7 +1160,8 @@ def _env_option_advance(tok: str) -> int:
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
     Short options may be clustered. No-operand flags (-i/-v and their exact
-    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    long aliases and signal-handling options) advance one slot; -u/-C consume
+    the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
     (#1292 Codex P2)
@@ -1170,6 +1171,16 @@ def _env_option_advance(tok: str) -> int:
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
     if tok in ("--ignore-environment", "--debug"):
+        return 1
+    if tok == "--list-signal-handling" or tok in (
+        "--block-signal",
+        "--default-signal",
+        "--ignore-signal",
+    ) or tok.startswith((
+        "--block-signal=",
+        "--default-signal=",
+        "--ignore-signal=",
+    )):
         return 1
     if tok == "--null":
         raise RunnerError(

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1072,18 +1072,20 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
 
 
 def _is_system32_wsl_bash(path: str) -> bool:
-    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    """True for Windows System32 WSL launchers, including Sysnative aliases."""
     if not path:
         return False
     base = os.path.basename(path).lower()
     if base not in ("bash", "bash.exe", "sh", "sh.exe"):
         return False
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    system32 = os.path.normcase(
-        os.path.join(os.path.abspath(system_root), "System32")
-    )
+    windows_root = os.path.abspath(system_root)
+    blocked_parents = {
+        os.path.normcase(os.path.join(windows_root, name))
+        for name in ("System32", "Sysnative")
+    }
     parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
-    return parent == system32
+    return parent in blocked_parents
 
 
 def _git_bash_well_known_paths():

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1216,9 +1216,6 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if tok == "--" and not options_done:
             options_done = True
             i += 1
@@ -1226,6 +1223,9 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1088,15 +1088,26 @@ def _is_system32_wsl_bash(path: str) -> bool:
 
 def _git_bash_well_known_paths():
     """Standard Git for Windows bash.exe locations."""
+    pf64 = os.environ.get("ProgramW6432") or ""
     pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
     pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
     local = os.environ.get("LOCALAPPDATA") or ""
-    paths = [
-        os.path.join(pf, "Git", "bin", "bash.exe"),
-        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
-    ]
+    roots = []
+    seen = set()
+    for root in (pf64, pf, pf86):
+        if not root:
+            continue
+        key = os.path.normcase(os.path.abspath(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(root)
+    paths = []
+    for root in roots:
+        paths.extend([
+            os.path.join(root, "Git", "bin", "bash.exe"),
+            os.path.join(root, "Git", "usr", "bin", "bash.exe"),
+        ])
     if local:
         paths.extend([
             os.path.join(local, "Programs", "Git", "bin", "bash.exe"),

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -119,6 +119,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -1156,35 +1157,105 @@ def _env_option_advance(tok: str) -> int:
     return 1
 
 
-def _env_bash_index(argv) -> int:
-    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+def _parse_env_split_string(value):
+    """Split an env(1) -S/--split-string operand into words, or None.
 
-    Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
-    and long forms) consume their arguments before the command token is
-    sought (#1292).
+    Approximates GNU env's own word-splitting (backslash escapes, single/
+    double quotes) via shlex.split(posix=True) closely enough to detect a
+    bash/sh command inside it. Returns None when the value cannot be parsed
+    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
+    """
+    try:
+        return shlex.split(value, posix=True)
+    except ValueError:
+        return None
+
+
+def _bash_index_in_env_tokens(tokens) -> int:
+    """Index of a bash/sh command among env-style tokens, or -1.
+
+    Tokens are NAME=value assignments followed by a command, the same shape
+    `env` itself parses — used both for top-level env argv and for the words
+    produced by splitting a -S/--split-string operand (#1292).
+    """
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _env_bash_index(argv):
+    """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
+
+    Matches the production cross-model shape `env VAR=… bash script.sh …`
+    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
+    arguments before the command token is sought (#1292).
+
+    Returns (argv_index, split_prefix). split_prefix is None when
+    argv[argv_index] is itself the bare bash/sh token. It is a string
+    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
+    operand with that literal prefix (e.g. "--split-string=") still attached
+    and the bash/sh command lives inside it after word-splitting — callers
+    must reparse and rewrite the operand's command word, not the whole token
+    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
+    because the split string's contents were never inspected). Returns
+    (-1, None) when no bash/sh command is present.
     """
     if not argv:
-        return -1
+        return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
-        return -1
+        return -1, None
     i = 1
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
+            return i, None
         if _env_assignment_token(tok):
             i += 1
+            continue
+        prefix = None
+        value = None
+        idx = i
+        advance = 1
+        if tok in ("-S", "--split-string"):
+            if i + 1 >= len(argv):
+                return -1, None
+            idx = i + 1
+            prefix = ""
+            value = argv[idx]
+            advance = 2
+        elif tok.startswith("--split-string="):
+            prefix = "--split-string="
+            value = tok[len(prefix):]
+        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
+            prefix = tok[:2]
+            value = tok[2:]
+        if prefix is not None:
+            tokens = _parse_env_split_string(value)
+            if tokens is None:
+                raise RunnerError(
+                    "cannot parse env -S/--split-string operand for peer "
+                    f"worker shell selection: {value!r}"
+                )
+            if _bash_index_in_env_tokens(tokens) >= 0:
+                return idx, prefix
+            i += advance
             continue
         if tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
-                return -1
+                return -1, None
             i += span
             continue
-        return -1
-    return -1
+        return -1, None
+    return -1, None
 
 
 def _windows_path_is_absolute(path: str) -> bool:
@@ -1211,18 +1282,46 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
+def _rewrite_env_split_string_value(value):
+    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
+
+    Returns (new_value, resolved_shell). Assumes `value` already contains a
+    resolvable bash/sh command, as checked by `_env_bash_index` via
+    `_bash_index_in_env_tokens` before this is called (#1292).
+    """
+    tokens = _parse_env_split_string(value)
+    if tokens is None:
+        raise RunnerError(
+            "cannot parse env -S/--split-string operand for peer worker "
+            f"shell selection: {value!r}"
+        )
+    idx = _bash_index_in_env_tokens(tokens)
+    shell = _prefer_windows_posix_shell(tokens[idx])
+    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
+        tokens[idx] = shell
+    return " ".join(shlex.quote(t) for t in tokens), shell
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2).
+    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
+    inside a -S/--split-string operand is rewritten in place within that
+    operand's word-split contents, preserving any `-S`/`--split-string=`
+    prefix still attached to the argv slot (#1292).
     """
-    idx = _env_bash_index(argv)
+    idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
+    if split_prefix is not None:
+        value = out[idx][len(split_prefix):]
+        new_value, shell = _rewrite_env_split_string_value(value)
+        out[idx] = split_prefix + new_value
+        return out, shell
+    shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
     return out, shell

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1228,7 +1228,7 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        if tok == "--" and not options_done:
+        if tok in ("-", "--") and not options_done:
             options_done = True
             i += 1
             continue

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1105,11 +1105,91 @@ def _git_bash_well_known_paths():
     return paths
 
 
+def _windows_path_shell_candidates():
+    """Every bash/sh on PATH in PATH order (not only shutil.which's first hit)."""
+    path_env = os.environ.get("PATH") or ""
+    names = ("bash.exe", "bash", "sh.exe", "sh")
+    found = []
+    seen = set()
+    for directory in path_env.split(os.pathsep):
+        if not directory:
+            continue
+        for name in names:
+            candidate = os.path.join(directory, name)
+            try:
+                if not os.path.isfile(candidate):
+                    continue
+            except OSError:
+                continue
+            key = os.path.normcase(os.path.abspath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(candidate)
+    return found
+
+
+def _env_assignment_token(token: str) -> bool:
+    """True for env(1) NAME=value operands (not options or the command)."""
+    if not token or token.startswith("-") or "=" not in token:
+        return False
+    name = token.split("=", 1)[0]
+    if not name or name[0].isdigit():
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _env_bash_index(argv) -> int:
+    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+
+    Matches the production cross-model shape:
+    `env VAR=… bash script.sh …` (#1268).
+    """
+    if not argv:
+        return -1
+    if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
+        return -1
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            # env -u NAME / --unset NAME consume the following argument.
+            if tok in ("-u", "--unset"):
+                i += 2
+                continue
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _rewrite_windows_env_bash_argv(argv):
+    """Rewrite bare bash/sh inside an env-prefixed argv.
+
+    Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
+    token is present but no usable non-WSL shell can be resolved.
+    """
+    idx = _env_bash_index(argv)
+    if idx < 0:
+        return list(argv), None
+    shell = _resolve_windows_posix_shell()
+    out = list(argv)
+    if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
+        out[idx] = shell
+    return out, shell
+
+
 def _resolve_windows_posix_shell() -> str:
     """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
 
     Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
-    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    installs, then every PATH bash/sh excluding System32 WSL. Fail closed when
     nothing usable remains — never select System32\\bash.exe (#1268).
     """
     candidates = []
@@ -1118,10 +1198,7 @@ def _resolve_windows_posix_shell() -> str:
         if val:
             candidates.append(val)
     candidates.extend(_git_bash_well_known_paths())
-    for name in ("bash", "sh"):
-        found = shutil.which(name)
-        if found:
-            candidates.append(found)
+    candidates.extend(_windows_path_shell_candidates())
 
     seen = set()
     for raw in candidates:
@@ -1149,8 +1226,9 @@ def _popen_argv(argv):
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
     worker must be launched through bash/sh. Prefer Git Bash over System32
-    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
-    to that absolute path. meta.json still records the caller argv for
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
+    `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
+    absolute path. meta.json still records the caller argv for
     authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
@@ -1158,7 +1236,8 @@ def _popen_argv(argv):
     head = argv[0]
     base = os.path.basename(head).lower()
     if base in ("env", "env.exe"):
-        return list(argv)
+        rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
+        return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
         shell = _resolve_windows_posix_shell()
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
@@ -1571,6 +1650,25 @@ def cmd_start(args, worker_argv) -> int:
         except RunnerError as exc:
             problem = str(exc)
             resolved = argv0
+    elif IS_WINDOWS and base0 in ("env", "env.exe"):
+        # Production cross-model: env VAR=… bash script.sh — rewrite bash
+        # before detach so env cannot PATH-resolve System32 WSL (#1268).
+        if os.sep in argv0 or (len(argv0) >= 2 and argv0[1] == ":"):
+            resolved = os.path.abspath(argv0)
+            if not os.path.isfile(resolved):
+                problem = "does not exist or is not a regular file"
+        else:
+            resolved = shutil.which(argv0)
+            if resolved is None:
+                problem = "was not found on PATH"
+                resolved = argv0
+        try:
+            rewritten, shell = _rewrite_windows_env_bash_argv(list(worker_argv))
+            if shell is not None:
+                windows_posix_shell = shell
+                worker_argv = rewritten
+        except RunnerError as exc:
+            problem = str(exc) if problem is None else f"{problem}; {exc}"
     elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1166,8 +1166,14 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if not tok.startswith("-") or tok.startswith("--"):
+    if not tok.startswith("-"):
         return 1
+    if tok.startswith("--"):
+        raise RunnerError(
+            f"unsupported env long option {tok!r} for native Windows peer "
+            "workers; use an exact supported option or pass -- before "
+            "option-like assignments"
+        )
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1233,6 +1233,7 @@ def _env_bash_index(argv):
             i += 1
             continue
         if _env_assignment_token(tok, allow_option_like=options_done):
+            options_done = True
             i += 1
             continue
         if not options_done and (

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -1159,7 +1159,7 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    Short options may be clustered. No-operand flags (-i/-v and their exact
     long aliases) advance one slot; -u/-C consume the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
@@ -1171,6 +1171,11 @@ def _env_option_advance(tok: str) -> int:
         return 1
     if tok in ("--ignore-environment", "--debug"):
         return 1
+    if tok == "--null":
+        raise RunnerError(
+            "env -0/--null cannot be used with a command by native Windows "
+            "peer workers; remove the null-output option"
+        )
     if not tok.startswith("-"):
         return 1
     if tok.startswith("--"):
@@ -1182,8 +1187,13 @@ def _env_option_advance(tok: str) -> int:
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):
-        if option in "i0v":
+        if option in "iv":
             continue
+        if option == "0":
+            raise RunnerError(
+                "env -0/--null cannot be used with a command by native "
+                "Windows peer workers; remove the null-output option"
+            )
         if option == "S":
             raise RunnerError(
                 "env -S/--split-string is unsupported for native Windows "
@@ -1225,9 +1235,6 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")
@@ -1244,6 +1251,9 @@ def _env_bash_index(argv):
                 return -1, None
             i += span
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         return -1, None
     return -1, None
 

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1150,8 +1150,7 @@ def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
         or "=" not in token
     ):
         return False
-    name = token.split("=", 1)[0]
-    return bool(name)
+    return True
 
 
 def _env_option_advance(tok: str) -> int:

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1157,14 +1157,17 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
-    cluster; -u/-C consume the rest of the token as an attached operand or the
-    next argv slot. Unsupported clusters fail closed before worker detach.
+    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    attached operand or the next argv slot. Unsupported options fail closed
+    before worker detach.
     (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
+        return 1
+    if tok in ("--ignore-environment", "--null", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1139,11 +1139,30 @@ def _env_assignment_token(token: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
+def _env_option_advance(tok: str) -> int:
+    """How many argv slots an env(1) option occupies (incl. the option itself).
+
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
+    -S/--split-string. Attached `--name=value` forms are a single slot.
+    Unknown flags advance one slot. (#1292 Codex P2)
+    """
+    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+        return 2
+    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+        return 1
+    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+        return 1
+    return 1
+
+
 def _env_bash_index(argv) -> int:
     """Index of bare bash/sh after `env` [options] [assignments], or -1.
 
     Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268).
+    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
+    and long forms) consume their arguments before the command token is
+    sought (#1292).
     """
     if not argv:
         return -1
@@ -1159,11 +1178,10 @@ def _env_bash_index(argv) -> int:
             i += 1
             continue
         if tok.startswith("-"):
-            # env -u NAME / --unset NAME consume the following argument.
-            if tok in ("-u", "--unset"):
-                i += 2
-                continue
-            i += 1
+            span = _env_option_advance(tok)
+            if span > 1 and i + 1 >= len(argv):
+                return -1
+            i += span
             continue
         return -1
     return -1

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -70,6 +70,10 @@ Environment overrides (defaults in parentheses):
   CE_PEER_RESULT_MAX_BYTES  result byte cap, supervise + read (5242880)
   CE_PEER_POLL_SECS         supervisor poll interval (2)
   CE_PEER_GRACE_SECS        TERM-to-KILL grace during reap (5)
+  CE_PEER_BASH              Windows: absolute bash.exe for peer workers
+                            (preferred over PATH / WSL System32 bash)
+  CLAUDE_CODE_GIT_BASH_PATH Claude Code Git Bash path; used on Windows when
+                            CE_PEER_BASH is unset (#1268)
 
 Security posture: the job root is a predictable, owner-private directory under
 world-shared /tmp. Every read of job state opens the file first (no-follow) and
@@ -1067,30 +1071,103 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
         time.sleep(min(0.1, max(0.01, end - time.monotonic())))
 
 
+def _is_system32_wsl_bash(path: str) -> bool:
+    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    if not path:
+        return False
+    base = os.path.basename(path).lower()
+    if base not in ("bash", "bash.exe", "sh", "sh.exe"):
+        return False
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    system32 = os.path.normcase(
+        os.path.join(os.path.abspath(system_root), "System32")
+    )
+    parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
+    return parent == system32
+
+
+def _git_bash_well_known_paths():
+    """Standard Git for Windows bash.exe locations."""
+    pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
+    pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
+    local = os.environ.get("LOCALAPPDATA") or ""
+    paths = [
+        os.path.join(pf, "Git", "bin", "bash.exe"),
+        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
+    ]
+    if local:
+        paths.extend([
+            os.path.join(local, "Programs", "Git", "bin", "bash.exe"),
+            os.path.join(local, "Programs", "Git", "usr", "bin", "bash.exe"),
+        ])
+    return paths
+
+
+def _resolve_windows_posix_shell() -> str:
+    """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
+
+    Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
+    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    nothing usable remains — never select System32\\bash.exe (#1268).
+    """
+    candidates = []
+    for key in ("CE_PEER_BASH", "CLAUDE_CODE_GIT_BASH_PATH"):
+        val = (os.environ.get(key) or "").strip()
+        if val:
+            candidates.append(val)
+    candidates.extend(_git_bash_well_known_paths())
+    for name in ("bash", "sh"):
+        found = shutil.which(name)
+        if found:
+            candidates.append(found)
+
+    seen = set()
+    for raw in candidates:
+        path = os.path.abspath(raw)
+        key = os.path.normcase(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not os.path.isfile(path):
+            continue
+        if _is_system32_wsl_bash(path):
+            continue
+        return path
+
+    raise RunnerError(
+        "no usable Git Bash (or other non-WSL POSIX shell) for native Windows "
+        "peer workers; install Git for Windows or set CE_PEER_BASH / "
+        "CLAUDE_CODE_GIT_BASH_PATH to an absolute bash.exe path "
+        "(System32\\bash.exe / WSL is not used)"
+    )
+
+
 def _popen_argv(argv):
     """Argv for subprocess.Popen.
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
-    worker must be launched through bash/sh. meta.json still records the
-    caller argv so authorize-dispatch contracts that forbid a shell prefix
-    stay exact. Already-prefixed workers (review skills use `bash script.sh`)
-    are left alone.
+    worker must be launched through bash/sh. Prefer Git Bash over System32
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
+    to that absolute path. meta.json still records the caller argv for
+    authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
     head = argv[0]
     base = os.path.basename(head).lower()
-    if base in ("bash", "bash.exe", "sh", "sh.exe", "env", "env.exe"):
+    if base in ("env", "env.exe"):
         return list(argv)
+    if base in ("bash", "bash.exe", "sh", "sh.exe"):
+        shell = _resolve_windows_posix_shell()
+        if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
+            return list(argv)
+        return [shell] + list(argv[1:])
     lower = head.lower()
     if not (lower.endswith(".sh") or lower.endswith(".bash")):
         return list(argv)
-    shell = shutil.which("bash") or shutil.which("sh")
-    if shell is None:
-        raise RunnerError(
-            "worker is a shell script but neither bash nor sh is on PATH; "
-            "install Git Bash or another POSIX shell to run it on Windows"
-        )
+    shell = _resolve_windows_posix_shell()
     return [shell, head] + list(argv[1:])
 
 
@@ -1484,18 +1561,28 @@ def cmd_start(args, worker_argv) -> int:
 
     argv0 = worker_argv[0]
     problem = None
-    if os.sep in argv0:
+    windows_posix_shell = None
+    base0 = os.path.basename(argv0).lower()
+    if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
+        # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        try:
+            resolved = _resolve_windows_posix_shell()
+            windows_posix_shell = resolved
+        except RunnerError as exc:
+            problem = str(exc)
+            resolved = argv0
+    elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):
             problem = "does not exist or is not a regular file"
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
             # CreateProcess cannot run shebang scripts; _popen_argv wraps with
-            # bash/sh. Require that shell now so start fails closed, not after
+            # Git Bash. Require that shell now so start fails closed, not after
             # detach. Skip the X_OK check — Windows often marks .sh non-exec.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
         elif not os.access(resolved, os.X_OK):
             problem = "is not executable"
     else:
@@ -1504,12 +1591,19 @@ def cmd_start(args, worker_argv) -> int:
             problem = "was not found on PATH"
             resolved = argv0
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
-            # Same shell requirement as the path-separator branch: a PATH hit
-            # on a bare `foo.sh` must not detach when bash/sh is missing.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
+        elif IS_WINDOWS and os.path.basename(resolved).lower() in (
+            "bash", "bash.exe", "sh", "sh.exe",
+        ):
+            # which() may have returned System32 WSL — rewrite now.
+            try:
+                resolved = _resolve_windows_posix_shell()
+                windows_posix_shell = resolved
+            except RunnerError as exc:
+                problem = str(exc)
     argv = [resolved] + list(worker_argv[1:])
 
     conf = cfg(args.skill)
@@ -1525,6 +1619,8 @@ def cmd_start(args, worker_argv) -> int:
         "sweep_enabled": not args.no_sweep,
         "supervision": conf,
     }
+    if windows_posix_shell:
+        meta["windows_posix_shell"] = windows_posix_shell
     try:
         create_exclusive(
             os.path.join(job_dir, "meta.json"),

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1167,7 +1167,7 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if tok in ("--ignore-environment", "--null", "--debug"):
+    if tok in ("--ignore-environment", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -119,7 +119,6 @@ import glob
 import json
 import os
 import re
-import shlex
 import shutil
 import signal
 import stat
@@ -1130,125 +1129,75 @@ def _windows_path_shell_candidates():
     return found
 
 
-def _env_assignment_token(token: str) -> bool:
+def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
     """True for env(1) NAME=value operands (not options or the command)."""
-    if not token or token.startswith("-") or "=" not in token:
+    if (
+        not token
+        or (token.startswith("-") and not allow_option_like)
+        or "=" not in token
+    ):
         return False
     name = token.split("=", 1)[0]
-    if not name or name[0].isdigit():
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
+    return bool(name)
 
 
 def _env_option_advance(tok: str) -> int:
     """How many argv slots an env(1) option occupies (incl. the option itself).
 
-    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
-    -S/--split-string. Attached `--name=value` forms are a single slot.
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir.
+    Attached `--name=value` forms are a single slot.
     Unknown flags advance one slot. (#1292 Codex P2)
     """
-    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+    if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
-    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+    if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+    # Short -uNAME (no space) and -CDIR are one slot.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
         return 1
     return 1
-
-
-def _parse_env_split_string(value):
-    """Split an env(1) -S/--split-string operand into words, or None.
-
-    Approximates GNU env's own word-splitting (backslash escapes, single/
-    double quotes) via shlex.split(posix=True) closely enough to detect a
-    bash/sh command inside it. Returns None when the value cannot be parsed
-    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
-    """
-    try:
-        return shlex.split(value, posix=True)
-    except ValueError:
-        return None
-
-
-def _bash_index_in_env_tokens(tokens) -> int:
-    """Index of a bash/sh command among env-style tokens, or -1.
-
-    Tokens are NAME=value assignments followed by a command, the same shape
-    `env` itself parses — used both for top-level env argv and for the words
-    produced by splitting a -S/--split-string operand (#1292).
-    """
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
-        if _env_assignment_token(tok):
-            i += 1
-            continue
-        return -1
-    return -1
 
 
 def _env_bash_index(argv):
     """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
 
     Matches the production cross-model shape `env VAR=… bash script.sh …`
-    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
-    arguments before the command token is sought (#1292).
+    (#1268). Operand-taking options (-u/-C and long forms) consume their
+    arguments before the command token is sought (#1292). Split-string forms
+    fail closed because Python shlex does not match Git env.exe semantics.
 
-    Returns (argv_index, split_prefix). split_prefix is None when
-    argv[argv_index] is itself the bare bash/sh token. It is a string
-    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
-    operand with that literal prefix (e.g. "--split-string=") still attached
-    and the bash/sh command lives inside it after word-splitting — callers
-    must reparse and rewrite the operand's command word, not the whole token
-    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
-    because the split string's contents were never inspected). Returns
-    (-1, None) when no bash/sh command is present.
+    Returns (argv_index, None), or (-1, None) when no bash/sh command is
+    present.
     """
     if not argv:
         return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
         return -1, None
     i = 1
+    options_done = False
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
             return i, None
-        if _env_assignment_token(tok):
+        if tok == "--" and not options_done:
+            options_done = True
             i += 1
             continue
-        prefix = None
-        value = None
-        idx = i
-        advance = 1
-        if tok in ("-S", "--split-string"):
-            if i + 1 >= len(argv):
-                return -1, None
-            idx = i + 1
-            prefix = ""
-            value = argv[idx]
-            advance = 2
-        elif tok.startswith("--split-string="):
-            prefix = "--split-string="
-            value = tok[len(prefix):]
-        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
-            prefix = tok[:2]
-            value = tok[2:]
-        if prefix is not None:
-            tokens = _parse_env_split_string(value)
-            if tokens is None:
-                raise RunnerError(
-                    "cannot parse env -S/--split-string operand for peer "
-                    f"worker shell selection: {value!r}"
-                )
-            if _bash_index_in_env_tokens(tokens) >= 0:
-                return idx, prefix
-            i += advance
+        if _env_assignment_token(tok, allow_option_like=options_done):
+            i += 1
             continue
-        if tok.startswith("-"):
+        if not options_done and (
+            tok in ("-S", "--split-string") or tok.startswith(
+                ("-S", "--split-string=")
+            )
+        ):
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if not options_done and tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
                 return -1, None
@@ -1282,45 +1231,20 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
-def _rewrite_env_split_string_value(value):
-    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
-
-    Returns (new_value, resolved_shell). Assumes `value` already contains a
-    resolvable bash/sh command, as checked by `_env_bash_index` via
-    `_bash_index_in_env_tokens` before this is called (#1292).
-    """
-    tokens = _parse_env_split_string(value)
-    if tokens is None:
-        raise RunnerError(
-            "cannot parse env -S/--split-string operand for peer worker "
-            f"shell selection: {value!r}"
-        )
-    idx = _bash_index_in_env_tokens(tokens)
-    shell = _prefer_windows_posix_shell(tokens[idx])
-    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
-        tokens[idx] = shell
-    return " ".join(shlex.quote(t) for t in tokens), shell
-
-
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
-    inside a -S/--split-string operand is rewritten in place within that
-    operand's word-split contents, preserving any `-S`/`--split-string=`
-    prefix still attached to the argv slot (#1292).
+    non-WSL bash tokens are kept unchanged (#1292 P2). Split-string options
+    are rejected before detach because their parser semantics are not safely
+    reproduced here (#1292).
     """
     idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
     out = list(argv)
-    if split_prefix is not None:
-        value = out[idx][len(split_prefix):]
-        new_value, shell = _rewrite_env_split_string_value(value)
-        out[idx] = split_prefix + new_value
-        return out, shell
+    assert split_prefix is None
     shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1169,16 +1169,41 @@ def _env_bash_index(argv) -> int:
     return -1
 
 
+def _windows_path_is_absolute(path: str) -> bool:
+    """True for Windows absolute paths (drive letter or path separator)."""
+    return os.sep in path or (len(path) >= 2 and path[1] == ":")
+
+
+def _prefer_windows_posix_shell(token: str) -> str:
+    """Absolute non-WSL bash/sh kept; bare names and System32 go through resolve.
+
+    Explicit absolute paths (portable Git, custom installs) must not be
+    substituted by the preferred resolver (#1292 Codex P2). Bare `bash`/`sh`
+    and System32 WSL launchers still use `_resolve_windows_posix_shell()`.
+    """
+    if _windows_path_is_absolute(token):
+        path = os.path.abspath(token)
+        if not os.path.isfile(path):
+            raise RunnerError(
+                f"peer worker shell does not exist or is not a regular file: {token}"
+            )
+        if _is_system32_wsl_bash(path):
+            return _resolve_windows_posix_shell()
+        return path
+    return _resolve_windows_posix_shell()
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
-    token is present but no usable non-WSL shell can be resolved.
+    token is present but no usable non-WSL shell can be resolved. Absolute
+    non-WSL bash tokens are kept unchanged (#1292 P2).
     """
     idx = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _resolve_windows_posix_shell()
+    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
@@ -1228,8 +1253,9 @@ def _popen_argv(argv):
     worker must be launched through bash/sh. Prefer Git Bash over System32
     WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
     `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
-    absolute path. meta.json still records the caller argv for
-    authorize-dispatch contracts that forbid a shell prefix on ce-work.
+    absolute path. Explicit absolute non-WSL bash/sh paths are kept (#1292 P2).
+    meta.json still records the caller argv for authorize-dispatch contracts
+    that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
@@ -1239,7 +1265,7 @@ def _popen_argv(argv):
         rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
         return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
-        shell = _resolve_windows_posix_shell()
+        shell = _prefer_windows_posix_shell(head)
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
             return list(argv)
         return [shell] + list(argv[1:])
@@ -1644,8 +1670,9 @@ def cmd_start(args, worker_argv) -> int:
     base0 = os.path.basename(argv0).lower()
     if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
         # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        # Keep an explicit absolute non-WSL bash (portable Git) (#1292 P2).
         try:
-            resolved = _resolve_windows_posix_shell()
+            resolved = _prefer_windows_posix_shell(argv0)
             windows_posix_shell = resolved
         except RunnerError as exc:
             problem = str(exc)

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1157,15 +1157,34 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Unknown flags advance one slot. (#1292 Codex P2)
+    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
+    cluster; -u/-C consume the rest of the token as an attached operand or the
+    next argv slot. Unsupported clusters fail closed before worker detach.
+    (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) and -CDIR are one slot.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
+    if not tok.startswith("-") or tok.startswith("--"):
         return 1
+
+    cluster = tok[1:]
+    for index, option in enumerate(cluster):
+        if option in "i0v":
+            continue
+        if option == "S":
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if option in "uC":
+            return 1 if index + 1 < len(cluster) else 2
+        raise RunnerError(
+            f"unsupported env short-option cluster {tok!r} for native "
+            "Windows peer workers; pass env options separately"
+        )
     return 1
 
 

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1160,7 +1160,8 @@ def _env_option_advance(tok: str) -> int:
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
     Short options may be clustered. No-operand flags (-i/-v and their exact
-    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    long aliases and signal-handling options) advance one slot; -u/-C consume
+    the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
     (#1292 Codex P2)
@@ -1170,6 +1171,16 @@ def _env_option_advance(tok: str) -> int:
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
     if tok in ("--ignore-environment", "--debug"):
+        return 1
+    if tok == "--list-signal-handling" or tok in (
+        "--block-signal",
+        "--default-signal",
+        "--ignore-signal",
+    ) or tok.startswith((
+        "--block-signal=",
+        "--default-signal=",
+        "--ignore-signal=",
+    )):
         return 1
     if tok == "--null":
         raise RunnerError(

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1072,18 +1072,20 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
 
 
 def _is_system32_wsl_bash(path: str) -> bool:
-    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    """True for Windows System32 WSL launchers, including Sysnative aliases."""
     if not path:
         return False
     base = os.path.basename(path).lower()
     if base not in ("bash", "bash.exe", "sh", "sh.exe"):
         return False
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    system32 = os.path.normcase(
-        os.path.join(os.path.abspath(system_root), "System32")
-    )
+    windows_root = os.path.abspath(system_root)
+    blocked_parents = {
+        os.path.normcase(os.path.join(windows_root, name))
+        for name in ("System32", "Sysnative")
+    }
     parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
-    return parent == system32
+    return parent in blocked_parents
 
 
 def _git_bash_well_known_paths():

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1216,9 +1216,6 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if tok == "--" and not options_done:
             options_done = True
             i += 1
@@ -1226,6 +1223,9 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1088,15 +1088,26 @@ def _is_system32_wsl_bash(path: str) -> bool:
 
 def _git_bash_well_known_paths():
     """Standard Git for Windows bash.exe locations."""
+    pf64 = os.environ.get("ProgramW6432") or ""
     pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
     pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
     local = os.environ.get("LOCALAPPDATA") or ""
-    paths = [
-        os.path.join(pf, "Git", "bin", "bash.exe"),
-        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
-    ]
+    roots = []
+    seen = set()
+    for root in (pf64, pf, pf86):
+        if not root:
+            continue
+        key = os.path.normcase(os.path.abspath(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(root)
+    paths = []
+    for root in roots:
+        paths.extend([
+            os.path.join(root, "Git", "bin", "bash.exe"),
+            os.path.join(root, "Git", "usr", "bin", "bash.exe"),
+        ])
     if local:
         paths.extend([
             os.path.join(local, "Programs", "Git", "bin", "bash.exe"),

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -119,6 +119,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -1156,35 +1157,105 @@ def _env_option_advance(tok: str) -> int:
     return 1
 
 
-def _env_bash_index(argv) -> int:
-    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+def _parse_env_split_string(value):
+    """Split an env(1) -S/--split-string operand into words, or None.
 
-    Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
-    and long forms) consume their arguments before the command token is
-    sought (#1292).
+    Approximates GNU env's own word-splitting (backslash escapes, single/
+    double quotes) via shlex.split(posix=True) closely enough to detect a
+    bash/sh command inside it. Returns None when the value cannot be parsed
+    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
+    """
+    try:
+        return shlex.split(value, posix=True)
+    except ValueError:
+        return None
+
+
+def _bash_index_in_env_tokens(tokens) -> int:
+    """Index of a bash/sh command among env-style tokens, or -1.
+
+    Tokens are NAME=value assignments followed by a command, the same shape
+    `env` itself parses — used both for top-level env argv and for the words
+    produced by splitting a -S/--split-string operand (#1292).
+    """
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _env_bash_index(argv):
+    """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
+
+    Matches the production cross-model shape `env VAR=… bash script.sh …`
+    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
+    arguments before the command token is sought (#1292).
+
+    Returns (argv_index, split_prefix). split_prefix is None when
+    argv[argv_index] is itself the bare bash/sh token. It is a string
+    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
+    operand with that literal prefix (e.g. "--split-string=") still attached
+    and the bash/sh command lives inside it after word-splitting — callers
+    must reparse and rewrite the operand's command word, not the whole token
+    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
+    because the split string's contents were never inspected). Returns
+    (-1, None) when no bash/sh command is present.
     """
     if not argv:
-        return -1
+        return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
-        return -1
+        return -1, None
     i = 1
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
+            return i, None
         if _env_assignment_token(tok):
             i += 1
+            continue
+        prefix = None
+        value = None
+        idx = i
+        advance = 1
+        if tok in ("-S", "--split-string"):
+            if i + 1 >= len(argv):
+                return -1, None
+            idx = i + 1
+            prefix = ""
+            value = argv[idx]
+            advance = 2
+        elif tok.startswith("--split-string="):
+            prefix = "--split-string="
+            value = tok[len(prefix):]
+        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
+            prefix = tok[:2]
+            value = tok[2:]
+        if prefix is not None:
+            tokens = _parse_env_split_string(value)
+            if tokens is None:
+                raise RunnerError(
+                    "cannot parse env -S/--split-string operand for peer "
+                    f"worker shell selection: {value!r}"
+                )
+            if _bash_index_in_env_tokens(tokens) >= 0:
+                return idx, prefix
+            i += advance
             continue
         if tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
-                return -1
+                return -1, None
             i += span
             continue
-        return -1
-    return -1
+        return -1, None
+    return -1, None
 
 
 def _windows_path_is_absolute(path: str) -> bool:
@@ -1211,18 +1282,46 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
+def _rewrite_env_split_string_value(value):
+    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
+
+    Returns (new_value, resolved_shell). Assumes `value` already contains a
+    resolvable bash/sh command, as checked by `_env_bash_index` via
+    `_bash_index_in_env_tokens` before this is called (#1292).
+    """
+    tokens = _parse_env_split_string(value)
+    if tokens is None:
+        raise RunnerError(
+            "cannot parse env -S/--split-string operand for peer worker "
+            f"shell selection: {value!r}"
+        )
+    idx = _bash_index_in_env_tokens(tokens)
+    shell = _prefer_windows_posix_shell(tokens[idx])
+    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
+        tokens[idx] = shell
+    return " ".join(shlex.quote(t) for t in tokens), shell
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2).
+    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
+    inside a -S/--split-string operand is rewritten in place within that
+    operand's word-split contents, preserving any `-S`/`--split-string=`
+    prefix still attached to the argv slot (#1292).
     """
-    idx = _env_bash_index(argv)
+    idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
+    if split_prefix is not None:
+        value = out[idx][len(split_prefix):]
+        new_value, shell = _rewrite_env_split_string_value(value)
+        out[idx] = split_prefix + new_value
+        return out, shell
+    shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
     return out, shell

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1228,7 +1228,7 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        if tok == "--" and not options_done:
+        if tok in ("-", "--") and not options_done:
             options_done = True
             i += 1
             continue

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1105,11 +1105,91 @@ def _git_bash_well_known_paths():
     return paths
 
 
+def _windows_path_shell_candidates():
+    """Every bash/sh on PATH in PATH order (not only shutil.which's first hit)."""
+    path_env = os.environ.get("PATH") or ""
+    names = ("bash.exe", "bash", "sh.exe", "sh")
+    found = []
+    seen = set()
+    for directory in path_env.split(os.pathsep):
+        if not directory:
+            continue
+        for name in names:
+            candidate = os.path.join(directory, name)
+            try:
+                if not os.path.isfile(candidate):
+                    continue
+            except OSError:
+                continue
+            key = os.path.normcase(os.path.abspath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(candidate)
+    return found
+
+
+def _env_assignment_token(token: str) -> bool:
+    """True for env(1) NAME=value operands (not options or the command)."""
+    if not token or token.startswith("-") or "=" not in token:
+        return False
+    name = token.split("=", 1)[0]
+    if not name or name[0].isdigit():
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _env_bash_index(argv) -> int:
+    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+
+    Matches the production cross-model shape:
+    `env VAR=… bash script.sh …` (#1268).
+    """
+    if not argv:
+        return -1
+    if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
+        return -1
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            # env -u NAME / --unset NAME consume the following argument.
+            if tok in ("-u", "--unset"):
+                i += 2
+                continue
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _rewrite_windows_env_bash_argv(argv):
+    """Rewrite bare bash/sh inside an env-prefixed argv.
+
+    Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
+    token is present but no usable non-WSL shell can be resolved.
+    """
+    idx = _env_bash_index(argv)
+    if idx < 0:
+        return list(argv), None
+    shell = _resolve_windows_posix_shell()
+    out = list(argv)
+    if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
+        out[idx] = shell
+    return out, shell
+
+
 def _resolve_windows_posix_shell() -> str:
     """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
 
     Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
-    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    installs, then every PATH bash/sh excluding System32 WSL. Fail closed when
     nothing usable remains — never select System32\\bash.exe (#1268).
     """
     candidates = []
@@ -1118,10 +1198,7 @@ def _resolve_windows_posix_shell() -> str:
         if val:
             candidates.append(val)
     candidates.extend(_git_bash_well_known_paths())
-    for name in ("bash", "sh"):
-        found = shutil.which(name)
-        if found:
-            candidates.append(found)
+    candidates.extend(_windows_path_shell_candidates())
 
     seen = set()
     for raw in candidates:
@@ -1149,8 +1226,9 @@ def _popen_argv(argv):
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
     worker must be launched through bash/sh. Prefer Git Bash over System32
-    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
-    to that absolute path. meta.json still records the caller argv for
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
+    `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
+    absolute path. meta.json still records the caller argv for
     authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
@@ -1158,7 +1236,8 @@ def _popen_argv(argv):
     head = argv[0]
     base = os.path.basename(head).lower()
     if base in ("env", "env.exe"):
-        return list(argv)
+        rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
+        return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
         shell = _resolve_windows_posix_shell()
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
@@ -1571,6 +1650,25 @@ def cmd_start(args, worker_argv) -> int:
         except RunnerError as exc:
             problem = str(exc)
             resolved = argv0
+    elif IS_WINDOWS and base0 in ("env", "env.exe"):
+        # Production cross-model: env VAR=… bash script.sh — rewrite bash
+        # before detach so env cannot PATH-resolve System32 WSL (#1268).
+        if os.sep in argv0 or (len(argv0) >= 2 and argv0[1] == ":"):
+            resolved = os.path.abspath(argv0)
+            if not os.path.isfile(resolved):
+                problem = "does not exist or is not a regular file"
+        else:
+            resolved = shutil.which(argv0)
+            if resolved is None:
+                problem = "was not found on PATH"
+                resolved = argv0
+        try:
+            rewritten, shell = _rewrite_windows_env_bash_argv(list(worker_argv))
+            if shell is not None:
+                windows_posix_shell = shell
+                worker_argv = rewritten
+        except RunnerError as exc:
+            problem = str(exc) if problem is None else f"{problem}; {exc}"
     elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1166,8 +1166,14 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if not tok.startswith("-") or tok.startswith("--"):
+    if not tok.startswith("-"):
         return 1
+    if tok.startswith("--"):
+        raise RunnerError(
+            f"unsupported env long option {tok!r} for native Windows peer "
+            "workers; use an exact supported option or pass -- before "
+            "option-like assignments"
+        )
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1233,6 +1233,7 @@ def _env_bash_index(argv):
             i += 1
             continue
         if _env_assignment_token(tok, allow_option_like=options_done):
+            options_done = True
             i += 1
             continue
         if not options_done and (

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -1159,7 +1159,7 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    Short options may be clustered. No-operand flags (-i/-v and their exact
     long aliases) advance one slot; -u/-C consume the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
@@ -1171,6 +1171,11 @@ def _env_option_advance(tok: str) -> int:
         return 1
     if tok in ("--ignore-environment", "--debug"):
         return 1
+    if tok == "--null":
+        raise RunnerError(
+            "env -0/--null cannot be used with a command by native Windows "
+            "peer workers; remove the null-output option"
+        )
     if not tok.startswith("-"):
         return 1
     if tok.startswith("--"):
@@ -1182,8 +1187,13 @@ def _env_option_advance(tok: str) -> int:
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):
-        if option in "i0v":
+        if option in "iv":
             continue
+        if option == "0":
+            raise RunnerError(
+                "env -0/--null cannot be used with a command by native "
+                "Windows peer workers; remove the null-output option"
+            )
         if option == "S":
             raise RunnerError(
                 "env -S/--split-string is unsupported for native Windows "
@@ -1225,9 +1235,6 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")
@@ -1244,6 +1251,9 @@ def _env_bash_index(argv):
                 return -1, None
             i += span
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         return -1, None
     return -1, None
 

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1150,8 +1150,7 @@ def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
         or "=" not in token
     ):
         return False
-    name = token.split("=", 1)[0]
-    return bool(name)
+    return True
 
 
 def _env_option_advance(tok: str) -> int:

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1157,14 +1157,17 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
-    cluster; -u/-C consume the rest of the token as an attached operand or the
-    next argv slot. Unsupported clusters fail closed before worker detach.
+    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    attached operand or the next argv slot. Unsupported options fail closed
+    before worker detach.
     (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
+        return 1
+    if tok in ("--ignore-environment", "--null", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1139,11 +1139,30 @@ def _env_assignment_token(token: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
+def _env_option_advance(tok: str) -> int:
+    """How many argv slots an env(1) option occupies (incl. the option itself).
+
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
+    -S/--split-string. Attached `--name=value` forms are a single slot.
+    Unknown flags advance one slot. (#1292 Codex P2)
+    """
+    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+        return 2
+    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+        return 1
+    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+        return 1
+    return 1
+
+
 def _env_bash_index(argv) -> int:
     """Index of bare bash/sh after `env` [options] [assignments], or -1.
 
     Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268).
+    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
+    and long forms) consume their arguments before the command token is
+    sought (#1292).
     """
     if not argv:
         return -1
@@ -1159,11 +1178,10 @@ def _env_bash_index(argv) -> int:
             i += 1
             continue
         if tok.startswith("-"):
-            # env -u NAME / --unset NAME consume the following argument.
-            if tok in ("-u", "--unset"):
-                i += 2
-                continue
-            i += 1
+            span = _env_option_advance(tok)
+            if span > 1 and i + 1 >= len(argv):
+                return -1
+            i += span
             continue
         return -1
     return -1

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -70,6 +70,10 @@ Environment overrides (defaults in parentheses):
   CE_PEER_RESULT_MAX_BYTES  result byte cap, supervise + read (5242880)
   CE_PEER_POLL_SECS         supervisor poll interval (2)
   CE_PEER_GRACE_SECS        TERM-to-KILL grace during reap (5)
+  CE_PEER_BASH              Windows: absolute bash.exe for peer workers
+                            (preferred over PATH / WSL System32 bash)
+  CLAUDE_CODE_GIT_BASH_PATH Claude Code Git Bash path; used on Windows when
+                            CE_PEER_BASH is unset (#1268)
 
 Security posture: the job root is a predictable, owner-private directory under
 world-shared /tmp. Every read of job state opens the file first (no-follow) and
@@ -1067,30 +1071,103 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
         time.sleep(min(0.1, max(0.01, end - time.monotonic())))
 
 
+def _is_system32_wsl_bash(path: str) -> bool:
+    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    if not path:
+        return False
+    base = os.path.basename(path).lower()
+    if base not in ("bash", "bash.exe", "sh", "sh.exe"):
+        return False
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    system32 = os.path.normcase(
+        os.path.join(os.path.abspath(system_root), "System32")
+    )
+    parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
+    return parent == system32
+
+
+def _git_bash_well_known_paths():
+    """Standard Git for Windows bash.exe locations."""
+    pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
+    pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
+    local = os.environ.get("LOCALAPPDATA") or ""
+    paths = [
+        os.path.join(pf, "Git", "bin", "bash.exe"),
+        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
+    ]
+    if local:
+        paths.extend([
+            os.path.join(local, "Programs", "Git", "bin", "bash.exe"),
+            os.path.join(local, "Programs", "Git", "usr", "bin", "bash.exe"),
+        ])
+    return paths
+
+
+def _resolve_windows_posix_shell() -> str:
+    """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
+
+    Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
+    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    nothing usable remains — never select System32\\bash.exe (#1268).
+    """
+    candidates = []
+    for key in ("CE_PEER_BASH", "CLAUDE_CODE_GIT_BASH_PATH"):
+        val = (os.environ.get(key) or "").strip()
+        if val:
+            candidates.append(val)
+    candidates.extend(_git_bash_well_known_paths())
+    for name in ("bash", "sh"):
+        found = shutil.which(name)
+        if found:
+            candidates.append(found)
+
+    seen = set()
+    for raw in candidates:
+        path = os.path.abspath(raw)
+        key = os.path.normcase(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not os.path.isfile(path):
+            continue
+        if _is_system32_wsl_bash(path):
+            continue
+        return path
+
+    raise RunnerError(
+        "no usable Git Bash (or other non-WSL POSIX shell) for native Windows "
+        "peer workers; install Git for Windows or set CE_PEER_BASH / "
+        "CLAUDE_CODE_GIT_BASH_PATH to an absolute bash.exe path "
+        "(System32\\bash.exe / WSL is not used)"
+    )
+
+
 def _popen_argv(argv):
     """Argv for subprocess.Popen.
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
-    worker must be launched through bash/sh. meta.json still records the
-    caller argv so authorize-dispatch contracts that forbid a shell prefix
-    stay exact. Already-prefixed workers (review skills use `bash script.sh`)
-    are left alone.
+    worker must be launched through bash/sh. Prefer Git Bash over System32
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
+    to that absolute path. meta.json still records the caller argv for
+    authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
     head = argv[0]
     base = os.path.basename(head).lower()
-    if base in ("bash", "bash.exe", "sh", "sh.exe", "env", "env.exe"):
+    if base in ("env", "env.exe"):
         return list(argv)
+    if base in ("bash", "bash.exe", "sh", "sh.exe"):
+        shell = _resolve_windows_posix_shell()
+        if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
+            return list(argv)
+        return [shell] + list(argv[1:])
     lower = head.lower()
     if not (lower.endswith(".sh") or lower.endswith(".bash")):
         return list(argv)
-    shell = shutil.which("bash") or shutil.which("sh")
-    if shell is None:
-        raise RunnerError(
-            "worker is a shell script but neither bash nor sh is on PATH; "
-            "install Git Bash or another POSIX shell to run it on Windows"
-        )
+    shell = _resolve_windows_posix_shell()
     return [shell, head] + list(argv[1:])
 
 
@@ -1484,18 +1561,28 @@ def cmd_start(args, worker_argv) -> int:
 
     argv0 = worker_argv[0]
     problem = None
-    if os.sep in argv0:
+    windows_posix_shell = None
+    base0 = os.path.basename(argv0).lower()
+    if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
+        # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        try:
+            resolved = _resolve_windows_posix_shell()
+            windows_posix_shell = resolved
+        except RunnerError as exc:
+            problem = str(exc)
+            resolved = argv0
+    elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):
             problem = "does not exist or is not a regular file"
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
             # CreateProcess cannot run shebang scripts; _popen_argv wraps with
-            # bash/sh. Require that shell now so start fails closed, not after
+            # Git Bash. Require that shell now so start fails closed, not after
             # detach. Skip the X_OK check — Windows often marks .sh non-exec.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
         elif not os.access(resolved, os.X_OK):
             problem = "is not executable"
     else:
@@ -1504,12 +1591,19 @@ def cmd_start(args, worker_argv) -> int:
             problem = "was not found on PATH"
             resolved = argv0
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
-            # Same shell requirement as the path-separator branch: a PATH hit
-            # on a bare `foo.sh` must not detach when bash/sh is missing.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
+        elif IS_WINDOWS and os.path.basename(resolved).lower() in (
+            "bash", "bash.exe", "sh", "sh.exe",
+        ):
+            # which() may have returned System32 WSL — rewrite now.
+            try:
+                resolved = _resolve_windows_posix_shell()
+                windows_posix_shell = resolved
+            except RunnerError as exc:
+                problem = str(exc)
     argv = [resolved] + list(worker_argv[1:])
 
     conf = cfg(args.skill)
@@ -1525,6 +1619,8 @@ def cmd_start(args, worker_argv) -> int:
         "sweep_enabled": not args.no_sweep,
         "supervision": conf,
     }
+    if windows_posix_shell:
+        meta["windows_posix_shell"] = windows_posix_shell
     try:
         create_exclusive(
             os.path.join(job_dir, "meta.json"),

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1167,7 +1167,7 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if tok in ("--ignore-environment", "--null", "--debug"):
+    if tok in ("--ignore-environment", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -119,7 +119,6 @@ import glob
 import json
 import os
 import re
-import shlex
 import shutil
 import signal
 import stat
@@ -1130,125 +1129,75 @@ def _windows_path_shell_candidates():
     return found
 
 
-def _env_assignment_token(token: str) -> bool:
+def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
     """True for env(1) NAME=value operands (not options or the command)."""
-    if not token or token.startswith("-") or "=" not in token:
+    if (
+        not token
+        or (token.startswith("-") and not allow_option_like)
+        or "=" not in token
+    ):
         return False
     name = token.split("=", 1)[0]
-    if not name or name[0].isdigit():
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
+    return bool(name)
 
 
 def _env_option_advance(tok: str) -> int:
     """How many argv slots an env(1) option occupies (incl. the option itself).
 
-    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
-    -S/--split-string. Attached `--name=value` forms are a single slot.
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir.
+    Attached `--name=value` forms are a single slot.
     Unknown flags advance one slot. (#1292 Codex P2)
     """
-    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+    if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
-    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+    if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+    # Short -uNAME (no space) and -CDIR are one slot.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
         return 1
     return 1
-
-
-def _parse_env_split_string(value):
-    """Split an env(1) -S/--split-string operand into words, or None.
-
-    Approximates GNU env's own word-splitting (backslash escapes, single/
-    double quotes) via shlex.split(posix=True) closely enough to detect a
-    bash/sh command inside it. Returns None when the value cannot be parsed
-    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
-    """
-    try:
-        return shlex.split(value, posix=True)
-    except ValueError:
-        return None
-
-
-def _bash_index_in_env_tokens(tokens) -> int:
-    """Index of a bash/sh command among env-style tokens, or -1.
-
-    Tokens are NAME=value assignments followed by a command, the same shape
-    `env` itself parses — used both for top-level env argv and for the words
-    produced by splitting a -S/--split-string operand (#1292).
-    """
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
-        if _env_assignment_token(tok):
-            i += 1
-            continue
-        return -1
-    return -1
 
 
 def _env_bash_index(argv):
     """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
 
     Matches the production cross-model shape `env VAR=… bash script.sh …`
-    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
-    arguments before the command token is sought (#1292).
+    (#1268). Operand-taking options (-u/-C and long forms) consume their
+    arguments before the command token is sought (#1292). Split-string forms
+    fail closed because Python shlex does not match Git env.exe semantics.
 
-    Returns (argv_index, split_prefix). split_prefix is None when
-    argv[argv_index] is itself the bare bash/sh token. It is a string
-    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
-    operand with that literal prefix (e.g. "--split-string=") still attached
-    and the bash/sh command lives inside it after word-splitting — callers
-    must reparse and rewrite the operand's command word, not the whole token
-    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
-    because the split string's contents were never inspected). Returns
-    (-1, None) when no bash/sh command is present.
+    Returns (argv_index, None), or (-1, None) when no bash/sh command is
+    present.
     """
     if not argv:
         return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
         return -1, None
     i = 1
+    options_done = False
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
             return i, None
-        if _env_assignment_token(tok):
+        if tok == "--" and not options_done:
+            options_done = True
             i += 1
             continue
-        prefix = None
-        value = None
-        idx = i
-        advance = 1
-        if tok in ("-S", "--split-string"):
-            if i + 1 >= len(argv):
-                return -1, None
-            idx = i + 1
-            prefix = ""
-            value = argv[idx]
-            advance = 2
-        elif tok.startswith("--split-string="):
-            prefix = "--split-string="
-            value = tok[len(prefix):]
-        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
-            prefix = tok[:2]
-            value = tok[2:]
-        if prefix is not None:
-            tokens = _parse_env_split_string(value)
-            if tokens is None:
-                raise RunnerError(
-                    "cannot parse env -S/--split-string operand for peer "
-                    f"worker shell selection: {value!r}"
-                )
-            if _bash_index_in_env_tokens(tokens) >= 0:
-                return idx, prefix
-            i += advance
+        if _env_assignment_token(tok, allow_option_like=options_done):
+            i += 1
             continue
-        if tok.startswith("-"):
+        if not options_done and (
+            tok in ("-S", "--split-string") or tok.startswith(
+                ("-S", "--split-string=")
+            )
+        ):
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if not options_done and tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
                 return -1, None
@@ -1282,45 +1231,20 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
-def _rewrite_env_split_string_value(value):
-    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
-
-    Returns (new_value, resolved_shell). Assumes `value` already contains a
-    resolvable bash/sh command, as checked by `_env_bash_index` via
-    `_bash_index_in_env_tokens` before this is called (#1292).
-    """
-    tokens = _parse_env_split_string(value)
-    if tokens is None:
-        raise RunnerError(
-            "cannot parse env -S/--split-string operand for peer worker "
-            f"shell selection: {value!r}"
-        )
-    idx = _bash_index_in_env_tokens(tokens)
-    shell = _prefer_windows_posix_shell(tokens[idx])
-    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
-        tokens[idx] = shell
-    return " ".join(shlex.quote(t) for t in tokens), shell
-
-
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
-    inside a -S/--split-string operand is rewritten in place within that
-    operand's word-split contents, preserving any `-S`/`--split-string=`
-    prefix still attached to the argv slot (#1292).
+    non-WSL bash tokens are kept unchanged (#1292 P2). Split-string options
+    are rejected before detach because their parser semantics are not safely
+    reproduced here (#1292).
     """
     idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
     out = list(argv)
-    if split_prefix is not None:
-        value = out[idx][len(split_prefix):]
-        new_value, shell = _rewrite_env_split_string_value(value)
-        out[idx] = split_prefix + new_value
-        return out, shell
+    assert split_prefix is None
     shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1169,16 +1169,41 @@ def _env_bash_index(argv) -> int:
     return -1
 
 
+def _windows_path_is_absolute(path: str) -> bool:
+    """True for Windows absolute paths (drive letter or path separator)."""
+    return os.sep in path or (len(path) >= 2 and path[1] == ":")
+
+
+def _prefer_windows_posix_shell(token: str) -> str:
+    """Absolute non-WSL bash/sh kept; bare names and System32 go through resolve.
+
+    Explicit absolute paths (portable Git, custom installs) must not be
+    substituted by the preferred resolver (#1292 Codex P2). Bare `bash`/`sh`
+    and System32 WSL launchers still use `_resolve_windows_posix_shell()`.
+    """
+    if _windows_path_is_absolute(token):
+        path = os.path.abspath(token)
+        if not os.path.isfile(path):
+            raise RunnerError(
+                f"peer worker shell does not exist or is not a regular file: {token}"
+            )
+        if _is_system32_wsl_bash(path):
+            return _resolve_windows_posix_shell()
+        return path
+    return _resolve_windows_posix_shell()
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
-    token is present but no usable non-WSL shell can be resolved.
+    token is present but no usable non-WSL shell can be resolved. Absolute
+    non-WSL bash tokens are kept unchanged (#1292 P2).
     """
     idx = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _resolve_windows_posix_shell()
+    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
@@ -1228,8 +1253,9 @@ def _popen_argv(argv):
     worker must be launched through bash/sh. Prefer Git Bash over System32
     WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
     `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
-    absolute path. meta.json still records the caller argv for
-    authorize-dispatch contracts that forbid a shell prefix on ce-work.
+    absolute path. Explicit absolute non-WSL bash/sh paths are kept (#1292 P2).
+    meta.json still records the caller argv for authorize-dispatch contracts
+    that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
@@ -1239,7 +1265,7 @@ def _popen_argv(argv):
         rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
         return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
-        shell = _resolve_windows_posix_shell()
+        shell = _prefer_windows_posix_shell(head)
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
             return list(argv)
         return [shell] + list(argv[1:])
@@ -1644,8 +1670,9 @@ def cmd_start(args, worker_argv) -> int:
     base0 = os.path.basename(argv0).lower()
     if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
         # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        # Keep an explicit absolute non-WSL bash (portable Git) (#1292 P2).
         try:
-            resolved = _resolve_windows_posix_shell()
+            resolved = _prefer_windows_posix_shell(argv0)
             windows_posix_shell = resolved
         except RunnerError as exc:
             problem = str(exc)

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1157,15 +1157,34 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Unknown flags advance one slot. (#1292 Codex P2)
+    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
+    cluster; -u/-C consume the rest of the token as an attached operand or the
+    next argv slot. Unsupported clusters fail closed before worker detach.
+    (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) and -CDIR are one slot.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
+    if not tok.startswith("-") or tok.startswith("--"):
         return 1
+
+    cluster = tok[1:]
+    for index, option in enumerate(cluster):
+        if option in "i0v":
+            continue
+        if option == "S":
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if option in "uC":
+            return 1 if index + 1 < len(cluster) else 2
+        raise RunnerError(
+            f"unsupported env short-option cluster {tok!r} for native "
+            "Windows peer workers; pass env options separately"
+        )
     return 1
 
 

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1160,7 +1160,8 @@ def _env_option_advance(tok: str) -> int:
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
     Short options may be clustered. No-operand flags (-i/-v and their exact
-    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    long aliases and signal-handling options) advance one slot; -u/-C consume
+    the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
     (#1292 Codex P2)
@@ -1170,6 +1171,16 @@ def _env_option_advance(tok: str) -> int:
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
     if tok in ("--ignore-environment", "--debug"):
+        return 1
+    if tok == "--list-signal-handling" or tok in (
+        "--block-signal",
+        "--default-signal",
+        "--ignore-signal",
+    ) or tok.startswith((
+        "--block-signal=",
+        "--default-signal=",
+        "--ignore-signal=",
+    )):
         return 1
     if tok == "--null":
         raise RunnerError(

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1072,18 +1072,20 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
 
 
 def _is_system32_wsl_bash(path: str) -> bool:
-    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    """True for Windows System32 WSL launchers, including Sysnative aliases."""
     if not path:
         return False
     base = os.path.basename(path).lower()
     if base not in ("bash", "bash.exe", "sh", "sh.exe"):
         return False
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    system32 = os.path.normcase(
-        os.path.join(os.path.abspath(system_root), "System32")
-    )
+    windows_root = os.path.abspath(system_root)
+    blocked_parents = {
+        os.path.normcase(os.path.join(windows_root, name))
+        for name in ("System32", "Sysnative")
+    }
     parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
-    return parent == system32
+    return parent in blocked_parents
 
 
 def _git_bash_well_known_paths():

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1216,9 +1216,6 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if tok == "--" and not options_done:
             options_done = True
             i += 1
@@ -1226,6 +1223,9 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1088,15 +1088,26 @@ def _is_system32_wsl_bash(path: str) -> bool:
 
 def _git_bash_well_known_paths():
     """Standard Git for Windows bash.exe locations."""
+    pf64 = os.environ.get("ProgramW6432") or ""
     pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
     pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
     local = os.environ.get("LOCALAPPDATA") or ""
-    paths = [
-        os.path.join(pf, "Git", "bin", "bash.exe"),
-        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
-    ]
+    roots = []
+    seen = set()
+    for root in (pf64, pf, pf86):
+        if not root:
+            continue
+        key = os.path.normcase(os.path.abspath(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(root)
+    paths = []
+    for root in roots:
+        paths.extend([
+            os.path.join(root, "Git", "bin", "bash.exe"),
+            os.path.join(root, "Git", "usr", "bin", "bash.exe"),
+        ])
     if local:
         paths.extend([
             os.path.join(local, "Programs", "Git", "bin", "bash.exe"),

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -119,6 +119,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -1156,35 +1157,105 @@ def _env_option_advance(tok: str) -> int:
     return 1
 
 
-def _env_bash_index(argv) -> int:
-    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+def _parse_env_split_string(value):
+    """Split an env(1) -S/--split-string operand into words, or None.
 
-    Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
-    and long forms) consume their arguments before the command token is
-    sought (#1292).
+    Approximates GNU env's own word-splitting (backslash escapes, single/
+    double quotes) via shlex.split(posix=True) closely enough to detect a
+    bash/sh command inside it. Returns None when the value cannot be parsed
+    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
+    """
+    try:
+        return shlex.split(value, posix=True)
+    except ValueError:
+        return None
+
+
+def _bash_index_in_env_tokens(tokens) -> int:
+    """Index of a bash/sh command among env-style tokens, or -1.
+
+    Tokens are NAME=value assignments followed by a command, the same shape
+    `env` itself parses — used both for top-level env argv and for the words
+    produced by splitting a -S/--split-string operand (#1292).
+    """
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _env_bash_index(argv):
+    """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
+
+    Matches the production cross-model shape `env VAR=… bash script.sh …`
+    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
+    arguments before the command token is sought (#1292).
+
+    Returns (argv_index, split_prefix). split_prefix is None when
+    argv[argv_index] is itself the bare bash/sh token. It is a string
+    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
+    operand with that literal prefix (e.g. "--split-string=") still attached
+    and the bash/sh command lives inside it after word-splitting — callers
+    must reparse and rewrite the operand's command word, not the whole token
+    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
+    because the split string's contents were never inspected). Returns
+    (-1, None) when no bash/sh command is present.
     """
     if not argv:
-        return -1
+        return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
-        return -1
+        return -1, None
     i = 1
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
+            return i, None
         if _env_assignment_token(tok):
             i += 1
+            continue
+        prefix = None
+        value = None
+        idx = i
+        advance = 1
+        if tok in ("-S", "--split-string"):
+            if i + 1 >= len(argv):
+                return -1, None
+            idx = i + 1
+            prefix = ""
+            value = argv[idx]
+            advance = 2
+        elif tok.startswith("--split-string="):
+            prefix = "--split-string="
+            value = tok[len(prefix):]
+        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
+            prefix = tok[:2]
+            value = tok[2:]
+        if prefix is not None:
+            tokens = _parse_env_split_string(value)
+            if tokens is None:
+                raise RunnerError(
+                    "cannot parse env -S/--split-string operand for peer "
+                    f"worker shell selection: {value!r}"
+                )
+            if _bash_index_in_env_tokens(tokens) >= 0:
+                return idx, prefix
+            i += advance
             continue
         if tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
-                return -1
+                return -1, None
             i += span
             continue
-        return -1
-    return -1
+        return -1, None
+    return -1, None
 
 
 def _windows_path_is_absolute(path: str) -> bool:
@@ -1211,18 +1282,46 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
+def _rewrite_env_split_string_value(value):
+    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
+
+    Returns (new_value, resolved_shell). Assumes `value` already contains a
+    resolvable bash/sh command, as checked by `_env_bash_index` via
+    `_bash_index_in_env_tokens` before this is called (#1292).
+    """
+    tokens = _parse_env_split_string(value)
+    if tokens is None:
+        raise RunnerError(
+            "cannot parse env -S/--split-string operand for peer worker "
+            f"shell selection: {value!r}"
+        )
+    idx = _bash_index_in_env_tokens(tokens)
+    shell = _prefer_windows_posix_shell(tokens[idx])
+    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
+        tokens[idx] = shell
+    return " ".join(shlex.quote(t) for t in tokens), shell
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2).
+    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
+    inside a -S/--split-string operand is rewritten in place within that
+    operand's word-split contents, preserving any `-S`/`--split-string=`
+    prefix still attached to the argv slot (#1292).
     """
-    idx = _env_bash_index(argv)
+    idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
+    if split_prefix is not None:
+        value = out[idx][len(split_prefix):]
+        new_value, shell = _rewrite_env_split_string_value(value)
+        out[idx] = split_prefix + new_value
+        return out, shell
+    shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
     return out, shell

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1228,7 +1228,7 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        if tok == "--" and not options_done:
+        if tok in ("-", "--") and not options_done:
             options_done = True
             i += 1
             continue

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1105,11 +1105,91 @@ def _git_bash_well_known_paths():
     return paths
 
 
+def _windows_path_shell_candidates():
+    """Every bash/sh on PATH in PATH order (not only shutil.which's first hit)."""
+    path_env = os.environ.get("PATH") or ""
+    names = ("bash.exe", "bash", "sh.exe", "sh")
+    found = []
+    seen = set()
+    for directory in path_env.split(os.pathsep):
+        if not directory:
+            continue
+        for name in names:
+            candidate = os.path.join(directory, name)
+            try:
+                if not os.path.isfile(candidate):
+                    continue
+            except OSError:
+                continue
+            key = os.path.normcase(os.path.abspath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(candidate)
+    return found
+
+
+def _env_assignment_token(token: str) -> bool:
+    """True for env(1) NAME=value operands (not options or the command)."""
+    if not token or token.startswith("-") or "=" not in token:
+        return False
+    name = token.split("=", 1)[0]
+    if not name or name[0].isdigit():
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _env_bash_index(argv) -> int:
+    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+
+    Matches the production cross-model shape:
+    `env VAR=… bash script.sh …` (#1268).
+    """
+    if not argv:
+        return -1
+    if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
+        return -1
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            # env -u NAME / --unset NAME consume the following argument.
+            if tok in ("-u", "--unset"):
+                i += 2
+                continue
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _rewrite_windows_env_bash_argv(argv):
+    """Rewrite bare bash/sh inside an env-prefixed argv.
+
+    Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
+    token is present but no usable non-WSL shell can be resolved.
+    """
+    idx = _env_bash_index(argv)
+    if idx < 0:
+        return list(argv), None
+    shell = _resolve_windows_posix_shell()
+    out = list(argv)
+    if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
+        out[idx] = shell
+    return out, shell
+
+
 def _resolve_windows_posix_shell() -> str:
     """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
 
     Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
-    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    installs, then every PATH bash/sh excluding System32 WSL. Fail closed when
     nothing usable remains — never select System32\\bash.exe (#1268).
     """
     candidates = []
@@ -1118,10 +1198,7 @@ def _resolve_windows_posix_shell() -> str:
         if val:
             candidates.append(val)
     candidates.extend(_git_bash_well_known_paths())
-    for name in ("bash", "sh"):
-        found = shutil.which(name)
-        if found:
-            candidates.append(found)
+    candidates.extend(_windows_path_shell_candidates())
 
     seen = set()
     for raw in candidates:
@@ -1149,8 +1226,9 @@ def _popen_argv(argv):
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
     worker must be launched through bash/sh. Prefer Git Bash over System32
-    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
-    to that absolute path. meta.json still records the caller argv for
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
+    `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
+    absolute path. meta.json still records the caller argv for
     authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
@@ -1158,7 +1236,8 @@ def _popen_argv(argv):
     head = argv[0]
     base = os.path.basename(head).lower()
     if base in ("env", "env.exe"):
-        return list(argv)
+        rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
+        return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
         shell = _resolve_windows_posix_shell()
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
@@ -1571,6 +1650,25 @@ def cmd_start(args, worker_argv) -> int:
         except RunnerError as exc:
             problem = str(exc)
             resolved = argv0
+    elif IS_WINDOWS and base0 in ("env", "env.exe"):
+        # Production cross-model: env VAR=… bash script.sh — rewrite bash
+        # before detach so env cannot PATH-resolve System32 WSL (#1268).
+        if os.sep in argv0 or (len(argv0) >= 2 and argv0[1] == ":"):
+            resolved = os.path.abspath(argv0)
+            if not os.path.isfile(resolved):
+                problem = "does not exist or is not a regular file"
+        else:
+            resolved = shutil.which(argv0)
+            if resolved is None:
+                problem = "was not found on PATH"
+                resolved = argv0
+        try:
+            rewritten, shell = _rewrite_windows_env_bash_argv(list(worker_argv))
+            if shell is not None:
+                windows_posix_shell = shell
+                worker_argv = rewritten
+        except RunnerError as exc:
+            problem = str(exc) if problem is None else f"{problem}; {exc}"
     elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1166,8 +1166,14 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if not tok.startswith("-") or tok.startswith("--"):
+    if not tok.startswith("-"):
         return 1
+    if tok.startswith("--"):
+        raise RunnerError(
+            f"unsupported env long option {tok!r} for native Windows peer "
+            "workers; use an exact supported option or pass -- before "
+            "option-like assignments"
+        )
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1233,6 +1233,7 @@ def _env_bash_index(argv):
             i += 1
             continue
         if _env_assignment_token(tok, allow_option_like=options_done):
+            options_done = True
             i += 1
             continue
         if not options_done and (

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -1159,7 +1159,7 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    Short options may be clustered. No-operand flags (-i/-v and their exact
     long aliases) advance one slot; -u/-C consume the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
@@ -1171,6 +1171,11 @@ def _env_option_advance(tok: str) -> int:
         return 1
     if tok in ("--ignore-environment", "--debug"):
         return 1
+    if tok == "--null":
+        raise RunnerError(
+            "env -0/--null cannot be used with a command by native Windows "
+            "peer workers; remove the null-output option"
+        )
     if not tok.startswith("-"):
         return 1
     if tok.startswith("--"):
@@ -1182,8 +1187,13 @@ def _env_option_advance(tok: str) -> int:
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):
-        if option in "i0v":
+        if option in "iv":
             continue
+        if option == "0":
+            raise RunnerError(
+                "env -0/--null cannot be used with a command by native "
+                "Windows peer workers; remove the null-output option"
+            )
         if option == "S":
             raise RunnerError(
                 "env -S/--split-string is unsupported for native Windows "
@@ -1225,9 +1235,6 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")
@@ -1244,6 +1251,9 @@ def _env_bash_index(argv):
                 return -1, None
             i += span
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         return -1, None
     return -1, None
 

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1150,8 +1150,7 @@ def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
         or "=" not in token
     ):
         return False
-    name = token.split("=", 1)[0]
-    return bool(name)
+    return True
 
 
 def _env_option_advance(tok: str) -> int:

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1157,14 +1157,17 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
-    cluster; -u/-C consume the rest of the token as an attached operand or the
-    next argv slot. Unsupported clusters fail closed before worker detach.
+    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    attached operand or the next argv slot. Unsupported options fail closed
+    before worker detach.
     (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
+        return 1
+    if tok in ("--ignore-environment", "--null", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1139,11 +1139,30 @@ def _env_assignment_token(token: str) -> bool:
     return all(c.isalnum() or c == "_" for c in name)
 
 
+def _env_option_advance(tok: str) -> int:
+    """How many argv slots an env(1) option occupies (incl. the option itself).
+
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
+    -S/--split-string. Attached `--name=value` forms are a single slot.
+    Unknown flags advance one slot. (#1292 Codex P2)
+    """
+    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+        return 2
+    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+        return 1
+    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+        return 1
+    return 1
+
+
 def _env_bash_index(argv) -> int:
     """Index of bare bash/sh after `env` [options] [assignments], or -1.
 
     Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268).
+    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
+    and long forms) consume their arguments before the command token is
+    sought (#1292).
     """
     if not argv:
         return -1
@@ -1159,11 +1178,10 @@ def _env_bash_index(argv) -> int:
             i += 1
             continue
         if tok.startswith("-"):
-            # env -u NAME / --unset NAME consume the following argument.
-            if tok in ("-u", "--unset"):
-                i += 2
-                continue
-            i += 1
+            span = _env_option_advance(tok)
+            if span > 1 and i + 1 >= len(argv):
+                return -1
+            i += span
             continue
         return -1
     return -1

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -70,6 +70,10 @@ Environment overrides (defaults in parentheses):
   CE_PEER_RESULT_MAX_BYTES  result byte cap, supervise + read (5242880)
   CE_PEER_POLL_SECS         supervisor poll interval (2)
   CE_PEER_GRACE_SECS        TERM-to-KILL grace during reap (5)
+  CE_PEER_BASH              Windows: absolute bash.exe for peer workers
+                            (preferred over PATH / WSL System32 bash)
+  CLAUDE_CODE_GIT_BASH_PATH Claude Code Git Bash path; used on Windows when
+                            CE_PEER_BASH is unset (#1268)
 
 Security posture: the job root is a predictable, owner-private directory under
 world-shared /tmp. Every read of job state opens the file first (no-follow) and
@@ -1067,30 +1071,103 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
         time.sleep(min(0.1, max(0.01, end - time.monotonic())))
 
 
+def _is_system32_wsl_bash(path: str) -> bool:
+    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    if not path:
+        return False
+    base = os.path.basename(path).lower()
+    if base not in ("bash", "bash.exe", "sh", "sh.exe"):
+        return False
+    system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+    system32 = os.path.normcase(
+        os.path.join(os.path.abspath(system_root), "System32")
+    )
+    parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
+    return parent == system32
+
+
+def _git_bash_well_known_paths():
+    """Standard Git for Windows bash.exe locations."""
+    pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
+    pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
+    local = os.environ.get("LOCALAPPDATA") or ""
+    paths = [
+        os.path.join(pf, "Git", "bin", "bash.exe"),
+        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "bin", "bash.exe"),
+        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
+    ]
+    if local:
+        paths.extend([
+            os.path.join(local, "Programs", "Git", "bin", "bash.exe"),
+            os.path.join(local, "Programs", "Git", "usr", "bin", "bash.exe"),
+        ])
+    return paths
+
+
+def _resolve_windows_posix_shell() -> str:
+    """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
+
+    Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
+    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    nothing usable remains — never select System32\\bash.exe (#1268).
+    """
+    candidates = []
+    for key in ("CE_PEER_BASH", "CLAUDE_CODE_GIT_BASH_PATH"):
+        val = (os.environ.get(key) or "").strip()
+        if val:
+            candidates.append(val)
+    candidates.extend(_git_bash_well_known_paths())
+    for name in ("bash", "sh"):
+        found = shutil.which(name)
+        if found:
+            candidates.append(found)
+
+    seen = set()
+    for raw in candidates:
+        path = os.path.abspath(raw)
+        key = os.path.normcase(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not os.path.isfile(path):
+            continue
+        if _is_system32_wsl_bash(path):
+            continue
+        return path
+
+    raise RunnerError(
+        "no usable Git Bash (or other non-WSL POSIX shell) for native Windows "
+        "peer workers; install Git for Windows or set CE_PEER_BASH / "
+        "CLAUDE_CODE_GIT_BASH_PATH to an absolute bash.exe path "
+        "(System32\\bash.exe / WSL is not used)"
+    )
+
+
 def _popen_argv(argv):
     """Argv for subprocess.Popen.
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
-    worker must be launched through bash/sh. meta.json still records the
-    caller argv so authorize-dispatch contracts that forbid a shell prefix
-    stay exact. Already-prefixed workers (review skills use `bash script.sh`)
-    are left alone.
+    worker must be launched through bash/sh. Prefer Git Bash over System32
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
+    to that absolute path. meta.json still records the caller argv for
+    authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
     head = argv[0]
     base = os.path.basename(head).lower()
-    if base in ("bash", "bash.exe", "sh", "sh.exe", "env", "env.exe"):
+    if base in ("env", "env.exe"):
         return list(argv)
+    if base in ("bash", "bash.exe", "sh", "sh.exe"):
+        shell = _resolve_windows_posix_shell()
+        if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
+            return list(argv)
+        return [shell] + list(argv[1:])
     lower = head.lower()
     if not (lower.endswith(".sh") or lower.endswith(".bash")):
         return list(argv)
-    shell = shutil.which("bash") or shutil.which("sh")
-    if shell is None:
-        raise RunnerError(
-            "worker is a shell script but neither bash nor sh is on PATH; "
-            "install Git Bash or another POSIX shell to run it on Windows"
-        )
+    shell = _resolve_windows_posix_shell()
     return [shell, head] + list(argv[1:])
 
 
@@ -1484,18 +1561,28 @@ def cmd_start(args, worker_argv) -> int:
 
     argv0 = worker_argv[0]
     problem = None
-    if os.sep in argv0:
+    windows_posix_shell = None
+    base0 = os.path.basename(argv0).lower()
+    if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
+        # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        try:
+            resolved = _resolve_windows_posix_shell()
+            windows_posix_shell = resolved
+        except RunnerError as exc:
+            problem = str(exc)
+            resolved = argv0
+    elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):
             problem = "does not exist or is not a regular file"
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
             # CreateProcess cannot run shebang scripts; _popen_argv wraps with
-            # bash/sh. Require that shell now so start fails closed, not after
+            # Git Bash. Require that shell now so start fails closed, not after
             # detach. Skip the X_OK check — Windows often marks .sh non-exec.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
         elif not os.access(resolved, os.X_OK):
             problem = "is not executable"
     else:
@@ -1504,12 +1591,19 @@ def cmd_start(args, worker_argv) -> int:
             problem = "was not found on PATH"
             resolved = argv0
         elif IS_WINDOWS and resolved.lower().endswith((".sh", ".bash")):
-            # Same shell requirement as the path-separator branch: a PATH hit
-            # on a bare `foo.sh` must not detach when bash/sh is missing.
-            if shutil.which("bash") is None and shutil.which("sh") is None:
-                problem = (
-                    "is a shell script but neither bash nor sh is on PATH"
-                )
+            try:
+                windows_posix_shell = _resolve_windows_posix_shell()
+            except RunnerError as exc:
+                problem = str(exc)
+        elif IS_WINDOWS and os.path.basename(resolved).lower() in (
+            "bash", "bash.exe", "sh", "sh.exe",
+        ):
+            # which() may have returned System32 WSL — rewrite now.
+            try:
+                resolved = _resolve_windows_posix_shell()
+                windows_posix_shell = resolved
+            except RunnerError as exc:
+                problem = str(exc)
     argv = [resolved] + list(worker_argv[1:])
 
     conf = cfg(args.skill)
@@ -1525,6 +1619,8 @@ def cmd_start(args, worker_argv) -> int:
         "sweep_enabled": not args.no_sweep,
         "supervision": conf,
     }
+    if windows_posix_shell:
+        meta["windows_posix_shell"] = windows_posix_shell
     try:
         create_exclusive(
             os.path.join(job_dir, "meta.json"),

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1167,7 +1167,7 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if tok in ("--ignore-environment", "--null", "--debug"):
+    if tok in ("--ignore-environment", "--debug"):
         return 1
     if not tok.startswith("-"):
         return 1

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -119,7 +119,6 @@ import glob
 import json
 import os
 import re
-import shlex
 import shutil
 import signal
 import stat
@@ -1130,125 +1129,75 @@ def _windows_path_shell_candidates():
     return found
 
 
-def _env_assignment_token(token: str) -> bool:
+def _env_assignment_token(token: str, allow_option_like: bool = False) -> bool:
     """True for env(1) NAME=value operands (not options or the command)."""
-    if not token or token.startswith("-") or "=" not in token:
+    if (
+        not token
+        or (token.startswith("-") and not allow_option_like)
+        or "=" not in token
+    ):
         return False
     name = token.split("=", 1)[0]
-    if not name or name[0].isdigit():
-        return False
-    return all(c.isalnum() or c == "_" for c in name)
+    return bool(name)
 
 
 def _env_option_advance(tok: str) -> int:
     """How many argv slots an env(1) option occupies (incl. the option itself).
 
-    GNU env options that take a separate operand: -u/--unset, -C/--chdir,
-    -S/--split-string. Attached `--name=value` forms are a single slot.
+    GNU env options that take a separate operand: -u/--unset, -C/--chdir.
+    Attached `--name=value` forms are a single slot.
     Unknown flags advance one slot. (#1292 Codex P2)
     """
-    if tok in ("-u", "--unset", "-C", "--chdir", "-S", "--split-string"):
+    if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
-    if tok.startswith(("--unset=", "--chdir=", "--split-string=")):
+    if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) is one slot; -CDIR / -SSTRING likewise.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uCS" and tok[2] != "-":
+    # Short -uNAME (no space) and -CDIR are one slot.
+    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
         return 1
     return 1
-
-
-def _parse_env_split_string(value):
-    """Split an env(1) -S/--split-string operand into words, or None.
-
-    Approximates GNU env's own word-splitting (backslash escapes, single/
-    double quotes) via shlex.split(posix=True) closely enough to detect a
-    bash/sh command inside it. Returns None when the value cannot be parsed
-    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
-    """
-    try:
-        return shlex.split(value, posix=True)
-    except ValueError:
-        return None
-
-
-def _bash_index_in_env_tokens(tokens) -> int:
-    """Index of a bash/sh command among env-style tokens, or -1.
-
-    Tokens are NAME=value assignments followed by a command, the same shape
-    `env` itself parses — used both for top-level env argv and for the words
-    produced by splitting a -S/--split-string operand (#1292).
-    """
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
-        if _env_assignment_token(tok):
-            i += 1
-            continue
-        return -1
-    return -1
 
 
 def _env_bash_index(argv):
     """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
 
     Matches the production cross-model shape `env VAR=… bash script.sh …`
-    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
-    arguments before the command token is sought (#1292).
+    (#1268). Operand-taking options (-u/-C and long forms) consume their
+    arguments before the command token is sought (#1292). Split-string forms
+    fail closed because Python shlex does not match Git env.exe semantics.
 
-    Returns (argv_index, split_prefix). split_prefix is None when
-    argv[argv_index] is itself the bare bash/sh token. It is a string
-    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
-    operand with that literal prefix (e.g. "--split-string=") still attached
-    and the bash/sh command lives inside it after word-splitting — callers
-    must reparse and rewrite the operand's command word, not the whole token
-    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
-    because the split string's contents were never inspected). Returns
-    (-1, None) when no bash/sh command is present.
+    Returns (argv_index, None), or (-1, None) when no bash/sh command is
+    present.
     """
     if not argv:
         return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
         return -1, None
     i = 1
+    options_done = False
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
             return i, None
-        if _env_assignment_token(tok):
+        if tok == "--" and not options_done:
+            options_done = True
             i += 1
             continue
-        prefix = None
-        value = None
-        idx = i
-        advance = 1
-        if tok in ("-S", "--split-string"):
-            if i + 1 >= len(argv):
-                return -1, None
-            idx = i + 1
-            prefix = ""
-            value = argv[idx]
-            advance = 2
-        elif tok.startswith("--split-string="):
-            prefix = "--split-string="
-            value = tok[len(prefix):]
-        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
-            prefix = tok[:2]
-            value = tok[2:]
-        if prefix is not None:
-            tokens = _parse_env_split_string(value)
-            if tokens is None:
-                raise RunnerError(
-                    "cannot parse env -S/--split-string operand for peer "
-                    f"worker shell selection: {value!r}"
-                )
-            if _bash_index_in_env_tokens(tokens) >= 0:
-                return idx, prefix
-            i += advance
+        if _env_assignment_token(tok, allow_option_like=options_done):
+            i += 1
             continue
-        if tok.startswith("-"):
+        if not options_done and (
+            tok in ("-S", "--split-string") or tok.startswith(
+                ("-S", "--split-string=")
+            )
+        ):
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if not options_done and tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
                 return -1, None
@@ -1282,45 +1231,20 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
-def _rewrite_env_split_string_value(value):
-    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
-
-    Returns (new_value, resolved_shell). Assumes `value` already contains a
-    resolvable bash/sh command, as checked by `_env_bash_index` via
-    `_bash_index_in_env_tokens` before this is called (#1292).
-    """
-    tokens = _parse_env_split_string(value)
-    if tokens is None:
-        raise RunnerError(
-            "cannot parse env -S/--split-string operand for peer worker "
-            f"shell selection: {value!r}"
-        )
-    idx = _bash_index_in_env_tokens(tokens)
-    shell = _prefer_windows_posix_shell(tokens[idx])
-    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
-        tokens[idx] = shell
-    return " ".join(shlex.quote(t) for t in tokens), shell
-
-
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
-    inside a -S/--split-string operand is rewritten in place within that
-    operand's word-split contents, preserving any `-S`/`--split-string=`
-    prefix still attached to the argv slot (#1292).
+    non-WSL bash tokens are kept unchanged (#1292 P2). Split-string options
+    are rejected before detach because their parser semantics are not safely
+    reproduced here (#1292).
     """
     idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
     out = list(argv)
-    if split_prefix is not None:
-        value = out[idx][len(split_prefix):]
-        new_value, shell = _rewrite_env_split_string_value(value)
-        out[idx] = split_prefix + new_value
-        return out, shell
+    assert split_prefix is None
     shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1169,16 +1169,41 @@ def _env_bash_index(argv) -> int:
     return -1
 
 
+def _windows_path_is_absolute(path: str) -> bool:
+    """True for Windows absolute paths (drive letter or path separator)."""
+    return os.sep in path or (len(path) >= 2 and path[1] == ":")
+
+
+def _prefer_windows_posix_shell(token: str) -> str:
+    """Absolute non-WSL bash/sh kept; bare names and System32 go through resolve.
+
+    Explicit absolute paths (portable Git, custom installs) must not be
+    substituted by the preferred resolver (#1292 Codex P2). Bare `bash`/`sh`
+    and System32 WSL launchers still use `_resolve_windows_posix_shell()`.
+    """
+    if _windows_path_is_absolute(token):
+        path = os.path.abspath(token)
+        if not os.path.isfile(path):
+            raise RunnerError(
+                f"peer worker shell does not exist or is not a regular file: {token}"
+            )
+        if _is_system32_wsl_bash(path):
+            return _resolve_windows_posix_shell()
+        return path
+    return _resolve_windows_posix_shell()
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
-    token is present but no usable non-WSL shell can be resolved.
+    token is present but no usable non-WSL shell can be resolved. Absolute
+    non-WSL bash tokens are kept unchanged (#1292 P2).
     """
     idx = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _resolve_windows_posix_shell()
+    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
@@ -1228,8 +1253,9 @@ def _popen_argv(argv):
     worker must be launched through bash/sh. Prefer Git Bash over System32
     WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
     `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
-    absolute path. meta.json still records the caller argv for
-    authorize-dispatch contracts that forbid a shell prefix on ce-work.
+    absolute path. Explicit absolute non-WSL bash/sh paths are kept (#1292 P2).
+    meta.json still records the caller argv for authorize-dispatch contracts
+    that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
         return list(argv)
@@ -1239,7 +1265,7 @@ def _popen_argv(argv):
         rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
         return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
-        shell = _resolve_windows_posix_shell()
+        shell = _prefer_windows_posix_shell(head)
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
             return list(argv)
         return [shell] + list(argv[1:])
@@ -1644,8 +1670,9 @@ def cmd_start(args, worker_argv) -> int:
     base0 = os.path.basename(argv0).lower()
     if IS_WINDOWS and base0 in ("bash", "bash.exe", "sh", "sh.exe"):
         # Prefer Git Bash over PATH/System32 WSL before meta + detach (#1268).
+        # Keep an explicit absolute non-WSL bash (portable Git) (#1292 P2).
         try:
-            resolved = _resolve_windows_posix_shell()
+            resolved = _prefer_windows_posix_shell(argv0)
             windows_posix_shell = resolved
         except RunnerError as exc:
             problem = str(exc)

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1157,15 +1157,34 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Unknown flags advance one slot. (#1292 Codex P2)
+    Short options may be clustered. No-operand flags (-i/-0/-v) continue the
+    cluster; -u/-C consume the rest of the token as an attached operand or the
+    next argv slot. Unsupported clusters fail closed before worker detach.
+    (#1292 Codex P2)
     """
     if tok in ("-u", "--unset", "-C", "--chdir"):
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    # Short -uNAME (no space) and -CDIR are one slot.
-    if len(tok) > 2 and tok[0] == "-" and tok[1] in "uC" and tok[2] != "-":
+    if not tok.startswith("-") or tok.startswith("--"):
         return 1
+
+    cluster = tok[1:]
+    for index, option in enumerate(cluster):
+        if option in "i0v":
+            continue
+        if option == "S":
+            raise RunnerError(
+                "env -S/--split-string is unsupported for native Windows "
+                "peer workers; pass env assignments and the command as "
+                "separate arguments"
+            )
+        if option in "uC":
+            return 1 if index + 1 < len(cluster) else 2
+        raise RunnerError(
+            f"unsupported env short-option cluster {tok!r} for native "
+            "Windows peer workers; pass env options separately"
+        )
     return 1
 
 

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1160,7 +1160,8 @@ def _env_option_advance(tok: str) -> int:
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
     Short options may be clustered. No-operand flags (-i/-v and their exact
-    long aliases) advance one slot; -u/-C consume the rest of the token as an
+    long aliases and signal-handling options) advance one slot; -u/-C consume
+    the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
     (#1292 Codex P2)
@@ -1170,6 +1171,16 @@ def _env_option_advance(tok: str) -> int:
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
     if tok in ("--ignore-environment", "--debug"):
+        return 1
+    if tok == "--list-signal-handling" or tok in (
+        "--block-signal",
+        "--default-signal",
+        "--ignore-signal",
+    ) or tok.startswith((
+        "--block-signal=",
+        "--default-signal=",
+        "--ignore-signal=",
+    )):
         return 1
     if tok == "--null":
         raise RunnerError(

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1072,18 +1072,20 @@ def _interruptible_sleep(secs: float, flag: dict, job_dir: str) -> None:
 
 
 def _is_system32_wsl_bash(path: str) -> bool:
-    """True when path is the Windows System32 WSL bash launcher (#1268)."""
+    """True for Windows System32 WSL launchers, including Sysnative aliases."""
     if not path:
         return False
     base = os.path.basename(path).lower()
     if base not in ("bash", "bash.exe", "sh", "sh.exe"):
         return False
     system_root = os.environ.get("SystemRoot") or r"C:\Windows"
-    system32 = os.path.normcase(
-        os.path.join(os.path.abspath(system_root), "System32")
-    )
+    windows_root = os.path.abspath(system_root)
+    blocked_parents = {
+        os.path.normcase(os.path.join(windows_root, name))
+        for name in ("System32", "Sysnative")
+    }
     parent = os.path.normcase(os.path.dirname(os.path.abspath(path)))
-    return parent == system32
+    return parent in blocked_parents
 
 
 def _git_bash_well_known_paths():

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1216,9 +1216,6 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if tok == "--" and not options_done:
             options_done = True
             i += 1
@@ -1226,6 +1223,9 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1088,15 +1088,26 @@ def _is_system32_wsl_bash(path: str) -> bool:
 
 def _git_bash_well_known_paths():
     """Standard Git for Windows bash.exe locations."""
+    pf64 = os.environ.get("ProgramW6432") or ""
     pf = os.environ.get("ProgramFiles") or r"C:\Program Files"
     pf86 = os.environ.get("ProgramFiles(x86)") or r"C:\Program Files (x86)"
     local = os.environ.get("LOCALAPPDATA") or ""
-    paths = [
-        os.path.join(pf, "Git", "bin", "bash.exe"),
-        os.path.join(pf, "Git", "usr", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "bin", "bash.exe"),
-        os.path.join(pf86, "Git", "usr", "bin", "bash.exe"),
-    ]
+    roots = []
+    seen = set()
+    for root in (pf64, pf, pf86):
+        if not root:
+            continue
+        key = os.path.normcase(os.path.abspath(root))
+        if key in seen:
+            continue
+        seen.add(key)
+        roots.append(root)
+    paths = []
+    for root in roots:
+        paths.extend([
+            os.path.join(root, "Git", "bin", "bash.exe"),
+            os.path.join(root, "Git", "usr", "bin", "bash.exe"),
+        ])
     if local:
         paths.extend([
             os.path.join(local, "Programs", "Git", "bin", "bash.exe"),

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -119,6 +119,7 @@ import glob
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -1156,35 +1157,105 @@ def _env_option_advance(tok: str) -> int:
     return 1
 
 
-def _env_bash_index(argv) -> int:
-    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+def _parse_env_split_string(value):
+    """Split an env(1) -S/--split-string operand into words, or None.
 
-    Matches the production cross-model shape:
-    `env VAR=… bash script.sh …` (#1268). Operand-taking options (-u/-C/-S
-    and long forms) consume their arguments before the command token is
-    sought (#1292).
+    Approximates GNU env's own word-splitting (backslash escapes, single/
+    double quotes) via shlex.split(posix=True) closely enough to detect a
+    bash/sh command inside it. Returns None when the value cannot be parsed
+    (unbalanced quotes) so callers fail closed instead of guessing (#1292).
+    """
+    try:
+        return shlex.split(value, posix=True)
+    except ValueError:
+        return None
+
+
+def _bash_index_in_env_tokens(tokens) -> int:
+    """Index of a bash/sh command among env-style tokens, or -1.
+
+    Tokens are NAME=value assignments followed by a command, the same shape
+    `env` itself parses — used both for top-level env argv and for the words
+    produced by splitting a -S/--split-string operand (#1292).
+    """
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if os.path.basename(tok).lower() in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _env_bash_index(argv):
+    """Locate the env(1)-launched bash/sh command, for #1268/#1292 rewriting.
+
+    Matches the production cross-model shape `env VAR=… bash script.sh …`
+    (#1268). Operand-taking options (-u/-C/-S and long forms) consume their
+    arguments before the command token is sought (#1292).
+
+    Returns (argv_index, split_prefix). split_prefix is None when
+    argv[argv_index] is itself the bare bash/sh token. It is a string
+    (possibly empty) when argv[argv_index] instead holds a -S/--split-string
+    operand with that literal prefix (e.g. "--split-string=") still attached
+    and the bash/sh command lives inside it after word-splitting — callers
+    must reparse and rewrite the operand's command word, not the whole token
+    (#1292 Codex round: `env -S "bash script.sh"` previously went unresolved
+    because the split string's contents were never inspected). Returns
+    (-1, None) when no bash/sh command is present.
     """
     if not argv:
-        return -1
+        return -1, None
     if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
-        return -1
+        return -1, None
     i = 1
     while i < len(argv):
         tok = argv[i]
         base = os.path.basename(tok).lower()
         if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i
+            return i, None
         if _env_assignment_token(tok):
             i += 1
+            continue
+        prefix = None
+        value = None
+        idx = i
+        advance = 1
+        if tok in ("-S", "--split-string"):
+            if i + 1 >= len(argv):
+                return -1, None
+            idx = i + 1
+            prefix = ""
+            value = argv[idx]
+            advance = 2
+        elif tok.startswith("--split-string="):
+            prefix = "--split-string="
+            value = tok[len(prefix):]
+        elif len(tok) > 2 and tok[0] == "-" and tok[1] == "S" and tok[2] != "-":
+            prefix = tok[:2]
+            value = tok[2:]
+        if prefix is not None:
+            tokens = _parse_env_split_string(value)
+            if tokens is None:
+                raise RunnerError(
+                    "cannot parse env -S/--split-string operand for peer "
+                    f"worker shell selection: {value!r}"
+                )
+            if _bash_index_in_env_tokens(tokens) >= 0:
+                return idx, prefix
+            i += advance
             continue
         if tok.startswith("-"):
             span = _env_option_advance(tok)
             if span > 1 and i + 1 >= len(argv):
-                return -1
+                return -1, None
             i += span
             continue
-        return -1
-    return -1
+        return -1, None
+    return -1, None
 
 
 def _windows_path_is_absolute(path: str) -> bool:
@@ -1211,18 +1282,46 @@ def _prefer_windows_posix_shell(token: str) -> str:
     return _resolve_windows_posix_shell()
 
 
+def _rewrite_env_split_string_value(value):
+    """Rewrite a bare/System32 bash|sh word inside an env -S operand value.
+
+    Returns (new_value, resolved_shell). Assumes `value` already contains a
+    resolvable bash/sh command, as checked by `_env_bash_index` via
+    `_bash_index_in_env_tokens` before this is called (#1292).
+    """
+    tokens = _parse_env_split_string(value)
+    if tokens is None:
+        raise RunnerError(
+            "cannot parse env -S/--split-string operand for peer worker "
+            f"shell selection: {value!r}"
+        )
+    idx = _bash_index_in_env_tokens(tokens)
+    shell = _prefer_windows_posix_shell(tokens[idx])
+    if os.path.normcase(os.path.abspath(tokens[idx])) != os.path.normcase(shell):
+        tokens[idx] = shell
+    return " ".join(shlex.quote(t) for t in tokens), shell
+
+
 def _rewrite_windows_env_bash_argv(argv):
     """Rewrite bare bash/sh inside an env-prefixed argv.
 
     Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
     token is present but no usable non-WSL shell can be resolved. Absolute
-    non-WSL bash tokens are kept unchanged (#1292 P2).
+    non-WSL bash tokens are kept unchanged (#1292 P2). A bash/sh command
+    inside a -S/--split-string operand is rewritten in place within that
+    operand's word-split contents, preserving any `-S`/`--split-string=`
+    prefix still attached to the argv slot (#1292).
     """
-    idx = _env_bash_index(argv)
+    idx, split_prefix = _env_bash_index(argv)
     if idx < 0:
         return list(argv), None
-    shell = _prefer_windows_posix_shell(argv[idx])
     out = list(argv)
+    if split_prefix is not None:
+        value = out[idx][len(split_prefix):]
+        new_value, shell = _rewrite_env_split_string_value(value)
+        out[idx] = split_prefix + new_value
+        return out, shell
+    shell = _prefer_windows_posix_shell(out[idx])
     if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
         out[idx] = shell
     return out, shell

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1228,7 +1228,7 @@ def _env_bash_index(argv):
     options_done = False
     while i < len(argv):
         tok = argv[i]
-        if tok == "--" and not options_done:
+        if tok in ("-", "--") and not options_done:
             options_done = True
             i += 1
             continue

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1105,11 +1105,91 @@ def _git_bash_well_known_paths():
     return paths
 
 
+def _windows_path_shell_candidates():
+    """Every bash/sh on PATH in PATH order (not only shutil.which's first hit)."""
+    path_env = os.environ.get("PATH") or ""
+    names = ("bash.exe", "bash", "sh.exe", "sh")
+    found = []
+    seen = set()
+    for directory in path_env.split(os.pathsep):
+        if not directory:
+            continue
+        for name in names:
+            candidate = os.path.join(directory, name)
+            try:
+                if not os.path.isfile(candidate):
+                    continue
+            except OSError:
+                continue
+            key = os.path.normcase(os.path.abspath(candidate))
+            if key in seen:
+                continue
+            seen.add(key)
+            found.append(candidate)
+    return found
+
+
+def _env_assignment_token(token: str) -> bool:
+    """True for env(1) NAME=value operands (not options or the command)."""
+    if not token or token.startswith("-") or "=" not in token:
+        return False
+    name = token.split("=", 1)[0]
+    if not name or name[0].isdigit():
+        return False
+    return all(c.isalnum() or c == "_" for c in name)
+
+
+def _env_bash_index(argv) -> int:
+    """Index of bare bash/sh after `env` [options] [assignments], or -1.
+
+    Matches the production cross-model shape:
+    `env VAR=… bash script.sh …` (#1268).
+    """
+    if not argv:
+        return -1
+    if os.path.basename(argv[0]).lower() not in ("env", "env.exe"):
+        return -1
+    i = 1
+    while i < len(argv):
+        tok = argv[i]
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i
+        if _env_assignment_token(tok):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            # env -u NAME / --unset NAME consume the following argument.
+            if tok in ("-u", "--unset"):
+                i += 2
+                continue
+            i += 1
+            continue
+        return -1
+    return -1
+
+
+def _rewrite_windows_env_bash_argv(argv):
+    """Rewrite bare bash/sh inside an env-prefixed argv.
+
+    Returns (argv, resolved_shell_or_None). Raises RunnerError when a bash/sh
+    token is present but no usable non-WSL shell can be resolved.
+    """
+    idx = _env_bash_index(argv)
+    if idx < 0:
+        return list(argv), None
+    shell = _resolve_windows_posix_shell()
+    out = list(argv)
+    if os.path.normcase(os.path.abspath(out[idx])) != os.path.normcase(shell):
+        out[idx] = shell
+    return out, shell
+
+
 def _resolve_windows_posix_shell() -> str:
     """Absolute path to a non-WSL POSIX shell for native Windows peer workers.
 
     Order: CE_PEER_BASH, CLAUDE_CODE_GIT_BASH_PATH, well-known Git Bash
-    installs, then PATH bash/sh excluding System32 WSL. Fail closed when
+    installs, then every PATH bash/sh excluding System32 WSL. Fail closed when
     nothing usable remains — never select System32\\bash.exe (#1268).
     """
     candidates = []
@@ -1118,10 +1198,7 @@ def _resolve_windows_posix_shell() -> str:
         if val:
             candidates.append(val)
     candidates.extend(_git_bash_well_known_paths())
-    for name in ("bash", "sh"):
-        found = shutil.which(name)
-        if found:
-            candidates.append(found)
+    candidates.extend(_windows_path_shell_candidates())
 
     seen = set()
     for raw in candidates:
@@ -1149,8 +1226,9 @@ def _popen_argv(argv):
 
     On Windows, CreateProcess does not honor shebang, so a bare *.sh / *.bash
     worker must be launched through bash/sh. Prefer Git Bash over System32
-    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) are rewritten
-    to that absolute path. meta.json still records the caller argv for
+    WSL bash (#1268). Bare `bash`/`sh` prefixes (review skills) and bare
+    `bash`/`sh` tokens after `env VAR=…` (cross-model) are rewritten to that
+    absolute path. meta.json still records the caller argv for
     authorize-dispatch contracts that forbid a shell prefix on ce-work.
     """
     if not IS_WINDOWS or not argv:
@@ -1158,7 +1236,8 @@ def _popen_argv(argv):
     head = argv[0]
     base = os.path.basename(head).lower()
     if base in ("env", "env.exe"):
-        return list(argv)
+        rewritten, _shell = _rewrite_windows_env_bash_argv(argv)
+        return rewritten
     if base in ("bash", "bash.exe", "sh", "sh.exe"):
         shell = _resolve_windows_posix_shell()
         if os.path.normcase(os.path.abspath(head)) == os.path.normcase(shell):
@@ -1571,6 +1650,25 @@ def cmd_start(args, worker_argv) -> int:
         except RunnerError as exc:
             problem = str(exc)
             resolved = argv0
+    elif IS_WINDOWS and base0 in ("env", "env.exe"):
+        # Production cross-model: env VAR=… bash script.sh — rewrite bash
+        # before detach so env cannot PATH-resolve System32 WSL (#1268).
+        if os.sep in argv0 or (len(argv0) >= 2 and argv0[1] == ":"):
+            resolved = os.path.abspath(argv0)
+            if not os.path.isfile(resolved):
+                problem = "does not exist or is not a regular file"
+        else:
+            resolved = shutil.which(argv0)
+            if resolved is None:
+                problem = "was not found on PATH"
+                resolved = argv0
+        try:
+            rewritten, shell = _rewrite_windows_env_bash_argv(list(worker_argv))
+            if shell is not None:
+                windows_posix_shell = shell
+                worker_argv = rewritten
+        except RunnerError as exc:
+            problem = str(exc) if problem is None else f"{problem}; {exc}"
     elif os.sep in argv0 or (IS_WINDOWS and len(argv0) >= 2 and argv0[1] == ":"):
         resolved = os.path.abspath(argv0)
         if not os.path.isfile(resolved):

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1166,8 +1166,14 @@ def _env_option_advance(tok: str) -> int:
         return 2
     if tok.startswith(("--unset=", "--chdir=")):
         return 1
-    if not tok.startswith("-") or tok.startswith("--"):
+    if not tok.startswith("-"):
         return 1
+    if tok.startswith("--"):
+        raise RunnerError(
+            f"unsupported env long option {tok!r} for native Windows peer "
+            "workers; use an exact supported option or pass -- before "
+            "option-like assignments"
+        )
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1233,6 +1233,7 @@ def _env_bash_index(argv):
             i += 1
             continue
         if _env_assignment_token(tok, allow_option_like=options_done):
+            options_done = True
             i += 1
             continue
         if not options_done and (

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -1159,7 +1159,7 @@ def _env_option_advance(tok: str) -> int:
 
     GNU env options that take a separate operand: -u/--unset, -C/--chdir.
     Attached `--name=value` forms are a single slot.
-    Short options may be clustered. No-operand flags (-i/-0/-v and their exact
+    Short options may be clustered. No-operand flags (-i/-v and their exact
     long aliases) advance one slot; -u/-C consume the rest of the token as an
     attached operand or the next argv slot. Unsupported options fail closed
     before worker detach.
@@ -1171,6 +1171,11 @@ def _env_option_advance(tok: str) -> int:
         return 1
     if tok in ("--ignore-environment", "--debug"):
         return 1
+    if tok == "--null":
+        raise RunnerError(
+            "env -0/--null cannot be used with a command by native Windows "
+            "peer workers; remove the null-output option"
+        )
     if not tok.startswith("-"):
         return 1
     if tok.startswith("--"):
@@ -1182,8 +1187,13 @@ def _env_option_advance(tok: str) -> int:
 
     cluster = tok[1:]
     for index, option in enumerate(cluster):
-        if option in "i0v":
+        if option in "iv":
             continue
+        if option == "0":
+            raise RunnerError(
+                "env -0/--null cannot be used with a command by native "
+                "Windows peer workers; remove the null-output option"
+            )
         if option == "S":
             raise RunnerError(
                 "env -S/--split-string is unsupported for native Windows "
@@ -1225,9 +1235,6 @@ def _env_bash_index(argv):
         if _env_assignment_token(tok, allow_option_like=options_done):
             i += 1
             continue
-        base = os.path.basename(tok).lower()
-        if base in ("bash", "bash.exe", "sh", "sh.exe"):
-            return i, None
         if not options_done and (
             tok in ("-S", "--split-string") or tok.startswith(
                 ("-S", "--split-string=")
@@ -1244,6 +1251,9 @@ def _env_bash_index(argv):
                 return -1, None
             i += span
             continue
+        base = os.path.basename(tok).lower()
+        if base in ("bash", "bash.exe", "sh", "sh.exe"):
+            return i, None
         return -1, None
     return -1, None
 

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -426,6 +426,7 @@ class PopenArgvBranch(unittest.TestCase):
 
     GIT_BASH = r"C:\Program Files\Git\bin\bash.exe"
     SYSTEM32_BASH = r"C:\Windows\System32\bash.exe"
+    SYSNATIVE_BASH = r"C:\Windows\Sysnative\bash.exe"
 
     def test_posix_passthrough(self):
         argv = ["/tmp/cross-model-work.sh", "a", "b"]
@@ -569,6 +570,20 @@ class PopenArgvBranch(unittest.TestCase):
                         [self.GIT_BASH, "script.sh"],
                     )
 
+    def test_windows_rewrites_absolute_sysnative_bash(self):
+        argv = [self.SYSNATIVE_BASH, "script.sh"]
+        with windows_platform(isfile_side_effect=_nt_exists(self.SYSNATIVE_BASH)):
+            with mock.patch.dict(
+                os.environ, {"SystemRoot": r"C:\Windows"}, clear=False
+            ):
+                with mock.patch.object(
+                    MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+                ):
+                    self.assertEqual(
+                        MOD._popen_argv(argv),
+                        [self.GIT_BASH, "script.sh"],
+                    )
+
     def test_windows_keeps_env_prefixed_absolute_non_wsl_bash(self):
         portable = r"C:\PortableGit\bin\bash.exe"
         argv = ["env", "FOO=1", portable, "script.sh"]
@@ -601,6 +616,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
 
     GIT_BASH = r"C:\Program Files\Git\bin\bash.exe"
     SYSTEM32_BASH = r"C:\Windows\System32\bash.exe"
+    SYSNATIVE_BASH = r"C:\Windows\Sysnative\bash.exe"
     PATH_GIT_BASH = r"C:\Tools\Git\bin\bash.exe"
     LOCAL_GIT_BASH = r"C:\Users\me\AppData\Local\Programs\Git\bin\bash.exe"
 
@@ -759,6 +775,23 @@ class WindowsPosixShellResolve(unittest.TestCase):
             "ce_peer_bash" in msg or "claude_code_git_bash_path" in msg
         )
 
+    def test_rejects_sysnative_only(self):
+        with windows_platform(isfile_side_effect=_nt_exists(self.SYSNATIVE_BASH)):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": "",
+                "CLAUDE_CODE_GIT_BASH_PATH": "",
+                "SystemRoot": r"C:\Windows",
+                "ProgramFiles": r"C:\Missing",
+                "ProgramFiles(x86)": r"C:\Missing (x86)",
+                "LOCALAPPDATA": "",
+            }, clear=False):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates",
+                    return_value=[self.SYSNATIVE_BASH],
+                ):
+                    with self.assertRaises(MOD.RunnerError):
+                        MOD._resolve_windows_posix_shell()
+
     def test_missing_override_falls_through(self):
         with windows_platform(isfile_side_effect=_nt_exists(self.GIT_BASH)):
             with mock.patch.dict(os.environ, {
@@ -778,6 +811,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
         with windows_ntpath():
             with mock.patch.dict(os.environ, {"SystemRoot": r"C:\Windows"}, clear=False):
                 self.assertTrue(MOD._is_system32_wsl_bash(self.SYSTEM32_BASH))
+                self.assertTrue(MOD._is_system32_wsl_bash(self.SYSNATIVE_BASH))
                 self.assertFalse(MOD._is_system32_wsl_bash(self.GIT_BASH))
 
     def test_prefer_keeps_absolute_portable(self):

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -907,7 +907,6 @@ class WindowsPosixShellResolve(unittest.TestCase):
         cases = (
             (["env", "--", "-0", "bash"], (-1, None)),
             (["env", "--", r"--chdir=C:\tools\bash", "bash"], (3, None)),
-            (["env", "--", r"-CC:\tools\sh.exe", "bash"], (2, None)),
         )
         for argv, expected in cases:
             with self.subTest(argv=argv):

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -426,35 +426,84 @@ class PopenArgvBranch(unittest.TestCase):
                 with self.assertRaises(MOD.RunnerError):
                     MOD._popen_argv(argv)
 
+    def test_windows_env_exe_passthrough_without_bash(self):
+        # env without a bash/sh token must stay unchanged (no false wrap).
+        argv = ["env", "CE_PEER_HARD_SECS=", "python", "x.py"]
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                self.assertEqual(MOD._popen_argv(argv), argv)
+                resolve.assert_not_called()
+
+    def test_windows_rewrites_env_prefixed_bash(self):
+        # Production cross-model: start -- env VAR=… bash script.sh
+        argv = [
+            "env",
+            "CROSS_MODEL_HOST_HARNESS=claude",
+            "CROSS_MODEL_FIXED_ROUTE=codex",
+            "bash",
+            r"C:\skills\ce-code-review\scripts\cross-model-adversarial-review.sh",
+            "x",
+        ]
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ):
+                self.assertEqual(
+                    MOD._popen_argv(argv),
+                    [
+                        "env",
+                        "CROSS_MODEL_HOST_HARNESS=claude",
+                        "CROSS_MODEL_FIXED_ROUTE=codex",
+                        self.GIT_BASH,
+                        argv[4],
+                        "x",
+                    ],
+                )
+
+    def test_windows_env_prefixed_bash_missing_shell_raises(self):
+        argv = ["env", "FOO=1", "bash", "script.sh"]
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.object(
+                MOD,
+                "_resolve_windows_posix_shell",
+                side_effect=MOD.RunnerError("no usable Git Bash"),
+            ):
+                with self.assertRaises(MOD.RunnerError):
+                    MOD._popen_argv(argv)
+
 
 class WindowsPosixShellResolve(unittest.TestCase):
     """#1268: prefer Git Bash over System32 WSL bash; fail closed otherwise."""
 
     GIT_BASH = r"C:\Program Files\Git\bin\bash.exe"
     SYSTEM32_BASH = r"C:\Windows\System32\bash.exe"
+    PATH_GIT_BASH = r"C:\Tools\Git\bin\bash.exe"
+    LOCAL_GIT_BASH = r"C:\Users\me\AppData\Local\Programs\Git\bin\bash.exe"
 
     def test_prefers_git_bash_when_system32_first_on_path(self):
-        which_map = {"bash": self.SYSTEM32_BASH, "sh": None}
-
-        def fake_which(name):
-            return which_map.get(name)
-
         with mock.patch.object(MOD, "IS_WINDOWS", True):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": "",
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
                 "SystemRoot": r"C:\Windows",
                 "ProgramFiles": r"C:\Program Files",
+                "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                "LOCALAPPDATA": "",
+                "PATH": r"C:\Windows\System32",
             }, clear=False):
-                with mock.patch.object(MOD.shutil, "which", side_effect=fake_which):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates",
+                    return_value=[self.SYSTEM32_BASH],
+                ):
                     with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
                         os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
                         or os.path.normcase(p) == os.path.normcase(self.SYSTEM32_BASH)
                     )):
-                        # Well-known Git path must win over System32 which()
+                        # Well-known Git path must win over System32 PATH hit
                         got = MOD._resolve_windows_posix_shell()
         self.assertEqual(os.path.normcase(got), os.path.normcase(self.GIT_BASH))
-
     def test_ce_peer_bash_overrides_path(self):
         override = r"C:\Custom\Git\bin\bash.exe"
         with mock.patch.object(MOD, "IS_WINDOWS", True):
@@ -463,7 +512,10 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
                 "SystemRoot": r"C:\Windows",
             }, clear=False):
-                with mock.patch.object(MOD.shutil, "which", return_value=self.SYSTEM32_BASH):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates",
+                    return_value=[self.SYSTEM32_BASH],
+                ):
                     with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
                         os.path.normcase(p) == os.path.normcase(override)
                     )):
@@ -478,12 +530,81 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 "CLAUDE_CODE_GIT_BASH_PATH": override,
                 "SystemRoot": r"C:\Windows",
             }, clear=False):
-                with mock.patch.object(MOD.shutil, "which", return_value=self.SYSTEM32_BASH):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates",
+                    return_value=[self.SYSTEM32_BASH],
+                ):
                     with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
                         os.path.normcase(p) == os.path.normcase(override)
                     )):
                         got = MOD._resolve_windows_posix_shell()
         self.assertEqual(os.path.normcase(got), os.path.normcase(override))
+
+    def test_whitespace_only_env_falls_through(self):
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": "   ",
+                "CLAUDE_CODE_GIT_BASH_PATH": "\t",
+                "SystemRoot": r"C:\Windows",
+                "ProgramFiles": r"C:\Program Files",
+                "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                "LOCALAPPDATA": "",
+            }, clear=False):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates", return_value=[]
+                ):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
+                    )):
+                        got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(os.path.normcase(got), os.path.normcase(self.GIT_BASH))
+
+    def test_path_walk_skips_system32_then_finds_later_bash(self):
+        # shutil.which would stop at System32; walk must keep going (#1268 review).
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": "",
+                "CLAUDE_CODE_GIT_BASH_PATH": "",
+                "SystemRoot": r"C:\Windows",
+                "ProgramFiles": r"C:\Program Files",
+                "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                "LOCALAPPDATA": "",
+            }, clear=False):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates",
+                    return_value=[self.SYSTEM32_BASH, self.PATH_GIT_BASH],
+                ):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) in {
+                            os.path.normcase(self.SYSTEM32_BASH),
+                            os.path.normcase(self.PATH_GIT_BASH),
+                        }
+                    )):
+                        got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(os.path.normcase(got), os.path.normcase(self.PATH_GIT_BASH))
+
+    def test_localappdata_well_known_git(self):
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": "",
+                "CLAUDE_CODE_GIT_BASH_PATH": "",
+                "SystemRoot": r"C:\Windows",
+                "ProgramFiles": r"C:\Program Files",
+                "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                "LOCALAPPDATA": r"C:\Users\me\AppData\Local",
+            }, clear=False):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates",
+                    return_value=[self.SYSTEM32_BASH],
+                ):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) in {
+                            os.path.normcase(self.SYSTEM32_BASH),
+                            os.path.normcase(self.LOCAL_GIT_BASH),
+                        }
+                    )):
+                        got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(os.path.normcase(got), os.path.normcase(self.LOCAL_GIT_BASH))
 
     def test_rejects_system32_only(self):
         with mock.patch.object(MOD, "IS_WINDOWS", True):
@@ -493,9 +614,11 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 "SystemRoot": r"C:\Windows",
                 "ProgramFiles": r"C:\Program Files",
                 "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                "LOCALAPPDATA": "",
             }, clear=False):
                 with mock.patch.object(
-                    MOD.shutil, "which", return_value=self.SYSTEM32_BASH
+                    MOD, "_windows_path_shell_candidates",
+                    return_value=[self.SYSTEM32_BASH],
                 ):
                     with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
                         os.path.normcase(p) == os.path.normcase(self.SYSTEM32_BASH)
@@ -515,8 +638,11 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
                 "SystemRoot": r"C:\Windows",
                 "ProgramFiles": r"C:\Program Files",
+                "LOCALAPPDATA": "",
             }, clear=False):
-                with mock.patch.object(MOD.shutil, "which", return_value=None):
+                with mock.patch.object(
+                    MOD, "_windows_path_shell_candidates", return_value=[]
+                ):
                     with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
                         os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
                     )):
@@ -528,6 +654,11 @@ class WindowsPosixShellResolve(unittest.TestCase):
             self.assertTrue(MOD._is_system32_wsl_bash(self.SYSTEM32_BASH))
             self.assertFalse(MOD._is_system32_wsl_bash(self.GIT_BASH))
 
+    def test_env_bash_index_finds_token_after_assignments(self):
+        argv = ["env", "A=1", "B=2", "bash", "script.sh"]
+        self.assertEqual(MOD._env_bash_index(argv), 3)
+        self.assertEqual(MOD._env_bash_index(["env", "python", "x.py"]), -1)
+        self.assertEqual(MOD._env_bash_index(["bash", "x.sh"]), -1)
 
 class BinaryRoundTrip(unittest.TestCase):
     """Windows CPython opens os.open() descriptors in CRT *text* mode: writes

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -895,6 +895,24 @@ class WindowsPosixShellResolve(unittest.TestCase):
             (2, None),
         )
 
+    def test_env_bash_index_classifies_attached_chdir_before_shell_name(self):
+        for option in (r"--chdir=C:\tools\bash", r"-CC:\tools\sh.exe"):
+            with self.subTest(option=option):
+                self.assertEqual(
+                    MOD._env_bash_index(["env", option, "bash", "script.sh"]),
+                    (2, None),
+                )
+
+    def test_env_bash_index_does_not_parse_options_after_terminator(self):
+        cases = (
+            (["env", "--", "-0", "bash"], (-1, None)),
+            (["env", "--", r"--chdir=C:\tools\bash", "bash"], (3, None)),
+            (["env", "--", r"-CC:\tools\sh.exe", "bash"], (2, None)),
+        )
+        for argv, expected in cases:
+            with self.subTest(argv=argv):
+                self.assertEqual(MOD._env_bash_index(argv), expected)
+
     def test_windows_popen_rejects_env_split_string_forms(self):
         cases = (
             ["env", "-S", "bash script.sh"],
@@ -915,7 +933,6 @@ class WindowsPosixShellResolve(unittest.TestCase):
             ["env", "--chd", "/tmp", "bash", "script.sh"],
             ["env", "--unse", "FOO", "bash", "script.sh"],
             ["env", "--split-s", "bash script.sh"],
-            ["env", "--null", "bash", "script.sh"],
             ["env", "--unknown", "bash", "script.sh"],
         )
         with windows_platform():
@@ -988,6 +1005,40 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 with self.subTest(argv=argv):
                     with self.assertRaises(MOD.RunnerError):
                         MOD._popen_argv(argv)
+
+    def test_windows_popen_rejects_env_null_option_before_shell_resolution(self):
+        cases = (
+            ["env", "-0", "bash", "script.sh"],
+            ["env", "-i0", "bash", "script.sh"],
+            ["env", "-0v", "bash", "script.sh"],
+            ["env", "--null", "bash", "script.sh"],
+        )
+        with windows_platform():
+            for argv in cases:
+                with self.subTest(argv=argv):
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        side_effect=AssertionError("must fail before shell resolution"),
+                    ):
+                        with self.assertRaises(MOD.RunnerError) as ctx:
+                            MOD._popen_argv(argv)
+                    self.assertIn("-0/--null", str(ctx.exception))
+
+    def test_windows_popen_rewrites_shell_after_attached_chdir(self):
+        for option in (r"--chdir=C:\tools\bash", r"-CC:\tools\sh.exe"):
+            argv = ["env", option, "bash", "script.sh"]
+            with self.subTest(option=option):
+                with windows_platform():
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        return_value=self.GIT_BASH,
+                    ):
+                        self.assertEqual(
+                            MOD._popen_argv(argv),
+                            ["env", option, self.GIT_BASH, "script.sh"],
+                        )
 
     def test_windows_popen_rewrites_bash_after_clustered_env_options(self):
         for argv in (

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -858,6 +858,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
             ["env", "--chd", "/tmp", "bash", "script.sh"],
             ["env", "--unse", "FOO", "bash", "script.sh"],
             ["env", "--split-s", "bash script.sh"],
+            ["env", "--null", "bash", "script.sh"],
             ["env", "--unknown", "bash", "script.sh"],
         )
         with windows_platform():
@@ -873,7 +874,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     self.assertIn("unsupported env long option", str(ctx.exception))
 
     def test_env_bash_index_accepts_exact_no_operand_long_options(self):
-        for option in ("--ignore-environment", "--null", "--debug"):
+        for option in ("--ignore-environment", "--debug"):
             with self.subTest(option=option):
                 self.assertEqual(
                     MOD._env_bash_index(["env", option, "bash", "script.sh"]),
@@ -881,7 +882,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 )
 
     def test_windows_popen_rewrites_bash_after_exact_no_operand_long_options(self):
-        for option in ("--ignore-environment", "--null", "--debug"):
+        for option in ("--ignore-environment", "--debug"):
             argv = ["env", option, "bash", "script.sh"]
             with self.subTest(option=option):
                 with windows_platform():

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -17,7 +17,6 @@ import io
 import json
 import ntpath
 import os
-import shlex
 import stat as stat_mod
 import subprocess
 import sys
@@ -504,6 +503,36 @@ class PopenArgvBranch(unittest.TestCase):
                     ],
                 )
 
+    def test_windows_rewrites_env_prefixed_bash_after_unusual_assignment_names(self):
+        for assignment in ("1=x", "a-b=x"):
+            with self.subTest(assignment=assignment):
+                argv = ["env", assignment, "bash", "script.sh"]
+                with windows_platform():
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        return_value=self.GIT_BASH,
+                    ):
+                        self.assertEqual(
+                            MOD._popen_argv(argv),
+                            ["env", assignment, self.GIT_BASH, "script.sh"],
+                        )
+
+    def test_windows_rewrites_env_assignment_after_option_terminator(self):
+        for assignment in ("-S=x", "--split-string=x"):
+            with self.subTest(assignment=assignment):
+                argv = ["env", "--", assignment, "bash", "script.sh"]
+                with windows_platform():
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        return_value=self.GIT_BASH,
+                    ):
+                        self.assertEqual(
+                            MOD._popen_argv(argv),
+                            ["env", "--", assignment, self.GIT_BASH, "script.sh"],
+                        )
+
     def test_windows_env_prefixed_bash_missing_shell_raises(self):
         argv = ["env", "FOO=1", "bash", "script.sh"]
         with windows_platform():
@@ -781,43 +810,20 @@ class WindowsPosixShellResolve(unittest.TestCase):
             (2, None),
         )
 
-    def test_env_bash_index_finds_bash_inside_split_string(self):
-        # env -S/--split-string word-splits its operand and runs the first
-        # non-assignment word as the command, so a bash/sh command hidden
-        # inside the split string must be found, not silently skipped
-        # (#1292 Codex round 4: `env -S "bash script.sh"` previously returned
-        # -1 because the split string's contents were never inspected,
-        # leaving System32 WSL bash reachable through this shape).
-        self.assertEqual(
-            MOD._env_bash_index(["env", "-S", "bash script.sh"]), (2, "")
+    def test_windows_popen_rejects_env_split_string_forms(self):
+        cases = (
+            ["env", "-S", "bash script.sh"],
+            ["env", "--split-string", "bash script.sh"],
+            ["env", "-Sbash script.sh"],
+            ["env", "--split-string=bash script.sh"],
+            ["env", "-S", "python x.py"],
         )
-        self.assertEqual(
-            MOD._env_bash_index(
-                ["env", "--split-string=FOO=1 bash script.sh"]
-            ),
-            (1, "--split-string="),
-        )
-        self.assertEqual(
-            MOD._env_bash_index(["env", "-Sbash script.sh"]), (1, "-S")
-        )
-
-    def test_env_bash_index_split_string_without_bash_still_finds_later_token(self):
-        # A split-string operand that does NOT itself resolve to bash/sh
-        # (e.g. a bare assignment) must not stop the scan -- a later plain
-        # bash/sh argv token must still be found.
-        self.assertEqual(
-            MOD._env_bash_index(
-                ["env", "-S", "FOO=1", "bash", "script.sh"]
-            ),
-            (3, None),
-        )
-
-    def test_env_bash_index_raises_on_unparsable_split_string(self):
-        # Fail closed rather than guess when the operand cannot be word-split
-        # (unbalanced quoting) -- silently ignoring it could let System32 WSL
-        # bash slip through unresolved.
-        with self.assertRaises(MOD.RunnerError):
-            MOD._env_bash_index(["env", "-S", "bash 'unterminated"])
+        with windows_platform():
+            for argv in cases:
+                with self.subTest(argv=argv):
+                    with self.assertRaises(MOD.RunnerError) as ctx:
+                        MOD._popen_argv(argv)
+                    self.assertIn("split-string", str(ctx.exception))
 
     def test_env_bash_index_skips_unset_attached(self):
         self.assertEqual(
@@ -853,64 +859,6 @@ class WindowsPosixShellResolve(unittest.TestCase):
             ) as resolve:
                 self.assertEqual(MOD._popen_argv(argv), argv)
                 resolve.assert_not_called()
-
-    def test_windows_popen_rewrites_bash_inside_split_string(self):
-        # The exact shape Codex flagged as still-reachable System32 WSL bash:
-        # `env -S "bash script.sh"` must resolve and rewrite the bash word
-        # inside the split string, not pass it through untouched (#1292).
-        argv = ["env", "-S", "bash script.sh"]
-        with windows_platform():
-            with mock.patch.object(
-                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
-            ):
-                expected_value = " ".join(
-                    shlex.quote(t) for t in (self.GIT_BASH, "script.sh")
-                )
-                self.assertEqual(
-                    MOD._popen_argv(argv),
-                    ["env", "-S", expected_value],
-                )
-
-    def test_windows_popen_rewrites_bash_inside_attached_split_string(self):
-        argv = ["env", "--split-string=FOO=1 bash script.sh"]
-        with windows_platform():
-            with mock.patch.object(
-                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
-            ):
-                expected_value = " ".join(
-                    shlex.quote(t) for t in ("FOO=1", self.GIT_BASH, "script.sh")
-                )
-                self.assertEqual(
-                    MOD._popen_argv(argv),
-                    ["env", "--split-string=" + expected_value],
-                )
-
-    def test_windows_popen_keeps_absolute_portable_bash_inside_split_string(self):
-        # A literal backslash inside an env -S/--split-string operand is an
-        # escape character to env's own word-splitting (mirrored here via
-        # shlex posix mode), so a Windows path must be backslash-escaped by
-        # the caller to survive splitting intact -- same as it would need to
-        # be for real GNU env, not an artifact of this parser.
-        portable = r"C:\PortableGit\bin\bash.exe"
-        escaped = portable.replace("\\", "\\\\")
-        argv = ["env", "-S", f"{escaped} script.sh"]
-        with windows_platform(isfile_side_effect=_nt_exists(portable)):
-            with mock.patch.object(
-                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
-            ) as resolve:
-                expected_value = " ".join(shlex.quote(t) for t in (portable, "script.sh"))
-                self.assertEqual(
-                    MOD._popen_argv(argv),
-                    ["env", "-S", expected_value],
-                )
-                resolve.assert_not_called()
-
-    def test_windows_popen_raises_on_unparsable_split_string(self):
-        argv = ["env", "-S", "bash 'unterminated"]
-        with windows_platform():
-            with self.assertRaises(MOD.RunnerError):
-                MOD._popen_argv(argv)
-
 
 class BinaryRoundTrip(unittest.TestCase):
     """Windows CPython opens os.open() descriptors in CRT *text* mode: writes

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -861,6 +861,50 @@ class WindowsPosixShellResolve(unittest.TestCase):
             MOD._env_bash_index(["env", "--unset=FOO", "bash", "script.sh"]), (2, None)
         )
 
+    def test_env_bash_index_parses_clustered_options_with_separate_operands(self):
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-iu", "FOO", "bash", "script.sh"]),
+            (3, None),
+        )
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-iC", "/tmp", "bash", "script.sh"]),
+            (3, None),
+        )
+
+    def test_env_bash_index_parses_clustered_options_with_attached_operands(self):
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-iuFOO", "bash", "script.sh"]),
+            (2, None),
+        )
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-iC/tmp", "bash", "script.sh"]),
+            (2, None),
+        )
+
+    def test_windows_popen_rejects_unsupported_env_short_option_clusters(self):
+        cases = (["env", "-iSvalue", "bash"], ["env", "-ix", "bash"])
+        with windows_platform():
+            for argv in cases:
+                with self.subTest(argv=argv):
+                    with self.assertRaises(MOD.RunnerError):
+                        MOD._popen_argv(argv)
+
+    def test_windows_popen_rewrites_bash_after_clustered_env_options(self):
+        for argv in (
+            ["env", "-iu", "FOO", "bash", "script.sh"],
+            ["env", "-iC", r"C:\workdir", "bash", "script.sh"],
+        ):
+            with self.subTest(argv=argv):
+                with windows_platform():
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        return_value=self.GIT_BASH,
+                    ):
+                        expected = list(argv)
+                        expected[-2] = self.GIT_BASH
+                        self.assertEqual(MOD._popen_argv(argv), expected)
+
     def test_windows_popen_rewrites_bash_after_chdir(self):
         argv = ["env", "-C", r"C:\workdir", "bash", "script.sh", "x"]
         with windows_platform():

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -604,6 +604,34 @@ class WindowsPosixShellResolve(unittest.TestCase):
     PATH_GIT_BASH = r"C:\Tools\Git\bin\bash.exe"
     LOCAL_GIT_BASH = r"C:\Users\me\AppData\Local\Programs\Git\bin\bash.exe"
 
+    def test_well_known_paths_prefer_distinct_programw6432_root(self):
+        with windows_ntpath():
+            with mock.patch.dict(os.environ, {
+                "ProgramW6432": r"C:\Program Files",
+                "ProgramFiles": r"C:\Program Files (x86)",
+                "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                "LOCALAPPDATA": "",
+            }, clear=False):
+                paths = MOD._git_bash_well_known_paths()
+        self.assertEqual(paths, [
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\usr\bin\bash.exe",
+        ])
+
+    def test_well_known_paths_deduplicate_matching_program_roots(self):
+        with windows_ntpath():
+            with mock.patch.dict(os.environ, {
+                "ProgramW6432": r"C:\Program Files",
+                "ProgramFiles": r"C:\Program Files",
+                "ProgramFiles(x86)": r"C:\Program Files (x86)",
+                "LOCALAPPDATA": "",
+            }, clear=False):
+                paths = MOD._git_bash_well_known_paths()
+        self.assertEqual(len(paths), 4)
+        self.assertEqual(paths[0], r"C:\Program Files\Git\bin\bash.exe")
+
     def test_prefers_git_bash_when_system32_first_on_path(self):
         with windows_platform(
             isfile_side_effect=_nt_exists(self.GIT_BASH, self.SYSTEM32_BASH)

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -872,6 +872,29 @@ class WindowsPosixShellResolve(unittest.TestCase):
                             MOD._popen_argv(argv)
                     self.assertIn("unsupported env long option", str(ctx.exception))
 
+    def test_env_bash_index_accepts_exact_no_operand_long_options(self):
+        for option in ("--ignore-environment", "--null", "--debug"):
+            with self.subTest(option=option):
+                self.assertEqual(
+                    MOD._env_bash_index(["env", option, "bash", "script.sh"]),
+                    (2, None),
+                )
+
+    def test_windows_popen_rewrites_bash_after_exact_no_operand_long_options(self):
+        for option in ("--ignore-environment", "--null", "--debug"):
+            argv = ["env", option, "bash", "script.sh"]
+            with self.subTest(option=option):
+                with windows_platform():
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        return_value=self.GIT_BASH,
+                    ):
+                        self.assertEqual(
+                            MOD._popen_argv(argv),
+                            ["env", option, self.GIT_BASH, "script.sh"],
+                        )
+
     def test_env_bash_index_skips_unset_attached(self):
         self.assertEqual(
             MOD._env_bash_index(["env", "-u", "FOO", "bash", "script.sh"]), (3, None)

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -520,19 +520,23 @@ class PopenArgvBranch(unittest.TestCase):
                         )
 
     def test_windows_rewrites_env_assignment_after_option_terminator(self):
-        for assignment in ("-S=x", "--split-string=x"):
-            with self.subTest(assignment=assignment):
-                argv = ["env", "--", assignment, "bash", "script.sh"]
-                with windows_platform():
-                    with mock.patch.object(
-                        MOD,
-                        "_resolve_windows_posix_shell",
-                        return_value=self.GIT_BASH,
-                    ):
-                        self.assertEqual(
-                            MOD._popen_argv(argv),
-                            ["env", "--", assignment, self.GIT_BASH, "script.sh"],
-                        )
+        for terminator in ("-", "--"):
+            for assignment in ("-S=x", "--split-string=x"):
+                with self.subTest(terminator=terminator, assignment=assignment):
+                    argv = ["env", terminator, assignment, "bash", "script.sh"]
+                    with windows_platform():
+                        with mock.patch.object(
+                            MOD,
+                            "_resolve_windows_posix_shell",
+                            return_value=self.GIT_BASH,
+                        ):
+                            self.assertEqual(
+                                MOD._popen_argv(argv),
+                                [
+                                    "env", terminator, assignment,
+                                    self.GIT_BASH, "script.sh",
+                                ],
+                            )
 
     def test_windows_env_prefixed_bash_missing_shell_raises(self):
         argv = ["env", "FOO=1", "bash", "script.sh"]
@@ -907,6 +911,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
         cases = (
             (["env", "--", "-0", "bash"], (-1, None)),
             (["env", "--", r"--chdir=C:\tools\bash", "bash"], (3, None)),
+            (["env", "-", "-S=x", "bash"], (3, None)),
         )
         for argv, expected in cases:
             with self.subTest(argv=argv):

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -514,6 +514,53 @@ class PopenArgvBranch(unittest.TestCase):
                 with self.assertRaises(MOD.RunnerError):
                     MOD._popen_argv(argv)
 
+    def test_windows_keeps_absolute_non_wsl_bash(self):
+        # Portable / non-well-known absolute bash must not be substituted (#1292 P2).
+        portable = r"C:\PortableGit\bin\bash.exe"
+        argv = [portable, "script.sh", "x"]
+        with windows_platform(isfile_side_effect=_nt_exists(portable)):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                self.assertEqual(MOD._popen_argv(argv), argv)
+                resolve.assert_not_called()
+
+    def test_windows_rewrites_absolute_system32_bash(self):
+        argv = [self.SYSTEM32_BASH, "script.sh"]
+        with windows_platform(isfile_side_effect=_nt_exists(self.SYSTEM32_BASH)):
+            with mock.patch.dict(
+                os.environ, {"SystemRoot": r"C:\Windows"}, clear=False
+            ):
+                with mock.patch.object(
+                    MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+                ):
+                    self.assertEqual(
+                        MOD._popen_argv(argv),
+                        [self.GIT_BASH, "script.sh"],
+                    )
+
+    def test_windows_keeps_env_prefixed_absolute_non_wsl_bash(self):
+        portable = r"C:\PortableGit\bin\bash.exe"
+        argv = ["env", "FOO=1", portable, "script.sh"]
+        with windows_platform(isfile_side_effect=_nt_exists(portable)):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                self.assertEqual(MOD._popen_argv(argv), argv)
+                resolve.assert_not_called()
+
+    def test_windows_absolute_bash_missing_raises(self):
+        missing = r"C:\Missing\PortableGit\bin\bash.exe"
+        argv = [missing, "script.sh"]
+        with windows_platform(isfile_side_effect=_nt_exists()):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                with self.assertRaises(MOD.RunnerError) as ctx:
+                    MOD._popen_argv(argv)
+                resolve.assert_not_called()
+        self.assertIn("does not exist", str(ctx.exception).lower())
+
 
 class WindowsPosixShellResolve(unittest.TestCase):
     """#1268: prefer Git Bash over System32 WSL bash; fail closed otherwise.
@@ -674,6 +721,36 @@ class WindowsPosixShellResolve(unittest.TestCase):
             with mock.patch.dict(os.environ, {"SystemRoot": r"C:\Windows"}, clear=False):
                 self.assertTrue(MOD._is_system32_wsl_bash(self.SYSTEM32_BASH))
                 self.assertFalse(MOD._is_system32_wsl_bash(self.GIT_BASH))
+
+    def test_prefer_keeps_absolute_portable(self):
+        portable = r"C:\PortableGit\bin\bash.exe"
+        with windows_platform(isfile_side_effect=_nt_exists(portable)):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                got = MOD._prefer_windows_posix_shell(portable)
+                resolve.assert_not_called()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(portable))
+
+    def test_prefer_rewrites_system32_via_resolver(self):
+        with windows_platform(isfile_side_effect=_nt_exists(self.SYSTEM32_BASH)):
+            with mock.patch.dict(
+                os.environ, {"SystemRoot": r"C:\Windows"}, clear=False
+            ):
+                with mock.patch.object(
+                    MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+                ):
+                    got = MOD._prefer_windows_posix_shell(self.SYSTEM32_BASH)
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(self.GIT_BASH))
+
+    def test_prefer_bare_delegates_to_resolver(self):
+        with windows_platform():
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                got = MOD._prefer_windows_posix_shell("bash")
+                resolve.assert_called_once_with()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(self.GIT_BASH))
 
     def test_env_bash_index_finds_token_after_assignments(self):
         argv = ["env", "A=1", "B=2", "bash", "script.sh"]

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -853,6 +853,25 @@ class WindowsPosixShellResolve(unittest.TestCase):
                         MOD._popen_argv(argv)
                     self.assertIn("split-string", str(ctx.exception))
 
+    def test_windows_popen_rejects_abbreviated_and_unknown_env_long_options(self):
+        cases = (
+            ["env", "--chd", "/tmp", "bash", "script.sh"],
+            ["env", "--unse", "FOO", "bash", "script.sh"],
+            ["env", "--split-s", "bash script.sh"],
+            ["env", "--unknown", "bash", "script.sh"],
+        )
+        with windows_platform():
+            for argv in cases:
+                with self.subTest(argv=argv):
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        side_effect=AssertionError("must fail before shell resolution"),
+                    ):
+                        with self.assertRaises(MOD.RunnerError) as ctx:
+                            MOD._popen_argv(argv)
+                    self.assertIn("unsupported env long option", str(ctx.exception))
+
     def test_env_bash_index_skips_unset_attached(self):
         self.assertEqual(
             MOD._env_bash_index(["env", "-u", "FOO", "bash", "script.sh"]), (3, None)

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -505,7 +505,7 @@ class PopenArgvBranch(unittest.TestCase):
                 )
 
     def test_windows_rewrites_env_prefixed_bash_after_unusual_assignment_names(self):
-        for assignment in ("1=x", "a-b=x"):
+        for assignment in ("=x", "1=x", "a-b=x"):
             with self.subTest(assignment=assignment):
                 argv = ["env", assignment, "bash", "script.sh"]
                 with windows_platform():

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -816,6 +816,29 @@ class WindowsPosixShellResolve(unittest.TestCase):
         self.assertEqual(MOD._env_bash_index(["env", "python", "x.py"]), (-1, None))
         self.assertEqual(MOD._env_bash_index(["bash", "x.sh"]), (-1, None))
 
+    def test_env_bash_index_does_not_match_assignment_value_as_command(self):
+        for assignment in (r"FOO=C:\tools\bash", r"FOO=C:\tools\sh.exe"):
+            with self.subTest(assignment=assignment):
+                self.assertEqual(
+                    MOD._env_bash_index(["env", assignment, "bash", "script.sh"]),
+                    (2, None),
+                )
+
+    def test_windows_popen_preserves_assignment_value_ending_in_shell_name(self):
+        for assignment in (r"FOO=C:\tools\bash", r"FOO=C:\tools\sh.exe"):
+            argv = ["env", assignment, "bash", "script.sh"]
+            with self.subTest(assignment=assignment):
+                with windows_platform():
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        return_value=self.GIT_BASH,
+                    ):
+                        self.assertEqual(
+                            MOD._popen_argv(argv),
+                            ["env", assignment, self.GIT_BASH, "script.sh"],
+                        )
+
     def test_env_bash_index_skips_chdir_operand(self):
         # -C / --chdir take DIR; a directory named bash must not be treated as
         # the command, and bash after a real DIR must still be found (#1292 P2).

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -15,6 +15,7 @@ surface:
 import importlib.util
 import io
 import json
+import ntpath
 import os
 import stat as stat_mod
 import subprocess
@@ -23,7 +24,7 @@ import tempfile
 import time
 import types
 import unittest
-from contextlib import redirect_stderr, redirect_stdout
+from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout
 from unittest import mock
 
 IS_WINDOWS = sys.platform == "win32"
@@ -46,6 +47,46 @@ def load_runner():
 
 MOD = load_runner()
 REAL_FSTAT = os.fstat
+
+# Patching IS_WINDOWS alone leaves MOD.os.path as host posixpath on Ubuntu CI,
+# so Windows drive strings break abspath/dirname/basename/normcase (#1268 / PR
+# #1292 Codex P1). Delegate those ops to ntpath while simulating Windows.
+_WIN_PATH_ATTRS = ("abspath", "normcase", "dirname", "basename", "join")
+
+
+@contextmanager
+def windows_ntpath():
+    """Patch MOD.os.path path ops to ntpath (portable Windows path semantics)."""
+    with ExitStack() as stack:
+        for name in _WIN_PATH_ATTRS:
+            stack.enter_context(
+                mock.patch.object(MOD.os.path, name, getattr(ntpath, name))
+            )
+        yield ntpath
+
+
+@contextmanager
+def windows_platform(*, isfile_side_effect=None):
+    """IS_WINDOWS=True + ntpath path ops; optional isfile mock."""
+    with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_ntpath():
+            if isfile_side_effect is None:
+                yield ntpath
+            else:
+                with mock.patch.object(
+                    MOD.os.path, "isfile", side_effect=isfile_side_effect
+                ):
+                    yield ntpath
+
+
+def _nt_exists(*paths):
+    """isfile side_effect: True when path matches any of the given Windows paths."""
+    want = {ntpath.normcase(p) for p in paths}
+
+    def _check(p):
+        return ntpath.normcase(p) in want
+
+    return _check
 
 
 def uid_mismatch_fstat(only_devino=None):
@@ -393,7 +434,7 @@ class PopenArgvBranch(unittest.TestCase):
 
     def test_windows_wraps_bare_shell_script(self):
         argv = [r"C:\skills\ce-work\scripts\cross-model-work.sh", "a", "b"]
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform():
             with mock.patch.object(
                 MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
             ):
@@ -406,7 +447,7 @@ class PopenArgvBranch(unittest.TestCase):
         # Review skills launch as `bash script.sh`; bare name must not stay
         # on PATH (System32 WSL) — rewrite to preferred absolute Git Bash.
         argv = ["bash", "/tmp/cross-model-adversarial-review.sh", "x"]
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform():
             with mock.patch.object(
                 MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
             ):
@@ -417,7 +458,7 @@ class PopenArgvBranch(unittest.TestCase):
 
     def test_windows_missing_shell_raises(self):
         argv = [r"C:\skills\ce-work\scripts\cross-model-work.sh"]
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform():
             with mock.patch.object(
                 MOD,
                 "_resolve_windows_posix_shell",
@@ -429,7 +470,7 @@ class PopenArgvBranch(unittest.TestCase):
     def test_windows_env_exe_passthrough_without_bash(self):
         # env without a bash/sh token must stay unchanged (no false wrap).
         argv = ["env", "CE_PEER_HARD_SECS=", "python", "x.py"]
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform():
             with mock.patch.object(
                 MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
             ) as resolve:
@@ -446,7 +487,7 @@ class PopenArgvBranch(unittest.TestCase):
             r"C:\skills\ce-code-review\scripts\cross-model-adversarial-review.sh",
             "x",
         ]
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform():
             with mock.patch.object(
                 MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
             ):
@@ -464,7 +505,7 @@ class PopenArgvBranch(unittest.TestCase):
 
     def test_windows_env_prefixed_bash_missing_shell_raises(self):
         argv = ["env", "FOO=1", "bash", "script.sh"]
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform():
             with mock.patch.object(
                 MOD,
                 "_resolve_windows_posix_shell",
@@ -475,7 +516,11 @@ class PopenArgvBranch(unittest.TestCase):
 
 
 class WindowsPosixShellResolve(unittest.TestCase):
-    """#1268: prefer Git Bash over System32 WSL bash; fail closed otherwise."""
+    """#1268: prefer Git Bash over System32 WSL bash; fail closed otherwise.
+
+    Runs under ntpath path ops so Ubuntu CI matches native Windows semantics
+    (PR #1292 Codex P1).
+    """
 
     GIT_BASH = r"C:\Program Files\Git\bin\bash.exe"
     SYSTEM32_BASH = r"C:\Windows\System32\bash.exe"
@@ -483,7 +528,9 @@ class WindowsPosixShellResolve(unittest.TestCase):
     LOCAL_GIT_BASH = r"C:\Users\me\AppData\Local\Programs\Git\bin\bash.exe"
 
     def test_prefers_git_bash_when_system32_first_on_path(self):
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(
+            isfile_side_effect=_nt_exists(self.GIT_BASH, self.SYSTEM32_BASH)
+        ):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": "",
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
@@ -497,16 +544,12 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     MOD, "_windows_path_shell_candidates",
                     return_value=[self.SYSTEM32_BASH],
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
-                        or os.path.normcase(p) == os.path.normcase(self.SYSTEM32_BASH)
-                    )):
-                        # Well-known Git path must win over System32 PATH hit
-                        got = MOD._resolve_windows_posix_shell()
-        self.assertEqual(os.path.normcase(got), os.path.normcase(self.GIT_BASH))
+                    got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(self.GIT_BASH))
+
     def test_ce_peer_bash_overrides_path(self):
         override = r"C:\Custom\Git\bin\bash.exe"
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(isfile_side_effect=_nt_exists(override)):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": override,
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
@@ -516,15 +559,12 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     MOD, "_windows_path_shell_candidates",
                     return_value=[self.SYSTEM32_BASH],
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) == os.path.normcase(override)
-                    )):
-                        got = MOD._resolve_windows_posix_shell()
-        self.assertEqual(os.path.normcase(got), os.path.normcase(override))
+                    got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(override))
 
     def test_claude_code_git_bash_path_when_ce_unset(self):
         override = r"D:\Tools\Git\bin\bash.exe"
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(isfile_side_effect=_nt_exists(override)):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": "",
                 "CLAUDE_CODE_GIT_BASH_PATH": override,
@@ -534,14 +574,11 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     MOD, "_windows_path_shell_candidates",
                     return_value=[self.SYSTEM32_BASH],
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) == os.path.normcase(override)
-                    )):
-                        got = MOD._resolve_windows_posix_shell()
-        self.assertEqual(os.path.normcase(got), os.path.normcase(override))
+                    got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(override))
 
     def test_whitespace_only_env_falls_through(self):
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(isfile_side_effect=_nt_exists(self.GIT_BASH)):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": "   ",
                 "CLAUDE_CODE_GIT_BASH_PATH": "\t",
@@ -553,15 +590,14 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 with mock.patch.object(
                     MOD, "_windows_path_shell_candidates", return_value=[]
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
-                    )):
-                        got = MOD._resolve_windows_posix_shell()
-        self.assertEqual(os.path.normcase(got), os.path.normcase(self.GIT_BASH))
+                    got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(self.GIT_BASH))
 
     def test_path_walk_skips_system32_then_finds_later_bash(self):
         # shutil.which would stop at System32; walk must keep going (#1268 review).
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(
+            isfile_side_effect=_nt_exists(self.SYSTEM32_BASH, self.PATH_GIT_BASH)
+        ):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": "",
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
@@ -574,17 +610,13 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     MOD, "_windows_path_shell_candidates",
                     return_value=[self.SYSTEM32_BASH, self.PATH_GIT_BASH],
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) in {
-                            os.path.normcase(self.SYSTEM32_BASH),
-                            os.path.normcase(self.PATH_GIT_BASH),
-                        }
-                    )):
-                        got = MOD._resolve_windows_posix_shell()
-        self.assertEqual(os.path.normcase(got), os.path.normcase(self.PATH_GIT_BASH))
+                    got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(self.PATH_GIT_BASH))
 
     def test_localappdata_well_known_git(self):
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(
+            isfile_side_effect=_nt_exists(self.SYSTEM32_BASH, self.LOCAL_GIT_BASH)
+        ):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": "",
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
@@ -597,17 +629,11 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     MOD, "_windows_path_shell_candidates",
                     return_value=[self.SYSTEM32_BASH],
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) in {
-                            os.path.normcase(self.SYSTEM32_BASH),
-                            os.path.normcase(self.LOCAL_GIT_BASH),
-                        }
-                    )):
-                        got = MOD._resolve_windows_posix_shell()
-        self.assertEqual(os.path.normcase(got), os.path.normcase(self.LOCAL_GIT_BASH))
+                    got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(self.LOCAL_GIT_BASH))
 
     def test_rejects_system32_only(self):
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(isfile_side_effect=_nt_exists(self.SYSTEM32_BASH)):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": "",
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
@@ -620,11 +646,8 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     MOD, "_windows_path_shell_candidates",
                     return_value=[self.SYSTEM32_BASH],
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) == os.path.normcase(self.SYSTEM32_BASH)
-                    )):
-                        with self.assertRaises(MOD.RunnerError) as ctx:
-                            MOD._resolve_windows_posix_shell()
+                    with self.assertRaises(MOD.RunnerError) as ctx:
+                        MOD._resolve_windows_posix_shell()
         msg = str(ctx.exception).lower()
         self.assertIn("git", msg)
         self.assertTrue(
@@ -632,7 +655,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
         )
 
     def test_missing_override_falls_through(self):
-        with mock.patch.object(MOD, "IS_WINDOWS", True):
+        with windows_platform(isfile_side_effect=_nt_exists(self.GIT_BASH)):
             with mock.patch.dict(os.environ, {
                 "CE_PEER_BASH": r"C:\Missing\bash.exe",
                 "CLAUDE_CODE_GIT_BASH_PATH": "",
@@ -643,16 +666,14 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 with mock.patch.object(
                     MOD, "_windows_path_shell_candidates", return_value=[]
                 ):
-                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
-                        os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
-                    )):
-                        got = MOD._resolve_windows_posix_shell()
-        self.assertEqual(os.path.normcase(got), os.path.normcase(self.GIT_BASH))
+                    got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(ntpath.normcase(got), ntpath.normcase(self.GIT_BASH))
 
     def test_is_system32_wsl_bash(self):
-        with mock.patch.dict(os.environ, {"SystemRoot": r"C:\Windows"}, clear=False):
-            self.assertTrue(MOD._is_system32_wsl_bash(self.SYSTEM32_BASH))
-            self.assertFalse(MOD._is_system32_wsl_bash(self.GIT_BASH))
+        with windows_ntpath():
+            with mock.patch.dict(os.environ, {"SystemRoot": r"C:\Windows"}, clear=False):
+                self.assertTrue(MOD._is_system32_wsl_bash(self.SYSTEM32_BASH))
+                self.assertFalse(MOD._is_system32_wsl_bash(self.GIT_BASH))
 
     def test_env_bash_index_finds_token_after_assignments(self):
         argv = ["env", "A=1", "B=2", "bash", "script.sh"]

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -17,6 +17,7 @@ import io
 import json
 import ntpath
 import os
+import shlex
 import stat as stat_mod
 import subprocess
 import sys
@@ -754,57 +755,76 @@ class WindowsPosixShellResolve(unittest.TestCase):
 
     def test_env_bash_index_finds_token_after_assignments(self):
         argv = ["env", "A=1", "B=2", "bash", "script.sh"]
-        self.assertEqual(MOD._env_bash_index(argv), 3)
-        self.assertEqual(MOD._env_bash_index(["env", "python", "x.py"]), -1)
-        self.assertEqual(MOD._env_bash_index(["bash", "x.sh"]), -1)
+        self.assertEqual(MOD._env_bash_index(argv), (3, None))
+        self.assertEqual(MOD._env_bash_index(["env", "python", "x.py"]), (-1, None))
+        self.assertEqual(MOD._env_bash_index(["bash", "x.sh"]), (-1, None))
 
     def test_env_bash_index_skips_chdir_operand(self):
         # -C / --chdir take DIR; a directory named bash must not be treated as
         # the command, and bash after a real DIR must still be found (#1292 P2).
         self.assertEqual(
-            MOD._env_bash_index(["env", "-C", "bash", "python", "x.py"]), -1
+            MOD._env_bash_index(["env", "-C", "bash", "python", "x.py"]), (-1, None)
         )
         self.assertEqual(
-            MOD._env_bash_index(["env", "-C", "/tmp", "bash", "script.sh"]), 3
+            MOD._env_bash_index(["env", "-C", "/tmp", "bash", "script.sh"]), (3, None)
         )
         self.assertEqual(
             MOD._env_bash_index(
                 ["env", "--chdir", "bash", "python", "x.py"]
             ),
-            -1,
+            (-1, None),
         )
         self.assertEqual(
             MOD._env_bash_index(
                 ["env", "--chdir=/tmp", "bash", "script.sh"]
             ),
-            2,
+            (2, None),
         )
 
-    def test_env_bash_index_skips_split_string_operand(self):
-        # -S / --split-string consume their string; do not treat tokens inside
-        # as argv-level bash (rewrite of -S body is out of scope).
+    def test_env_bash_index_finds_bash_inside_split_string(self):
+        # env -S/--split-string word-splits its operand and runs the first
+        # non-assignment word as the command, so a bash/sh command hidden
+        # inside the split string must be found, not silently skipped
+        # (#1292 Codex round 4: `env -S "bash script.sh"` previously returned
+        # -1 because the split string's contents were never inspected,
+        # leaving System32 WSL bash reachable through this shape).
         self.assertEqual(
-            MOD._env_bash_index(["env", "-S", "bash script.sh"]), -1
+            MOD._env_bash_index(["env", "-S", "bash script.sh"]), (2, "")
         )
         self.assertEqual(
             MOD._env_bash_index(
                 ["env", "--split-string=FOO=1 bash script.sh"]
             ),
-            -1,
+            (1, "--split-string="),
         )
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-Sbash script.sh"]), (1, "-S")
+        )
+
+    def test_env_bash_index_split_string_without_bash_still_finds_later_token(self):
+        # A split-string operand that does NOT itself resolve to bash/sh
+        # (e.g. a bare assignment) must not stop the scan -- a later plain
+        # bash/sh argv token must still be found.
         self.assertEqual(
             MOD._env_bash_index(
                 ["env", "-S", "FOO=1", "bash", "script.sh"]
             ),
-            3,
+            (3, None),
         )
+
+    def test_env_bash_index_raises_on_unparsable_split_string(self):
+        # Fail closed rather than guess when the operand cannot be word-split
+        # (unbalanced quoting) -- silently ignoring it could let System32 WSL
+        # bash slip through unresolved.
+        with self.assertRaises(MOD.RunnerError):
+            MOD._env_bash_index(["env", "-S", "bash 'unterminated"])
 
     def test_env_bash_index_skips_unset_attached(self):
         self.assertEqual(
-            MOD._env_bash_index(["env", "-u", "FOO", "bash", "script.sh"]), 3
+            MOD._env_bash_index(["env", "-u", "FOO", "bash", "script.sh"]), (3, None)
         )
         self.assertEqual(
-            MOD._env_bash_index(["env", "--unset=FOO", "bash", "script.sh"]), 2
+            MOD._env_bash_index(["env", "--unset=FOO", "bash", "script.sh"]), (2, None)
         )
 
     def test_windows_popen_rewrites_bash_after_chdir(self):
@@ -833,6 +853,63 @@ class WindowsPosixShellResolve(unittest.TestCase):
             ) as resolve:
                 self.assertEqual(MOD._popen_argv(argv), argv)
                 resolve.assert_not_called()
+
+    def test_windows_popen_rewrites_bash_inside_split_string(self):
+        # The exact shape Codex flagged as still-reachable System32 WSL bash:
+        # `env -S "bash script.sh"` must resolve and rewrite the bash word
+        # inside the split string, not pass it through untouched (#1292).
+        argv = ["env", "-S", "bash script.sh"]
+        with windows_platform():
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ):
+                expected_value = " ".join(
+                    shlex.quote(t) for t in (self.GIT_BASH, "script.sh")
+                )
+                self.assertEqual(
+                    MOD._popen_argv(argv),
+                    ["env", "-S", expected_value],
+                )
+
+    def test_windows_popen_rewrites_bash_inside_attached_split_string(self):
+        argv = ["env", "--split-string=FOO=1 bash script.sh"]
+        with windows_platform():
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ):
+                expected_value = " ".join(
+                    shlex.quote(t) for t in ("FOO=1", self.GIT_BASH, "script.sh")
+                )
+                self.assertEqual(
+                    MOD._popen_argv(argv),
+                    ["env", "--split-string=" + expected_value],
+                )
+
+    def test_windows_popen_keeps_absolute_portable_bash_inside_split_string(self):
+        # A literal backslash inside an env -S/--split-string operand is an
+        # escape character to env's own word-splitting (mirrored here via
+        # shlex posix mode), so a Windows path must be backslash-escaped by
+        # the caller to survive splitting intact -- same as it would need to
+        # be for real GNU env, not an artifact of this parser.
+        portable = r"C:\PortableGit\bin\bash.exe"
+        escaped = portable.replace("\\", "\\\\")
+        argv = ["env", "-S", f"{escaped} script.sh"]
+        with windows_platform(isfile_side_effect=_nt_exists(portable)):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                expected_value = " ".join(shlex.quote(t) for t in (portable, "script.sh"))
+                self.assertEqual(
+                    MOD._popen_argv(argv),
+                    ["env", "-S", expected_value],
+                )
+                resolve.assert_not_called()
+
+    def test_windows_popen_raises_on_unparsable_split_string(self):
+        argv = ["env", "-S", "bash 'unterminated"]
+        with windows_platform():
+            with self.assertRaises(MOD.RunnerError):
+                MOD._popen_argv(argv)
 
 
 class BinaryRoundTrip(unittest.TestCase):

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -538,6 +538,24 @@ class PopenArgvBranch(unittest.TestCase):
                                 ],
                             )
 
+    def test_windows_rewrites_after_option_like_assignment_in_assignment_phase(self):
+        for assignment in ("-S=x", "--split-string=x"):
+            with self.subTest(assignment=assignment):
+                argv = ["env", "A=1", assignment, "bash", "script.sh"]
+                with windows_platform():
+                    with mock.patch.object(
+                        MOD,
+                        "_resolve_windows_posix_shell",
+                        return_value=self.GIT_BASH,
+                    ):
+                        self.assertEqual(
+                            MOD._popen_argv(argv),
+                            [
+                                "env", "A=1", assignment,
+                                self.GIT_BASH, "script.sh",
+                            ],
+                        )
+
     def test_windows_env_prefixed_bash_missing_shell_raises(self):
         argv = ["env", "FOO=1", "bash", "script.sh"]
         with windows_platform():
@@ -912,6 +930,7 @@ class WindowsPosixShellResolve(unittest.TestCase):
             (["env", "--", "-0", "bash"], (-1, None)),
             (["env", "--", r"--chdir=C:\tools\bash", "bash"], (3, None)),
             (["env", "-", "-S=x", "bash"], (3, None)),
+            (["env", "A=1", "-S=x", "bash"], (3, None)),
         )
         for argv, expected in cases:
             with self.subTest(argv=argv):

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -971,7 +971,17 @@ class WindowsPosixShellResolve(unittest.TestCase):
                     self.assertIn("unsupported env long option", str(ctx.exception))
 
     def test_env_bash_index_accepts_exact_no_operand_long_options(self):
-        for option in ("--ignore-environment", "--debug"):
+        for option in (
+            "--ignore-environment",
+            "--debug",
+            "--block-signal",
+            "--block-signal=PIPE",
+            "--default-signal",
+            "--default-signal=PIPE",
+            "--ignore-signal",
+            "--ignore-signal=PIPE",
+            "--list-signal-handling",
+        ):
             with self.subTest(option=option):
                 self.assertEqual(
                     MOD._env_bash_index(["env", option, "bash", "script.sh"]),
@@ -979,7 +989,17 @@ class WindowsPosixShellResolve(unittest.TestCase):
                 )
 
     def test_windows_popen_rewrites_bash_after_exact_no_operand_long_options(self):
-        for option in ("--ignore-environment", "--debug"):
+        for option in (
+            "--ignore-environment",
+            "--debug",
+            "--block-signal",
+            "--block-signal=PIPE",
+            "--default-signal",
+            "--default-signal=PIPE",
+            "--ignore-signal",
+            "--ignore-signal=PIPE",
+            "--list-signal-handling",
+        ):
             argv = ["env", option, "bash", "script.sh"]
             with self.subTest(option=option):
                 with windows_platform():

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -758,6 +758,83 @@ class WindowsPosixShellResolve(unittest.TestCase):
         self.assertEqual(MOD._env_bash_index(["env", "python", "x.py"]), -1)
         self.assertEqual(MOD._env_bash_index(["bash", "x.sh"]), -1)
 
+    def test_env_bash_index_skips_chdir_operand(self):
+        # -C / --chdir take DIR; a directory named bash must not be treated as
+        # the command, and bash after a real DIR must still be found (#1292 P2).
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-C", "bash", "python", "x.py"]), -1
+        )
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-C", "/tmp", "bash", "script.sh"]), 3
+        )
+        self.assertEqual(
+            MOD._env_bash_index(
+                ["env", "--chdir", "bash", "python", "x.py"]
+            ),
+            -1,
+        )
+        self.assertEqual(
+            MOD._env_bash_index(
+                ["env", "--chdir=/tmp", "bash", "script.sh"]
+            ),
+            2,
+        )
+
+    def test_env_bash_index_skips_split_string_operand(self):
+        # -S / --split-string consume their string; do not treat tokens inside
+        # as argv-level bash (rewrite of -S body is out of scope).
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-S", "bash script.sh"]), -1
+        )
+        self.assertEqual(
+            MOD._env_bash_index(
+                ["env", "--split-string=FOO=1 bash script.sh"]
+            ),
+            -1,
+        )
+        self.assertEqual(
+            MOD._env_bash_index(
+                ["env", "-S", "FOO=1", "bash", "script.sh"]
+            ),
+            3,
+        )
+
+    def test_env_bash_index_skips_unset_attached(self):
+        self.assertEqual(
+            MOD._env_bash_index(["env", "-u", "FOO", "bash", "script.sh"]), 3
+        )
+        self.assertEqual(
+            MOD._env_bash_index(["env", "--unset=FOO", "bash", "script.sh"]), 2
+        )
+
+    def test_windows_popen_rewrites_bash_after_chdir(self):
+        argv = ["env", "-C", r"C:\workdir", "bash", "script.sh", "x"]
+        with windows_platform():
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ):
+                self.assertEqual(
+                    MOD._popen_argv(argv),
+                    [
+                        "env",
+                        "-C",
+                        r"C:\workdir",
+                        self.GIT_BASH,
+                        "script.sh",
+                        "x",
+                    ],
+                )
+
+    def test_windows_popen_does_not_rewrite_chdir_named_bash(self):
+        argv = ["env", "-C", "bash", "python", "x.py"]
+        with windows_platform():
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ) as resolve:
+                self.assertEqual(MOD._popen_argv(argv), argv)
+                resolve.assert_not_called()
+
+
 class BinaryRoundTrip(unittest.TestCase):
     """Windows CPython opens os.open() descriptors in CRT *text* mode: writes
     expand \\n -> \\r\\n and reads stop at the first 0x1A (Ctrl-Z EOF), which

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -380,7 +380,11 @@ class ClassifyExitWithPendingReap(unittest.TestCase):
 
 class PopenArgvBranch(unittest.TestCase):
     """Windows CreateProcess cannot honor shebang; bare *.sh must go through
-    bash/sh at spawn time. meta.json still records the caller argv."""
+    a preferred non-WSL bash at spawn time (#1268). meta.json still records
+    the caller argv for authorize-dispatch (ce-work bare adapter)."""
+
+    GIT_BASH = r"C:\Program Files\Git\bin\bash.exe"
+    SYSTEM32_BASH = r"C:\Windows\System32\bash.exe"
 
     def test_posix_passthrough(self):
         argv = ["/tmp/cross-model-work.sh", "a", "b"]
@@ -390,26 +394,139 @@ class PopenArgvBranch(unittest.TestCase):
     def test_windows_wraps_bare_shell_script(self):
         argv = [r"C:\skills\ce-work\scripts\cross-model-work.sh", "a", "b"]
         with mock.patch.object(MOD, "IS_WINDOWS", True):
-            with mock.patch.object(MOD.shutil, "which", side_effect=lambda n: {
-                "bash": r"C:\Git\bin\bash.exe",
-                "sh": None,
-            }.get(n)):
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ):
                 self.assertEqual(
                     MOD._popen_argv(argv),
-                    [r"C:\Git\bin\bash.exe"] + argv,
+                    [self.GIT_BASH] + argv,
                 )
 
-    def test_windows_leaves_explicit_bash_prefix(self):
+    def test_windows_rewrites_bare_bash_prefix(self):
+        # Review skills launch as `bash script.sh`; bare name must not stay
+        # on PATH (System32 WSL) — rewrite to preferred absolute Git Bash.
         argv = ["bash", "/tmp/cross-model-adversarial-review.sh", "x"]
         with mock.patch.object(MOD, "IS_WINDOWS", True):
-            self.assertEqual(MOD._popen_argv(argv), argv)
+            with mock.patch.object(
+                MOD, "_resolve_windows_posix_shell", return_value=self.GIT_BASH
+            ):
+                self.assertEqual(
+                    MOD._popen_argv(argv),
+                    [self.GIT_BASH, argv[1], "x"],
+                )
 
     def test_windows_missing_shell_raises(self):
         argv = [r"C:\skills\ce-work\scripts\cross-model-work.sh"]
         with mock.patch.object(MOD, "IS_WINDOWS", True):
-            with mock.patch.object(MOD.shutil, "which", return_value=None):
+            with mock.patch.object(
+                MOD,
+                "_resolve_windows_posix_shell",
+                side_effect=MOD.RunnerError("no usable Git Bash"),
+            ):
                 with self.assertRaises(MOD.RunnerError):
                     MOD._popen_argv(argv)
+
+
+class WindowsPosixShellResolve(unittest.TestCase):
+    """#1268: prefer Git Bash over System32 WSL bash; fail closed otherwise."""
+
+    GIT_BASH = r"C:\Program Files\Git\bin\bash.exe"
+    SYSTEM32_BASH = r"C:\Windows\System32\bash.exe"
+
+    def test_prefers_git_bash_when_system32_first_on_path(self):
+        which_map = {"bash": self.SYSTEM32_BASH, "sh": None}
+
+        def fake_which(name):
+            return which_map.get(name)
+
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": "",
+                "CLAUDE_CODE_GIT_BASH_PATH": "",
+                "SystemRoot": r"C:\Windows",
+                "ProgramFiles": r"C:\Program Files",
+            }, clear=False):
+                with mock.patch.object(MOD.shutil, "which", side_effect=fake_which):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
+                        or os.path.normcase(p) == os.path.normcase(self.SYSTEM32_BASH)
+                    )):
+                        # Well-known Git path must win over System32 which()
+                        got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(os.path.normcase(got), os.path.normcase(self.GIT_BASH))
+
+    def test_ce_peer_bash_overrides_path(self):
+        override = r"C:\Custom\Git\bin\bash.exe"
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": override,
+                "CLAUDE_CODE_GIT_BASH_PATH": "",
+                "SystemRoot": r"C:\Windows",
+            }, clear=False):
+                with mock.patch.object(MOD.shutil, "which", return_value=self.SYSTEM32_BASH):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) == os.path.normcase(override)
+                    )):
+                        got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(os.path.normcase(got), os.path.normcase(override))
+
+    def test_claude_code_git_bash_path_when_ce_unset(self):
+        override = r"D:\Tools\Git\bin\bash.exe"
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": "",
+                "CLAUDE_CODE_GIT_BASH_PATH": override,
+                "SystemRoot": r"C:\Windows",
+            }, clear=False):
+                with mock.patch.object(MOD.shutil, "which", return_value=self.SYSTEM32_BASH):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) == os.path.normcase(override)
+                    )):
+                        got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(os.path.normcase(got), os.path.normcase(override))
+
+    def test_rejects_system32_only(self):
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": "",
+                "CLAUDE_CODE_GIT_BASH_PATH": "",
+                "SystemRoot": r"C:\Windows",
+                "ProgramFiles": r"C:\Program Files",
+                "ProgramFiles(x86)": r"C:\Program Files (x86)",
+            }, clear=False):
+                with mock.patch.object(
+                    MOD.shutil, "which", return_value=self.SYSTEM32_BASH
+                ):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) == os.path.normcase(self.SYSTEM32_BASH)
+                    )):
+                        with self.assertRaises(MOD.RunnerError) as ctx:
+                            MOD._resolve_windows_posix_shell()
+        msg = str(ctx.exception).lower()
+        self.assertIn("git", msg)
+        self.assertTrue(
+            "ce_peer_bash" in msg or "claude_code_git_bash_path" in msg
+        )
+
+    def test_missing_override_falls_through(self):
+        with mock.patch.object(MOD, "IS_WINDOWS", True):
+            with mock.patch.dict(os.environ, {
+                "CE_PEER_BASH": r"C:\Missing\bash.exe",
+                "CLAUDE_CODE_GIT_BASH_PATH": "",
+                "SystemRoot": r"C:\Windows",
+                "ProgramFiles": r"C:\Program Files",
+            }, clear=False):
+                with mock.patch.object(MOD.shutil, "which", return_value=None):
+                    with mock.patch.object(MOD.os.path, "isfile", side_effect=lambda p: (
+                        os.path.normcase(p) == os.path.normcase(self.GIT_BASH)
+                    )):
+                        got = MOD._resolve_windows_posix_shell()
+        self.assertEqual(os.path.normcase(got), os.path.normcase(self.GIT_BASH))
+
+    def test_is_system32_wsl_bash(self):
+        with mock.patch.dict(os.environ, {"SystemRoot": r"C:\Windows"}, clear=False):
+            self.assertTrue(MOD._is_system32_wsl_bash(self.SYSTEM32_BASH))
+            self.assertFalse(MOD._is_system32_wsl_bash(self.GIT_BASH))
 
 
 class BinaryRoundTrip(unittest.TestCase):

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -274,18 +274,26 @@ class WindowsPeerJobSmoke(unittest.TestCase):
             "reap must sweep the orphan grandchild",
         )
 
-    def test_bare_sh_worker_wraps_when_bash_present(self):
-        # Prefer the runner's Git-Bash resolver (#1268) over bare which():
-        # System32 WSL bash or a missing PATH entry must not skip this smoke.
-        try:
-            bash = MOD._resolve_windows_posix_shell()
-        except MOD.RunnerError:
-            bash = shutil.which("bash") or shutil.which("sh")
-        if bash is None:
-            self.skipTest("no usable Git Bash / bash on this host")
+    def _write_stub_sh(self):
         stub = os.path.join(self.root, "stub.sh")
         with open(stub, "w", encoding="utf-8", newline="\n") as f:
             f.write("#!/usr/bin/env bash\nexit 0\n")
+        return stub
+
+    def _require_git_bash(self):
+        try:
+            return MOD._resolve_windows_posix_shell()
+        except MOD.RunnerError:
+            bash = shutil.which("bash") or shutil.which("sh")
+            if bash is None:
+                self.skipTest("no usable Git Bash / bash on this host")
+            return bash
+
+    def test_bare_sh_worker_wraps_when_bash_present(self):
+        # Prefer the runner's Git-Bash resolver (#1268) over bare which():
+        # System32 WSL bash or a missing PATH entry must not skip this smoke.
+        self._require_git_bash()
+        stub = self._write_stub_sh()
         started = self._run(
             ["start", "--skill", "ce-doc-review", "--run-id", "run1", "--", stub]
         )
@@ -305,6 +313,82 @@ class WindowsPeerJobSmoke(unittest.TestCase):
             MOD._is_system32_wsl_bash(meta["windows_posix_shell"]),
             meta["windows_posix_shell"],
         )
+
+    def test_bash_prefix_worker_sets_meta_shell(self):
+        bash = self._require_git_bash()
+        stub = self._write_stub_sh()
+        started = self._run(
+            [
+                "start", "--skill", "ce-doc-review", "--run-id", "run-bash-prefix",
+                "--", "bash", stub,
+            ]
+        )
+        self.assertEqual(started.returncode, 0, started.stderr)
+        job_id = started.stdout.strip()
+        meta_path = os.path.join(
+            self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", "run-bash-prefix",
+            "jobs", job_id, "meta.json",
+        )
+        with open(meta_path, encoding="utf-8") as f:
+            meta = json.load(f)
+        self.assertIn("windows_posix_shell", meta)
+        self.assertFalse(
+            MOD._is_system32_wsl_bash(meta["windows_posix_shell"]),
+            meta["windows_posix_shell"],
+        )
+        self.assertFalse(
+            MOD._is_system32_wsl_bash(meta["worker_argv"][0]),
+            meta["worker_argv"][0],
+        )
+        waited = self._run(["wait", "--max-secs", "20", job_id])
+        self.assertEqual(waited.returncode, 0, waited.stderr)
+
+    def test_env_prefixed_bash_worker_sets_meta_shell(self):
+        # Production cross-model shape: start -- env VAR=… bash script.sh
+        bash = self._require_git_bash()
+        env_exe = shutil.which("env") or shutil.which("env.exe")
+        if env_exe is None:
+            # Git usr\bin\env.exe is usual; derive from resolved bash.
+            cand = os.path.join(os.path.dirname(bash), "env.exe")
+            if os.path.isfile(cand):
+                env_exe = cand
+            else:
+                usr = os.path.join(os.path.dirname(os.path.dirname(bash)), "usr", "bin", "env.exe")
+                if os.path.isfile(usr):
+                    env_exe = usr
+        if env_exe is None:
+            self.skipTest("no env.exe alongside Git Bash on this host")
+        stub = self._write_stub_sh()
+        started = self._run(
+            [
+                "start", "--skill", "ce-doc-review", "--run-id", "run-env-bash",
+                "--", env_exe, "SMOKE_PEER=1", "bash", stub,
+            ]
+        )
+        self.assertEqual(started.returncode, 0, started.stderr)
+        job_id = started.stdout.strip()
+        meta_path = os.path.join(
+            self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", "run-env-bash",
+            "jobs", job_id, "meta.json",
+        )
+        with open(meta_path, encoding="utf-8") as f:
+            meta = json.load(f)
+        self.assertIn("windows_posix_shell", meta)
+        self.assertFalse(
+            MOD._is_system32_wsl_bash(meta["windows_posix_shell"]),
+            meta["windows_posix_shell"],
+        )
+        # bash token rewritten to absolute non-WSL shell
+        self.assertTrue(
+            any(
+                os.path.normcase(os.path.abspath(t))
+                == os.path.normcase(os.path.abspath(meta["windows_posix_shell"]))
+                for t in meta["worker_argv"]
+            ),
+            meta["worker_argv"],
+        )
+        waited = self._run(["wait", "--max-secs", "20", job_id])
+        self.assertEqual(waited.returncode, 0, waited.stderr)
 
     def test_reap_during_long_poll_classifies_timeout_not_failed(self):
         # Regression (#1248): with poll=2s, min(grace, 1.0) alone races into

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -482,6 +482,33 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                 self.assertEqual(len(job_dirs), 1)
                 self.assertFalse(os.path.exists(os.path.join(jobs_root, job_dirs[0], "pid")))
 
+    def test_env_abbreviated_and_unknown_long_options_fail_before_detach(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        cases = (
+            ["--chd", ".", "bash"],
+            ["--unse", "FOO", "bash"],
+            ["--split-s", "bash -c 'exit 0'"],
+            ["--unknown", "bash"],
+        )
+        for index, env_args in enumerate(cases, start=1):
+            with self.subTest(env_args=env_args):
+                run_id = f"run-env-long-option-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, *env_args,
+                    ]
+                )
+                self.assertNotEqual(started.returncode, 0)
+                self.assertIn("unsupported env long option", started.stderr)
+                jobs_root = os.path.join(
+                    self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", run_id, "jobs"
+                )
+                job_dirs = os.listdir(jobs_root)
+                self.assertEqual(len(job_dirs), 1)
+                self.assertFalse(os.path.exists(os.path.join(jobs_root, job_dirs[0], "pid")))
+
     def test_reap_during_long_poll_classifies_timeout_not_failed(self):
         # Regression (#1248): with poll=2s, min(grace, 1.0) alone races into
         # the fallback kill path and used to record "failed" from the kill

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -289,6 +289,20 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                 self.skipTest("no usable Git Bash / bash on this host")
             return bash
 
+    def _require_git_env(self, bash):
+        env_exe = shutil.which("env") or shutil.which("env.exe")
+        if env_exe is None:
+            candidates = (
+                os.path.join(os.path.dirname(bash), "env.exe"),
+                os.path.join(
+                    os.path.dirname(os.path.dirname(bash)), "usr", "bin", "env.exe"
+                ),
+            )
+            env_exe = next((path for path in candidates if os.path.isfile(path)), None)
+        if env_exe is None:
+            self.skipTest("no env.exe alongside Git Bash on this host")
+        return env_exe
+
     def test_bare_sh_worker_wraps_when_bash_present(self):
         # Prefer the runner's Git-Bash resolver (#1268) over bare which():
         # System32 WSL bash or a missing PATH entry must not skip this smoke.
@@ -346,18 +360,7 @@ class WindowsPeerJobSmoke(unittest.TestCase):
     def test_env_prefixed_bash_worker_sets_meta_shell(self):
         # Production cross-model shape: start -- env VAR=… bash script.sh
         bash = self._require_git_bash()
-        env_exe = shutil.which("env") or shutil.which("env.exe")
-        if env_exe is None:
-            # Git usr\bin\env.exe is usual; derive from resolved bash.
-            cand = os.path.join(os.path.dirname(bash), "env.exe")
-            if os.path.isfile(cand):
-                env_exe = cand
-            else:
-                usr = os.path.join(os.path.dirname(os.path.dirname(bash)), "usr", "bin", "env.exe")
-                if os.path.isfile(usr):
-                    env_exe = usr
-        if env_exe is None:
-            self.skipTest("no env.exe alongside Git Bash on this host")
+        env_exe = self._require_git_env(bash)
         stub = self._write_stub_sh()
         started = self._run(
             [
@@ -389,6 +392,95 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         )
         waited = self._run(["wait", "--max-secs", "20", job_id])
         self.assertEqual(waited.returncode, 0, waited.stderr)
+
+    def test_env_unusual_assignment_names_rewrite_to_git_bash(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        stub = self._write_stub_sh()
+        for index, assignment in enumerate(("1=x", "a-b=x"), start=1):
+            with self.subTest(assignment=assignment):
+                run_id = f"run-env-assignment-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, assignment, "bash", stub,
+                    ]
+                )
+                self.assertEqual(started.returncode, 0, started.stderr)
+                job_id = started.stdout.strip()
+                meta_path = os.path.join(
+                    self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", run_id,
+                    "jobs", job_id, "meta.json",
+                )
+                with open(meta_path, encoding="utf-8") as f:
+                    meta = json.load(f)
+                self.assertEqual(meta["worker_argv"][1], assignment)
+                self.assertEqual(
+                    os.path.normcase(os.path.abspath(meta["worker_argv"][2])),
+                    os.path.normcase(os.path.abspath(meta["windows_posix_shell"])),
+                )
+                waited = self._run(
+                    ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
+                )
+                self.assertEqual(waited.returncode, 0, waited.stderr)
+
+    def test_env_option_terminator_allows_hyphen_prefixed_assignments(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        stub = self._write_stub_sh()
+        for index, assignment in enumerate(("-S=x", "--split-string=x"), start=1):
+            with self.subTest(assignment=assignment):
+                run_id = f"run-env-option-terminator-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, "--", assignment, "bash", stub,
+                    ]
+                )
+                self.assertEqual(started.returncode, 0, started.stderr)
+                job_id = started.stdout.strip()
+                meta_path = os.path.join(
+                    self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", run_id,
+                    "jobs", job_id, "meta.json",
+                )
+                with open(meta_path, encoding="utf-8") as f:
+                    meta = json.load(f)
+                self.assertEqual(meta["worker_argv"][2], assignment)
+                self.assertEqual(
+                    os.path.normcase(os.path.abspath(meta["worker_argv"][3])),
+                    os.path.normcase(os.path.abspath(meta["windows_posix_shell"])),
+                )
+                waited = self._run(
+                    ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
+                )
+                self.assertEqual(waited.returncode, 0, waited.stderr)
+
+    def test_env_split_string_forms_fail_before_detach(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        cases = (
+            ["-S", "bash -c 'exit 0'"],
+            ["--split-string", "bash -c 'exit 0'"],
+            ["-Sbash -c 'exit 0'"],
+            ["--split-string=bash -c 'exit 0'"],
+        )
+        for index, env_args in enumerate(cases, start=1):
+            with self.subTest(env_args=env_args):
+                run_id = f"run-env-split-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, *env_args,
+                    ]
+                )
+                self.assertNotEqual(started.returncode, 0)
+                self.assertIn("split-string", started.stderr)
+                jobs_root = os.path.join(
+                    self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", run_id, "jobs"
+                )
+                job_dirs = os.listdir(jobs_root)
+                self.assertEqual(len(job_dirs), 1)
+                self.assertFalse(os.path.exists(os.path.join(jobs_root, job_dirs[0], "pid")))
 
     def test_reap_during_long_poll_classifies_timeout_not_failed(self):
         # Regression (#1248): with poll=2s, min(grace, 1.0) alone races into

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -502,6 +502,27 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                 self.assertEqual(waited.returncode, 0, waited.stderr)
                 self.assertEqual(waited.stdout.strip(), "done")
 
+    def test_env_assignment_phase_allows_option_shaped_assignments(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        stub = self._write_stub_sh()
+        for index, assignment in enumerate(("-S=x", "--split-string=x"), start=1):
+            with self.subTest(assignment=assignment):
+                run_id = f"run-env-assignment-phase-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, "A=1", assignment, "bash", stub,
+                    ]
+                )
+                self.assertEqual(started.returncode, 0, started.stderr)
+                job_id = started.stdout.strip()
+                waited = self._run(
+                    ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
+                )
+                self.assertEqual(waited.returncode, 0, waited.stderr)
+                self.assertEqual(waited.stdout.strip(), "done")
+
     def test_env_exact_no_operand_long_options_rewrite_to_git_bash(self):
         bash = self._require_git_bash()
         env_exe = self._require_git_env(bash)

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -455,6 +455,39 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                 )
                 self.assertEqual(waited.returncode, 0, waited.stderr)
 
+    def test_env_exact_no_operand_long_options_rewrite_to_git_bash(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        stub = self._write_stub_sh()
+        for index, option in enumerate(
+            ("--ignore-environment", "--null", "--debug"), start=1
+        ):
+            with self.subTest(option=option):
+                run_id = f"run-env-long-option-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, option, "bash", stub,
+                    ]
+                )
+                self.assertEqual(started.returncode, 0, started.stderr)
+                job_id = started.stdout.strip()
+                meta_path = os.path.join(
+                    self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", run_id,
+                    "jobs", job_id, "meta.json",
+                )
+                with open(meta_path, encoding="utf-8") as f:
+                    meta = json.load(f)
+                self.assertEqual(meta["worker_argv"][1], option)
+                self.assertEqual(
+                    os.path.normcase(os.path.abspath(meta["worker_argv"][2])),
+                    os.path.normcase(os.path.abspath(meta["windows_posix_shell"])),
+                )
+                waited = self._run(
+                    ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
+                )
+                self.assertEqual(waited.returncode, 0, waited.stderr)
+
     def test_env_split_string_forms_fail_before_detach(self):
         bash = self._require_git_bash()
         env_exe = self._require_git_env(bash)

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -406,7 +406,7 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         bash = self._require_git_bash()
         env_exe = self._require_git_env(bash)
         stub = self._write_stub_sh()
-        for index, assignment in enumerate(("1=x", "a-b=x"), start=1):
+        for index, assignment in enumerate(("=x", "1=x", "a-b=x"), start=1):
             with self.subTest(assignment=assignment):
                 run_id = f"run-env-assignment-{index}"
                 started = self._run(

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -468,13 +468,19 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         bash = self._require_git_bash()
         env_exe = self._require_git_env(bash)
         stub = self._write_stub_sh()
-        for index, assignment in enumerate(("-S=x", "--split-string=x"), start=1):
-            with self.subTest(assignment=assignment):
+        cases = (
+            ("--", "-S=x"),
+            ("--", "--split-string=x"),
+            ("-", "-S=x"),
+            ("-", "--split-string=x"),
+        )
+        for index, (terminator, assignment) in enumerate(cases, start=1):
+            with self.subTest(terminator=terminator, assignment=assignment):
                 run_id = f"run-env-option-terminator-{index}"
                 started = self._run(
                     [
                         "start", "--skill", "ce-doc-review", "--run-id", run_id,
-                        "--", env_exe, "--", assignment, "bash", stub,
+                        "--", env_exe, terminator, assignment, "bash", stub,
                     ]
                 )
                 self.assertEqual(started.returncode, 0, started.stderr)

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -356,6 +356,7 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         )
         waited = self._run(["wait", "--max-secs", "20", job_id])
         self.assertEqual(waited.returncode, 0, waited.stderr)
+        self.assertEqual(waited.stdout.strip(), "done")
 
     def test_env_prefixed_bash_worker_sets_meta_shell(self):
         # Production cross-model shape: start -- env VAR=… bash script.sh
@@ -392,6 +393,14 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         )
         waited = self._run(["wait", "--max-secs", "20", job_id])
         self.assertEqual(waited.returncode, 0, waited.stderr)
+        self.assertEqual(waited.stdout.strip(), "done")
+
+    def test_sysnative_shell_alias_is_classified_as_wsl(self):
+        system_root = os.environ.get("SystemRoot") or r"C:\Windows"
+        for name in ("bash.exe", "sh.exe"):
+            with self.subTest(name=name):
+                path = os.path.join(system_root, "Sysnative", name)
+                self.assertTrue(MOD._is_system32_wsl_bash(path), path)
 
     def test_env_unusual_assignment_names_rewrite_to_git_bash(self):
         bash = self._require_git_bash()

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -423,6 +423,7 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                     ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
                 )
                 self.assertEqual(waited.returncode, 0, waited.stderr)
+                self.assertEqual(waited.stdout.strip(), "done")
 
     def test_env_option_terminator_allows_hyphen_prefixed_assignments(self):
         bash = self._require_git_bash()
@@ -454,14 +455,13 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                     ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
                 )
                 self.assertEqual(waited.returncode, 0, waited.stderr)
+                self.assertEqual(waited.stdout.strip(), "done")
 
     def test_env_exact_no_operand_long_options_rewrite_to_git_bash(self):
         bash = self._require_git_bash()
         env_exe = self._require_git_env(bash)
         stub = self._write_stub_sh()
-        for index, option in enumerate(
-            ("--ignore-environment", "--null", "--debug"), start=1
-        ):
+        for index, option in enumerate(("--ignore-environment", "--debug"), start=1):
             with self.subTest(option=option):
                 run_id = f"run-env-long-option-{index}"
                 started = self._run(
@@ -487,6 +487,7 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                     ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
                 )
                 self.assertEqual(waited.returncode, 0, waited.stderr)
+                self.assertEqual(waited.stdout.strip(), "done")
 
     def test_env_split_string_forms_fail_before_detach(self):
         bash = self._require_git_bash()
@@ -522,6 +523,7 @@ class WindowsPeerJobSmoke(unittest.TestCase):
             ["--chd", ".", "bash"],
             ["--unse", "FOO", "bash"],
             ["--split-s", "bash -c 'exit 0'"],
+            ["--null", "bash", "-c", "exit 0"],
             ["--unknown", "bash"],
         )
         for index, env_args in enumerate(cases, start=1):

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -12,6 +12,7 @@ wrapping when bash is on PATH.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import shutil
@@ -27,6 +28,10 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 RUNNER = os.path.join(
     REPO_ROOT, "skills", "ce-doc-review", "scripts", "peer-job-runner.py"
 )
+
+_spec = importlib.util.spec_from_file_location("peer_job_runner_smoke", RUNNER)
+MOD = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(MOD)
 
 FAST = {
     "CE_PEER_POLL_SECS": "0.2",
@@ -270,9 +275,14 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         )
 
     def test_bare_sh_worker_wraps_when_bash_present(self):
-        bash = shutil.which("bash") or shutil.which("sh")
+        # Prefer the runner's Git-Bash resolver (#1268) over bare which():
+        # System32 WSL bash or a missing PATH entry must not skip this smoke.
+        try:
+            bash = MOD._resolve_windows_posix_shell()
+        except MOD.RunnerError:
+            bash = shutil.which("bash") or shutil.which("sh")
         if bash is None:
-            self.skipTest("bash/sh not on PATH (unexpected on windows-latest)")
+            self.skipTest("no usable Git Bash / bash on this host")
         stub = os.path.join(self.root, "stub.sh")
         with open(stub, "w", encoding="utf-8", newline="\n") as f:
             f.write("#!/usr/bin/env bash\nexit 0\n")
@@ -284,6 +294,17 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         waited = self._run(["wait", "--max-secs", "20", job_id])
         self.assertEqual(waited.returncode, 0, waited.stderr)
         self.assertEqual(waited.stdout.strip(), "done")
+        meta_path = os.path.join(
+            self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", "run1", "jobs",
+            job_id, "meta.json",
+        )
+        with open(meta_path, encoding="utf-8") as f:
+            meta = json.load(f)
+        self.assertIn("windows_posix_shell", meta)
+        self.assertFalse(
+            MOD._is_system32_wsl_bash(meta["windows_posix_shell"]),
+            meta["windows_posix_shell"],
+        )
 
     def test_reap_during_long_poll_classifies_timeout_not_failed(self):
         # Regression (#1248): with poll=2s, min(grace, 1.0) alone races into

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -527,7 +527,18 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         bash = self._require_git_bash()
         env_exe = self._require_git_env(bash)
         stub = self._write_stub_sh()
-        for index, option in enumerate(("--ignore-environment", "--debug"), start=1):
+        options = (
+            "--ignore-environment",
+            "--debug",
+            "--block-signal",
+            "--block-signal=PIPE",
+            "--default-signal",
+            "--default-signal=PIPE",
+            "--ignore-signal",
+            "--ignore-signal=PIPE",
+            "--list-signal-handling",
+        )
+        for index, option in enumerate(options, start=1):
             with self.subTest(option=option):
                 run_id = f"run-env-long-option-{index}"
                 started = self._run(

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -562,7 +562,6 @@ class WindowsPeerJobSmoke(unittest.TestCase):
             ["--chd", ".", "bash"],
             ["--unse", "FOO", "bash"],
             ["--split-s", "bash -c 'exit 0'"],
-            ["--null", "bash", "-c", "exit 0"],
             ["--unknown", "bash"],
         )
         for index, env_args in enumerate(cases, start=1):
@@ -582,6 +581,69 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                 job_dirs = os.listdir(jobs_root)
                 self.assertEqual(len(job_dirs), 1)
                 self.assertFalse(os.path.exists(os.path.join(jobs_root, job_dirs[0], "pid")))
+
+    def test_env_null_options_fail_before_detach(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        cases = (
+            ["-0", "bash", "-c", "exit 0"],
+            ["-i0", "bash", "-c", "exit 0"],
+            ["-0v", "bash", "-c", "exit 0"],
+            ["--null", "bash", "-c", "exit 0"],
+        )
+        for index, env_args in enumerate(cases, start=1):
+            with self.subTest(env_args=env_args):
+                run_id = f"run-env-null-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, *env_args,
+                    ]
+                )
+                self.assertNotEqual(started.returncode, 0)
+                self.assertIn("-0/--null", started.stderr)
+                jobs_root = os.path.join(
+                    self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", run_id, "jobs"
+                )
+                job_dirs = os.listdir(jobs_root)
+                self.assertEqual(len(job_dirs), 1)
+                self.assertFalse(os.path.exists(os.path.join(jobs_root, job_dirs[0], "pid")))
+
+    def test_env_attached_chdir_ending_in_shell_rewrites_actual_bash(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        stub = self._write_stub_sh()
+        workdir = os.path.join(self.root, "bash")
+        os.makedirs(workdir)
+        for index, option in enumerate(
+            (f"--chdir={workdir}", f"-C{workdir}"), start=1
+        ):
+            with self.subTest(option=option):
+                run_id = f"run-env-attached-chdir-{index}"
+                started = self._run(
+                    [
+                        "start", "--skill", "ce-doc-review", "--run-id", run_id,
+                        "--", env_exe, option, "bash", stub,
+                    ]
+                )
+                self.assertEqual(started.returncode, 0, started.stderr)
+                job_id = started.stdout.strip()
+                meta_path = os.path.join(
+                    self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", run_id,
+                    "jobs", job_id, "meta.json",
+                )
+                with open(meta_path, encoding="utf-8") as f:
+                    meta = json.load(f)
+                self.assertEqual(meta["worker_argv"][1], option)
+                self.assertEqual(
+                    os.path.normcase(os.path.abspath(meta["worker_argv"][2])),
+                    os.path.normcase(os.path.abspath(meta["windows_posix_shell"])),
+                )
+                waited = self._run(
+                    ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
+                )
+                self.assertEqual(waited.returncode, 0, waited.stderr)
+                self.assertEqual(waited.stdout.strip(), "done")
 
     def test_reap_during_long_poll_classifies_timeout_not_failed(self):
         # Regression (#1248): with poll=2s, min(grace, 1.0) alone races into

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -425,6 +425,36 @@ class WindowsPeerJobSmoke(unittest.TestCase):
                 self.assertEqual(waited.returncode, 0, waited.stderr)
                 self.assertEqual(waited.stdout.strip(), "done")
 
+    def test_env_assignment_value_ending_in_bash_remains_unchanged(self):
+        bash = self._require_git_bash()
+        env_exe = self._require_git_env(bash)
+        stub = self._write_stub_sh()
+        assignment = r"SMOKE_PEER=C:\tools\bash"
+        started = self._run(
+            [
+                "start", "--skill", "ce-doc-review", "--run-id",
+                "run-env-value-bash", "--", env_exe, assignment, "bash", stub,
+            ]
+        )
+        self.assertEqual(started.returncode, 0, started.stderr)
+        job_id = started.stdout.strip()
+        meta_path = os.path.join(
+            self.env["CE_PEER_JOBS_ROOT"], "ce-doc-review", "run-env-value-bash",
+            "jobs", job_id, "meta.json",
+        )
+        with open(meta_path, encoding="utf-8") as f:
+            meta = json.load(f)
+        self.assertEqual(meta["worker_argv"][1], assignment)
+        self.assertEqual(
+            os.path.normcase(os.path.abspath(meta["worker_argv"][2])),
+            os.path.normcase(os.path.abspath(meta["windows_posix_shell"])),
+        )
+        waited = self._run(
+            ["wait", "--skill", "ce-doc-review", "--max-secs", "20", job_id]
+        )
+        self.assertEqual(waited.returncode, 0, waited.stderr)
+        self.assertEqual(waited.stdout.strip(), "done")
+
     def test_env_option_terminator_allows_hyphen_prefixed_assignments(self):
         bash = self._require_git_bash()
         env_exe = self._require_git_env(bash)


### PR DESCRIPTION
On native Windows, peer workers that launched through bare `bash` (or the cross-model `env … bash script.sh` shape) could land on System32 WSL bash, miss Windows `jq`/Claude CLI, and silently skip. They now resolve Git Bash first (env overrides → well-known installs → non-WSL PATH), rewrite those bash/sh tokens before detach, and fail closed with a clear error when nothing usable remains.

Session-settled from planning: own only #1268; fail closed with no WSL fallback; rewrite bare `bash`/`sh` (user-directed).

**Validation:** unit fixture (PATH order, env-prefix rewrite, fail-closed), Windows smoke (bare `.sh`, `bash` prefix, `env … bash`), and six-skill runner parity — all green on a native Windows host with Git Bash.

Fixes #1268.

## Security Disclosure
Changes Windows peer-worker shell selection: prefers Git Bash / configured absolute bash over System32 WSL, and rewrites bare `bash`/`sh` (including after `env VAR=…`) before detach. Residual: WindowsApps/Sysnative WSL aliases are not specially rejected.

## Agent Disclosure
- **Model:** Cursor · Grok