### PR TITLE
fix(ce-commit): lean skill for stronger models, keep load-bearing protocol

### DIFF
--- a/docs/skills/ce-commit.md
+++ b/docs/skills/ce-commit.md
@@ -27,8 +27,8 @@ Manual commits go wrong in predictable ways:
 - **Wrong commit convention** — defaulting to conventional commits when the repo uses ticket-prefix style, or vice versa
 - **Mixing distinct concerns** — backend models + frontend components + docs all in one commit because nobody bothered to split
 - **Subject lines that describe what changed, not why** — `update foo.rb` tells future readers nothing
-- **Detached-HEAD commits** that the user doesn't realize will be hard to recover later
-- **Default-branch commits** that surprise the user (no warning before committing to `main`)
+- **Detached-HEAD commits** that are hard to recover later
+- **Default-branch commits** that fight PR workflow and branch protection
 
 ## The Solution
 
@@ -37,8 +37,7 @@ Manual commits go wrong in predictable ways:
 - **Convention detection** — repo conventions in context first, then recent 10 commits, then conventional-commits fallback
 - **Explicit staging** — never `git add -A`/`git add .`; stage files by name
 - **Logical splitting** at the file level (no `git add -p`) when 2-3 distinct concerns are present; single commit when ambiguous
-- **Detached-HEAD handling** — asks whether to create a feature branch before committing
-- **Default-branch warning** — asks before committing to `main`/`master`
+- **Detached HEAD / default branch** — automatically creates a feature branch (commit-only still must not leave work only on detached HEAD or the default branch)
 - **Heredoc commit messages** — preserves multi-line formatting without shell-escape pain
 
 ---
