### PR TITLE
fix(ce-proof): 62% smaller SKILL.md, references carry the API and workflows

### DIFF
--- a/skills/ce-proof/SKILL.md
+++ b/skills/ce-proof/SKILL.md
@@ -10,38 +10,50 @@ allowed-tools:
 
 # Proof - Collaborative Markdown Editor
 
-Proof is a collaborative document editor for humans and agents, reached through the hosted web API at `https://www.proofeditor.ai` (HTTP/`Bash`). **Outcome:** the user holds a working tokenized Proof link, or the doc carries the read, comment, suggestion, or edit they asked for. **Done:** the operation the user asked for is confirmed at its own level — a create by the `tokenUrl` it returned, a mutation by `ok: true` (a `202` or a `partial: true` response by re-reading `v3/document`), a pull by the local file it wrote, a read by the content it returned — and the user has the result plus a short summary.
+Proof is a collaborative document editor for humans and agents. It is reached through the hosted web API at `https://www.proofeditor.ai`, over HTTP from `Bash`.
 
-**Read `references/api.md` before the first Proof read or mutation, HTTP or MCP** — it owns the endpoints (`share/markdown`, `/api/agent/<slug>/v3/document`, `/api/agent/<slug>/v3/edit`, presence, title, `/api/documents/<slug>` DELETE), the operation tables, and the error/retry classes. **Read `references/workflows.md`** before reviewing a shared doc, creating and sharing one, or pulling a doc to a local file; those flows have exact recipes there. Do not invent agent mutation paths outside v3.
+**Outcome:** the user holds a working tokenized Proof link, or the doc carries the read, comment, suggestion, or edit they asked for.
 
-If typed `proof_*` MCP tools are already available in the harness (`proof_share_markdown`, `proof_v3_document`, `proof_v3_edit`, `proof_presence`, `proof_document_title`, `proof_document_delete`, `proof_report_bug`), prefer them; otherwise use the HTTP recipes. In MCP mode the server injects `by`, `X-Agent-Id`, and presence identity — pass the `?token=` value from the Proof URL as `shareToken` for edits and presence on docs the signed-in user does not own. Delete authority is unchanged in MCP mode: an unclaimed doc still needs its `ownerSecret`, a claimed doc its owner's session — an editor `accessToken` passed as `shareToken` cannot delete.
+**Done:** the operation is confirmed at its own level, and the user has the result plus a short summary. A create is confirmed by the `tokenUrl` it returned. A mutation is confirmed by `ok: true`; on a `202` or a `partial: true` response, confirm by re-reading `v3/document`. A pull is confirmed by the local file it wrote, and a read by the content it returned.
 
-On Claude Code, each new `curl` pattern prompts for permission; suggest (do not silently add) the allowlist rule `"Bash(curl * https://www.proofeditor.ai/*)"` under `permissions.allow` if the user wants a quieter session.
+**Read `references/api.md` before the first Proof read or mutation, HTTP or MCP.** It owns the endpoints — `share/markdown`, the v3 document and edit surfaces, presence, title, and `DELETE /api/documents/<slug>` — along with the operation tables, the error and retry classes, and the `curl` permission hint for Claude Code.
+
+**Read `references/workflows.md`** before reviewing a shared doc, before creating and sharing one, and before pulling a doc to a local file. Those flows have exact recipes there.
+
+If typed `proof_*` MCP tools are already available in the harness (`proof_share_markdown`, `proof_v3_document`, `proof_v3_edit`, `proof_presence`, `proof_document_title`, `proof_document_delete`, `proof_report_bug`), prefer them. Otherwise use the HTTP recipes. In MCP mode the server injects `by`, `X-Agent-Id`, and presence identity. Pass the `?token=` value from the Proof URL as `shareToken` for edits and presence on docs the signed-in user does not own.
+
+Delete authority is unchanged in MCP mode. An unclaimed doc still needs its `ownerSecret`, and a claimed doc needs its owner's session. An editor `accessToken` passed as `shareToken` cannot delete.
 
 ## Identity
 
-Every write is attributed with both fields, and they do not vary: machine ID `ai:compound-engineering` (as `by` on every op and the `X-Agent-Id` header) and display name `Compound Engineering` (as `name` on `POST /presence`, set once per doc session so Proof binds it to that agent ID). A caller may pass a different `identity` pair when a distinct sub-agent should own the doc; never improvise a variant such as `ai:compound`.
+Every write is attributed with both fields, and they do not vary. The machine ID is `ai:compound-engineering`, sent as `by` on every op and as the `X-Agent-Id` header. The display name is `Compound Engineering`, sent as `name` on `POST /presence`, set once per doc session so Proof binds it to that agent ID. A caller may pass a different `identity` pair when a distinct sub-agent should own the doc. Never improvise a variant such as `ai:compound`.
 
 ## Credentials and boundaries
 
-- `accessToken` is the everyday bearer for read, edit, presence, and events. `ownerSecret` is owner authority only — delete and other owner-level ops — never the everyday bearer. Capture both at create time and persist `ownerSecret` for the session separately from `accessToken` (shell vars or equivalent) — it is required for owner delete while the doc is unclaimed. Neither belongs in repo-tracked files, commits, or durable logs, and `ownerSecret` never appears in user-facing copy.
+- `accessToken` is the everyday bearer for read, edit, presence, and events. `ownerSecret` carries owner authority only — delete and other owner-level ops — and is never the everyday bearer. Capture both at create time, and persist `ownerSecret` for the session separately from `accessToken`, in shell vars or equivalent; it is required for owner delete while the doc is unclaimed. Neither belongs in repo-tracked files, commits, or durable logs, and `ownerSecret` never appears in user-facing copy.
 - Hand humans the tokenized link (`tokenUrl`), never a bare `/d/<slug>` — the editor token doubles as claim capability for ownerless docs.
-- Public creates are ownerless until a signed-in Every user claims the doc in the browser. Claiming permanently revokes `ownerSecret` while `accessToken` keeps working, so delete then needs the owner's Every session — ask the owner, or use their session token. A `403` with `code: "DOCUMENT_DELETE_FORBIDDEN"` and `reason: "CREDENTIAL_NOT_OWNER"`, or a `401` when presenting the creation `ownerSecret`, means the secret was revoked: stop using it rather than retrying. `reason: "DOCUMENT_HAS_NO_OWNER"` is the opposite — still unclaimed, so only the original `ownerSecret` can delete it and an Every session cannot.
+- Public creates are ownerless until a signed-in Every user claims the doc in the browser. Claiming permanently revokes `ownerSecret` while `accessToken` keeps working, so delete then needs the owner's Every session — ask the owner, or use their session token. Two responses mean the secret was revoked: a `403` with `code: "DOCUMENT_DELETE_FORBIDDEN"` and `reason: "CREDENTIAL_NOT_OWNER"`, or a `401` when presenting the creation `ownerSecret`. Stop using the secret rather than retrying. `reason: "DOCUMENT_HAS_NO_OWNER"` is the opposite: the doc is still unclaimed, so only the original `ownerSecret` can delete it and an Every session cannot.
 - Never put secrets, credentials, API keys, private tokens, or sensitive personal data into a Proof doc unless the user explicitly approves, and never silently replace a repo-tracked project doc with a Proof link.
-- Emptying the markdown does **not** scrub comment marks — quotes and commentary stay readable to anyone with the share credential, so a content wipe is not a privacy cleanup. Deleting the document is (with `ownerSecret` while unclaimed, or the owner after claim).
-- Do not auto-delete after a publish handoff; review docs must linger. Delete when the user asks, or when finishing an explicitly ephemeral scratch doc.
+- Emptying the markdown does **not** scrub comment marks. Quotes and commentary stay readable to anyone with the share credential, so a content wipe is not a privacy cleanup. Deleting the document is — with `ownerSecret` while the doc is unclaimed, or as the owner after a claim.
+- Do not auto-delete after a publish handoff. Review docs must linger. Delete when the user asks, or when finishing an explicitly ephemeral scratch doc.
 
 ## Publish mode
 
