### PR TITLE
fix(ce-pov): stop the panel guessing the cross-model host argument

### DIFF
--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -13,11 +13,13 @@
 # runs on ONE editorially selected model and reasoning tier per provider.
 #
 # Usage:
-#   cross-model-adversarial-review.sh <host-provider> <candidates> <base-ref> <run-dir>
+#   cross-model-adversarial-review.sh <host-serving-family> <candidates> <base-ref> <run-dir>
 #
-#   <host-provider> the peer-key of the host's OWN serving provider, attested by
-#                   the calling skill (it knows its harness): openai->codex,
-#                   anthropic->claude, xai->grok, cursor/composer->composer.
+#   <host-serving-family>
+#                   the peer-key of the host's OWN serving family, attested by
+#                   the calling skill (it knows its harness). A peer-key, never
+#                   a provider name: openai->codex, anthropic->claude,
+#                   xai->grok, cursor/composer->composer.
 #                   Excluded from selection when attested. `unknown` is allowed,
 #                   but any returned review remains non-independent and cannot
 #                   promote agreement.

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -16,12 +16,14 @@
 # on extra-high; composer's -fast tier is its ceiling (accepted exceptions).
 #
 # Usage:
-#   cross-model-doc-review.sh <host-provider> <candidates> <reviewer-name> \
+#   cross-model-doc-review.sh <host-serving-family> <candidates> <reviewer-name> \
 #                             <document-path> <document-type> <origin> <run-dir>
 #
-#   <host-provider> the peer-key of the host's OWN serving provider, attested by
-#                   the calling skill (it knows its harness): openai->codex,
-#                   anthropic->claude, xai->grok, cursor/composer->composer.
+#   <host-serving-family>
+#                   the peer-key of the host's OWN serving family, attested by
+#                   the calling skill (it knows its harness). A peer-key, never
+#                   a provider name: openai->codex, anthropic->claude,
+#                   xai->grok, cursor/composer->composer.
 #                   Excluded from selection when attested. `unknown` is allowed,
 #                   but any returned review remains non-independent and cannot
 #                   promote agreement.

--- a/skills/ce-pov/references/cross-model-panel.md
+++ b/skills/ce-pov/references/cross-model-panel.md
@@ -29,6 +29,27 @@ not present it as different-model corroboration. If the host family is unknown,
 automatic discovery excludes any candidate whose independence cannot be
 verified rather than guessing.
 
+Attest the host harness and its serving family as two separate tokens:
+
+```bash
+if [ "${CLAUDECODE:-}" = "1" ]; then XHOST_HARNESS=claude; XHOST_FAMILY=claude;
+elif [ -n "${CODEX_SANDBOX:-}${CODEX_SANDBOX_NETWORK_DISABLED:-}${CODEX_SESSION_ID:-}${CODEX_THREAD_ID:-}${CODEX_CI:-}" ]; then XHOST_HARNESS=codex; XHOST_FAMILY=codex;
+elif [ -n "${CURSOR_AGENT:-}${CURSOR_CONVERSATION_ID:-}" ]; then XHOST_HARNESS=cursor; XHOST_FAMILY=unknown;
+else XHOST_HARNESS=unknown; XHOST_FAMILY=unknown; fi
+```
+
+Both tokens come from the same peer-key vocabulary as the targets above, never
+from a provider's corporate name: `<host-serving-family>` (`XHOST_FAMILY`) is
+`codex`, `claude`, `grok`, `composer`, or `unknown`. `<host-harness>`
+(`XHOST_HARNESS`) is `codex`, `claude`, `grok`, `cursor`, or `unknown`. Claude
+Code maps to harness/family `claude`; Codex maps to `codex`. Cursor maps to
+harness `cursor` and family `unknown` unless an observable serving-family
+attestation lets you set `XHOST_FAMILY` to `codex`, `claude`, `grok`, or
+`composer`. Never infer serving family from the Cursor brand. Section 4 passes
+`XHOST_FAMILY` as the worker's first argument and `XHOST_HARNESS` as
+`CROSS_MODEL_HOST_HARNESS`; a provider name such as `anthropic`, `openai`, or
+`xai` in either slot fail-closes the job with no artifact.
+
 `Cursor` and `Composer` are distinct targets:
 
 - `cursor` uses `cursor-agent` with no forced model, allowing Cursor's configured
@@ -208,13 +229,12 @@ partial-panel degradation rule.
 
 Use `scripts/cross-model-pov.sh` from this skill's directory to run one resolved
 fixed route per peer, and `scripts/peer-job-runner.py` for detached lifecycle
