### PR TITLE
docs(cross-model): point superseded peer benchmarks at the luna/xhigh decision

### DIFF
--- a/docs/plans/2026-07-17-001-eval-cross-model-peer-model-config.md
+++ b/docs/plans/2026-07-17-001-eval-cross-model-peer-model-config.md
@@ -1,5 +1,11 @@
 # Eval: is `gpt-5.6-terra` (high) a non-inferior, cheaper, faster Codex peer than `gpt-5.6-sol`?
 
+> **Superseded (2026-07-21).** This write-up priced cost in token volume and did not
+> run a Luna arm. The refreshed benchmark re-priced cost in API dollars and adopted
+> `gpt-5.6-luna` at `xhigh` (#1208); see
+> `docs/solutions/skill-design/benchmark-review-peer-model-and-reasoning-tier.md`
+> for the current recommendation. Kept as the historical record.
+
 Executable eval spec for the ce-code-review (and parity-tested ce-doc-review)
 cross-model adversarial peer. Decides whether to swap the Codex route's model.
 

--- a/docs/plans/2026-07-18-adversarial-peer-benchmark-report.md
+++ b/docs/plans/2026-07-18-adversarial-peer-benchmark-report.md
@@ -1,5 +1,11 @@
 # Adversarial-Review Peer — Model & Reasoning-Tier Benchmark
 
+> **Superseded (2026-07-21).** This write-up priced cost in token volume and did not
+> run a Luna arm. The refreshed benchmark re-priced cost in API dollars and adopted
+> `gpt-5.6-luna` at `xhigh` (#1208); see
+> `docs/solutions/skill-design/benchmark-review-peer-model-and-reasoning-tier.md`
+> for the current recommendation. Kept as the historical record.
+
 **Date:** 2026-07-18 · **Scope:** ce-code-review cross-model adversarial pass ·
 **Visual:** https://claude.ai/code/artifact/693e1aa6-6619-4a81-a61f-59b08da137e5 ·
 **Harness:** github.com/tmchow/cross-model-peer-eval (private)

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -75,6 +75,8 @@ skip() { log "$*"; exit 0; }   # non-blocking: announce reason, exit clean, no o
 # CROSS_MODEL_MODEL_OVERRIDE, same target/family only) and the reasoning effort
 # (CROSS_MODEL_EFFORT_OVERRIDE, validated per route); both fail closed.
 # Keep these in sync with ce-doc-review's script (parity-tested in CI).
+# codex: luna/xhigh is the benchmarked pick on API dollars (~0.30x sol-medium, tied
+# detection, slower tail) -- docs/solutions/skill-design/benchmark-review-peer-model-and-reasoning-tier.md
 M_CODEX="gpt-5.6-luna"         # codex CLI            (-c model_reasoning_effort="xhigh")
 M_CLAUDE="claude-opus-5"       # claude CLI, Opus 5   (--effort high)
 M_GROK="grok-4.6"              # grok CLI             (--effort high)

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -87,6 +87,8 @@ skip() { log "$*"; exit 0; }   # non-blocking: announce reason, exit clean, no o
 # A checkout may override the model (CROSS_MODEL_MODEL_OVERRIDE_TARGET +
 # CROSS_MODEL_MODEL_OVERRIDE, same target/family only) and the reasoning effort
 # (CROSS_MODEL_EFFORT_OVERRIDE, validated per route); both fail closed.
+# codex: luna/xhigh is the benchmarked pick on API dollars (~0.30x sol-medium, tied
+# detection, slower tail) -- docs/solutions/skill-design/benchmark-review-peer-model-and-reasoning-tier.md
 M_CODEX="gpt-5.6-luna"         # codex CLI            (-c model_reasoning_effort="xhigh")
 M_CLAUDE="claude-opus-5"       # claude CLI, Opus 5   (--effort high)
 M_GROK="grok-4.6"              # grok CLI             (--effort high)


### PR DESCRIPTION
## Summary

The two `docs/plans/` peer benchmark write-ups still read as the current recommendation (`gpt-5.6-sol` at `medium`), but the API-dollar re-benchmark in `docs/solutions/skill-design/benchmark-review-peer-model-and-reasoning-tier.md` superseded them and adopted `gpt-5.6-luna` at `xhigh` (#1208). Nothing pointed from the old docs to the new one, and the `M_CODEX` comment in the parity scripts cited no evidence, so a reader landing on the plans concluded the shipped mapping contradicted the benchmark. Each old write-up now opens with a superseded pointer, and both scripts' `M_CODEX` comment names the benchmark and its trade-off. No behavior change.

Related: #1261

## Validation

Cross-model route tests for `ce-code-review` and `ce-doc-review` (including the kernel parity check): 145/145 pass.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** `Claude Code · claude-fable-5`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

