### PR TITLE
docs(readme): fix Grok Bot install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,15 @@ Or search for "compound engineering" in the plugin marketplace.
 
 ### Grok Bot
 
-Grok Bot loads Compound Engineering from the Cursor account it is signed into. In Cursor Agent chat:
+Grok Bot is its own app, but it uses your Cursor account and plugin library. There is no separate Grok Bot login. Install Compound Engineering once on that account and Grok Bot agents can load it.
+
+In Cursor Agent chat:
 
 ```text
 /add-plugin compound-engineering
 ```
 
-Or search for "compound engineering" in the Cursor plugin marketplace. Do not run `/add-plugin` or other Cursor/Claude plugin commands in the Grok Bot chat, and do not clone this repository onto the Grok Bot computer.
+Or search for "compound engineering" in the Cursor plugin marketplace. Do not run `/add-plugin` in the Grok Bot chat, and do not clone this repository onto the Grok Bot computer.
 
 ### Codex App
 
@@ -490,7 +492,7 @@ Refresh the marketplace from the **Plugins** panel (remove and re-add the `Every
 
 **Grok Bot**
 
-Reinstall or refresh Compound Engineering on the Cursor account Grok Bot is signed into (`/add-plugin compound-engineering` in Cursor Agent chat, or marketplace search). Grok Bot then picks up the new snapshot from that account's plugin cache. Do not clone this repository onto the Grok Bot computer for a normal update.
+Reinstall or refresh Compound Engineering on that Cursor account (`/add-plugin compound-engineering` in Cursor Agent chat, or marketplace search). Grok Bot then loads the new snapshot from the shared plugin library. Do not clone this repository onto the Grok Bot computer for a normal update.
 
 If you configured a host with a direct path or sparse path under `plugins/compound-engineering`, edit or reinstall that source so it points at the repository root with no sparse path.
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ Or search for "compound engineering" in the plugin marketplace.
 
 ### Grok Bot
 
-In Grok Bot, send:
+Grok Bot loads Compound Engineering from the Cursor account it is signed into. In Cursor Agent chat:
 
 ```text
-Install Compound Engineering from https://github.com/EveryInc/compound-engineering-plugin
+/add-plugin compound-engineering
 ```
+
+Or search for "compound engineering" in the Cursor plugin marketplace. Do not run `/add-plugin` or other Cursor/Claude plugin commands in the Grok Bot chat, and do not clone this repository onto the Grok Bot computer.
 
 ### Codex App
 
@@ -488,7 +490,7 @@ Refresh the marketplace from the **Plugins** panel (remove and re-add the `Every
 
 **Grok Bot**
 
-Tell Grok Bot to reinstall or refresh Compound Engineering from `https://github.com/EveryInc/compound-engineering-plugin`. Do not clone this repository onto the Grok Bot computer for normal updates.
+Reinstall or refresh Compound Engineering on the Cursor account Grok Bot is signed into (`/add-plugin compound-engineering` in Cursor Agent chat, or marketplace search). Grok Bot then picks up the new snapshot from that account's plugin cache. Do not clone this repository onto the Grok Bot computer for a normal update.
 
 If you configured a host with a direct path or sparse path under `plugins/compound-engineering`, edit or reinstall that source so it points at the repository root with no sparse path.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Grok Bot install and existing-install update instructions to use the verified Cursor-account plugin-library path instead of telling Grok Bot to install from a GitHub repository URL.

Validation: not run (README-only documentation change).

## Security Disclosure
No security-relevant changes.

## Agent Disclosure
- **Model:** Cursor · GPT-5.5
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0bae64e-f62c-4afa-823a-cd18af43ea93?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0bae64e-f62c-4afa-823a-cd18af43ea93&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