-The primary use is one-way publishing: read an existing local markdown file in full, post its contents as the new doc's body, and hand the user the shareable URL. The local file stays canonical — publishing syncs nothing back to disk. Two entry points with identical mechanics: a bare user request naming a local markdown file ("share this to proof", "get me a proof link for this doc" — ask which file only if it is ambiguous; this needs no upstream caller), or a handoff from `ce-brainstorm`, `ce-ideate`, or `ce-plan` passing the file path and title.
+The primary use is one-way publishing. Read an existing local markdown file in full, post its contents as the new doc's body, and hand the user the shareable URL. The local file stays canonical — publishing syncs nothing back to disk.
+
+Two entry points share those mechanics. One is a bare user request naming a local markdown file ("share this to proof", "get me a proof link for this doc"); ask which file only if it is ambiguous, and expect no upstream caller. The other is a handoff from `ce-brainstorm`, `ce-ideate`, or `ce-plan` passing the file path and title.
 
 Only publish markdown. If the source is an HTML unified plan, return the local browser/open path instead of uploading it. When publishing a unified plan, label the title by readiness when it is known, e.g. `Plan: <title> (requirements-only)` or `Plan: <title> (implementation-ready)`.
 
-Publish the source file's bytes, never hand-written or placeholder content: `references/workflows.md` gives the `jq --rawfile` recipe that escapes newlines, quotes, and backticks correctly. After a publish handoff, surface the URL and return control.
+Publish the source file's bytes, never hand-written or placeholder content. `references/workflows.md` gives the `jq --rawfile` recipe that escapes newlines, quotes, and backticks correctly. After a publish handoff, surface the URL and return control.
 
 ## Editing
 
-`GET /api/agent/<slug>/v3/document` and `POST /api/agent/<slug>/v3/edit` are the only agent read and mutation surfaces — comments, replies, resolutions, suggestions, and content changes are all `operations` in the v3 edit body, so a path you did not read in `references/api.md` is one you invented. Read `v3/document` as the source of truth before editing, then choose the narrowest operation that expresses the change: a scoped `replace` / `insert` / `delete` for prose; `suggest` when the change should be visible as tracked changes; `set_document` only when the user asks for whole-doc replacement or the change cannot be expressed narrowly. Targets are visible text in `markdown`, never raw markdown syntax or block refs. `comments[]` and `suggestions[]` from that read are the review state — reply, resolve, unresolve, accept, or reject by id; v3 has no delete-comment op, and a comment marked `orphaned: true` is still readable and replyable but its old quote is no longer a live anchor.
+`GET /api/agent/<slug>/v3/document` and `POST /api/agent/<slug>/v3/edit` are the only agent read and mutation surfaces. Comments, replies, resolutions, suggestions, and content changes are all `operations` in the v3 edit body, so a path you did not read in `references/api.md` is one you invented.
+
+Read `v3/document` as the source of truth before editing. Then choose the narrowest operation that expresses the change: a scoped `replace`, `insert`, or `delete` for prose; `suggest` when the change should be visible as tracked changes; `set_document` only when the user asks for a whole-doc replacement, or the change cannot be expressed narrowly. Targets are visible text in `markdown`, never raw markdown syntax or block refs.
+
+`comments[]` and `suggestions[]` from that read are the review state. Reply, resolve, unresolve, accept, or reject by id. v3 has no delete-comment op. A comment marked `orphaned: true` is still readable and replyable, but its old quote is no longer a live anchor.
 
 Stop classes, before retrying anything:
 
@@ -50,4 +62,4 @@ Stop classes, before retrying anything:
 - `202` / `PENDING`, or `ok: false` with `partial: true` — the write may have committed. Re-read `v3/document` before chaining or reporting success, and retry only the failed op (a repeated `Idempotency-Key` replays safely).
 - Still failing after a fresh read and one safe retry — report the bug per `references/api.md` rather than looping.
 
-Pulling a doc down to a local file overwrites that file, so when the pull is a side effect of some other action rather than what the user asked for, confirm the path first.
+Pulling a doc down to a local file overwrites that file. When the pull is a side effect of some other action rather than something the user asked for, confirm the path first.

--- a/skills/ce-proof/SKILL.md
+++ b/skills/ce-proof/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools:
 
 # Proof - Collaborative Markdown Editor
 
-Proof is a collaborative document editor for humans and agents, reached through the hosted web API at `https://www.proofeditor.ai` (HTTP/`Bash`). **Outcome:** the user holds a working tokenized Proof link, or the doc carries the read, comment, suggestion, or edit they asked for. **Done:** the API returned `ok: true` (or a `202` re-read confirmed it), the intended change is visible in a fresh `v3/document` read, and the link plus a short summary went back to the user.
+Proof is a collaborative document editor for humans and agents, reached through the hosted web API at `https://www.proofeditor.ai` (HTTP/`Bash`). **Outcome:** the user holds a working tokenized Proof link, or the doc carries the read, comment, suggestion, or edit they asked for. **Done:** the operation the user asked for is confirmed at its own level — a create by the `tokenUrl` it returned, a mutation by `ok: true` (a `202` or a `partial: true` response by re-reading `v3/document`), a pull by the local file it wrote, a read by the content it returned — and the user has the result plus a short summary.
 
 **Read `references/api.md` before the first Proof read or mutation, HTTP or MCP** — it owns the endpoints (`share/markdown`, `/api/agent/<slug>/v3/document`, `/api/agent/<slug>/v3/edit`, presence, title, `/api/documents/<slug>` DELETE), the operation tables, and the error/retry classes. **Read `references/workflows.md`** before reviewing a shared doc, creating and sharing one, or pulling a doc to a local file; those flows have exact recipes there. Do not invent agent mutation paths outside v3.
 

--- a/skills/ce-proof/SKILL.md
+++ b/skills/ce-proof/SKILL.md
@@ -10,344 +10,44 @@ allowed-tools:
 
 # Proof - Collaborative Markdown Editor
 
-Proof is a collaborative document editor for humans and agents. This skill uses the **hosted web API** at `https://www.proofeditor.ai` (HTTP/`Bash`). If typed `proof_*` MCP tools are already available in the harness (`proof_share_markdown`, `proof_v3_document`, `proof_v3_edit`, `proof_presence`, `proof_document_title`, `proof_document_delete`, `proof_report_bug`), prefer them; otherwise use the HTTP recipes below. In MCP mode the server injects `by`, `X-Agent-Id`, and presence identity — pass the `?token=` value from the Proof URL as `shareToken` for edits and presence on docs the signed-in user does not own. Delete authority is unchanged in MCP mode: an unclaimed doc still needs its `ownerSecret`, a claimed doc its owner's session — an editor `accessToken` passed as `shareToken` cannot delete.
+Proof is a collaborative document editor for humans and agents, reached through the hosted web API at `https://www.proofeditor.ai` (HTTP/`Bash`). **Outcome:** the user holds a working tokenized Proof link, or the doc carries the read, comment, suggestion, or edit they asked for. **Done:** the API returned `ok: true` (or a `202` re-read confirmed it), the intended change is visible in a fresh `v3/document` read, and the link plus a short summary went back to the user.
+
+**Read `references/api.md` before the first Proof read or mutation, HTTP or MCP** — it owns the endpoints (`share/markdown`, `/api/agent/<slug>/v3/document`, `/api/agent/<slug>/v3/edit`, presence, title, `/api/documents/<slug>` DELETE), the operation tables, and the error/retry classes. **Read `references/workflows.md`** before reviewing a shared doc, creating and sharing one, or pulling a doc to a local file; those flows have exact recipes there. Do not invent agent mutation paths outside v3.
+
+If typed `proof_*` MCP tools are already available in the harness (`proof_share_markdown`, `proof_v3_document`, `proof_v3_edit`, `proof_presence`, `proof_document_title`, `proof_document_delete`, `proof_report_bug`), prefer them; otherwise use the HTTP recipes. In MCP mode the server injects `by`, `X-Agent-Id`, and presence identity — pass the `?token=` value from the Proof URL as `shareToken` for edits and presence on docs the signed-in user does not own. Delete authority is unchanged in MCP mode: an unclaimed doc still needs its `ownerSecret`, a claimed doc its owner's session — an editor `accessToken` passed as `shareToken` cannot delete.
 
 On Claude Code, each new `curl` pattern prompts for permission; suggest (do not silently add) the allowlist rule `"Bash(curl * https://www.proofeditor.ai/*)"` under `permissions.allow` if the user wants a quieter session.
 
-## Identity and Attribution
+## Identity
 