-control. Follow the worker's current usage rather than reconstructing provider
-arguments. Pass the fixed target/route, any host-resolved same-family model
-override, the canonical scope and identity, payload path, and round output
-directory. Pass the actual repository root separately from any narrower read
-root, and pre-create the round output directory as private scratch outside the
-repository. For named peers, start one job per exact target; for a selected panel,
-start one job per selected peer. Start all jobs before waiting.
+control. Fill in the start command below rather than reconstructing the worker's
+arguments from its usage header. Pass the actual repository root separately from
+any narrower read root, and pre-create the round output directory as private
+scratch outside the repository. For named peers, start one job per exact target;
+for a selected panel, start one job per selected peer. Start all jobs before
+waiting.
 
 **At the defaults, the peer budget needs nothing from you.** This skill's worker
 self-bounds at 600s and the runner supervisor derives a floor of 1230s, so the
@@ -246,6 +266,31 @@ execution rather than presence.
 ```bash
 PY="$(for c in python3 python py; do command -v "$c" >/dev/null 2>&1 && "$c" -c '' >/dev/null 2>&1 && { echo "$c"; break; }; done)"; [ -n "$PY" ] || { echo "no working Python 3 interpreter on PATH" >&2; exit 1; };
 ```
+
+Start one job per peer with the command below, filling every `<...>` slot. Set
+`SKILL_DIR` to the absolute directory of **this** skill's `SKILL.md`; the Bash
+tool's CWD is the user's project on every host, not the skill directory.
+
+```bash
+SKILL_DIR="<absolute path of the directory containing the SKILL.md you just read>";
+PY="$(for c in python3 python py; do command -v "$c" >/dev/null 2>&1 && "$c" -c '' >/dev/null 2>&1 && { echo "$c"; break; }; done)"; [ -n "$PY" ] || { echo "no working Python 3 interpreter on PATH" >&2; exit 1; };
+CE_PEER_HARD_SECS= "$PY" "$SKILL_DIR/scripts/peer-job-runner.py" start --skill ce-pov --run-id "<run-id>" --label "<target>" --result-path "<run-dir>/pov-<target>.json" -- env CROSS_MODEL_HOST_HARNESS="<host-harness>" CROSS_MODEL_REPO_ROOT="<repo-root>" CROSS_MODEL_READ_ROOT="<read-root>" CROSS_MODEL_SCRATCH_PARENT="<scratch-dir>" bash "$SKILL_DIR/scripts/cross-model-pov.sh" "<host-serving-family>" "<fixed-route>" "<payload-path>" "<run-dir>"
+```
+
+- `<host-serving-family>` is `codex`, `claude`, `grok`, `composer`, or
+  `unknown`; `<host-harness>` is `codex`, `claude`, `grok`, `cursor`, or
+  `unknown`. Both are the Section 1 attestation, not a provider name.
+- `<fixed-route>` is the sanctioned route token from Section 3's table;
+  `<target>` is its resolved target, with `grok-cli` and `grok-cursor`
+  collapsing to `grok`.
+- `<payload-path>` is this round's mode-600 payload and `<run-dir>` the
+  pre-created round output directory; `<scratch-dir>` is the Phase 1 scratch
+  root, and `<run-id>` its basename.
+- `<read-root>` is Section 2's normalized workspace root and `<repo-root>` the
+  actual repository root containing it.
+- Add `CROSS_MODEL_INCLUDE_PATHS` / `CROSS_MODEL_EXCLUDE_PATHS` only when
+  Section 2 resolved patterns, and `CROSS_MODEL_MODEL_OVERRIDE_TARGET` /
+  `CROSS_MODEL_MODEL_OVERRIDE` only for a Section 3 same-family substitution.
 
 Record every job id and the epoch after the final start. Poll all jobs in
 bounded slices (resolve `$PY` again in each tool call — shells do not persist):

--- a/skills/ce-pov/scripts/cross-model-pov.sh
+++ b/skills/ce-pov/scripts/cross-model-pov.sh
@@ -13,11 +13,13 @@
 # -fast tier is its ceiling, an accepted exception).
 #
 # Usage:
-#   cross-model-pov.sh <host-provider> <fixed-route> <subject-payload> <run-dir>
+#   cross-model-pov.sh <host-serving-family> <fixed-route> <subject-payload> <run-dir>
 #
-#   <host-provider> the peer-key of the host's OWN serving provider, attested by
-#                   the calling skill (it knows its harness): openai->codex,
-#                   anthropic->claude, xai->grok, cursor/composer->composer.
+#   <host-serving-family>
+#                   the peer-key of the host's OWN serving family, attested by
+#                   the calling skill (it knows its harness). A peer-key, never
+#                   a provider name: openai->codex, anthropic->claude,
+#                   xai->grok, cursor/composer->composer.
 #                   Used only to verify independence. `unknown` is allowed for an
 #                   explicitly named peer, but its receipt remains unverified;
 #                   automatic discovery must exclude it before calling this worker.
