### PR TITLE
docs(readme): explain portable subagent workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The first pass tightens recent branch changes before review. The targeted pass i
 
 After installing, run `/ce-setup` in any project. It checks repo-local config, reports optional tool capabilities, and helps keep machine-local CE settings safely gitignored.
 
-The `compound-engineering` plugin currently ships 32 skills and 0 standalone agents. Specialist review, research, and workflow behavior lives inside the owning skills as skill-local prompt assets.
+The `compound-engineering` plugin currently ships 32 skills. Its core workflows spawn specialist subagents on demand for research, review, planning, and implementation. Each skill seeds generic subagents with its own prompts instead of relying on standalone plugin agents, keeping the workflows portable across harnesses that handle formal agent definitions differently.
 
 ### Full Skill Inventory
 


### PR DESCRIPTION
## Summary

Clarifies that Compound Engineering's skills spawn specialist subagents on demand, and explains why skill-local prompts keep those workflows portable across harnesses with different approaches to formal agent definitions.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** `Orca · GPT-5`
