### PR TITLE
docs(readme): fix Grok Bot install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Or search for "compound engineering" in the plugin marketplace.
 
 ### Grok Bot
 
-Install Compound Engineering on the Cursor account that Grok Bot uses: in Cursor Agent chat run `/add-plugin compound-engineering`, or search for "compound engineering" in the Cursor plugin marketplace. Grok Bot reads skills from that account plugin cache; do not run Cursor IDE or Claude Code plugin commands on the Grok Bot host.
+In Grok Bot, send:
+
+```text
+Install Compound Engineering from https://github.com/EveryInc/compound-engineering-plugin
+```
 
 ### Codex App
 
@@ -484,7 +488,7 @@ Refresh the marketplace from the **Plugins** panel (remove and re-add the `Every
 
 **Grok Bot**
 
-Refresh or reinstall Compound Engineering on the Cursor account so Grok Bot's account plugin cache picks up the new snapshot. Do not clone this repository onto the Grok Bot computer for normal updates.
+Tell Grok Bot to reinstall or refresh Compound Engineering from `https://github.com/EveryInc/compound-engineering-plugin`. Do not clone this repository onto the Grok Bot computer for normal updates.
 
 If you configured a host with a direct path or sparse path under `plugins/compound-engineering`, edit or reinstall that source so it points at the repository root with no sparse path.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Summary:
- Replace the Grok Bot install instructions with a direct pasteable message for Grok Bot.
- Update the Existing Installs Grok Bot note to tell the bot to reinstall or refresh from the repo URL.

Validation:
- Reviewed README-only diff; no tests run because this is documentation-only.

## Security Disclosure
No security-relevant changes.

## Agent Disclosure
- **Model:** Cursor Cloud · GPT-5.5
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b057a65e-2b82-4212-8acc-cbca8f96f972?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b057a65e-2b82-4212-8acc-cbca8f96f972&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

