### PR TITLE
fix(cross-model): send grok peers the prompt verbatim on read-only routes

### DIFF
--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -224,7 +224,9 @@ adapter_argv() {
     grok-cli)
       # Read allowed (in-tree context); deny writes / shell / subagents / web / MCP.
       # Schema forces non-streaming json on grok — keep hard-only (no PEERLOG idle).
-      printf '%s\0' grok --prompt-file "$PROMPT_FILE" --model "$(route_model grok-cli)" --effort high \
+      # --verbatim: without it grok offloads a large prompt to a session file and
+      # sends only a preview, spending scarce turns to re-read what it was given.
+      printf '%s\0' grok --prompt-file "$PROMPT_FILE" --verbatim --model "$(route_model grok-cli)" --effort high \
         --cwd "$PEER_WORKDIR" --permission-mode dontAsk
       [ -z "${LARGE_DIFF_CONTEXT_DIR:-}" ] || printf '%s\0' --allow "Read($LARGE_DIFF_CONTEXT_DIR/**)"
       printf '%s\0' --deny Edit --deny Write --deny Bash --deny Task --deny 'mcp__*' \

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -221,7 +221,9 @@ adapter_argv() {
       ;;
     grok-cli)
       # Schema forces buffered json — hard-only, no PEERLOG idle (#1270).
-      printf '%s\0' grok --prompt-file "$PROMPT_FILE" --model "$(route_model grok-cli)" --effort high \
+      # --verbatim: without it grok offloads a large prompt to a session file and
+      # sends only a preview — unrecoverable here, because Read is denied below.
+      printf '%s\0' grok --prompt-file "$PROMPT_FILE" --verbatim --model "$(route_model grok-cli)" --effort high \
         --cwd "$PEER_WORKDIR" --permission-mode dontAsk \
         --deny Read --deny Edit --deny Write --deny Bash --deny Task --deny 'mcp__*' \
         --disable-web-search --no-subagents --max-turns 15 \

--- a/skills/ce-pov/scripts/cross-model-pov.sh
+++ b/skills/ce-pov/scripts/cross-model-pov.sh
@@ -216,7 +216,9 @@ adapter_argv() {
       ;;
     grok-cli)
       # Schema forces buffered json — hard-only, no PEERLOG idle (#1270).
-      printf '%s\0' grok --prompt-file "$PROMPT_FILE" --model "$(route_model grok-cli)" --effort high \
+      # --verbatim: without it grok offloads a large prompt to a session file and
+      # sends only a preview, spending scarce turns to re-read what it was given.
+      printf '%s\0' grok --prompt-file "$PROMPT_FILE" --verbatim --model "$(route_model grok-cli)" --effort high \
         --cwd "$READ_ROOT" --permission-mode dontAsk \
         --deny Edit --deny Write --deny Bash --deny Task --deny 'mcp__*' \
         --no-subagents --max-turns 15 \

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -346,6 +346,9 @@ printf '%s' '{"structured_output":{"reviewer":"adversarial","findings":[],"resid
     expect(cmd).toContain("--deny Edit")
     expect(cmd).toContain("--deny Write")
     expect(cmd).toContain("--deny Bash")
+    // Without --verbatim grok offloads a large prompt to a session file and
+    // sends only a preview, so the peer reviews a diff it never received.
+    expect(cmd).toContain("--verbatim")
     expect(cmd).toContain("--disable-web-search")
     expect(cmd).toContain("--no-subagents")
     expect(cmd).toContain("--permission-mode dontAsk")