-Every write to a Proof doc must be attributed. Two fields carry the agent's identity:
+Every write is attributed with both fields, and they do not vary: machine ID `ai:compound-engineering` (as `by` on every op and the `X-Agent-Id` header) and display name `Compound Engineering` (as `name` on `POST /presence`, set once per doc session so Proof binds it to that agent ID). A caller may pass a different `identity` pair when a distinct sub-agent should own the doc; never improvise a variant such as `ai:compound`.
 
-- **Machine ID (`by` on every op, `X-Agent-Id` header):** `ai:compound-engineering` — stable, lowercase-hyphenated, machine-parseable. Appears in marks, events, and the API response.
-- **Display name (`name` on `POST /presence`):** `Compound Engineering` — human-readable, shown in Proof's presence chips and comment-author badges.
+## Credentials and boundaries
 
-Set the display name once per doc session by posting to presence with the `X-Agent-Id` header; Proof binds the name to that agent ID for the session. These values are the defaults for any caller of this skill; a caller may pass a different `identity` pair if a distinct sub-agent should own the doc. Do not use `ai:compound` or other ad-hoc variants — identity stays uniform unless a caller explicitly overrides it.
+- `accessToken` is the everyday bearer for read, edit, presence, and events. `ownerSecret` is owner authority only — delete and other owner-level ops — never the everyday bearer. Capture both at create time and persist `ownerSecret` for the session separately from `accessToken` (shell vars or equivalent) — it is required for owner delete while the doc is unclaimed. Neither belongs in repo-tracked files, commits, or durable logs, and `ownerSecret` never appears in user-facing copy.
+- Hand humans the tokenized link (`tokenUrl`), never a bare `/d/<slug>` — the editor token doubles as claim capability for ownerless docs.
+- Public creates are ownerless until a signed-in Every user claims the doc in the browser. Claiming permanently revokes `ownerSecret` while `accessToken` keeps working, so delete then needs the owner's Every session — ask the owner, or use their session token. A `403` with `code: "DOCUMENT_DELETE_FORBIDDEN"` and `reason: "CREDENTIAL_NOT_OWNER"`, or a `401` when presenting the creation `ownerSecret`, means the secret was revoked: stop using it rather than retrying. `reason: "DOCUMENT_HAS_NO_OWNER"` is the opposite — still unclaimed, so only the original `ownerSecret` can delete it and an Every session cannot.
+- Never put secrets, credentials, API keys, private tokens, or sensitive personal data into a Proof doc unless the user explicitly approves, and never silently replace a repo-tracked project doc with a Proof link.
+- Emptying the markdown does **not** scrub comment marks — quotes and commentary stay readable to anyone with the share credential, so a content wipe is not a privacy cleanup. Deleting the document is (with `ownerSecret` while unclaimed, or the owner after claim).
+- Do not auto-delete after a publish handoff; review docs must linger. Delete when the user asks, or when finishing an explicitly ephemeral scratch doc.
 
-## Publish Mode
+## Publish mode
 
-The primary use is one-way publishing: take an existing local markdown file (a brainstorm, a unified plan, a learning, a draft), read its full contents and post them as the new doc's body (see "Workflow: Create and Share a New Document" for the source-file recipe — never publish placeholder content), and hand the user a shareable URL. The local file stays canonical — publishing does not sync anything back to disk. The user can open the link to read, comment, and share with others; the agent can also participate via the edit APIs below when given the URL. Two entry points, identical mechanics (see "Workflow: Create and Share a New Document"):
+The primary use is one-way publishing: read an existing local markdown file in full, post its contents as the new doc's body, and hand the user the shareable URL. The local file stays canonical — publishing syncs nothing back to disk. Two entry points with identical mechanics: a bare user request naming a local markdown file ("share this to proof", "get me a proof link for this doc" — ask which file only if it is ambiguous; this needs no upstream caller), or a handoff from `ce-brainstorm`, `ce-ideate`, or `ce-plan` passing the file path and title.
 
-- **Direct user request** — a bare user phrase naming a local markdown file and asking to share it via Proof: "share this to proof", "publish this to proof", "open this in proof editor so I can review", "get me a proof link for this doc". The file is whichever markdown the user just created, edited, or referenced; if ambiguous, ask which file. This is a first-class entry point — do not require an upstream caller.
-- **Upstream skill handoff** — `ce-brainstorm`, `ce-ideate`, or `ce-plan` finishes a draft and hands it off to publish for human review, passing the file path and title explicitly.
+Only publish markdown. If the source is an HTML unified plan, return the local browser/open path instead of uploading it. When publishing a unified plan, label the title by readiness when it is known, e.g. `Plan: <title> (requirements-only)` or `Plan: <title> (implementation-ready)`.
 
-Only publish markdown. If the source is an HTML unified plan, do not upload it
-to Proof; return the local browser/open path instead. When publishing a unified
-plan, label the title by readiness when available, e.g. `Plan: <title>
-(requirements-only)` or `Plan: <title> (implementation-ready)`.
+Publish the source file's bytes, never hand-written or placeholder content: `references/workflows.md` gives the `jq --rawfile` recipe that escapes newlines, quotes, and backticks correctly. After a publish handoff, surface the URL and return control.
 
-Do not silently replace repo-tracked project docs with Proof links. Do not put secrets, credentials, API keys, private tokens, or sensitive personal data in Proof unless the user explicitly approves.
+## Editing
 
-## Credentials
+`GET /api/agent/<slug>/v3/document` and `POST /api/agent/<slug>/v3/edit` are the only agent read and mutation surfaces — comments, replies, resolutions, suggestions, and content changes are all `operations` in the v3 edit body, so a path you did not read in `references/api.md` is one you invented. Read `v3/document` as the source of truth before editing, then choose the narrowest operation that expresses the change: a scoped `replace` / `insert` / `delete` for prose; `suggest` when the change should be visible as tracked changes; `set_document` only when the user asks for whole-doc replacement or the change cannot be expressed narrowly. Targets are visible text in `markdown`, never raw markdown syntax or block refs. `comments[]` and `suggestions[]` from that read are the review state — reply, resolve, unresolve, accept, or reject by id; v3 has no delete-comment op, and a comment marked `orphaned: true` is still readable and replyable but its old quote is no longer a live anchor.
 
-Document creation returns two credentials with different jobs:
+Stop classes, before retrying anything:
 
-- `accessToken` — everyday bearer for read, edit, presence, and events. Use this for all non-owner agent API calls.
-- `ownerSecret` — owner authority only (delete and other owner-level ops). Never use it as the everyday bearer.
+- `TARGET_AMBIGUOUS` — the anchor matched more than once and nothing changed. Disambiguate with `occurrence` / `before` / `after` from `error.candidates`; never assume silent first-match, and never blind-retry a comment.
+- `retryable: false` — fix the request. `retryable: true` with `error.current` — re-resolve targets against `current`, then retry once.
+- `202` / `PENDING`, or `ok: false` with `partial: true` — the write may have committed. Re-read `v3/document` before chaining or reporting success, and retry only the failed op (a repeated `Idempotency-Key` replays safely).
+- Still failing after a fresh read and one safe retry — report the bug per `references/api.md` rather than looping.
 