@@ -70,18 +69,11 @@ The deliberate avoidance is documented in the skill — `git add -A` and `git ad
 
 Before staging, the skill scans changed files for naturally distinct concerns. If files clearly group into 2-3 separate logical changes (a refactor in one directory, a new feature in another; or test files for a different change than source files), the skill creates separate commits. Splits happen at the **file level only** — no `git add -p`, no hunk-level interactive splitting. When the split is ambiguous, one commit is fine. The sweet spot is 2-3 commits, not many tiny ones.
 
-### 4. Detached-HEAD handling
+### 4. Detached HEAD and default branch — auto feature branch
 
-If the current branch is empty (detached HEAD), the skill explains the situation and asks whether to create a feature branch first. The user can:
+If HEAD is detached, or the current branch is `main`/`master`/the resolved default, the skill creates a feature branch from the change content and continues there. It does not ask and does not commit on the default branch or leave work only on a detached HEAD.
 
-- Create a branch (skill derives the name from change content)
-- Continue with the detached-HEAD commit (rarely the right answer)
-
-### 5. Default-branch warning
-
-If the current branch is `main`, `master`, or the resolved default branch, the skill warns before committing and offers to create a feature branch first. This prevents the case where someone accidentally commits to the default branch in a repo with branch-protection that they'll have to back out.
-
-### 6. Heredoc commit messages — clean multi-line formatting
+### 5. Heredoc commit messages — clean multi-line formatting
 
 The skill uses a `cat <<'EOF'` heredoc for the commit message so multi-line bodies preserve their formatting. Example:
 
@@ -97,9 +89,9 @@ EOF
 
 The quoted sentinel (`'EOF'`) prevents `$VAR`, backticks, and embedded `EOF` from being expanded inside the body.
 
-### 7. Subject focused on *why*, not *what*
+### 6. Subject focused on outcome, not file inventory
 
-The skill writes subject lines in imperative mood, focused on motivation rather than mechanical description. "Fix double-submit on checkout" beats "Update checkout.rb." The body explains motivation, trade-offs, or context a future reader would need; it's omitted for obvious single-purpose changes.
+The skill writes subject lines in imperative mood that name what is now possible or fixed. "Fix double-submit on checkout" beats "Update checkout.rb." A body is added only when the motivation is not obvious from the subject.
 
 ---
 
@@ -177,8 +169,8 @@ There are no arguments. Convention detection, file grouping, and message composi
 | 1 | Gather context (git status, diff, branch, recent commits, default branch) |
 | 2 | Determine commit message convention (instructions > recent history > conventional-commits) |
 | 3 | Consider logical commits (file-level split when concerns are clearly distinct) |
-| 4 | Stage and commit (per-group; warn on default branch; handle detached HEAD) |
-| 5 | Confirm via `git status`; report commit hashes |
+| 4–6 | Convention, logical split, message, stage/commit (auto-branch if needed) |
+| 7 | Confirm via `git status`; report commit hashes |
 
 ---
 
@@ -193,8 +185,8 @@ Because hunk-level splitting (`git add -p`) is interactive and fragile in agent 
 **What if my repo uses a non-standard convention?**
 The skill detects from project instructions first (which is the right place to document conventions), then recent commit history (which is the de facto convention even when not documented). Conventional commits is just the fallback when neither source applies.
 
-**Why ask before committing on the default branch?**
-Because most repos with branch protection will reject a default-branch commit, and the user usually didn't intend to commit there. The warning catches the case before anything irreversible happens.
+**Why auto-create a feature branch on the default branch or detached HEAD?**
+Committing on the default branch fights normal PR workflows and branch protection; a detached HEAD commit is easy to lose. Creating a feature branch is the safe default and matches `ce-commit-push-pr`.
 
 **What if I want to push and PR after?**
 Use `/ce-commit-push-pr` for the full flow, or run `git push` and `gh pr create` manually after this skill commits.

--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -1,88 +1,54 @@
 ---
 name: ce-commit
-description: Create a git commit with a clear, value-communication message. Use when the user asks to commit/save staged or unstaged changes with a repo-appropriate, value-communicating message.
+description: Create a git commit with a clear, value-communicating message. Use when the user asks to commit/save staged or unstaged changes with a repo-appropriate message.
 ---
 
 # Git Commit
 
-Create a single, well-crafted git commit from the current working tree changes.
+Create well-crafted local commit(s) from the current working tree. No push, no PR — use `ce-commit-push-pr` for the full ship flow.
+
+**Done when:** each logical change is committed with an explicit file list and a message that states the outcome, and `git status` is clean of those changes. **Stop when:** the tree is clean (nothing to commit).
 
 ## Context
 
-Gather the working-tree context by running each command below as its **own** shell tool call — a single argv-style invocation (just the program and its arguments). Do **not** join them with `;`, `&&`, `||`, pipes, `$(...)`, or redirects like `2>/dev/null`: that syntax parses only under POSIX shells and aborts under Windows PowerShell. Read each command's exit status directly — a non-zero exit is a normal state to interpret, not a failure to suppress.
+Gather context with each command as its **own** shell tool call (program + args only). Do **not** join with `;`, `&&`, `||`, pipes, `$(...)`, or redirects — that syntax fails under Windows PowerShell. A non-zero exit is a normal state to interpret, not a failure to suppress.
 
-| Command | Purpose | Non-zero exit / empty output means |
+| Command | Purpose | Non-zero / empty means |
 | --- | --- | --- |
-| `git status` | Working-tree state | Not a git repository — report and stop |
-| `git diff HEAD` | Uncommitted changes | Unborn repo with no commits yet — treat every tracked change as new |
-| `git branch --show-current` | Current branch | Empty output = detached HEAD |
-| `git log --oneline -10` | Recent commit style | Unborn repo — no history to match yet |
-| `git rev-parse --abbrev-ref origin/HEAD` | Remote default branch | No `origin/HEAD` set — resolve the default branch per Step 1 |
+| `git status` | Working-tree state | Not a git repo — stop |
+| `git diff HEAD` | Uncommitted changes | Unborn repo / no commits yet |
+| `git branch --show-current` | Current branch | Empty = detached HEAD |
+| `git log --oneline -10` | Recent message style | Unborn repo — no history |
+| `git rev-parse --abbrev-ref origin/HEAD` | Remote default branch | Resolve via `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`, else `main` |
 
-These values are a snapshot taken before any action. Re-read anything consequential (the current branch, the staged set) immediately before committing, since the working tree can change between gathering context and acting on it.
-
----
+Treat this as a snapshot. Re-read branch and staged set immediately before committing if anything may have changed.
 
 ## Workflow
 
-### Step 1: Gather context
+0. **Gather** — run every Context command above (own shell call each), then continue.
 
-Run the commands from the **Context** section above (git status, working tree diff, current branch, recent commits, remote default branch), each as its own shell tool call.
+1. **Nothing to commit** — if `git status` shows no staged, modified, or untracked files, report that and stop. Do not use `git diff HEAD` alone as cleanliness (it misses untracked files).
 
-The remote default branch value returns something like `origin/main`. Strip the `origin/` prefix to get the branch name. If that command exited non-zero (no `origin/HEAD` set) or returned a bare `HEAD`, try:
+2. **Branch first** — if detached HEAD, or on the default branch (`main` / `master` / resolved default above), create a feature branch from the change content (`git checkout -b <name>`), then re-read `git branch --show-current`. Do not ask — commit-only still must not leave work only on a detached HEAD or the default branch. If the derived name exists, pick a non-conflicting suffix.
 
-```bash
-gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
-```
+3. **Convention** — match project commit conventions already in context; else match the recent log pattern; else conventional commits (`type(scope): description`). When using conventional commits and `fix`/`feat` both fit, default to `fix:` (remedying broken or missing behavior); reserve `feat:` for new capabilities. User override wins.
 
-If both fail, fall back to `main`.
+4. **Logical commits** — if changed files clearly split into distinct concerns, make separate commits (file level only, 2–3 max, no `git add -p`). If ambiguous, one commit.
 
-If `git status` shows a clean working tree (no staged, modified, or untracked files), report that there is nothing to commit and stop.
+5. **Message** — subject is imperative and names the outcome (what is now possible or fixed), not the file list. Body only when motivation or trade-offs are not obvious from the subject.
 
-If the current branch is empty, the repository is in detached HEAD state. Explain that a branch is required before committing if the user wants this work attached to a branch. Ask whether to create a feature branch now. Use the platform's blocking question tool: `AskUserQuestion` in Claude Code (call `ToolSearch` with `select:AskUserQuestion` first if its schema isn't loaded), `request_user_input` in Codex, `ask_question` in Antigravity CLI (`agy`), `ask_user` in Pi (requires the `pi-ask-user` extension). Fall back to presenting options in chat only when no blocking tool exists in the harness or the call errors (e.g., Codex edit modes) — not because a schema load is required. Never silently skip the question.
+   - Bad: `Update checkout.rb` / `Add tests and fix stuff`
+   - Good: `Fix double-submit on checkout`
 
-- If the user chooses to create a branch, derive the name from the change content, create it with `git checkout -b <branch-name>`, then run `git branch --show-current` again and use that result as the current branch name for the rest of the workflow.
-- If the user declines, continue with the detached HEAD commit.
-
-### Step 2: Determine commit message convention
-
-Follow this priority order:
-
-1. **Repo conventions already in context** -- If project instructions (AGENTS.md, CLAUDE.md, or similar) are already loaded and specify commit message conventions, follow those. Do not re-read these files; they are loaded at session start.
-2. **Recent commit history** -- If no explicit convention is documented, examine the 10 most recent commits from Step 1. If a clear pattern emerges (e.g., conventional commits, ticket prefixes, emoji prefixes), match that pattern.
-3. **Default: conventional commits** -- If neither source provides a pattern, use conventional commit format: `type(scope): description` where type is one of `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `ci`, `style`, `build`.
-
-When using conventional commits, choose the type that most precisely describes the change (the type list above). Where `fix:` and `feat:` both seem to fit, default to `fix:`: a change that remedies broken or missing behavior is `fix:` even when implemented by adding code. Reserve `feat:` for capabilities the user could not previously accomplish. Other types remain primary when they fit better. The user may override for a specific change.
-
-### Step 3: Consider logical commits
-
-Before staging everything together, scan the changed files for naturally distinct concerns. If modified files clearly group into separate logical changes (e.g., a refactor in one directory and a new feature in another, or test files for a different change than source files), create separate commits for each group.
-
-Keep this lightweight:
-- Group at the **file level only** -- do not use `git add -p` or try to split hunks within a file.
-- If the separation is obvious (different features, unrelated fixes), split. If it's ambiguous, one commit is fine.
-- Two or three logical commits is the sweet spot. Do not over-slice into many tiny commits.
-
-### Step 4: Stage and commit
-
-If the current branch from the context above is `main`, `master`, or the resolved default branch from Step 1, automatically create a feature branch before committing. Derive the branch name from the change content, create it with `git checkout -b <branch-name>`, run `git branch --show-current` to confirm, and use the new branch as the current branch for the rest of the workflow. Do not ask whether to branch — committing on the default branch is not an option here.
-
-Write the commit message:
-- **Subject line**: Concise, imperative mood, focused on *why* not *what*. Follow the convention determined in Step 2.
-- **Body** (when needed): Add a body separated by a blank line for non-trivial changes. Explain motivation, trade-offs, or anything a future reader would need. Omit the body for obvious single-purpose changes.
-
-For each commit group, stage and commit in a single call. Prefer staging specific files by name over `git add -A` or `git add .` to avoid accidentally including sensitive files (.env, credentials) or unrelated changes. Use a heredoc to preserve formatting:
+6. **Stage and commit** — stage **named files only** (never `git add -A` or `git add .`). Prefer one shell call per commit group:
 
 ```bash
 git add file1 file2 file3 && git commit -m "$(cat <<'EOF'
 type(scope): subject line here
 
-Optional body explaining why this change was made,
-not just what changed.
+Optional body when the why is not obvious from the subject.
 EOF
 )"
 ```
 