--- a/tests/skills/ce-doc-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-doc-review-cross-model-routes.test.ts
@@ -280,6 +280,9 @@ printf '%s' '{"structured_output":{"reviewer":"adversarial","findings":[],"resid
   test("grok CLI: deny Read + web/subagents off + dontAsk + effort high", () => {
     const cmd = emitAdapter("grok-cli")
     expect(cmd).toContain("--deny Read")
+    // Load-bearing with --deny Read: without --verbatim grok offloads a large
+    // prompt to a session file the peer is then forbidden to read back.
+    expect(cmd).toContain("--verbatim")
     expect(cmd).toContain("--disable-web-search")
     expect(cmd).toContain("--no-subagents")
     expect(cmd).toContain("--permission-mode dontAsk")

--- a/tests/skills/ce-pov-cross-model-routes.test.ts
+++ b/tests/skills/ce-pov-cross-model-routes.test.ts
@@ -107,6 +107,9 @@ describe("ce-pov cross-model route safety", () => {
     expect(emit("grok-cli")).toContain("--deny Edit")
     expect(emit("grok-cli")).toContain("--deny Write")
     expect(emit("grok-cli")).toContain("--deny Bash")
+    // Without --verbatim grok offloads a large prompt to a session file and
+    // sends only a preview, so the peer answers on context it never received.
+    expect(emit("grok-cli")).toContain("--verbatim")
     expect(emit("grok-cli")).toContain("--output-format json")
     expect(emit("grok-cli")).not.toContain("stream-json")
     for (const route of ["grok-cursor", "cursor", "composer"]) {


### PR DESCRIPTION
## Problem

`grok --prompt-file` does not send the file as given. Past roughly 50KB the CLI writes a large-prompt offload file, inlines a bounded preview in its place, and expects the agent to read the remainder back with a file tool. The mechanism is observable in the binary itself (grok 0.2.118 carries the string `failed to write large-prompt offload file; sending bounded preview with no file reference`). `--verbatim` is documented as "Send the prompt exactly as given" and turns it off.

Three of the four peer scripts never pass it:

| script | `--verbatim` |
|---|---|
| `skills/ce-code-review/scripts/cross-model-adversarial-review.sh` | missing |
| `skills/ce-doc-review/scripts/cross-model-doc-review.sh` | missing |
| `skills/ce-pov/scripts/cross-model-pov.sh` | missing |
| `skills/ce-work/scripts/cross-model-work.sh` | present |

On `ce-doc-review`, which passes `--deny Read`, the offloaded prompt is unrecoverable. The observed symptom is a peer that reviews only the tail of the document and returns confident, schema-valid findings about it — or, in one run, findings quoting text that does not exist in the document at all. Neither failure is visible downstream: the artifact is well-formed and carries `independence_verified: true`.

On `ce-code-review` and `ce-pov`, which do allow Read, it is a degradation rather than a guaranteed loss: the offload file lands outside the `--cwd` they pin, and any recovery attempt spends turns against a tight `--max-turns` on a `--json-schema` route that returns nothing at all if it runs out.

## Why it was missed

`ce-work` already has the flag, and it also grants `--tools Read,Write,Edit`, so it is safe twice over and could recover an offloaded prompt without the flag. The flag landed first on the one route whose permissions made it least necessary, and was never carried to the stricter reviewers, where it is the only thing standing between a peer and a review of content it never received.

The fix is the flag, not weaker isolation. `--deny Read` stays exactly as it is.

## Verification

Isolated A/B, grok-4.5, identical flags, question placed at the head of the payload:

| prompt size | `--verbatim` | result |
|---|---|---|
| 17,637 B | no | correct (below the offload threshold) |
| 52,302 B | no | peer narrates "the direct read was blocked", answers `NO_DOCUMENT` |
| 52,302 B | yes | correct |

End-to-end through `cross-model-doc-review.sh` itself, same lens and document, measuring where in the document each returned evidence quote actually appears:

| arm | quotes verified present | position in document |
|---|---|---|
| stock | 6/6 | 96%, 97%, 98%, 99%, 99%, 96% |
| patched | 11/11 | 11%–51% |

The control arm's quotes are all genuine. They are all drawn from the final 4% of the file, because that is all the peer received.

## Changes

`--verbatim` added to the `grok-cli` adapter in the three scripts that lack it, with a rationale comment at each site. Each script's existing route-safety test now pins the flag; all three assertions fail against the pre-fix scripts.

`bun run test` 2908 pass / 0 fail across 110 files. `release:validate` and `plugin:validate --strict` both pass.

## Follow-up, not included here

Neither failure shape is detectable at synthesis today. An evidence-quote existence check would catch the fabricating run and miss the truncating one, since its quotes are real. A positional check — evidence clustering in the tail of the document means the peer never saw the body — would catch both. That is a design change to synthesis rather than a one-flag fix, so it is left for a separate issue.
