### PR TITLE
fix(skills): make model-invoked descriptions context pointers

### DIFF
--- a/skills/ce-babysit-pr/SKILL.md
+++ b/skills/ce-babysit-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-babysit-pr
-description: "Babysits an open GitHub PR until merge-ready, continuously reacting to review comments, CI failures, and snapshot-flagged branch-currency items. Use when asked to babysit, watch, monitor, or keep an eye on a PR over time — not for one-shot comment resolution or one CI failure. GitHub (incl. Enterprise) only."
+description: "Babysits an open GitHub PR until merge-ready. Use when asked to watch a PR over time — not for one-shot comment resolution or one CI failure. GitHub (incl. Enterprise) only."
 argument-hint: "[PR number|URL|blank=current branch] [watch|checkpoint] [duration] [posture:target|stack-ready|stack-land]"
 ---
 

--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-brainstorm
-description: 'Explore vague or ambitious ideas into a right-sized requirements-only unified plan. Use when the user wants to brainstorm, scope what to build, or needs collaborative product framing before planning. Also use when they must scope work in territory they say they do not know ("I know nothing about X but need to...") or ask for a blindspot pass. Not for executing already-specified work — implementation, debugging, or code review with no product scope left to decide. Not for a verdict on whether to adopt or switch to a named external technology, library, or platform; that is ce-pov.'
+description: "Explore vague or ambitious ideas into a right-sized requirements-only unified plan. Use when the user wants to brainstorm, scope what to build, or needs collaborative product framing before planning. Also use when they must scope work in territory they do not know, or ask for a blindspot pass. Not for executing already-specified work — implementation, debugging, or code review with no product scope left to decide. Not for a verdict on whether to adopt or switch to a named external technology, library, or platform; that is ce-pov."
 argument-hint: "[feature idea or problem to explore] [output:html]"
 ---
 

--- a/skills/ce-code-review/SKILL.md
+++ b/skills/ce-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-code-review
-description: "Structured code review for bugs, regressions, tests, and standards. Use before PRs or when asked for review; report-only by default, with explicit local apply available for user-directed fix workflows."
+description: "Structured code review for bugs, regressions, tests, and standards. Use before PRs or when asked to review code. Use when the user asks to apply this review's findings locally. Not for resolving feedback already left on a PR; that is ce-resolve-pr-feedback."
 argument-hint: "[mode:agent] [apply:local] [blank to review current branch, or provide PR link]"
 ---
 

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-compound
-description: Document a recently solved problem as a durable repo learning, or capture project vocabulary in CONCEPTS.md. Use when capturing a learning after work.
+description: Document a recently solved problem as a durable repo learning. Use when capturing a learning after work.
 argument-hint: "[optional: brief context] [mode:non-interactive] [depth:lightweight|full]"
 ---
 

--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-debug
-description: 'Diagnosis loop for bugs and failing behavior. Use for errors, stack traces, regressions, failed tests, issue-tracker bugs, stuck investigations after failed fixes, or asks to debug/fix a bug.'
+description: "Diagnosis loop for bugs and failing behavior. Use when asked to debug or fix failing behavior."
 argument-hint: "[issue reference, error message, test path, or description of broken behavior]"
 ---
 

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-explain
-description: "Create a durable, visual teaching artifact — plus an optional check-in (predict-then-reveal for diffs, corrected exercises) that makes it stick — for something worth learning: a concept, a diff, an idea, or a window of your own recent work. Use when the user wants to be taught, wants a deep explainer, wants to understand a substantial change, or wants a work recap built for retention. Not for ordinary Q&A, brief 'why?' follow-ups, operational diagnosis, status updates, or a concise trade-off answer that belongs inline in chat. For learning, not repo docs or verdicts."
+description: "Create a durable visual teaching artifact for something worth learning. Use when the user wants to be taught, wants a deep explainer, or wants a work recap built for retention. Not for ordinary Q&A, operational diagnosis, or a concise trade-off that belongs in chat. For learning, not repo docs or verdicts."
 argument-hint: "[a concept, a diff ref, an idea, or 'what happened this week?'] — or invoke bare to be asked"
 ---
 

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-explain
-description: "Create a durable visual teaching artifact for something worth learning. Use when the user wants to be taught, wants a deep explainer, or wants a work recap built for retention. Not for ordinary Q&A, operational diagnosis, or a concise trade-off that belongs in chat. For learning, not repo docs or verdicts."
+description: "Create a durable visual teaching artifact for something worth learning. Use when the user wants to be taught, wants a deep explainer, wants to understand a substantial change, or wants a work recap built for retention. Not for ordinary Q&A, operational diagnosis, or a concise trade-off that belongs in chat. For learning, not repo docs or verdicts."
 argument-hint: "[a concept, a diff ref, an idea, or 'what happened this week?'] — or invoke bare to be asked"
 ---
 

