### PR TITLE
fix(ce-sweep): open state files with explicit UTF-8 encoding

### DIFF
--- a/skills/ce-sweep/scripts/sweep-state.py
+++ b/skills/ce-sweep/scripts/sweep-state.py
@@ -254,7 +254,7 @@ def load_state(path):
     """Return (status, data): ('absent', None), ('corrupt', None), or
     ('ok', dict). A file that parses but lacks schema_version is corrupt."""
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             # A machine-local state file can live under world-shared /tmp, and
             # it is a correctness dependency (lease, cursors, closed status) as
             # well as an injection sink (item bodies re-read into agent
@@ -268,7 +268,7 @@ def load_state(path):
             text = f.read()
     except FileNotFoundError:
         return ("absent", None)
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return ("corrupt", None)
     if not text.strip():
         return ("absent", None)
@@ -295,7 +295,7 @@ def write_state(path, state):
     os.makedirs(d, exist_ok=True)
     fd, tmp = tempfile.mkstemp(dir=d, prefix=".tmp-sweep-", suffix=".yml")
     try:
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
             f.write(text)
         os.replace(tmp, path)
     except BaseException:
@@ -606,9 +606,9 @@ def cmd_import_legacy(args):
 
 def _read_legacy(path):
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             raw = f.read()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     # Try JSON first (Cora persists JSON); fall back to our YAML subset.
     try:
@@ -764,7 +764,7 @@ _MUTATING = {
 def _run_locked(handler, args):
     lock_path = str(args.state) + ".lock"
     try:
-        lock_fd = open(lock_path, "w")
+        lock_fd = open(lock_path, "w", encoding="utf-8")
     except OSError:
         return handler(args)  # cannot create a lock file; degrade to unlocked
     try:

--- a/tests/sweep-state.test.ts
+++ b/tests/sweep-state.test.ts
@@ -587,14 +587,15 @@ describe("sweep-state engine — encoding (locale-independent UTF-8, #1306)", ()
       legacy,
       JSON.stringify({
         channels: { C111: { last_processed_ts: "1699999999.000100" } },
-        items: { "C111:1699999999.000100": { status: "acknowledged", note: TITLE } },
+        // title is one of the fields _import_legacy_items actually copies
+        items: { "C111:1699999999.000100": { status: "acknowledged", title: TITLE } },
       }),
     )
     const r = runGuarded(dir, "import-legacy", "--state", s, "--file", legacy)
     expect(status(r.stdout)).toBe("OK")
     expect(payload(r.stdout)).toEqual({ cursors_imported: 1, items_imported: 1 })
     const state = read(dir, s)
-    expect(state.items["C111:1699999999.000100"].note).toBe(TITLE)
+    expect(state.items["C111:1699999999.000100"].title).toBe(TITLE)
   })
 
   test("a state file with invalid UTF-8 bytes is CORRUPT, never a traceback", () => {

--- a/tests/sweep-state.test.ts
+++ b/tests/sweep-state.test.ts
@@ -526,3 +526,92 @@ describe("sweep-state engine — robustness", () => {
     expect(run(dir).code).not.toBe(0)
   })
 })
