### PR TITLE
fix(ce-setup): support read-only sandboxes

### DIFF
--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -299,7 +299,7 @@ capability_missing=0
 results=()
 
 for entry in "${deps[@]}"; do
-  IFS='|' read -r name install_cmd url capability <<< "$entry"
+  IFS='|' read -r name install_cmd url capability < <(printf '%s\n' "$entry")
   capability_total=$((capability_total + 1))
   if command -v "$name" >/dev/null 2>&1; then
     capability_ok=$((capability_ok + 1))
@@ -514,7 +514,7 @@ fi
 section "Optional capabilities  ${capability_ok}/${capability_total}"
 
 for result in "${results[@]}"; do
-  IFS='|' read -r name status install_cmd url capability <<< "$result"
+  IFS='|' read -r name status install_cmd url capability < <(printf '%s\n' "$result")
   if [ "$status" = "ok" ]; then
     ok "$name -- $capability"
   else

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -51,6 +51,12 @@ async function initConfiguredRepo(root: string, localConfig: string): Promise<vo
 }
 
 describe("ce-setup check-health", () => {
+  test("does not require temporary-file-backed here-strings", async () => {
+    const script = await readFile(checkHealthScript, "utf8")
+
+    expect(script).not.toMatch(/<<<\s/)
+  })
+
   test("keeps the committed example identical to the bundled template", async () => {
     const [template, example] = await Promise.all([
       readFile(configTemplate, "utf8"),


### PR DESCRIPTION
## Summary

Replace the two Bash here-strings in `ce-setup` health reporting with `printf` process substitutions. Bash here-strings require temporary-file creation, so Codex read-only sandboxes could corrupt capability counts while the script still exited successfully.

Add a focused invariant test that prevents the health script from reintroducing temporary-file-backed here-strings.

Closes #1406

## Validation

- `bun test tests/skills/ce-setup-check-health.test.ts` — 54 passed
- `bun run test` — 3,162 passed, 1 skipped
- Codex CLI 0.147.0 with `--sandbox read-only` — health script exited 0, reported 2/5 capabilities, and emitted no temporary-file or permission error
- `bash -n skills/ce-setup/scripts/check-health`
- `git diff --check`

## Security Disclosure

This changes shell parsing but introduces no new command execution, interpolation, or external input surface. Records are still parsed into the same fixed fields; the change only removes the temporary-file requirement.

## Agent Disclosure

- **Model:** Codex CLI · GPT-5