--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-optimize
-description: "Run metric-driven optimization loops. Use when improving measurable outcomes such as search relevance, clustering quality, build performance, prompt quality, or scored behavior through experiments."
+description: "Run metric-driven optimization loops. Use when improving a measurable outcome through experiments."
 argument-hint: "[path to optimization spec YAML, or describe the optimization goal]"
 ---
 

--- a/skills/ce-pov/SKILL.md
+++ b/skills/ce-pov/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-pov
-description: "Give a decisive, project-grounded point of view: a graded verdict on an external-adoption question, a holistic take on a document, or a position on a supplied approach set. Use for a solo POV, a mid-session second opinion, a named-peer or `oracle` cross-check, any request to consult other models or reconcile their opinions, and a correction-cost-gated proactive cross-check offer. Not for findings review (use ce-doc-review), neutral explainers, or generating options (use ce-ideate or ce-brainstorm)."
+description: "Give a decisive, project-grounded point of view: a graded verdict on an external-adoption question, a holistic take on a document, or a position on a supplied approach set. Use for a solo POV. Use when asked to consult or reconcile other models. Not for findings review (use ce-doc-review), neutral explainers, or generating options (use ce-ideate or ce-brainstorm)."
 argument-hint: "[question, document, or approaches] [cross-check] — or bare"
 ---
 

--- a/skills/ce-pov/SKILL.md
+++ b/skills/ce-pov/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-pov
-description: "Give a decisive, project-grounded point of view: a graded verdict on an external-adoption question, a holistic take on a document, or a position on a supplied approach set. Use for a solo POV. Use when asked to consult or reconcile other models. Not for findings review (use ce-doc-review), neutral explainers, or generating options (use ce-ideate or ce-brainstorm)."
+description: "Give a decisive, project-grounded point of view: a graded verdict on an external-adoption question, a holistic take on a document, or a position on a supplied approach set. Use for a solo POV. Use when asked to consult other models, reconcile their opinions, or `oracle`. Not for findings review (use ce-doc-review), neutral explainers, or generating options (use ce-ideate or ce-brainstorm)."
 argument-hint: "[question, document, or approaches] [cross-check] — or bare"
 ---
 

--- a/skills/ce-prototype/SKILL.md
+++ b/skills/ce-prototype/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-prototype
-description: Build a throwaway prototype to answer how something should work, feel, or read — an interface, a flow, a state model, a visual direction. Use when committing the wrong answer would be expensive to unravel and a cheap sketch cannot settle it, whether the user settles it by driving the artifact or by seeing it at real finish — one question, or the next related question after that. Not a rough visual probe during brainstorming, not for deciding what to build, not polishing a feature that already works, not implementing the real thing.
+description: Build a throwaway prototype to answer how something should work, feel, or read. Use when committing the wrong answer would be expensive to unravel and a cheap sketch cannot settle it. Not a rough visual probe during brainstorming, not for deciding what to build, not polishing a feature that already works, not implementing the real thing.
 argument-hint: "[prompt, brainstorm path, or plan path]"
 ---
 

--- a/skills/ce-resolve-pr-feedback/SKILL.md
+++ b/skills/ce-resolve-pr-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-resolve-pr-feedback
-description: Resolve PR review feedback. Use when addressing review comments, resolving review threads, or fixing code-review feedback.
+description: Resolve PR review feedback. Use when addressing feedback already left on a PR. Not for reviewing the code before feedback exists; that is ce-code-review.
 argument-hint: "[PR number, comment URL, or blank for current branch's PR]"
 allowed-tools: Bash(gh *), Bash(git *), Read
 ---