-Store them separately for the session (shell vars or equivalent non-repo memory). Never write `ownerSecret` or `accessToken` into repo-tracked files, commits, or durable project logs. Never expose `ownerSecret` in user-facing UI copy.
-
-Always hand humans the tokenized link (`tokenUrl`), never a bare `/d/<slug>` alone — the editor token doubles as claim capability for ownerless docs.
-
-Public creates are ownerless until a signed-in Every user claims the doc in the browser (account menu → Claim ownership). Claiming permanently revokes `ownerSecret`; `accessToken` keeps working. After claim, delete and other owner ops belong to the owner's Every account — ask the owner, or use their Every session token. Do not retry delete with a revoked `ownerSecret`.
-
-Treat a `403` with `code: "DOCUMENT_DELETE_FORBIDDEN"` and `reason: "CREDENTIAL_NOT_OWNER"`, or a `401` when presenting the creation `ownerSecret`, as evidence the secret was revoked (commonly after claim). Stop using that `ownerSecret`; ask the owner to delete or supply an Every owner session. `reason: "DOCUMENT_HAS_NO_OWNER"` means the opposite: the doc is still unclaimed, so only its original `ownerSecret` can delete it — an Every session cannot until someone claims it.
-
-## Web API
-
-Auth on document surfaces (preferred first):
-
-- `Authorization: Bearer <accessToken>`
-- `x-share-token: <accessToken>`
-- `?token=<accessToken>` on the request URL
-
-Canonical agent read/write (v3 only — do not invent other agent mutation paths):
-
-- Read: `GET /api/agent/<slug>/v3/document`
-- Write: `POST /api/agent/<slug>/v3/edit`
-
-### Create a Shared Document
-
-No authentication required on the public create route. Returns a shareable URL with tokens.
-
-```bash
-curl -sS -X POST https://www.proofeditor.ai/share/markdown \
-  -H "Content-Type: application/json" \
-  -d '{"title":"My Doc","markdown":"# Hello\n\nContent here."}'
-```
-
-**Response fields to keep:**
-
-```json
-{
-  "slug": "abc123",
-  "tokenUrl": "https://www.proofeditor.ai/d/abc123?token=xxx",
-  "accessToken": "xxx",
-  "ownerSecret": "yyy",
-  "shareUrl": "https://www.proofeditor.ai/d/abc123",
-  "_links": {
-    "read": "https://www.proofeditor.ai/api/agent/abc123/v3/document",
-    "edit": { "method": "POST", "href": "/api/agent/abc123/v3/edit" },
-    "delete": { "method": "DELETE", "href": "/api/documents/abc123" }
-  }
-}
-```
-
-Use `tokenUrl` as the shareable link. Extract `slug`, `accessToken`, and `ownerSecret` immediately — `ownerSecret` is required for cleanup while the doc is still unclaimed.
-
-### Read a Shared Document
-
-If you already have a shared Proof URL, fetch with content negotiation or v3:
-
-```bash
-curl -sS -H "Accept: application/json" "https://www.proofeditor.ai/d/{slug}?token=<token>"
-curl -sS -H "Accept: text/markdown" "https://www.proofeditor.ai/d/{slug}?token=<token>"
-
-curl -sS "https://www.proofeditor.ai/api/agent/{slug}/v3/document" \
-  -H "Authorization: Bearer <token>" \
-  -H "X-Agent-Id: ai:compound-engineering"
-# -> { ok, revision, title, markdown, comments[], suggestions[], mutationReady? }
-```
-
-ACTIVE docs can be read tokenlessly via `v3/document`. Mutations, presence, and events need a tokenized credential. Tokenless `GET /d/<slug>` JSON reports `role: null` and no mutation links — that is truthful capability reporting, not a browser lock.
-
-`comments[]` and `suggestions[]` on the v3 read are the source of review state. Use a comment's `id` for `reply` / `resolve` / `unresolve`. Use a suggestion's `id` for `accept` / `reject`. v3 supports resolving and unresolving comments; it does **not** support deleting comments. A comment with `orphaned: true` and an empty `quote` has lost its anchor — its thread is still readable and replyable, but do not treat its old target text as a live anchor.
-
-When `mutationReady` is `false`, `revision` may be `null` — omit `baseRevision` and re-read shortly.
-
-### Edit a Shared Document
-
-Send `{ by, baseRevision?, operations: [...] }` to `POST /api/agent/{slug}/v3/edit`. Targets are **visible text** in `markdown` (not raw markdown syntax, not block refs). There is no base token. `baseRevision` (integer from the last read) is an optional conflict guard — omit it to apply at head. `Idempotency-Key` is optional; use one for important writes and retries.
-
-```bash
-curl -sS -X POST "https://www.proofeditor.ai/api/agent/{slug}/v3/edit" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <token>" \
-  -H "X-Agent-Id: ai:compound-engineering" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d '{
-    "by":"ai:compound-engineering",
-    "operations":[
-      {"op":"replace","find":"old visible text","with":"new text"},
-      {"op":"comment","on":"text to anchor on","body":"Is this still accurate?"}
-    ]
-  }'
-```
-
-**Content operations:**
-
-| op | body |
-|---|---|
-| `replace` | `find`, `with` (optional `occurrence` / `before` / `after`) |
-| `insert` | `after` or `before` + `markdown` (anchor: quote, `heading:Title`, `section:Title`, `"start"`, or `"end"`) |
-| `delete` | `find` |
-| `set_document` | `markdown` (whole-doc replace as a minimal diff; safe with live collaborators) |
-
-**Review operations:**
-
-| op | body |
-|---|---|
-| `comment` | `on`, `body` (optional `occurrence`) |
-| `reply` | `comment` (id), `body`, optional `resolve: true` |
-| `resolve` / `unresolve` | `comment` (id) |
-| `suggest` | `kind: "insert"\|"delete"\|"replace"`, `find`, `with?` (`with` required for insert/replace) |
-| `accept` / `reject` | `suggestion` (id) |
-| `modify_suggestion` | `suggestion` (id), `with` — replace the proposed text of a pending plain insert/replace suggestion |
-
-`suggest` also accepts typed structural forms (`command: "table.*"`, `"format.*"`, `"node.update"`, and atom `target: {node: "image"|"hr"|...}`); see `https://www.proofeditor.ai/agent-docs` before using them. A request holds at most 100 operations; `set_document` accepts at most 2 MiB of markdown.
-
-### Edit Strategy
-
-Prefer the narrowest op:
-
-1. Literal or scoped prose change → `replace` / `insert` / `delete`
-2. Visible track-changes desired → `suggest` (then `accept`/`reject` as needed)
-3. Whole-doc replacement → `set_document` only when the user asks for full replacement or the change cannot be expressed narrowly
-
-If a `find`/anchor matches more than once, the server rejects with `TARGET_AMBIGUOUS` and `error.candidates` — nothing is changed. Disambiguate with `occurrence` (`"first"`, `"last"`, or 0-based index) or `before`/`after`. Never assume silent first-match.
-
-Content ops in one request apply atomically; review ops then apply in order. If a review op fails after content committed, the response is `ok: false` with `partial: true` — re-read and retry only the failed op (same `Idempotency-Key` safely replays).
-
-**Errors** use `{ ok:false, error:{ code, message, retryable, opIndex?, target?, candidates?, current? } }`. Codes: `AUTH`, `NOT_FOUND`, `INVALID_REQUEST`, `TARGET_NOT_FOUND`, `TARGET_AMBIGUOUS`, `CONFLICT`, `TOO_LARGE`, `BUSY`, `PENDING`, `INTERNAL`.
-
-- `retryable: false` — fix the request; do not blind-retry
-- `retryable: true` with `error.current` — re-resolve targets against `current` and retry once
-- `TARGET_AMBIGUOUS` — add `occurrence` / `before` / `after` from `candidates`
-- `BUSY` — brief backoff and retry
-- Retryable `CONFLICT` on a structural suggestion — a connected editor is on an older suggestion reader; retry after it reconnects. Non-retryable `CONFLICT` — the op crosses frontmatter, raw HTML, or unknown content; use a whole-block op or leave it
-- `accept` that keeps failing with `SUGGESTION_OWNERSHIP_MISSING` after a fresh read — the suggestion is wedged; `reject` it (always allowed) and recreate instead of retrying `accept`
-- Settled `200` with `ok:true` — inspect returned `revision` / document; chain without an extra read when the body is complete
-- `202` / `PENDING` — write may have committed; re-read `v3/document` before chaining or reporting success
-
-After every successful edit: confirm `ok:true`, confirm the intended text/comment/suggestion, then report the Proof link with a short summary.
-
-### Presence
-
-```bash
-curl -sS -X POST "https://www.proofeditor.ai/api/agent/{slug}/presence" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <token>" \
-  -H "X-Agent-Id: ai:compound-engineering" \
-  -d '{"name":"Compound Engineering","status":"reading","summary":"Joining the doc"}'
-```
-
-Common statuses: `reading`, `thinking`, `acting`, `waiting`, `completed`, `error`.
-
-### Title
-
-```bash
-curl -sS -X PUT "https://www.proofeditor.ai/api/documents/{slug}/title" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer <token>" \
-  -d '{"title":"Updated document title"}'
-```
-
-### Delete
-
-Only owner credentials can delete:
-
-```bash
-curl -sS -X DELETE "https://www.proofeditor.ai/api/documents/{slug}" \
-  -H "Authorization: Bearer <ownerSecret>"
-```
-
-Viewer, commenter, and editor `accessToken` values cannot delete. Success returns `shareState: "DELETED"`; later reads return deleted-document responses (`410` on many routes).
-
-**Lifecycle:** Do **not** auto-delete after every publish handoff — review docs must linger. Persist `ownerSecret` for the session. Delete when the user asks to remove/clean up, or when finishing an explicitly ephemeral scratch doc the user is done with.
-
-### Marks and privacy
-
-Emptying the markdown (including `set_document` to blank/minimal content) does **not** scrub comment marks. Quote and commentary fields can remain readable via `v3/document` to anyone with the share credential. Without owner delete authority, content wipe is not a privacy cleanup — delete the document with `ownerSecret` (while unclaimed) or ask the owner after claim.
-
-### When the loop breaks
-
-If a mutation keeps failing after a fresh read and one safe retry, call `POST https://www.proofeditor.ai/api/bridge/report_bug` with the failing request ID, slug, and raw response. The server enriches and files an issue. Ask before including the user's name/email.
-
-## Workflow: Review a Shared Document
-
-When given a Proof URL like `https://www.proofeditor.ai/d/abc123?token=xxx`:
-
-1. Extract the slug and token
-2. Bind presence with the CE identity defaults
-3. Read via `v3/document`
-4. Edit with `v3/edit` (narrow content ops; review ops for comments/suggestions)
-
-```bash
-TOKEN="xxx"
-SLUG="abc123"
-AGENT="ai:compound-engineering"
-
-curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-Agent-Id: $AGENT" \
-  -d '{"name":"Compound Engineering","status":"reading","summary":"Reviewing doc"}'
-
-DOC=$(curl -sS "https://www.proofeditor.ai/api/agent/$SLUG/v3/document" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-Agent-Id: $AGENT")
-REVISION=$(printf '%s' "$DOC" | jq -r '.revision // empty')
-
-# Comment on visible text
-curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-Agent-Id: $AGENT" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d "$(jq -n --argjson rev "${REVISION:-null}" '{
-    by:"ai:compound-engineering",
-    baseRevision: (if $rev == null then null else $rev end),
-    operations:[{op:"comment",on:"text to comment on",body:"Your comment here"}]
-  } | if .baseRevision == null then del(.baseRevision) else . end')"
-
-# Narrow content edit
-curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-Agent-Id: $AGENT" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d '{"by":"ai:compound-engineering","operations":[{"op":"replace","find":"old","with":"new"}]}'
-
-# Tracked suggestion
-curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-Agent-Id: $AGENT" \
-  -H "Idempotency-Key: $(uuidgen)" \
-  -d '{"by":"ai:compound-engineering","operations":[{"op":"suggest","kind":"replace","find":"old","with":"new"}]}'
-```
-
-## Workflow: Create and Share a New Document
-
-**Publishing a local file (the primary case):** read the file and JSON-encode its full contents into the `markdown` field with `jq --rawfile` so newlines, quotes, and backticks are escaped correctly. Never hand-write the body or leave an inline placeholder — that publishes a placeholder doc instead of the source artifact.
-
-```bash
-SRC="path/to/plan.md"
-TITLE="Plan: Foo"
-
-RESPONSE=$(jq -n --arg title "$TITLE" --rawfile md "$SRC" '{title:$title, markdown:$md}' \
-  | curl -sS -X POST https://www.proofeditor.ai/share/markdown \
-    -H "Content-Type: application/json" -d @-)
-
-URL=$(echo "$RESPONSE" | jq -r '.tokenUrl')
-SLUG=$(echo "$RESPONSE" | jq -r '.slug')
-TOKEN=$(echo "$RESPONSE" | jq -r '.accessToken')
-OWNER_SECRET=$(echo "$RESPONSE" | jq -r '.ownerSecret')   # required for owner delete while unclaimed
-
-# Keep OWNER_SECRET in session memory only — never write it into the repo tree.
-
-curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-Agent-Id: ai:compound-engineering" \
-  -d '{"name":"Compound Engineering","status":"reading","summary":"Uploaded doc"}'
-
-echo "$URL"
-```
-
-After publish handoffs from planning workflows, surface the URL and return control — do not delete the doc automatically.
-
-When the user later asks to clean up an unclaimed doc you created:
-
-```bash
-curl -sS -X DELETE "https://www.proofeditor.ai/api/documents/$SLUG" \
-  -H "Authorization: Bearer $OWNER_SECRET"
-```
-
-## Workflow: Pull a Proof Doc to Local
-
-Sync the current Proof doc state to a local markdown file. Used for:
-
-- Ad-hoc snapshots of a Proof doc to disk
-- Pulling a shared Proof doc that the user (or others) edited back down to a local working copy
-- Refreshing a local working copy against the live Proof version
-
-Canonical read for this workflow: `GET /api/agent/$SLUG/v3/document`.
-
-```bash
-SLUG=<slug>
-TOKEN=<accessToken>
-LOCAL=<absolute-path>
-
-STATE_TMP=$(mktemp "${TMPDIR:-/tmp}/ce-proof-state.XXXXXX")
-curl -sS "https://www.proofeditor.ai/api/agent/$SLUG/v3/document" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "X-Agent-Id: ai:compound-engineering" > "$STATE_TMP"
-REVISION=$(jq -r '.revision // empty' "$STATE_TMP")
-
-TMP="${LOCAL}.proof-sync.$$"
-jq -jr '.markdown' "$STATE_TMP" > "$TMP" && mv "$TMP" "$LOCAL"
-rm "$STATE_TMP"
-```
-
-`jq -jr` streams markdown bytes without going through a shell variable, so trailing newlines survive. `mv` within the same filesystem is atomic.
-
-**Confirm before writing when the pull isn't directly asked for.** If a workflow ends up pulling as a side-effect of a different action, surface the impending write with a short confirm like "Sync Proof doc to `<localPath>`?" A silent overwrite is surprising.
-
-## Safety
-
-- Use `v3/document` as source of truth before editing
-- Prefer narrow `replace` / `insert` / `delete` before `suggest` or `set_document`
-- Always include `by: "ai:compound-engineering"` on writes and `X-Agent-Id: ai:compound-engineering` in headers
-- Use `accessToken` for everyday calls; reserve `ownerSecret` for owner delete
-- Never commit share tokens or owner secrets to the project tree
-- On `TARGET_AMBIGUOUS` / retryable errors, re-resolve against `error.current` — do not double-apply comments blindly
+Pulling a doc down to a local file overwrites that file, so when the pull is a side effect of some other action rather than what the user asked for, confirm the path first.