+
+describe("sweep-state engine — encoding (locale-independent UTF-8, #1306)", () => {
+  // PEP 597: with these vars set, any open()/os.fdopen() that falls back to
+  // the locale-default encoding raises EncodingWarning as an error, so the
+  // command tracebacks and loses its STATUS WORD. This makes the guard
+  // deterministic on UTF-8 CI machines, where the cp1252 corruption itself
+  // cannot reproduce.
+  function runGuarded(
+    cwd: string,
+    ...args: string[]
+  ): { code: number; stdout: string; stderr: string } {
+    const r = spawnSync("python3", [SCRIPT, ...args], {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PYTHONWARNDEFAULTENCODING: "1",
+        PYTHONWARNINGS: "error::EncodingWarning",
+      },
+    })
+    return {
+      code: r.status ?? -1,
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+    }
+  }
+
+  const TITLE = "em—dash and “curly” quotes"
+
+  test("non-ASCII round-trips as valid UTF-8 with LF endings, no locale-default open", () => {
+    const dir = tmp()
+    const s = statePath(dir)
+    expect(
+      status(
+        runGuarded(dir, "lease-acquire", "--state", s, "--writer", "w1", "--now", NOW).stdout,
+      ),
+    ).toBe("OK")
+    const up = runGuarded(
+      dir, "upsert-item", "--state", s, "--id", "i1", "--source", "src1",
+      "--writer", "w1", "--now", NOW,
+      "--json", JSON.stringify({ status: "ingested", title: TITLE }),
+    )
+    expect(status(up.stdout)).toBe("OK")
+    const bytes = readFileSync(s)
+    // fatal: true throws on the invalid single-byte cp1252 encoding this bug produced
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    expect(text).toContain("em—dash")
+    expect(text).not.toContain("\r")
+    const rd = runGuarded(dir, "read", "--state", s)
+    expect(status(rd.stdout)).toBe("OK")
+    expect(payload(rd.stdout).items["src1:i1"].title).toBe(TITLE)
+  })
+
+  test("import-legacy reads a non-ASCII legacy file without locale-default open", () => {
+    const dir = tmp()
+    const s = statePath(dir)
+    const legacy = path.join(dir, "legacy.json")
+    writeFileSync(
+      legacy,
+      JSON.stringify({
+        channels: { C111: { last_processed_ts: "1699999999.000100" } },
+        items: { "C111:1699999999.000100": { status: "acknowledged", note: TITLE } },
+      }),
+    )
+    const r = runGuarded(dir, "import-legacy", "--state", s, "--file", legacy)
+    expect(status(r.stdout)).toBe("OK")
+    expect(payload(r.stdout)).toEqual({ cursors_imported: 1, items_imported: 1 })
+    const state = read(dir, s)
+    expect(state.items["C111:1699999999.000100"].note).toBe(TITLE)
+  })
+
+  test("a state file with invalid UTF-8 bytes is CORRUPT, never a traceback", () => {
+    const dir = tmp()
+    const s = statePath(dir)
+    // schema-shaped prefix + a lone 0x97 (cp1252 em-dash), invalid as UTF-8 —
+    // exactly what a pre-fix Windows run left behind
+    writeFileSync(
+      s,
+      Buffer.concat([
+        Buffer.from("schema_version: 1\nsources: {}\nitems: {}\n# ", "utf8"),
+        Buffer.from([0x97]),
+        Buffer.from("\n", "utf8"),
+      ]),
+    )
+    const r = run(dir, "read", "--state", s)
+    expect(r.code).toBe(0)
+    expect(status(r.stdout)).toBe("CORRUPT")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #1306.

`sweep-state.py` opened the state file, the legacy-import file, and the lock file with the locale-default encoding. On non-UTF-8 locales (Windows with cp1252), non-ASCII item text (em-dashes, curly quotes - common in real GitHub/Slack content) was silently written as single locale bytes, producing an invalid-UTF-8 committed state file that breaks any strict reader: CI, a stricter YAML parser, or a teammate on Linux/macOS pulling the same shared-branch state.

## Changes

- `load_state()`, `_read_legacy()`, `write_state()`, and the lock-file `open()` now pass `encoding="utf-8"` explicitly.
- `write_state()` also pins `newline="
"` so Windows runs cannot introduce CRLF churn into the shared committed file.
- Strict decoding makes `UnicodeDecodeError` reachable on the two read paths: `load_state()` maps it to `CORRUPT` and `_read_legacy()` to `None`, preserving the script's never-traceback contract for state files corrupted by pre-fix runs.

## Validation

New `describe` block in `tests/sweep-state.test.ts` runs the script with PEP 597 (`PYTHONWARNDEFAULTENCODING=1` + `PYTHONWARNINGS=error::EncodingWarning`), so any locale-default open raises and loses its STATUS WORD - the guard fails deterministically on UTF-8 CI machines, where the cp1252 corruption itself cannot reproduce. Three tests: non-ASCII round-trip yielding valid UTF-8/LF-only bytes, import-legacy of a non-ASCII legacy file, and an invalid-UTF-8 state file yielding `CORRUPT` with exit 0.

Also verified manually on Windows 11 (cp1252, Python 3.11): the pre-fix script reproduces the exact reported corruption (lone `0x97` byte, `UnicodeDecodeError` on strict decode); the patched script round-trips em-dash and curly quotes as valid UTF-8.

## Security Disclosure

No security-relevant changes. No shell/exec introduced or changed; the diff adds explicit encoding arguments to existing file opens and adds tests.

## Agent Disclosure

Claude Code - claude-fable-5