--- a/skills/ce-riffrec-feedback-analysis/SKILL.md
+++ b/skills/ce-riffrec-feedback-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-riffrec-feedback-analysis
-description: Analyze Riffrec feedback captures from bundles or standalone recordings. Use when the input is a Riffrec capture, a screen or voice recording, or a capture/share request.
+description: Analyze Riffrec feedback captures from bundles or standalone recordings. Use when the input is a `riffrec-*.zip`, an unpacked Riffrec bundle (`session.json`, `events.json`, `recording.webm`, `voice.webm`), a screen or voice recording, or a capture/share request.
 ---
 
 # Riffrec Feedback Analysis

--- a/skills/ce-riffrec-feedback-analysis/SKILL.md
+++ b/skills/ce-riffrec-feedback-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-riffrec-feedback-analysis
-description: Analyze Riffrec feedback captures from bundles or standalone recordings. Always load for `riffrec-*.zip`, `session.json` + `events.json` + `recording.webm` + `voice.webm` bundles, `.mp4`/`.mov`/`.webm` videos, `.m4a`/`.mp3`/`.wav` audio, or capture/share requests.
+description: Analyze Riffrec feedback captures from bundles or standalone recordings. Use when the input is a Riffrec capture, a screen or voice recording, or a capture/share request.
 ---
 
 # Riffrec Feedback Analysis

--- a/skills/ce-test-browser/SKILL.md
+++ b/skills/ce-test-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-test-browser
-description: Run browser tests for pages affected by the current branch or PR.
+description: Run browser tests for pages affected by the current branch or PR. Use when asked to run or check browser tests for the current change.
 argument-hint: "[PR number, branch name, 'current', or --port PORT]"
 ---
 

--- a/skills/ce-work/SKILL.md
+++ b/skills/ce-work/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-work
-description: Execute a plan or concrete work prompt end-to-end. Use when implementing from a plan document, a spec path, or a clear build request; use ce-debug for open-ended bugs. Standalone use owns the shipping tail; outer orchestrators pass `mode:return-to-caller [implementation_engine:<compact-json>] [implementation_run:<safe-id>] <plan path>` for implementation, recovery, and local verification only.
+description: Execute a plan or concrete work prompt end-to-end. Use when implementing from a plan document, a spec path, or a clear build request; use ce-debug for open-ended bugs. Use when an outer orchestrator needs implementation and local verification only, without the shipping tail.
 argument-hint: "[Plan path, work description, or recovery request with run id; blank uses latest] | [mode:return-to-caller [implementation_engine:<compact-json>] [implementation_run:<safe-id>] <plan path> for outer orchestrators]"
 ---
 

--- a/skills/ce-worktree/SKILL.md
+++ b/skills/ce-worktree/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-worktree
-description: Set up isolated git worktrees — create a new branch for fresh work, or attach a worktree to an existing branch/PR/commit to work on it in isolation. Use when starting isolated work or isolating an existing ref; detects existing isolation first.
+description: Set up isolated git worktrees — create a new branch for fresh work, or attach a worktree to an existing branch, PR, or commit. Use when starting isolated work or isolating an existing ref.
 ---
 
 # Worktree Isolation

--- a/skills/lfg/SKILL.md
+++ b/skills/lfg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lfg
-description: "Run the full autonomous shipping pipeline end-to-end, hands-off with no check-ins: plan, implement, review and fix, commit, push a branch, open a PR, and watch CI to green. Use only when the user explicitly asks to build or ship something autonomously all the way to an open PR, or invokes lfg directly — it pushes and opens a PR without stopping. Not for in-the-loop work where the user reviews each step: use ce-plan, ce-work, ce-debug, or ce-commit-push-pr instead."
+description: "Run the full autonomous shipping pipeline end-to-end, hands-off with no check-ins. Use only when the user explicitly asks to build or ship something autonomously all the way to an open PR, or invokes lfg directly — it pushes and opens a PR without stopping. Not for in-the-loop work where the user reviews each step: use ce-plan, ce-work, ce-debug, or ce-commit-push-pr instead."
 argument-hint: "[feature description; optionally assign planning and/or implementation to a model or harness]"
 ---
 