--- a/skills/ce-proof/references/api.md
+++ b/skills/ce-proof/references/api.md
@@ -4,6 +4,8 @@ Required read before any Proof HTTP call. Endpoints, operation tables, error han
 
 ## Web API
 
+On Claude Code, each new `curl` pattern prompts for permission. Suggest the allowlist rule `"Bash(curl * https://www.proofeditor.ai/*)"` under `permissions.allow` if the user wants a quieter session; do not add it silently.
+
 Auth on document surfaces (preferred first):
 
 - `Authorization: Bearer <accessToken>`

--- a/skills/ce-proof/references/api.md
+++ b/skills/ce-proof/references/api.md
@@ -1,0 +1,174 @@
+# Proof web API reference
+
+Required read before any Proof HTTP call. Endpoints, operation tables, error handling, and lifecycle; the skill body carries the identity, credential, and safety boundaries.
+
+## Web API
+
+Auth on document surfaces (preferred first):
+
+- `Authorization: Bearer <accessToken>`
+- `x-share-token: <accessToken>`
+- `?token=<accessToken>` on the request URL
+
+Canonical agent read/write (v3 only — do not invent other agent mutation paths):
+
+- Read: `GET /api/agent/<slug>/v3/document`
+- Write: `POST /api/agent/<slug>/v3/edit`
+
+### Create a Shared Document
+
+No authentication required on the public create route. Returns a shareable URL with tokens.
+
+```bash
+curl -sS -X POST https://www.proofeditor.ai/share/markdown \
+  -H "Content-Type: application/json" \
+  -d '{"title":"My Doc","markdown":"# Hello\n\nContent here."}'
+```
+
+**Response fields to keep:**
+
+```json
+{
+  "slug": "abc123",
+  "tokenUrl": "https://www.proofeditor.ai/d/abc123?token=xxx",
+  "accessToken": "xxx",
+  "ownerSecret": "yyy",
+  "shareUrl": "https://www.proofeditor.ai/d/abc123",
+  "_links": {
+    "read": "https://www.proofeditor.ai/api/agent/abc123/v3/document",
+    "edit": { "method": "POST", "href": "/api/agent/abc123/v3/edit" },
+    "delete": { "method": "DELETE", "href": "/api/documents/abc123" }
+  }
+}
+```
+
+Use `tokenUrl` as the shareable link. Extract `slug`, `accessToken`, and `ownerSecret` immediately — `ownerSecret` is required for cleanup while the doc is still unclaimed.
+
+### Read a Shared Document
+
+If you already have a shared Proof URL, fetch with content negotiation or v3:
+
+```bash
+curl -sS -H "Accept: application/json" "https://www.proofeditor.ai/d/{slug}?token=<token>"
+curl -sS -H "Accept: text/markdown" "https://www.proofeditor.ai/d/{slug}?token=<token>"
+
+curl -sS "https://www.proofeditor.ai/api/agent/{slug}/v3/document" \
+  -H "Authorization: Bearer <token>" \
+  -H "X-Agent-Id: ai:compound-engineering"
+# -> { ok, revision, title, markdown, comments[], suggestions[], mutationReady? }
+```
+
+ACTIVE docs can be read tokenlessly via `v3/document`. Mutations, presence, and events need a tokenized credential. Tokenless `GET /d/<slug>` JSON reports `role: null` and no mutation links — that is truthful capability reporting, not a browser lock.
+
+`comments[]` and `suggestions[]` on the v3 read are the source of review state. Use a comment's `id` for `reply` / `resolve` / `unresolve`. Use a suggestion's `id` for `accept` / `reject`. v3 supports resolving and unresolving comments; it does **not** support deleting comments. A comment with `orphaned: true` and an empty `quote` has lost its anchor — its thread is still readable and replyable, but do not treat its old target text as a live anchor.
+
+When `mutationReady` is `false`, `revision` may be `null` — omit `baseRevision` and re-read shortly.
+
+### Edit a Shared Document
+
+Send `{ by, baseRevision?, operations: [...] }` to `POST /api/agent/{slug}/v3/edit`. Targets are **visible text** in `markdown` (not raw markdown syntax, not block refs). There is no base token. `baseRevision` (integer from the last read) is an optional conflict guard — omit it to apply at head. `Idempotency-Key` is optional; use one for important writes and retries.
+
+```bash
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/{slug}/v3/edit" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -H "X-Agent-Id: ai:compound-engineering" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d '{
+    "by":"ai:compound-engineering",
+    "operations":[
+      {"op":"replace","find":"old visible text","with":"new text"},
+      {"op":"comment","on":"text to anchor on","body":"Is this still accurate?"}
+    ]
+  }'
+```
+
+**Content operations:**
+
+| op | body |
+|---|---|
+| `replace` | `find`, `with` (optional `occurrence` / `before` / `after`) |
+| `insert` | `after` or `before` + `markdown` (anchor: quote, `heading:Title`, `section:Title`, `"start"`, or `"end"`) |
+| `delete` | `find` |
+| `set_document` | `markdown` (whole-doc replace as a minimal diff; safe with live collaborators) |
+
+**Review operations:**
+
+| op | body |
+|---|---|
+| `comment` | `on`, `body` (optional `occurrence`) |
+| `reply` | `comment` (id), `body`, optional `resolve: true` |
+| `resolve` / `unresolve` | `comment` (id) |
+| `suggest` | `kind: "insert"\|"delete"\|"replace"`, `find`, `with?` (`with` required for insert/replace) |
+| `accept` / `reject` | `suggestion` (id) |
+| `modify_suggestion` | `suggestion` (id), `with` — replace the proposed text of a pending plain insert/replace suggestion |
+
+`suggest` also accepts typed structural forms (`command: "table.*"`, `"format.*"`, `"node.update"`, and atom `target: {node: "image"|"hr"|...}`); see `https://www.proofeditor.ai/agent-docs` before using them. A request holds at most 100 operations; `set_document` accepts at most 2 MiB of markdown.
+
+### Edit Strategy
+
+Prefer the narrowest op:
+
+1. Literal or scoped prose change → `replace` / `insert` / `delete`
+2. Visible track-changes desired → `suggest` (then `accept`/`reject` as needed)
+3. Whole-doc replacement → `set_document` only when the user asks for full replacement or the change cannot be expressed narrowly
+
+If a `find`/anchor matches more than once, the server rejects with `TARGET_AMBIGUOUS` and `error.candidates` — nothing is changed. Disambiguate with `occurrence` (`"first"`, `"last"`, or 0-based index) or `before`/`after`. Never assume silent first-match.
+
+Content ops in one request apply atomically; review ops then apply in order. If a review op fails after content committed, the response is `ok: false` with `partial: true` — re-read and retry only the failed op (same `Idempotency-Key` safely replays).
+
+**Errors** use `{ ok:false, error:{ code, message, retryable, opIndex?, target?, candidates?, current? } }`. Codes: `AUTH`, `NOT_FOUND`, `INVALID_REQUEST`, `TARGET_NOT_FOUND`, `TARGET_AMBIGUOUS`, `CONFLICT`, `TOO_LARGE`, `BUSY`, `PENDING`, `INTERNAL`.
+
+- `retryable: false` — fix the request; do not blind-retry
+- `retryable: true` with `error.current` — re-resolve targets against `current` and retry once
+- `TARGET_AMBIGUOUS` — add `occurrence` / `before` / `after` from `candidates`
+- `BUSY` — brief backoff and retry
+- Retryable `CONFLICT` on a structural suggestion — a connected editor is on an older suggestion reader; retry after it reconnects. Non-retryable `CONFLICT` — the op crosses frontmatter, raw HTML, or unknown content; use a whole-block op or leave it
+- `accept` that keeps failing with `SUGGESTION_OWNERSHIP_MISSING` after a fresh read — the suggestion is wedged; `reject` it (always allowed) and recreate instead of retrying `accept`
+- Settled `200` with `ok:true` — inspect returned `revision` / document; chain without an extra read when the body is complete
+- `202` / `PENDING` — write may have committed; re-read `v3/document` before chaining or reporting success
+
+After every successful edit: confirm `ok:true`, confirm the intended text/comment/suggestion, then report the Proof link with a short summary.
+
+### Presence
+
+```bash
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/{slug}/presence" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -H "X-Agent-Id: ai:compound-engineering" \
+  -d '{"name":"Compound Engineering","status":"reading","summary":"Joining the doc"}'
+```
+
+Common statuses: `reading`, `thinking`, `acting`, `waiting`, `completed`, `error`.
+
+### Title
+
+```bash
+curl -sS -X PUT "https://www.proofeditor.ai/api/documents/{slug}/title" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"title":"Updated document title"}'
+```
+
+### Delete
+
+Only owner credentials can delete:
+
+```bash
+curl -sS -X DELETE "https://www.proofeditor.ai/api/documents/{slug}" \
+  -H "Authorization: Bearer <ownerSecret>"
+```
+
+Viewer, commenter, and editor `accessToken` values cannot delete. Success returns `shareState: "DELETED"`; later reads return deleted-document responses (`410` on many routes).
+
+**Lifecycle:** Do **not** auto-delete after every publish handoff — review docs must linger. Persist `ownerSecret` for the session. Delete when the user asks to remove/clean up, or when finishing an explicitly ephemeral scratch doc the user is done with.
+
+### Marks and privacy
+
+Emptying the markdown (including `set_document` to blank/minimal content) does **not** scrub comment marks. Quote and commentary fields can remain readable via `v3/document` to anyone with the share credential. Without owner delete authority, content wipe is not a privacy cleanup — delete the document with `ownerSecret` (while unclaimed) or ask the owner after claim.
+
+### When the loop breaks
+
+If a mutation keeps failing after a fresh read and one safe retry, call `POST https://www.proofeditor.ai/api/bridge/report_bug` with the failing request ID, slug, and raw response. The server enriches and files an issue. Ask before including the user's name/email.
+

