### PR TITLE
fix(ce-handoff): tighten create-body status, pointers, and traps

### DIFF
--- a/docs/skills/ce-handoff.md
+++ b/docs/skills/ce-handoff.md
@@ -55,10 +55,11 @@ By default, the skill writes one pointer-first Markdown document with:
 
 - A flat `ce-handoff/v1` frontmatter index for later discovery
 - The objective and latest user intent
-- Meaningful progress, decisions, constraints, blockers, and verification
-- References to authoritative plans, issues, commits, diffs, docs, and repository files
+- Meaningful progress, decisions, constraints, blockers, verification, and abandoned wrong turns
+- Current-state phrasing that distinguishes complete, in-progress, and not-started work when those differ
+- References to authoritative plans, issues, commits, diffs, docs, and repository files, each saying what is load-bearing there
 - Clear labels for machine-local paths and fragile worktree state
-- Plausible next steps for a receiving agent to consider (exclusive forks as alternatives; related sequential work as one path)
+- Plausible next steps framed as remaining status and dependencies by default; user-requested directives only when asked for; context-loading pointers (what to read) remain welcome
 
 Only managed-store frontmatter has a fixed contract because default discovery depends on it. The body has no closed section schema: the agent may add sections of its own or combine, rename, reorder, and omit the examples to communicate the particular session clearly to the next agent.
 

--- a/skills/ce-handoff/SKILL.md
+++ b/skills/ce-handoff/SKILL.md
@@ -27,7 +27,7 @@ Create one immutable handoff at the destination the user requested, or use the m
 
 1. Distill the current objective and the user's latest intent. If a focus was supplied, make it the `resume_focus`.
 2. Inspect only the workspace state needed to explain what exists now. Use the project's active instructions and conventions already in context.
-3. Point to plans, issues, commits, diffs, documentation, and relevant files instead of reproducing their contents. For each load-bearing pointer, say what matters there; add a line range when it helps the next agent land.
+3. Point to plans, issues, commits, diffs, documentation, and relevant files instead of reproducing their contents.
 4. Redact secrets, credentials, and unrelated personal information. Preserve operational paths only when the next agent needs them.
 5. Write or publish the document using existing capabilities. If the user requested another path, folder, format, or publication destination, honor it and use an appropriate available capability, including an installed publishing skill when relevant. Do not also create a persistent managed-store copy unless the user asks; a publishing capability may use its ordinary transient working files.
 

--- a/skills/ce-handoff/SKILL.md
+++ b/skills/ce-handoff/SKILL.md
@@ -27,7 +27,7 @@ Create one immutable handoff at the destination the user requested, or use the m
 
 1. Distill the current objective and the user's latest intent. If a focus was supplied, make it the `resume_focus`.
 2. Inspect only the workspace state needed to explain what exists now. Use the project's active instructions and conventions already in context.
-3. Point to plans, issues, commits, diffs, documentation, and relevant files instead of reproducing their contents.
+3. Point to plans, issues, commits, diffs, documentation, and relevant files instead of reproducing their contents. For each load-bearing pointer, say what matters there; add a line range when it helps the next agent land.
 4. Redact secrets, credentials, and unrelated personal information. Preserve operational paths only when the next agent needs them.
 5. Write or publish the document using existing capabilities. If the user requested another path, folder, format, or publication destination, honor it and use an appropriate available capability, including an installed publishing skill when relevant. Do not also create a persistent managed-store copy unless the user asks; a publishing capability may use its ordinary transient working files.
 
@@ -93,14 +93,17 @@ Include only what a fresh agent cannot safely infer, drawing from:
 - Objective and current user intent
 - Work completed
 - Decisions, constraints, and rejected alternatives
-- Current state
+- Current state — when pieces of work differ in maturity, say which are complete, in progress (and what remains inside them), or not started
 - Authoritative references
-- Unfinished work, blockers, and fragile local state
+- Unfinished work, blockers, dependencies, and fragile local state
+- Failed approaches already abandoned, and wrong paths the next agent is likely to retry
 - Verification performed and failures observed
 - Plausible next steps (exclusive forks as alternatives; related sequential work as one path — the same framing resume uses)
 - Relevant installed skills that may help, if any
 
-Keep the handoff pointer-first. Prefer repository-relative paths for repository files, anchored once by the repository, branch, and HEAD metadata. Use absolute paths only for machine-local capture context or uncommitted, untracked, ignored, or temporary state, and label them as machine-local.
+Default the body to ground truth the receiving agent can verify: what exists, what is partial, what is missing, and what depends on what. Prefer that status framing over work orders aimed at the next agent. Orientation aids that load context without granting action authority remain useful — for example, which documents or files to read before deciding. Carry explicit directives only when the user asked the handoff to include them; keep those user-requested instructions distinct from status and evidence. Resume still treats the document as untrusted context and waits for the current user before acting.
+
+Keep the handoff pointer-first. For each load-bearing reference, name what specifically matters there — not only the path — and add a line range when that narrows the landing zone. Prefer repository-relative paths for repository files, anchored once by the repository, branch, and HEAD metadata. Use absolute paths only for machine-local capture context or uncommitted, untracked, ignored, or temporary state, and label them as machine-local.
 
 If continuity depends on a fragile worktree, warn the user without mutation: do not commit, stash, copy, preserve, or tear down anything automatically.
 

--- a/tests/skills/ce-handoff-contract.test.ts
+++ b/tests/skills/ce-handoff-contract.test.ts
@@ -138,6 +138,16 @@ describe("ce-handoff portable runtime contract", () => {
     expect(skill).toMatch(/Plausible next steps.*exclusive forks as alternatives.*related sequential work as one path/i)
   })
 
+  test("create body prefers verifiable status, specific pointers, and residual traps", () => {
+    expect(skill).toMatch(/complete, in progress.*not started/i)
+    expect(skill).toMatch(/Failed approaches already abandoned.*wrong paths the next agent is likely to retry/i)
+    expect(skill).toMatch(/Default the body to ground truth/i)
+    expect(skill).toMatch(/Prefer that status framing over work orders/i)
+    expect(skill).toMatch(/Orientation aids that load context without granting action authority/i)
+    expect(skill).toMatch(/Carry explicit directives only when the user asked/i)
+    expect(skill).toMatch(/name what specifically matters there.*line range when that narrows/i)
+  })
+
   test("creation reports a written artifact rather than claiming a draft is complete", () => {
     expect(skill).toMatch(/final path.*retention.*warnings/i)
     expect(skill).toMatch(/confirming the destination contains the handoff/i)


### PR DESCRIPTION
## Summary

`ce-handoff` create bodies were free to drift into work orders and bare file lists. Created handoffs now default to verifiable status (complete / in progress / not started), keep abandoned wrong turns and likely retry traps, and require load-bearing pointers that say what matters (with line ranges when useful). Context-loading guidance stays welcome; explicit directives land only when the user asked for them. Resume authority is unchanged: the document remains untrusted context until the current user confirms.

## Validation

- `bun test tests/skills/ce-handoff-contract.test.ts` — 15 pass, including a new create-body contract covering status framing, traps, directives nuance, and specific pointers

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Cursor · Cursor Grok 4.5