--- a/tests/skills/unified-plan-artifact-contract.test.ts
+++ b/tests/skills/unified-plan-artifact-contract.test.ts
@@ -492,7 +492,9 @@ describe("unified plan artifact contract", () => {
   })
 
   test("ce-work surfaces its caller-owned mode in discovery metadata and public docs", () => {
-    expect(ceWork).toMatch(/description:.*outer orchestrators pass `mode:return-to-caller \[implementation_engine:<compact-json>\] \[implementation_run:<safe-id>\] <plan path>`/i)
+    // Description states the orchestrator-only branch; the flag grammar lives in
+    // argument-hint and the body so the always-on catalog is not a procedure dump.
+    expect(ceWork).toMatch(/description:.*outer orchestrator needs implementation and local verification only, without the shipping tail/i)
     expect(ceWork).toMatch(/argument-hint:.*mode:return-to-caller \[implementation_engine:<compact-json>\] \[implementation_run:<safe-id>\] <plan path> for outer orchestrators/i)
     expect(ceWorkDocs).toContain("## Use Beneath an Outer Orchestrator")
     expect(ceWorkDocs).toContain("standalone_shipping_skipped: true")


### PR DESCRIPTION
## Summary

Model-invoked skill descriptions are now context pointers: what the skill is, one trigger per distinct branch, and only the negatives that block a real neighbor.

The size-restructure sweep extracted bodies into `references/` but left 28 of 33 descriptions as they were. Those descriptions sit in the catalog every turn, so synonym lists, caller flags, and phase procedure were prepaid context. This pass restates the 15 that failed that test. Skill bodies are unchanged.

Codex independently reviewed the same question and held the same 15-item set after one reconcile round. Two descriptions the first pass had left alone (`ce-babysit-pr`, `ce-test-browser`) were added; `ce-resolve-pr-feedback` uses the condition "feedback already left on a PR" instead of listing surfaces.

## What changed

| Skill | What left the description |
|---|---|
| `ce-work` | Caller flag grammar (`mode:return-to-caller …`). The orchestrator-only *branch* stays; the tokens stay in `argument-hint` and the body. Test pin moved with them. |
| `lfg` | Pipeline step list. Explicit-ask trigger and push-without-stopping guardrail stay. Still model-invoked. |
| `ce-code-review` | `apply:local` / report-only mode dump. Apply is now a Use when; PR-comment resolution routes to `ce-resolve-pr-feedback`. |
| `ce-resolve-pr-feedback` | Review-thread synonym list. Covers top-level issue comments without naming surfaces. |
| `ce-babysit-pr` | Synonym and watch-event catalog. One-shot / GitHub-only negatives stay. Still does not advertise base movement. |
| `ce-compound` | `CONCEPTS.md` as a peer purpose (body already sends standalone bootstrap to `ce-compound-refresh`). |
| `ce-brainstorm`, `ce-debug`, `ce-optimize`, `ce-explain`, `ce-pov`, `ce-prototype`, `ce-riffrec-feedback-analysis`, `ce-worktree`, `ce-test-browser` | Quoted examples, one-branch catalogs, or missing Use when. |

Eight `disable-model-invocation` skills were left alone: they are not always-on catalog entries.

## Validation

- `bun test` on `tests/frontmatter.test.ts`, `tests/skill-conventions.test.ts`, `tests/skills/unified-plan-artifact-contract.test.ts`, and the babysit "description does not advertise base movement" pin: pass.
- Activation eval on Claude and Codex was not run. This host has no `skill-creator` eval workflow that injects the current `SKILL.md` into a fresh subagent. Highest-risk follow-up: "watch this PR" on a literal model after the babysit synonym cut.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Grok Build · grok-4.6
- Codex CLI · gpt-5.6-sol (requested; served model unverified) independently reviewed the description set and held the same 15-item landing after one reconcile round.