@@ -31,7 +33,7 @@
 #   <run-dir>         existing private dir outside the repository; output ->
 #                     <run-dir>/pov-<target>.json, where <target> is the resolved
 #                     <fixed-route> target (grok-cli/grok-cursor both collapse to
-#                     grok) -- NOT the <host-provider> key.
+#                     grok) -- NOT the <host-serving-family> key.
 #
 # Test/introspection mode (no model call, no side effects):
 #   cross-model-pov.sh --emit-adapter <route>

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -1156,6 +1156,34 @@ describe("cross-model peer skip legibility", () => {
     })
   }
 
+  // Same bug class as the route-token check above, one argument to the left: the
+  // first worker positional is a peer-key, so a caller that reads its name and
+  // reconstructs a provider name (`anthropic`) fail-closes both jobs. Wherever a
+  // reference names `<host-serving-family>`, it must spell out the accepted set.
+  for (const { worker, reference } of routeTokenPairs) {
+    test(`${reference} enumerates the worker's accepted host-serving-family tokens`, async () => {
+      const workerSrc = await readRepoFile(worker)
+      const caseBody = workerSrc.match(/case "\$HOST_PROVIDER" in\s*\n\s*([a-z|]+)\)/)?.[1]
+      expect(caseBody).toBeTruthy()
+      const tokens = caseBody!.split("|")
+      expect(tokens).toContain("unknown")
+      expect(tokens.length).toBeGreaterThanOrEqual(5)
+
+      // Collapse whitespace: ce-pov hard-wraps prose, so one enumeration can
+      // straddle a line break while the sibling bullets do not. Stop each span
+      // at `;` as well as `.`: the adjacent <host-harness> clause repeats four
+      // of these five tokens, so a span that runs into it would satisfy this
+      // assertion out of the neighbour's text.
+      const ref = (await readRepoFile(reference)).replace(/\s+/g, " ")
+      const spans = [...ref.matchAll(/`<host-serving-family>`[^.;]*/g)].map((m) => m[0])
+      expect(spans.length).toBeGreaterThan(0)
+      expect(
+        spans.some((span) => tokens.every((token) => span.includes(`\`${token}\``))),
+        `${reference} must enumerate ${tokens.join("|")} where it names <host-serving-family>`,
+      ).toBe(true)
+    })
+  }
+
   // A fixed route succeeded only
   // when it returned a reviewer-shaped object with a top-level `findings` array
   // — not merely any valid JSON. Accepting an error/envelope object (e.g. a grok
@@ -1218,7 +1246,7 @@ describe("cross-model peer skip legibility", () => {
     })
   }
 
-  for (const reference of pairs.map((p) => p.reference)) {
+  for (const reference of routeTokenPairs.map((p) => p.reference)) {
     test(`${reference} keeps Cursor harness identity separate from serving family`, async () => {
       const src = await readRepoFile(reference)
       expect(src).toContain("XHOST_HARNESS=cursor; XHOST_FAMILY=unknown")


### PR DESCRIPTION
## Summary

A cross-model panel run lost both peers to one bad argument: the orchestrator passed `anthropic` where the worker wanted the peer-key `claude`, and each job fail-closed with no artifact and no verdict. The cause is that ce-pov's panel reference was the only one of the three cross-model callers with no host-attestation step and no worker start template — and its dispatch paragraph listed every argument except the host key. The caller had nothing to copy, so it reconstructed the value from the script's usage header and inverted the mapping.

`cross-model-panel.md` now carries what `ce-code-review` and `ce-doc-review` already had: an attestation snippet plus the token vocabulary in section 1, and a literal `peer-job-runner.py start` command with an argument legend in section 4. The usage-header parameter is renamed `<host-provider>` → `<host-serving-family>` in all three workers, matching the `host serving family ... invalid` text those same scripts already print. That rename is docstring-only — the shell variable and its validation are untouched.

The new guard mirrors the one that exists for the neighbouring route-token argument: each reference must enumerate the host tokens its worker accepts, read out of the worker's own `case` block. Mutation-checked in both directions — the pre-fix panel fails it, and so does dropping `grok` from a reference's enumeration while the adjacent `<host-harness>` clause still contains it.

A follow-up PR will take the third defect from the same incident: the worker reports a caller-side argument error and a genuinely unavailable route identically (log to stderr, exit 0, no artifact), so the two failure classes cost a diagnostic round-trip to tell apart.

Related: #1282

## Validation

`bun run test` (3081 pass / 0 fail), `bun run release:validate`, and `bun run plugin:validate` all clean.

## Security Disclosure

No security-relevant changes. The parameter rename touches docstrings only, and the worker's accepted-token validation is unchanged. The new panel guidance adds no recipient, no widened read scope, and no new egress path — the start template passes the same read-root, repo-root, and scratch variables the worker already reads.

## Agent Disclosure
- **Model:** `Claude Code · claude-opus-5[1m]`