--- a/skills/ce-proof/references/workflows.md
+++ b/skills/ce-proof/references/workflows.md
@@ -1,0 +1,124 @@
+# Proof workflows
+
+Required read before running one of these end to end: reviewing a shared doc, creating and sharing a new one, or pulling a doc down to a local file. Endpoint and operation detail lives in `api.md`.
+
+## Workflow: Review a Shared Document
+
+When given a Proof URL like `https://www.proofeditor.ai/d/abc123?token=xxx`:
+
+1. Extract the slug and token
+2. Bind presence with the CE identity defaults
+3. Read via `v3/document`
+4. Edit with `v3/edit` (narrow content ops; review ops for comments/suggestions)
+
+```bash
+TOKEN="xxx"
+SLUG="abc123"
+AGENT="ai:compound-engineering"
+
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
+  -d '{"name":"Compound Engineering","status":"reading","summary":"Reviewing doc"}'
+
+DOC=$(curl -sS "https://www.proofeditor.ai/api/agent/$SLUG/v3/document" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT")
+REVISION=$(printf '%s' "$DOC" | jq -r '.revision // empty')
+
+# Comment on visible text
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d "$(jq -n --argjson rev "${REVISION:-null}" '{
+    by:"ai:compound-engineering",
+    baseRevision: (if $rev == null then null else $rev end),
+    operations:[{op:"comment",on:"text to comment on",body:"Your comment here"}]
+  } | if .baseRevision == null then del(.baseRevision) else . end')"
+
+# Narrow content edit
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d '{"by":"ai:compound-engineering","operations":[{"op":"replace","find":"old","with":"new"}]}'
+
+# Tracked suggestion
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/v3/edit" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: $AGENT" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -d '{"by":"ai:compound-engineering","operations":[{"op":"suggest","kind":"replace","find":"old","with":"new"}]}'
+```
+
+## Workflow: Create and Share a New Document
+
+**Publishing a local file (the primary case):** read the file and JSON-encode its full contents into the `markdown` field with `jq --rawfile` so newlines, quotes, and backticks are escaped correctly. Never hand-write the body or leave an inline placeholder — that publishes a placeholder doc instead of the source artifact.
+
+```bash
+SRC="path/to/plan.md"
+TITLE="Plan: Foo"
+
+RESPONSE=$(jq -n --arg title "$TITLE" --rawfile md "$SRC" '{title:$title, markdown:$md}' \
+  | curl -sS -X POST https://www.proofeditor.ai/share/markdown \
+    -H "Content-Type: application/json" -d @-)
+
+URL=$(echo "$RESPONSE" | jq -r '.tokenUrl')
+SLUG=$(echo "$RESPONSE" | jq -r '.slug')
+TOKEN=$(echo "$RESPONSE" | jq -r '.accessToken')
+OWNER_SECRET=$(echo "$RESPONSE" | jq -r '.ownerSecret')   # required for owner delete while unclaimed
+
+# Keep OWNER_SECRET in session memory only — never write it into the repo tree.
+
+curl -sS -X POST "https://www.proofeditor.ai/api/agent/$SLUG/presence" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: ai:compound-engineering" \
+  -d '{"name":"Compound Engineering","status":"reading","summary":"Uploaded doc"}'
+
+echo "$URL"
+```
+
+After publish handoffs from planning workflows, surface the URL and return control — do not delete the doc automatically.
+
+When the user later asks to clean up an unclaimed doc you created:
+
+```bash
+curl -sS -X DELETE "https://www.proofeditor.ai/api/documents/$SLUG" \
+  -H "Authorization: Bearer $OWNER_SECRET"
+```
+
+## Workflow: Pull a Proof Doc to Local
+
+Sync the current Proof doc state to a local markdown file. Used for:
+
+- Ad-hoc snapshots of a Proof doc to disk
+- Pulling a shared Proof doc that the user (or others) edited back down to a local working copy
+- Refreshing a local working copy against the live Proof version
+
+Canonical read for this workflow: `GET /api/agent/$SLUG/v3/document`.
+
+```bash
+SLUG=<slug>
+TOKEN=<accessToken>
+LOCAL=<absolute-path>
+
+STATE_TMP=$(mktemp "${TMPDIR:-/tmp}/ce-proof-state.XXXXXX")
+curl -sS "https://www.proofeditor.ai/api/agent/$SLUG/v3/document" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Agent-Id: ai:compound-engineering" > "$STATE_TMP"
+REVISION=$(jq -r '.revision // empty' "$STATE_TMP")
+
+TMP="${LOCAL}.proof-sync.$$"
+jq -jr '.markdown' "$STATE_TMP" > "$TMP" && mv "$TMP" "$LOCAL"
+rm "$STATE_TMP"
+```
+
+`jq -jr` streams markdown bytes without going through a shell variable, so trailing newlines survive. `mv` within the same filesystem is atomic.
+
+**Confirm before writing when the pull isn't directly asked for.** If a workflow ends up pulling as a side-effect of a different action, surface the impending write with a short confirm like "Sync Proof doc to `<localPath>`?" A silent overwrite is surprising.

