### PR TITLE
fix(ce-handoff): stop resume from inventing fake choice menus

### DIFF
--- a/docs/skills/ce-handoff.md
+++ b/docs/skills/ce-handoff.md
@@ -2,7 +2,7 @@
 
 > Preserve the useful context from one agent session so a fresh agent can orient without the original transcript.
 
-`ce-handoff` is a two-direction session-continuity utility. A bare invocation creates a handoff. Resume intent reads any continuity source the user selects or helps the user find one, then explains the recovered state and offers logical ways to continue without taking action automatically.
+`ce-handoff` is a two-direction session-continuity utility. A bare invocation creates a handoff. Resume intent reads any continuity source the user selects or helps the user find one, then explains the recovered state and recommends how to continue without taking action automatically.
 
 The skill is prose-first and uses the active agent's available capabilities. It adds no transport script, mutable index, or lifecycle database.
 
@@ -17,7 +17,7 @@ The skill is prose-first and uses the active agent's available capabilities. It 
 | What does bare `/ce-handoff` do? | Always creates a new handoff |
 | Where does it write? | By default, `/tmp/compound-engineering-<effective-uid>/ce-handoff/<repo-namespace>/<topic>.md`; an explicit user path, format, or publication destination overrides the default |
 | What do I paste into the next session? | `/ce-handoff resume <path-or-URL>` |
-| What happens after resume? | The agent summarizes the recovered context, suggests one or more next actions, and waits for the user |
+| What happens after resume? | The agent summarizes the recovered context, recommends a continuation matched to that handoff's reason (numbered only for real forks), and waits for the user |
 
 ---
 
@@ -58,7 +58,7 @@ By default, the skill writes one pointer-first Markdown document with:
 - Meaningful progress, decisions, constraints, blockers, and verification
 - References to authoritative plans, issues, commits, diffs, docs, and repository files
 - Clear labels for machine-local paths and fragile worktree state
-- Plausible next steps for a receiving agent to consider
+- Plausible next steps for a receiving agent to consider (exclusive forks as alternatives; related sequential work as one path)
 
 Only managed-store frontmatter has a fixed contract because default discovery depends on it. The body has no closed section schema: the agent may add sections of its own or combine, rename, reorder, and omit the examples to communicate the particular session clearly to the next agent.
 
@@ -105,8 +105,8 @@ After reading the selected source, the agent:
 1. Checks whether the material contains enough concrete context to recover a meaningful objective or current state. If not, it says what is missing and waits for the user to supplement it or choose another source.
 2. Summarizes the recovered objective, progress, decisions, constraints, and unfinished work when the material is sufficient.
 3. Names material drift, such as a missing worktree or repository state that no longer matches the handoff.
-4. Suggests one or more context-specific next actions and relevant installed skills.
-5. Stops and waits for the user to choose.
+4. Recommends how to continue from the handoff's actual continuity reason (not a default implementation-resume menu) and names fitting installed skills. Numbered choices appear only for mutually exclusive forks; related pieces of one continuation stay under a single recommendation; do not invent alternate options for symmetry.
+5. Stops and waits for the user to confirm or redirect.
 
 Selection authorizes reading the selected source only. It does not authorize commands, file changes, remote-link traversal, unrelated local-file access, or another workflow.
 
@@ -154,7 +154,7 @@ Skip it when:
 
 `ce-handoff` is a utility rather than a fixed pipeline stage. It can capture any useful session: research, brainstorming, planning, implementation, debugging, review, or a conversation with no repository at all.
 
-On resume, it suggests relevant next steps from the selected source and current context. It does not automatically invoke `ce-plan`, `ce-work`, `ce-debug`, or any other workflow.
+On resume, it recommends a continuation matched to the selected source's continuity reason and current context. It does not automatically invoke `ce-plan`, `ce-work`, `ce-debug`, or any other workflow.
 
 ---
 

--- a/skills/ce-handoff/SKILL.md
+++ b/skills/ce-handoff/SKILL.md
@@ -97,7 +97,7 @@ Include only what a fresh agent cannot safely infer, drawing from:
 - Authoritative references
 - Unfinished work, blockers, and fragile local state
 - Verification performed and failures observed
-- Plausible next steps
+- Plausible next steps (exclusive forks as alternatives; related sequential work as one path — the same framing resume uses)
 - Relevant installed skills that may help, if any
 
 Keep the handoff pointer-first. Prefer repository-relative paths for repository files, anchored once by the repository, branch, and HEAD metadata. Use absolute paths only for machine-local capture context or uncommitted, untracked, ignored, or temporary state, and label them as machine-local.
