### PR TITLE
docs(codex): correct app marketplace instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or search for "compound engineering" in the plugin marketplace.
 Compound Engineering is not listed in Codex's built-in plugin marketplace yet. Add it as a custom marketplace:
 
 1. In the Codex app, open **Plugins** from the sidebar.
-2. Click **Add** / **Add plugin marketplace**.
+2. Click the arrow next to **Create**, then select **Add marketplace**.
 3. Enter:
 
    | Field | Value |
@@ -40,7 +40,7 @@ Compound Engineering is not listed in Codex's built-in plugin marketplace yet. A
    | Sparse paths | leave blank |
 
 4. Click **Add marketplace**.
-5. Select **Compound Engineering**, install **compound-engineering**, then restart Codex.
+5. Search for **Compound Engineering**, select **compound-engineering-plugin**, then restart Codex.
 
 The Codex app install is self-contained for Compound Engineering. Specialist reviewer and research behavior lives inside the skills as local prompt assets; no separate custom-agent install step is required.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Compound Engineering is not listed in Codex's built-in plugin marketplace yet. A
    | Sparse paths | leave blank |
 
 4. Click **Add marketplace**.
-5. Search for **Compound Engineering**, select **compound-engineering-plugin**, then restart Codex.
+5. Search for **Compound Engineering**, install **compound-engineering-plugin**, then restart Codex.
 
 The Codex app install is self-contained for Compound Engineering. Specialist reviewer and research behavior lives inside the skills as local prompt assets; no separate custom-agent install step is required.
 


### PR DESCRIPTION
## Summary

- correct the Codex App menu path for adding a marketplace
- clarify how to find and select the Compound Engineering marketplace after adding it

Closes #1298

## Testing

- git diff --check

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

The bulk of this change was authored with Codex App · GPT-5.