--- a/tests/codex-skill-prompt-budget.test.ts
+++ b/tests/codex-skill-prompt-budget.test.ts
@@ -43,7 +43,6 @@ const OVER_BUDGET = new Set([
   "ce-plan",
   "ce-pov",
   "ce-product-pulse",
-  "ce-proof",
   "ce-prototype",
   "ce-resolve-pr-feedback",
   "ce-retune",

--- a/tests/skills/ce-proof-body-pins.test.ts
+++ b/tests/skills/ce-proof-body-pins.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync, readdirSync } from "fs"
+import path from "path"
+
+// ce-proof's body was cut to fit Codex's 8000-byte skill prompt budget, with the
+// endpoint recipes moved to references/api.md and the end-to-end flows to
+// references/workflows.md. Guards split by load-time: credential, privacy, and
+// mutation rules that must fire before any reference is read are pinned against
+// SKILL.md; relocated recipe detail is pinned against the whole skill corpus.
+const SKILL_DIR = path.join(import.meta.dir, "..", "..", "skills", "ce-proof")
+const body = readFileSync(path.join(SKILL_DIR, "SKILL.md"), "utf8")
+const corpus = [
+  body,
+  ...readdirSync(path.join(SKILL_DIR, "references")).map((f) =>
+    readFileSync(path.join(SKILL_DIR, "references", f), "utf8"),
+  ),
+].join("\n")
+
+describe("ce-proof always-loaded body pins", () => {
+  test("states its outcome and done bar", () => {
+    expect(body).toContain("**Outcome:**")
+    expect(body).toContain("**Done:**")
+  })
+
+  test("keeps the credential split and the revocation signals", () => {
+    expect(body).toContain("everyday bearer")
+    expect(body).toContain("persist `ownerSecret` for the session")
+    expect(body).toContain('code: "DOCUMENT_DELETE_FORBIDDEN"')
+    expect(body).toContain('reason: "CREDENTIAL_NOT_OWNER"')
+    expect(body).toContain('reason: "DOCUMENT_HAS_NO_OWNER"')
+  })
+
+  test("keeps the privacy rules that a content wipe would otherwise violate", () => {
+    // Emptying markdown leaves comment quotes readable to any share credential.
+    expect(body).toContain("scrub comment marks")
+    expect(body).toMatch(/never put secrets/i)
+  })
+
+  test("keeps the mutation constraints that also govern the MCP path", () => {
+    expect(body).toContain("no delete-comment op")
+    expect(body).toContain("orphaned")
+    expect(body).toContain("TARGET_AMBIGUOUS")
+    expect(body).toContain("partial: true")
+  })
+
+  test("gates both references at their point of use, MCP included", () => {
+    expect(body).toContain("before the first Proof read or mutation, HTTP or MCP")
+    expect(body).toContain("references/workflows.md")
+  })
+})
+
+describe("ce-proof relocated recipes stay greppable in the corpus", () => {
+  for (const invariant of [
+    "https://www.proofeditor.ai/share/markdown",
+    "/api/agent/{slug}/v3/edit",
+    "/api/agent/{slug}/presence",
+    "/api/documents/{slug}/title",
+    "set_document",
+    "modify_suggestion",
+    "SUGGESTION_OWNERSHIP_MISSING",
+    "at most 100 operations",
+    "2 MiB",
+    "mutationReady",
+    "--rawfile",
+    "report_bug",
+  ]) {
+    test(`corpus keeps: ${invariant}`, () => {
+      expect(corpus).toContain(invariant)
+    })
+  }
+})


### PR DESCRIPTION
`ce-proof` was a 20KB always-loaded HTTP manual: every curl recipe, every operation table, and every error code sat in the context window on every invocation, including the invocations that only needed to publish one file. The body is now the part that must fire without a read — identity, credentials, privacy, publish conditions, edit strategy, stop classes — and the recipes live in two references named at their point of use.

## Size

| | Before | After | Change |
|---|---|---|---|
| `SKILL.md` (CRLF-adjusted) | 20,102 | 7,738 | **62% smaller** |
| Corpus (body + references) | 20,102 | 22,160 | +10.2% |

Corpus growth is relocation plus four invariants the adversarial read found weakened, restored in stronger form. Nothing was dropped. Bytes are measured as `tests/codex-skill-prompt-budget.test.ts` measures them (UTF-8 bytes + newline count, i.e. a CRLF checkout).

## What relocated where

- **`references/api.md`** (9,147 bytes) — auth headers; create / read / edit / presence / title / delete recipes; the content and review operation tables; typed structural `suggest` forms; the 100-op and 2 MiB limits; `mutationReady` / `baseRevision` semantics; the full error-code list and retry rules; the bug-report route. Gated in the body as a required read **before the first Proof read or mutation, HTTP or MCP**.
- **`references/workflows.md`** (5,211 bytes) — review a shared doc, create and share a new one (the `jq --rawfile` publish recipe), pull a doc to a local file. Gated before running any of those end to end.

The body keeps: outcome and done bar; the MCP-vs-HTTP preference and MCP delete-authority rule; the fixed identity pair; the `accessToken`/`ownerSecret` split with claim-revocation signals; hand-over-`tokenUrl`; the no-secrets and no-replacing-repo-docs rules; the comment-marks privacy rule; the no-auto-delete lifecycle; publish-mode entry conditions, "Only publish markdown", and the readiness-labelled plan title; the v3-only mutation surface; narrowest-op strategy; and the stop classes (`TARGET_AMBIGUOUS`, `retryable`, `202`/`partial`, escalate rather than loop).

## Adversarial cross-model read

Grok (grok-4.6) got the old body, the new body, and both references, and was asked what went missing or got weaker. Premises were re-verified; four findings were real and are fixed:

- The reference gate said "before the first HTTP call", but MCP is the *preferred* path — so on the preferred path every relocated mutation rule was skippable. The gate now reads "before the first Proof read or mutation, HTTP or MCP".
- Post-claim delete had lost "use their Every session token".
- The delete-error signals had lost their `code:` vs `reason:` field names, which is what makes them parseable.
- "Neither belongs in ... user-facing copy" contradicted the required `tokenUrl` handoff; `ownerSecret` alone carries that rule now.

Also promoted into the body from the moved text: visible-text targeting, "v3 has no delete-comment op", and the orphaned-anchor rule — all mutation constraints that govern the MCP path too.

## Review round

Codex (P2) and Cursor Bugbot both landed on the same block: the new done bar demanded `ok: true` plus a fresh `v3/document` read for *every* outcome, which a create (its response has no `ok` field), a pull (the local file is the result), and a plain read cannot satisfy — and it contradicted the settled-`200` rule that lets an edit be confirmed from its own response. Fixed as a condition per operation shape rather than a list of exceptions: each operation is confirmed at its own level — create by `tokenUrl`, mutation by `ok: true` (a `202`/`partial` by re-reading), pull by the local file, read by the content returned.

## Tests

- `ce-proof` removed from `OVER_BUDGET` in `tests/codex-skill-prompt-budget.test.ts`.
- New `tests/skills/ce-proof-body-pins.test.ts`, split by load-time: body pins for the outcome/done bar, the credential split and revocation signals, the privacy rules, the mutation constraints that also bind MCP, and both reference gates; corpus greps for the twelve relocated recipe details (`share/markdown`, the v3 edit and presence paths, the title route, `set_document`, `modify_suggestion`, `SUGGESTION_OWNERSHIP_MISSING`, the 100-op and 2 MiB limits, `mutationReady`, `--rawfile`, `report_bug`).
- `tests/skills/ce-proof-contract.test.ts` and `tests/skills/unified-plan-artifact-contract.test.ts` still pin their phrases on the body and pass unchanged.

`bun run test` (3,211 tests) and `bun run release:validate` are green.

## Extraction eval

One scenario on three harnesses, read-only: publish a `requirements-only` plan file, comment on a phrase, then delete a doc that a signed-in user claimed in between. Each run ended with `FILES_READ:`.

| Harness | Publish body | Title | Link | Comment op | Ambiguous anchor | Delete after claim | FILES_READ |
|---|---|---|---|---|---|---|---|
| Claude Code (Opus) | `jq --rawfile` ✅ | `Plan: Foo (requirements-only)` ✅ | `tokenUrl` ✅ | v3 edit ✅ | `occurrence` from candidates ✅ | owner's Every session ✅ | SKILL.md, api.md, workflows.md |
| Codex CLI (first draft) | `jq --rawfile` ✅ | `Foo Plan (requirements only)` ⚠️ | `tokenUrl` ✅ | **invented `/api/v1/documents/{slug}/comments`** ❌ | asked the user ⚠️ | correct ✅ | SKILL.md only |
| Codex CLI (after fix) | `jq --rawfile` ✅ | `Plan: Foo (requirements-only)` ✅ | `tokenUrl` ✅ | v3 edit ✅ | `occurrence` from candidates ✅ | owner's Every session ✅ | SKILL.md, api.md, workflows.md |
| Grok CLI (grok-4.6) | `jq --rawfile` ✅ | `Plan: Foo (requirements-only)` ✅ | `tokenUrl` ✅ | v3 edit ✅ | `occurrence` from candidates ✅ | owner's Every session ✅ | SKILL.md, api.md, workflows.md |

The first Codex run is the reason the body changed again: with the endpoints only in the reference and the reference not read, it fabricated a plausible REST path. The fix states the condition at the point of use — the v3 read and edit paths are named in the Editing section, with "a path you did not read in `references/api.md` is one you invented" — and both later runs follow the body into both references.

Harness gotchas: Codex `exec` needs `< /dev/null`, streams its transcript to stderr, and needs `bun run codex:dev -- local` so the linked skill is the one under test; Grok `-p` prints narration to stdout before the answer.

## Does the cap bind today?

No. Per `docs/specs/agent-plugins.md` the root manifest stays schema-less, so Codex does not truncate on the shipping path. The cap is the ratchet goal and a ceiling, not the target — this body is 4% under a third of the old size because a thin always-loaded body is worth having on every host regardless.

## Readability pass

Squeezing to fit had fused unrelated ideas into single dash- and semicolon-chained sentences. Every such sentence was rewritten plainly, one idea at a time, with nothing compressed to fit:

- The opening paragraph carried the product description, the **Outcome**, and a **Done** bar with four confirmation levels nested in dashes and parentheses. It is now four paragraphs, and each Done level is its own sentence.
- The two reference gates were one sentence; they are now one paragraph each, stated as "read X before Y".
- The MCP paragraph carried the tool list, the preference, the injected fields, the `shareToken` rule, and MCP delete authority. Delete authority is now its own paragraph.
- **Editing** was a single 6-clause sentence covering the mutation surfaces, the read-first rule, the narrowest-op menu, the targeting rule, and the review-state ops. It is three paragraphs.
- `Identity`, the `accessToken`/`ownerSecret` split, the revocation signals, the comment-marks rule, and publish mode's two entry points were each de-chained the same way.

The rewrite added bytes, so the room came from one relocation rather than from squeezing: the Claude Code `curl` allowlist hint moved into `references/api.md`, which owns the HTTP calls that trigger the prompt and is a required read before the first one. The body's gate line now names it. No invariant was dropped and no pinned string changed.

Final: **7,673 raw / 7,738 CRLF-adjusted bytes** (was 7,749 / 7,802) — 262 under the cap.

## Security Disclosure

No security-relevant changes. Credential handling is stated more precisely, not more loosely: the revocation signals regained their `code`/`reason` field names, the `ownerSecret` no-user-facing-copy rule no longer conflicts with the required `tokenUrl` handoff, and the privacy rule that a content wipe does not scrub comment marks stays always-loaded.

## Agent Disclosure

Claude Code · claude-opus-5