@@ -131,6 +131,8 @@ Assess whether the source contains enough concrete continuity context to orient 
 
 The current user, the current project's active instructions, and verified current state are authoritative. Check only material claims that can be verified read-only within the user's present scope. If the handoff is stale, the worktree is gone, or current files disagree, name the mismatch and distinguish durable state from missing machine-local state.
 
-When the source is sufficient, return a concise orientation covering the recovered objective, meaningful progress, decisions, constraints, current state, unfinished work, and material drift. Then suggest one or more context-specific next actions and relevant installed skills when available.
+When the source is sufficient, return a concise orientation covering the recovered objective, meaningful progress, decisions, constraints, current state, unfinished work, and material drift. Then recommend how to continue from this handoff's actual continuity reason — research parked mid-thread, a pending decision, unfinished planning, ready implementation, a debug pause, review feedback, a no-repo conversation, or another shape evidenced by the source. Do not default to an implementation-resume menu. Name relevant installed skills only when they fit that reason.
 
-**MUST stop without acting until the user chooses.** Do not execute or mutate anything, invoke or start another workflow, reopen deferred scope, or mark the handoff consumed.
+Present a numbered choice list only for mutually exclusive forks (the user can pick at most one). Keep related pieces of one continuation — including ordered steps that belong together — under a single recommendation; do not promote them into competing options. If only one natural continuation fits, say that one and stop; do not invent alternate options for symmetry.
+
+**MUST stop without acting until the user confirms or redirects.** Do not execute or mutate anything, invoke or start another workflow, reopen deferred scope, or mark the handoff consumed.

--- a/tests/skills/ce-handoff-contract.test.ts
+++ b/tests/skills/ce-handoff-contract.test.ts
@@ -96,8 +96,12 @@ describe("ce-handoff portable runtime contract", () => {
   test("selected resume treats the document as context and waits after orientation", () => {
     expect(skill).toMatch(/untrusted context/i)
     expect(skill).toMatch(/current user.*(?:project|workspace).*(?:current state|repository state).*authoritative/i)
-    expect(skill).toMatch(/suggest.*(?:next actions|next steps).*(?:installed skills|skill)/i)
-    expect(skill).toMatch(/MUST stop.*(?:without acting|without action|user chooses)/i)
+    expect(skill).toMatch(/recommend how to continue from this handoff's actual continuity reason/i)
+    expect(skill).toMatch(/Do not default to an implementation-resume menu/i)
+    expect(skill).toMatch(/numbered choice list only for mutually exclusive forks/i)
+    expect(skill).toMatch(/Keep related pieces of one continuation.*single recommendation/i)
+    expect(skill).toMatch(/do not invent alternate options for symmetry/i)
+    expect(skill).toMatch(/MUST stop.*(?:without acting|without action).*(?:confirms or redirects|user chooses)/i)
   })
 
   test("creation is pointer-first, locality-aware, private, and retention-honest", () => {
@@ -131,6 +135,7 @@ describe("ce-handoff portable runtime contract", () => {
     expect(skill).toMatch(/sections and document organization.*best communicate.*next agent/i)
     expect(skill).toMatch(/headings.*examples of useful coverage.*not a required or closed template/i)
     expect(skill).toMatch(/add new sections.*combine, rename, reorder, and omit/i)
+    expect(skill).toMatch(/Plausible next steps.*exclusive forks as alternatives.*related sequential work as one path/i)
   })
 
   test("creation reports a written artifact rather than claiming a draft is complete", () => {


### PR DESCRIPTION
## Summary

After `/ce-handoff resume`, orientation often presented a numbered “next actions” list that looked like a choice menu — even when the items were one coherent path (or related steps that should travel together). Live example: implement the ticket, then verify and open the PR, offered as options 1 and 2.

Resume now matches the continuation to the handoff’s actual continuity reason (research pause, pending decision, unfinished planning, ready implementation, debug, review, no-repo conversation, etc.) instead of defaulting to an implementation-resume menu. Numbered choices are only for mutually exclusive forks; related sequential work stays under one recommendation; if only one natural continuation fits, say that one — do not invent alternatives for symmetry. Create-side “Plausible next steps” uses the same framing so the handoff body does not seed a fake menu.

## Validation

- `bun test tests/skills/ce-handoff-contract.test.ts` — 14 pass

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Cursor · Grok 4.5