-### Step 5: Confirm
-
-Run `git status` after the commit to verify success. Report the commit hash(es) and subject line(s).
+7. **Confirm** — `git status`; report hash(es) and subject(s).

--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -19,9 +19,11 @@ Gather context with each command as its **own** shell tool call (program + args 
 | `git diff HEAD` | Uncommitted changes | Unborn repo / no commits yet |
 | `git branch --show-current` | Current branch | Empty = detached HEAD |
 | `git log --oneline -10` | Recent message style | Unborn repo — no history |
-| `git rev-parse --abbrev-ref origin/HEAD` | Remote default branch | Resolve via `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`, else `main` |
+| `git rev-parse --abbrev-ref origin/HEAD` | Remote default branch | No `origin/HEAD` / bare `HEAD` — try `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`, else `main` |
 
 Treat this as a snapshot. Re-read branch and staged set immediately before committing if anything may have changed.
+
+**Default branch name:** strip a leading `origin/` from `origin/HEAD` (so `origin/trunk` → `trunk`). Use that bare name for all “on the default branch?” checks — never compare against `origin/<name>`.
 
 ## Workflow
 
@@ -29,7 +31,7 @@ Treat this as a snapshot. Re-read branch and staged set immediately before commi
 
 1. **Nothing to commit** — if `git status` shows no staged, modified, or untracked files, report that and stop. Do not use `git diff HEAD` alone as cleanliness (it misses untracked files).
 
-2. **Branch first** — if detached HEAD, or on the default branch (`main` / `master` / resolved default above), create a feature branch from the change content (`git checkout -b <name>`), then re-read `git branch --show-current`. Do not ask — commit-only still must not leave work only on a detached HEAD or the default branch. If the derived name exists, pick a non-conflicting suffix.
+2. **Branch first** — if detached HEAD, or on the default branch (`main` / `master` / the bare default name above), create a feature branch from the change content (`git checkout -b <name>`), then re-read `git branch --show-current`. Do not ask — commit-only still must not leave work only on a detached HEAD or the default branch. If the derived name exists, pick a non-conflicting suffix.
 
 3. **Convention** — match project commit conventions already in context; else match the recent log pattern; else conventional commits (`type(scope): description`). When using conventional commits and `fix`/`feat` both fit, default to `fix:` (remedying broken or missing behavior); reserve `feat:` for new capabilities. User override wins.
 

--- a/tests/ce-commit-contract.test.ts
+++ b/tests/ce-commit-contract.test.ts
@@ -31,6 +31,9 @@ describe("ce-commit contract", () => {
     expect(content).toMatch(/default branch/i)
     expect(content).toContain("git checkout -b")
     expect(content).toMatch(/Do not ask/)
+    // Bare default name for comparison — origin/trunk must not skip auto-branch
+    expect(content).toMatch(/strip a leading `origin\/`/)
+    expect(content).toMatch(/never compare against `origin\/<name>`/)
     // No blocking-question adapter — commit-only has no interactive branch ask
     expect(content).not.toContain("AskUserQuestion")
     expect(content).not.toContain("request_user_input")

--- a/tests/ce-commit-contract.test.ts
+++ b/tests/ce-commit-contract.test.ts
@@ -1,0 +1,71 @@
+import { readFile } from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+
+async function readRepoFile(relativePath: string): Promise<string> {
+  return readFile(path.join(process.cwd(), relativePath), "utf8")
+}
+
+describe("ce-commit contract", () => {
+  test("keeps argv-only context gathering and status-based cleanliness", async () => {
+    const content = await readRepoFile("skills/ce-commit/SKILL.md")
+
+    expect(content).toContain("own** shell tool call")
+    expect(content).toMatch(/Do \*\*not\*\* join with `;`, `&&`, `\|\|`/)
+    expect(content).toContain("`git status`")
+    expect(content).toContain("`git diff HEAD`")
+    expect(content).toContain("`git branch --show-current`")
+    expect(content).toContain("`git log --oneline -10`")
+    // Workflow forces gather before branch/commit decisions (order is load-bearing)
+    expect(content).toMatch(
+      /0\.\s+\*\*Gather\*\* — run every Context command above/,
+    )
+    // Cleanliness is status-based; diff alone misses untracked files
+    expect(content).toMatch(/Do not use `git diff HEAD` alone as cleanliness/)
+  })
+
+  test("auto-branches off default and detached HEAD without asking", async () => {
+    const content = await readRepoFile("skills/ce-commit/SKILL.md")
+
+    expect(content).toMatch(/detached HEAD/i)
+    expect(content).toMatch(/default branch/i)
+    expect(content).toContain("git checkout -b")
+    expect(content).toMatch(/Do not ask/)
+    // No blocking-question adapter — commit-only has no interactive branch ask
+    expect(content).not.toContain("AskUserQuestion")
+    expect(content).not.toContain("request_user_input")
+  })
+
+  test("forbids blanket staging and requires named files", async () => {
+    const content = await readRepoFile("skills/ce-commit/SKILL.md")
+
+    expect(content).toMatch(/never `git add -A` or `git add \.`/)
+    expect(content).toContain("named files")
+    expect(content).toContain("git add file1 file2 file3")
+    expect(content).toContain("<<'EOF'")
+  })
+
+  test("defaults fix over feat and leads messages with outcome", async () => {
+    const content = await readRepoFile("skills/ce-commit/SKILL.md")
+
+    expect(content).toMatch(/default to `fix:`/)
+    expect(content).toMatch(/reserve `feat:`/i)
+    expect(content).toMatch(/names the outcome/)
+    expect(content).toContain("Fix double-submit on checkout")
+    expect(content).toContain("Update checkout.rb")
+  })
+
+  test("scopes to local commits and points ship flow at ce-commit-push-pr", async () => {
+    const content = await readRepoFile("skills/ce-commit/SKILL.md")
+
+    expect(content).toMatch(/No push, no PR/)
+    expect(content).toContain("ce-commit-push-pr")
+  })
+
+  test("does not hardcode instruction filenames on the read path", async () => {
+    const content = await readRepoFile("skills/ce-commit/SKILL.md")
+
+    expect(content).not.toMatch(/AGENTS\.md|CLAUDE\.md|GEMINI\.md/)
+    expect(content).toMatch(/project commit conventions already in context/)
+  })
+})


### PR DESCRIPTION
## Summary

`ce-commit` was an 88-line skill that mixed load-bearing git protocol with weaker-model scaffolding (long detached-HEAD ask paths, duplicated gather restatement, instruction-file names on the read path). This rewrites it leaner so capable models get a short outcome spine and numbered workflow, while keeping the protocol that prevents real failures.

### Size savings

| Surface | Before (`main`) | After | Savings |
|---|---:|---:|---:|
| `skills/ce-commit/SKILL.md` | 88 lines | 54 lines | **−39%** (−34 lines) |

### What stayed (protocol)

- Argv-only Context table (PowerShell-safe)
- Status-based cleanliness (not `git diff HEAD` alone)
- Named-file staging — never `git add -A` / `git add .`
- Heredoc commits, fix-over-feat, logical file-level splits
- **Gather first** (workflow step 0) before branch/message/commit
- Auto feature branch on detached HEAD and default branch (no ask)

### What left

- Blocking-question adapter (no remaining asks)
- Detached-HEAD “continue detached” branch
- Restated Context/Step 1 prose and hardcoded AGENTS/CLAUDE filenames

### Docs + tests

- `docs/skills/ce-commit.md` aligned with auto-branch behavior
- `tests/ce-commit-contract.test.ts` pins gather-first, staging, conventions, branch routing

## Validation

- `bun test tests/ce-commit-contract.test.ts` — 6 pass
- Paired behavioral evals (old 88 vs new 54): mean NEW 100% on message, ticket-prefix convention, default-branch, detached-head (no ask), staging, gather-order

## Security Disclosure

No security-relevant changes. Skill prose, docs, and mechanical contract tests only.

## Agent Disclosure

- **Model:** Grok Build · grok-4.5
