### PR TITLE
fix(ce-explain): define an outcome for non-capacity scout dispatch failure

### DIFF
--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -45,7 +45,7 @@ Dispatch is tiered by task shape, never hardcoded to a model name:
 - **Extraction tier** — the work-recap scout: search-and-quote work. Use the platform's cheapest capable model when the harness exposes a known override; otherwise inherit.
 - **Ceiling tier** — the explainer composition, the check-in reasoning, and the corrections. These run in the main conversation on the orchestrator's model; nothing is dispatched for them.
 
-**Degradation rule.** When the platform's subagent primitive cannot select per-agent models, dispatch scouts on the inherited model and keep their read budgets. When the platform has no subagent primitive at all, run the scout work inline with the same budgets.
+**Degradation rule.** When the platform's subagent primitive cannot select per-agent models, dispatch scouts on the inherited model and keep their read budgets. When the platform has no subagent primitive at all, run the scout work inline with the same budgets. When a dispatch fails, treat a concurrency or active-agent-limit error as backpressure — retry after a slot frees; a launch that fails for any other reason runs that scout's work inline with the same budgets, disclosed in one line.
 
 ## Artifact Root
 


### PR DESCRIPTION
## Summary

A ce-explain scout launch that failed for a non-capacity reason — permission denial, tool error, timeout — previously had no defined outcome: the degradation rule covered only the no-subagent-primitive case, so the run could stall or improvise instead of completing the recap. This is the same gap class a Codex P1 caught in ce-simplify-code's restored wording on #1313, found by auditing the other dispatch skills for it; ce-explain was the one remaining skill with the gap and a scout-owned evidence pass to lose. The fix adopts the failure-classification convention the sibling skills already carry (ce-doc-review, ce-optimize, ce-code-review, and post-#1313 ce-simplify-code): concurrency/active-agent-limit errors are backpressure to retry, and any other launch failure runs that scout's work inline with the same budgets, disclosed in one line.

Related: #1313

## Validation

- `bun run test` — 2874 pass, 0 fail
- One-sentence skill-prose change; no behavioral eval run — the sentence is the established convention text-shape already validated on the sibling skills

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Claude Code · claude-fable-5

https://claude.ai/code/session_01LT5t2keHt5MaJ9kcuFB4hr
