### PR TITLE
fix(ce-babysit-pr): decode gh output as UTF-8 on Windows

### DIFF
--- a/skills/ce-babysit-pr/scripts/pr-snapshot
+++ b/skills/ce-babysit-pr/scripts/pr-snapshot
@@ -272,7 +272,7 @@ def _iso(dt):
 
 
 def _run(cmd):
-    return subprocess.run(cmd, capture_output=True, text=True)
+    return subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8")
 
 
 def _run_checked(cmd, label):
@@ -2001,7 +2001,7 @@ def _process_identity(pid):
         return _win_process_identity(pid)
     try:
         r = subprocess.run(["ps", "-p", str(pid), "-o", "lstart=", "-o", "command="],
-                           capture_output=True, text=True)
+                           capture_output=True, text=True, encoding="utf-8")
     except OSError:
         return None   # no ps on PATH: unproven identity, same as a failed lookup
     if r.returncode != 0:

--- a/tests/ce-babysit-pr-snapshot.test.ts
+++ b/tests/ce-babysit-pr-snapshot.test.ts
@@ -3508,3 +3508,39 @@ print(json.dumps({"ids": [t["thread_id"] for t in threads], "calls": calls}))
     expect(watch(sd, withNew).reason).toBe("actionable")
   }, 15000)
 })
+
+// UTF-8 gh/git output under a non-UTF-8 locale (issue #1346)
+//
+// _run() used subprocess.run(..., text=True) with no encoding=, so Python decoded
+// stdout with the locale encoding (cp1252 on Windows, ascii under C). gh emits UTF-8;
+// a curly quote (U+201D, last byte 0x9d) crashed the reader thread and left stdout None.
+// Forcing C + PYTHONUTF8=0 reproduces that decode failure on UTF-8 CI.
+describe("pr-snapshot _run pins UTF-8 under a non-UTF-8 locale (#1346)", () => {
+  const NON_UTF8_LOCALE = {
+    ...process.env,
+    LC_ALL: "C",
+    LANG: "C",
+    LC_CTYPE: "C",
+    PYTHONUTF8: "0",
+    PYTHONCOERCECLOCALE: "0",
+  }
+
+  test("_run decodes UTF-8 curly-quote stdout instead of raising UnicodeDecodeError", () => {
+    const python = `
+import json, sys
+from importlib.machinery import SourceFileLoader
+m = SourceFileLoader("prs", ${JSON.stringify(SCRIPT)}).load_module()
+child = [sys.executable, "-c",
+         "import sys; sys.stdout.buffer.write(b'{\\"title\\": \\"hello \\\\xe2\\\\x80\\\\x9d world\\"}')"]
+r = m._run(child)
+print(json.dumps({"returncode": r.returncode, "stdout": r.stdout, "title": json.loads(r.stdout)["title"]}))
+`
+    const r = spawnSync("python3", ["-c", python], { encoding: "utf8", env: NON_UTF8_LOCALE })
+    expect(r.status, r.stderr).toBe(0)
+    expect(JSON.parse(r.stdout)).toEqual({
+      returncode: 0,
+      stdout: '{"title": "hello \u201d world"}',
+      title: "hello \u201d world",
+    })
+  })
+})


### PR DESCRIPTION
## Summary

`ce-babysit-pr`'s watch used to die on Windows when a PR title, body, or comment contained a curly quote. It now decodes `gh` output as UTF-8 instead of the OS locale.

The crash looked like `json.loads(None)`. The real failure was `UnicodeDecodeError` on byte `0x9d` (the last byte of `”`) under `cp1252`. The same helper also decodes the Unix `ps` identity probe as UTF-8.

Fixes #1346.

## Validation

A C-locale `_run` test failed before the pin (`ascii` decode of `0xe2`) and passed after. `tests/ce-babysit-pr-snapshot.test.ts` 128/128. Related babysit tests 4/4.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Grok Build TUI · grok-4.6

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
