### PR TITLE
fix(ce-debug): body enum names fixed-not-pushed like the producer and consumer

### DIFF
--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -30,7 +30,7 @@ fi
 
 Default is **interactive**: investigate, run the Phase 2 fix-choice gate, then the Phase 4 handoff.
 
-**`mode:pipeline`** (set by an orchestrator such as `ce-babysit-pr` or `lfg`): run fully non-interactively and never call the blocking-question tool. Strip the token from `<bug_description>`, then **read `references/pipeline-mode.md` and follow it** — it overrides every "ask the user" point with a conservative default, replaces the Phase 2 fix-gate with "fix convergent bugs, defer divergent ones", and replaces the Phase 4 handoff with a structured return whose `status` is exactly one of `fixed-and-pushed | fixed-not-pushed | diagnosed-no-fix | flaky-infra | needs-human`. The caller branches on those four spellings, so never rename, abbreviate, or add to them.
+**`mode:pipeline`** (set by an orchestrator such as `ce-babysit-pr` or `lfg`): run fully non-interactively and never call the blocking-question tool. Strip the token from `<bug_description>`, then **read `references/pipeline-mode.md` and follow it** — it overrides every "ask the user" point with a conservative default, replaces the Phase 2 fix-gate with "fix convergent bugs, defer divergent ones", and replaces the Phase 4 handoff with a structured return whose `status` is exactly one of `fixed-and-pushed | fixed-not-pushed | diagnosed-no-fix | flaky-infra | needs-human`. The caller branches on those exact spellings, so never rename, abbreviate, or add to them.
 
 ## Blocking questions
 

--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -30,7 +30,7 @@ fi
 
 Default is **interactive**: investigate, run the Phase 2 fix-choice gate, then the Phase 4 handoff.
 
-**`mode:pipeline`** (set by an orchestrator such as `ce-babysit-pr` or `lfg`): run fully non-interactively and never call the blocking-question tool. Strip the token from `<bug_description>`, then **read `references/pipeline-mode.md` and follow it** — it overrides every "ask the user" point with a conservative default, replaces the Phase 2 fix-gate with "fix convergent bugs, defer divergent ones", and replaces the Phase 4 handoff with a structured return whose `status` is exactly one of `fixed-and-pushed | diagnosed-no-fix | flaky-infra | needs-human`. The caller branches on those four spellings, so never rename, abbreviate, or add to them.
+**`mode:pipeline`** (set by an orchestrator such as `ce-babysit-pr` or `lfg`): run fully non-interactively and never call the blocking-question tool. Strip the token from `<bug_description>`, then **read `references/pipeline-mode.md` and follow it** — it overrides every "ask the user" point with a conservative default, replaces the Phase 2 fix-gate with "fix convergent bugs, defer divergent ones", and replaces the Phase 4 handoff with a structured return whose `status` is exactly one of `fixed-and-pushed | fixed-not-pushed | diagnosed-no-fix | flaky-infra | needs-human`. The caller branches on those four spellings, so never rename, abbreviate, or add to them.
 
 ## Blocking questions
 


### PR DESCRIPTION
## Why

#1449 (ce-debug restructure) hoisted the `mode:pipeline` status enum into the always-loaded body so `ce-babysit-pr`'s contract is visible without a reference load, and says the spellings may not be renamed, abbreviated, or extended. #1463 then added `fixed-not-pushed` to the producer (`references/pipeline-mode.md`), the babysit consumer (`references/tick.md`), and the parity test. Both merged; the body was the one place that lagged, so on `main` the always-loaded text names four values while the producer, consumer, and test name five.

## What changed

Two adjacent sentences in `skills/ce-debug/SKILL.md`: the enum now reads `fixed-and-pushed | fixed-not-pushed | diagnosed-no-fix | flaky-infra | needs-human`, and the invariant that follows it now says the caller branches on "those exact spellings" instead of "those four spellings" (review round 1) — a duplicated count in the sentence pinning the contract is what let the body drift out of sync in the first place. Body 16,529 CRLF-adjusted bytes (was 16,510; stays in `OVER_BUDGET` as documented on #1449).

## Validation

`ce-babysit-pr-contract` + `codex-skill-prompt-budget`: 47 pass. Grep across `skills/`, `docs/skills/`, `tests/` for the four-value form: no remaining occurrences.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

Claude Code · claude-fable-5

