### PR TITLE
fix(ce-resolve-pr-feedback): keep replies out of pending reviews

### DIFF
--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -33,7 +33,7 @@ Returns a JSON object with these keys:
 | Key | Contents | Has file/line? | Resolvable? |
 |-----|----------|---------------|-------------|
 | `pending_review` | Node ID of your own unsubmitted (PENDING) review on this PR, or `null` | n/a | n/a |
-| `review_threads` | Unresolved inline code review threads (includes outdated; each carries its `isOutdated` flag so line drift can be accounted for) | Yes | Yes (GraphQL) |
+| `review_threads` | Unresolved inline code review threads (includes outdated); each wrapper carries `root_comment_id` for REST replies and each node carries its GraphQL thread ID for resolution | Yes | Yes (GraphQL) |
 | `pr_comments` | Top-level PR conversation comments | No | No |
 | `review_bodies` | Review submission bodies with non-empty text | No | No |
 | `pr_author` / `viewer` | The PR author's login and the acting account's login, for judging identity in step 2 | n/a | n/a |
@@ -177,35 +177,46 @@ SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback
 GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/COMMENT_ID --jq .node_id
 GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/get-thread-for-comment" PR_NUMBER COMMENT_NODE_ID OWNER/REPO
 ```
-The returned `id` is the authoritative thread ID to use for reply and resolve. If it differs from what `get-pr-comments` returned, use the one from this script.
+The returned `id` is the authoritative thread ID for resolution, and `root_comment_id` is the numeric ID of the thread's first comment for the REST reply. If the thread ID differs from what `get-pr-comments` returned, use the one from this script.
 
-1. **Reply** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread). If the bundled script is missing, reply with `gh api --method POST repos/{owner}/{repo}/pulls/PR_NUMBER/comments/COMMENT_ID/replies -f body=...` against the thread's first comment — never `gh pr review` or a `/reviews` POST, which open an unsubmitted draft review that swallows this reply and every one after it:
+1. **Reply directly to the root comment over REST** using [scripts/reply-to-pr-thread](../scripts/reply-to-pr-thread). If the bundled script is missing, use the same `POST repos/{owner}/{repo}/pulls/PR_NUMBER/comments/ROOT_COMMENT_ID/replies` endpoint. Do not substitute `addPullRequestReviewThreadReply`, `gh pr review`, or a `/reviews` POST: those operations participate in review-submission state, while a successful reply must be immediately submitted and visible.
 Feed the body through a quoted heredoc, never `echo "..."` or `printf`. A reply is multi-line Markdown (a quote line, a blank line, then the response), and `echo` neither interprets `\n` nor survives a body composed with escape sequences — the reviewer then sees a single run-on line containing literal `\n` characters. The quoted delimiter (`<<'EOF'`) also stops the shell from expanding backticks, `$`, and `!` inside quoted code:
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
-GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/reply-to-pr-thread" THREAD_ID <<'EOF'
+GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/reply-to-pr-thread" PR_NUMBER ROOT_COMMENT_ID OWNER/REPO <<'EOF'
 > the specific sentence being addressed from the reviewer's comment
 
 Fixed in abc1234 — the lookup now null-checks before dereferencing.
 EOF
 ```
-Check that the returned comment URL contains the correct `OWNER/REPO` and PR number before proceeding.
+The helper exits nonzero if a pending review is visible after the POST. Stop without resolving on that error; do not submit or discard the review. Check that the returned comment URL contains the correct `OWNER/REPO` and PR number before proceeding.
 
-2. **Verify the posted body renders as Markdown** before resolving. Take the numeric ID from the returned URL fragment (`#discussion_r2589700` → `2589700`) and read back what GitHub actually stored:
+2. **Verify the REST-created reply is visible and submitted** before resolving. Take its numeric ID from the returned URL fragment (`#discussion_r2589700` → `2589700`) and read back what GitHub stored:
 ```bash
-GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/COMMENT_ID --jq .body
+GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/REPLY_COMMENT_ID --jq '{body, pull_request_review_id}'
 ```
-The output must show real line breaks. If instead it shows `\n` (or `\n\n`) as literal backslash-n characters inside one line, the body was posted escaped: **do not resolve the thread**. Fix it first by rewriting the body through a heredoc, then re-verify:
+The body must show real line breaks. If instead it shows `\n` (or `\n\n`) as literal backslash-n characters inside one line, the body was posted escaped: **do not resolve the thread**. Fix it first by rewriting the body through a heredoc, then re-verify:
 ```bash
-GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api --method PATCH repos/{owner}/{repo}/pulls/comments/COMMENT_ID -f body="$(cat <<'EOF'
+GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api --method PATCH repos/{owner}/{repo}/pulls/comments/REPLY_COMMENT_ID -f body="$(cat <<'EOF'
 > the specific sentence being addressed from the reviewer's comment
 
 Fixed in abc1234 — the lookup now null-checks before dereferencing.
 EOF
 )"
 ```
+If `pull_request_review_id` is non-null, fetch that review and require a state other than `PENDING`; a pending state means the reply is not submitted, regardless of the successful POST response:
+```bash
+GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/PR_NUMBER/reviews/REVIEW_ID --jq .state
+```
 
-3. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread) (if the bundled script is missing, resolve the thread with `gh api` if supported):
+3. **Re-fetch pending-review state after posting.** This closes the race after the initial fetch and detects a draft created during the reply loop:
+```bash
+SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
+GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/get-pr-comments" PR_NUMBER OWNER/REPO | jq -r '.pending_review // empty'
+```
+If this prints an ID, stop without resolving any thread from this reply pass. Report the pending review, but do not submit or discard it.
+
+4. **Resolve** using [scripts/resolve-pr-thread](../scripts/resolve-pr-thread) (if the bundled script is missing, resolve the thread with `gh api` if supported):
 ```bash
 SKILL_DIR="<absolute path of the directory containing the ce-resolve-pr-feedback SKILL.md>";
 GH_HOST=<derived-host> bash "$SKILL_DIR/scripts/resolve-pr-thread" THREAD_ID

--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -165,7 +165,7 @@ git push
 
 ## 7. Reply and Resolve
 
-After the push succeeds, post replies and resolve where applicable. The done condition for an ordinary review thread is one visible, submitted substantive reply plus authoritative resolution; never repeat a satisfied half of that condition. Post for every newly handled item: fix-list items use the fixer's `reply_text`; reply-list and human-list items use the reply text you composed in step 3. For resolution-pending threads, verify the existing reply is visible and submitted, re-fetch pending-review state, then resolve without reposting or reapplying. A **class item** carries multiple covered feedback IDs (`feedback_ids`/`feedback_types` from its fixer) — reply to and resolve *every* one, posting the shared `reply_text` on each thread, not just the first; a covered thread left unresolved re-actionizes in the next babysit loop. The mechanism depends on the feedback type.
+After the push succeeds, post replies and resolve where applicable. The done condition for an ordinary review thread is one visible, submitted substantive reply plus authoritative resolution; satisfy each condition independently and never repeat a satisfied half. Post for every newly handled item: fix-list items use the fixer's `reply_text`; reply-list and human-list items use the reply text you composed in step 3. A **class item** carries multiple covered feedback IDs (`feedback_ids`/`feedback_types` from its fixer) — reply to and resolve *every* one, posting the shared `reply_text` on each thread, not just the first; a covered thread left unresolved re-actionizes in the next babysit loop. The mechanism depends on the feedback type.
 
 ### Reply format
 
@@ -174,6 +174,8 @@ All replies quote the relevant part of the original feedback for continuity — 
 For `needs-human` verdicts, post the natural-sounding reply but do NOT resolve the thread. Leave it open for human input.
 
 ### Review threads
+
+For every calling mode, select the first unsatisfied completion condition before acting. A thread with no visible submitted substantive reply runs steps 0-4. A `resolution-pending` thread skips only step 1, uses its existing reply IDs for step 2, and runs steps 2-4; do not judge, fix, or post again. A `needs-human` thread stops after its visible submitted reply and remains unresolved.
 
 0. **Verify the thread ID** before replying. GitHub Enterprise can return inconsistent node IDs for the same thread depending on the query path. Always confirm the ID from `get-pr-comments` resolves to the correct thread using [scripts/get-thread-for-comment](../scripts/get-thread-for-comment) with the comment's numeric URL ID. Extract the numeric comment ID from the comment URL (e.g. `discussion_r2589700` → `2589700`) for the `gh api` call; if the bundled script is missing, use `gh api` to inspect the review thread instead:
 ```bash

--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -50,9 +50,13 @@ gh api repos/{owner}/{repo}/pulls/PR_NUMBER/comments
 
 ## 2. Triage: Separate New from Pending
 
-Before processing, classify each piece of feedback as **new** or **already handled**.
+Before processing, reconcile the reply and resolution state of each piece of feedback.
 
-**Review threads**: Read the thread's comments. If there's a substantive reply that acknowledges the concern but defers action (e.g., "need to align on this", "going to think through this", or a reply that presents options without resolving), it's a **pending decision** -- don't re-process. If there's only the original reviewer comment(s) with no substantive response, it's **new**.
+**Review threads**: An ordinarily handled thread is complete only when it has both a visible, submitted substantive reply and authoritative thread resolution. Reconcile those conditions independently:
+
+- A reply that explicitly defers a human choice (e.g., "need to align on this", "going to think through this", or options without a decision) is a **pending decision**. Keep the thread open and do not re-process it.
+- A reply that records a completed fix or reply verdict while the thread is still open is **resolution-pending**. Do not repost the reply or reapply the fix; carry the existing visible reply to step 7 and complete only the missing resolution after pending-review state is empty.
+- A thread without either kind of substantive response is **new**.
 
 **PR comments and review bodies**: These have no resolve mechanism, so they reappear on every run. Apply two filters in order:
 
@@ -63,7 +67,7 @@ The distinction is about content, not who posted what. A deferral from a teammat
 
 **Silent drop.** Non-actionable items are dropped without narration. Do not announce, list, or count dropped items in conversation, the task list, or the step 9 summary. Review-bot wrappers from CodeRabbit, Codex, Gemini Code Assist, and Copilot (bodies like "Here are some automated review suggestions...") commonly appear here -- recognize them by their boilerplate content, drop silently. The fetch layer pre-filters only blank bodies. Every identity and surface — the PR author, CI/status bots such as Codecov, review bots — relies on this content-aware check, so identity reuse or format changes cannot silently hide actionable feedback.
 
-If there are no new items across all feedback types, skip steps 3-8 and go straight to step 9.
+If there are no new or resolution-pending items across all feedback types, skip steps 3-8 and go straight to step 9. If only resolution-pending threads remain, skip steps 3-6 and go straight to step 7.
 
 ## 3. Consolidate & Decide (the legitimacy gate)
 
@@ -161,7 +165,7 @@ git push
 
 ## 7. Reply and Resolve
 
-After the push succeeds, post replies and resolve where applicable. Post for every handled item: fix-list items use the fixer's `reply_text`; reply-list and human-list items use the reply text you composed in step 3. A **class item** carries multiple covered feedback IDs (`feedback_ids`/`feedback_types` from its fixer) — reply to and resolve *every* one, posting the shared `reply_text` on each thread, not just the first; a covered thread left unresolved re-actionizes in the next babysit loop. The mechanism depends on the feedback type.
+After the push succeeds, post replies and resolve where applicable. The done condition for an ordinary review thread is one visible, submitted substantive reply plus authoritative resolution; never repeat a satisfied half of that condition. Post for every newly handled item: fix-list items use the fixer's `reply_text`; reply-list and human-list items use the reply text you composed in step 3. For resolution-pending threads, verify the existing reply is visible and submitted, re-fetch pending-review state, then resolve without reposting or reapplying. A **class item** carries multiple covered feedback IDs (`feedback_ids`/`feedback_types` from its fixer) — reply to and resolve *every* one, posting the shared `reply_text` on each thread, not just the first; a covered thread left unresolved re-actionizes in the next babysit loop. The mechanism depends on the feedback type.
 
 ### Reply format
 

--- a/skills/ce-resolve-pr-feedback/references/full-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/full-mode.md
@@ -193,9 +193,10 @@ The helper exits nonzero if a pending review is visible after the POST. Stop wit
 
 2. **Verify the REST-created reply is visible and submitted** before resolving. Take its numeric ID from the returned URL fragment (`#discussion_r2589700` → `2589700`) and read back what GitHub stored:
 ```bash
-GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/REPLY_COMMENT_ID --jq '{body, pull_request_review_id}'
+GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/REPLY_COMMENT_ID --jq .body
+GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/comments/REPLY_COMMENT_ID --jq '.pull_request_review_id // empty'
 ```
-The body must show real line breaks. If instead it shows `\n` (or `\n\n`) as literal backslash-n characters inside one line, the body was posted escaped: **do not resolve the thread**. Fix it first by rewriting the body through a heredoc, then re-verify:
+The first command prints the decoded body, which must show real line breaks. If instead it shows `\n` (or `\n\n`) as literal backslash-n characters inside one line, the body was posted escaped: **do not resolve the thread**. Fix it first by rewriting the body through a heredoc, then re-verify:
 ```bash
 GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api --method PATCH repos/{owner}/{repo}/pulls/comments/REPLY_COMMENT_ID -f body="$(cat <<'EOF'
 > the specific sentence being addressed from the reviewer's comment
@@ -204,7 +205,7 @@ Fixed in abc1234 — the lookup now null-checks before dereferencing.
 EOF
 )"
 ```
-If `pull_request_review_id` is non-null, fetch that review and require a state other than `PENDING`; a pending state means the reply is not submitted, regardless of the successful POST response:
+If the second command prints a review ID, fetch that review and require a state other than `PENDING`; a pending state means the reply is not submitted, regardless of the successful POST response:
 ```bash
 GH_HOST=<derived-host> GH_REPO=OWNER/REPO gh api repos/{owner}/{repo}/pulls/PR_NUMBER/reviews/REVIEW_ID --jq .state
 ```

--- a/skills/ce-resolve-pr-feedback/references/targeted-mode.md
+++ b/skills/ce-resolve-pr-feedback/references/targeted-mode.md
@@ -35,6 +35,8 @@ If this prints anything, stop. Tell the user they have an unsubmitted review on 
 
 ## 2. Judge, Fix, Reply, Resolve
 
+Apply Full Mode step 7's independent reply/resolution completion check before judgment. When the target is already `resolution-pending`, that shared step owns the only remaining work; skip judgment, fixing, validation, and commit, then complete the missing resolution without posting again.
+
 **Judge first (the gate).** Apply the rubric in `references/evaluation-rubric.md` to this one thread, in your own context. Account for `isOutdated` and the location fields (`line`, `originalLine`, `startLine`, `originalStartLine`) -- targeted threads can be outdated too and need the same relocation handling. The cross-item reasoning in the rubric is a no-op for a single thread, but the read-depth and divert logic apply in full: deep-read (callers, invariants, `git blame`/PR rationale for author intent) before accepting a contestable finding or overriding code that looks deliberate. This is the legitimacy check — don't fix on the reviewer's authority alone.
 
 **Then act on the verdict:**

--- a/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
+++ b/skills/ce-resolve-pr-feedback/scripts/get-pr-comments
@@ -29,7 +29,7 @@ if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
     exit 1
 fi
 
-# Output is a JSON object with four keys:
+# Output is a JSON object with these keys:
 #   pending_review   - node ID of the viewer's own unsubmitted (PENDING) review
 #                      on this PR, or null. Replies posted while one exists get
 #                      silently absorbed into that draft and stay invisible
@@ -37,9 +37,9 @@ fi
 #                      reply loop when this is non-null. Costs no extra request:
 #                      the reviews query below already selects `state`, and a
 #                      PENDING review is only visible to its own author.
-#   review_threads   - unresolved inline review threads, edge-wrapped as
-#                      [{ node: { id, isResolved, isOutdated, path, line, ...,
-#                                 comments: { nodes: [...] } } }]
+#   review_threads   - unresolved inline review threads, edge-wrapped with the
+#                      root numeric REST comment ID used for direct replies:
+#                      [{ root_comment_id, node: { id, isResolved, ... } }]
 #   pr_comments      - non-empty top-level PR conversation comments
 #   review_bodies    - non-empty review submission bodies
 #   pr_author        - the PR author's login, or null
@@ -161,7 +161,12 @@ jq -n \
       | select(.state == "PENDING")
       | select(($viewer == null) or (.author.login == $viewer))
       | .id) // null),
-    review_threads: [$unresolved[] | { node: . }],
+    review_threads: [$unresolved[] | {
+      node: .,
+      root_comment_id: (.comments.nodes[0].url
+        | capture("discussion_r(?<id>[0-9]+)").id
+        | tonumber)
+    }],
     pr_comments: [$all_comments[]
       | select((.body // "") | test("^\\s*$") | not)],
     review_bodies: [$all_reviews[]

--- a/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
+++ b/skills/ce-resolve-pr-feedback/scripts/get-thread-for-comment
@@ -76,4 +76,9 @@ jq -e -n --slurpfile pages "$tmp_threads" --arg cid "$COMMENT_NODE_ID" '
   [$pages[0][].data.repository.pullRequest.reviewThreads.nodes[]
    | select(any(.comments.nodes[]; .id == $cid))]
   | if length == 0 then error("No thread found for comment \($cid)") else .[0] end
+  | . + {
+      root_comment_id: (.comments.nodes[0].url
+        | capture("discussion_r(?<id>[0-9]+)").id
+        | tonumber)
+    }
 '

--- a/skills/ce-resolve-pr-feedback/scripts/reply-to-pr-thread
+++ b/skills/ce-resolve-pr-feedback/scripts/reply-to-pr-thread
@@ -1,45 +1,57 @@
 #!/usr/bin/env bash
 
-# Replies to a PR review thread. Body is read from stdin to avoid
-# shell escaping issues with markdown (quotes, newlines, etc.).
-#
-# GraphQL rather than REST (`POST pulls/{n}/comments/{id}/replies`) because the
-# surrounding pipeline is thread-node-ID-native: get-pr-comments returns PRRT_
-# IDs and resolveReviewThread has no REST equivalent, so replying by thread ID
-# keeps one ID currency end to end. REST addresses a *comment*, which would mean
-# carrying the thread's root comment databaseId purely for this call. Both
-# produce a real inline threaded reply -- this is not a capability difference.
-#
-# Omitting pullRequestReviewId below means the reply is absorbed into the
-# viewer's PENDING review when one exists, returning success while staying
-# invisible until that draft is submitted. The modes guard against this via
-# get-pr-comments' pending_review key; do not add a reviewId here without one.
+# Replies directly to a PR review thread's root comment. Body is read from
+# stdin to preserve Markdown quotes and newlines. The REST reply endpoint is
+# load-bearing: GraphQL addPullRequestReviewThreadReply can attach the reply to
+# a pending review and return success before the reply is submitted or visible.
 
 set -e
 
-if [ $# -lt 1 ]; then
-    echo "Usage: echo 'reply body' | reply-to-pr-thread THREAD_ID"
-    echo "Example: echo 'Addressed: added null check' | reply-to-pr-thread PRRT_kwDOABC123"
+if [ $# -lt 2 ]; then
+    echo "Usage: reply-to-pr-thread PR_NUMBER ROOT_COMMENT_ID [OWNER/REPO] < reply-body.md"
+    echo "Example: reply-to-pr-thread 123 456789 EveryInc/cora < reply-body.md"
     exit 1
 fi
 
-THREAD_ID=$1
+PR_NUMBER=$1
+ROOT_COMMENT_ID=$2
 BODY=$(cat)
+
+if [ -n "$3" ]; then
+    OWNER=$(echo "$3" | cut -d/ -f1)
+    REPO=$(echo "$3" | cut -d/ -f2)
+else
+    OWNER=$(gh repo view --json owner -q .owner.login 2>/dev/null || true)
+    REPO=$(gh repo view --json name -q .name 2>/dev/null || true)
+fi
+
+if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
+    echo "Error: could not resolve owner/repo. Pass OWNER/REPO as the third argument." >&2
+    exit 1
+fi
+
+case "$PR_NUMBER" in
+    ''|*[!0-9]*) echo "Error: PR_NUMBER must be numeric." >&2; exit 1 ;;
+esac
+
+case "$ROOT_COMMENT_ID" in
+    ''|*[!0-9]*) echo "Error: ROOT_COMMENT_ID must be numeric." >&2; exit 1 ;;
+esac
 
 if [ -z "$BODY" ]; then
     echo "Error: No body provided on stdin."
     exit 1
 fi
 
-gh api graphql -f threadId="$THREAD_ID" -f body="$BODY" -f query='
-mutation ReplyToReviewThread($threadId: ID!, $body: String!) {
-  addPullRequestReviewThreadReply(input: {
-    pullRequestReviewThreadId: $threadId
-    body: $body
-  }) {
-    comment {
-      id
-      url
-    }
-  }
-}'
+gh api --method POST \
+  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments/$ROOT_COMMENT_ID/replies" \
+  -f body="$BODY"
+
+PENDING_REVIEW=$(gh api --paginate \
+  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/reviews" \
+  --jq '.[] | select(.state == "PENDING") | .id')
+
+if [ -n "$PENDING_REVIEW" ]; then
+    echo "Error: a pending review appeared after posting. Stop without resolving the thread; do not submit or discard the review." >&2
+    exit 2
+fi

--- a/tests/resolve-pr-feedback-pagination.test.ts
+++ b/tests/resolve-pr-feedback-pagination.test.ts
@@ -134,7 +134,10 @@ describe("ce-resolve-pr-feedback scripts paginate GraphQL connections (issue #79
       )
 
       expect(result.status, result.stderr).toBe(0)
-      expect(JSON.parse(result.stdout)).toEqual(thread)
+      expect(JSON.parse(result.stdout)).toEqual({
+        ...thread,
+        root_comment_id: 1,
+      })
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
@@ -281,7 +284,7 @@ fi
       // silently dropped the request (#1435 eval). Only a blank body (pc3) is filtered.
       expect(JSON.parse(result.stdout)).toEqual({
         pending_review: "pending-1",
-        review_threads: [{ node: unresolved }],
+        review_threads: [{ node: unresolved, root_comment_id: 1 }],
         pr_comments: [
           { id: "pc1", author: { login: "reviewer" }, body: "top-level note" },
           {

--- a/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
@@ -7,6 +7,7 @@ import { extractBashBlocks } from "./fenced-blocks"
 
 const SKILL_DIR = path.join(import.meta.dir, "..", "..", "skills", "ce-resolve-pr-feedback")
 const FULL_MODE = readFileSync(path.join(SKILL_DIR, "references", "full-mode.md"), "utf8")
+const TARGETED_MODE = readFileSync(path.join(SKILL_DIR, "references", "targeted-mode.md"), "utf8")
 const REPLY_SCRIPT = path.join(SKILL_DIR, "scripts", "reply-to-pr-thread")
 
 const blocks = extractBashBlocks(FULL_MODE).map((b) => b.body)
@@ -91,7 +92,9 @@ describe("ce-resolve-pr-feedback reply bodies keep real newlines", () => {
     expect(FULL_MODE).toMatch(/visible, submitted substantive reply[^.]+authoritative thread resolution/i)
     expect(FULL_MODE).toMatch(/resolution-pending[\s\S]{0,220}do not repost[^;]+reapply/i)
     expect(FULL_MODE).toMatch(/only resolution-pending[^.]+skip steps 3-6[^.]+step 7/i)
-    expect(FULL_MODE).toMatch(/verify the existing reply[^.]+re-fetch pending-review state[^.]+resolve without reposting or reapplying/i)
+    expect(FULL_MODE).toMatch(/resolution-pending[^.]+skips only step 1[^.]+runs steps 2-4/i)
+    expect(FULL_MODE).toMatch(/do not judge, fix, or post again/i)
+    expect(TARGETED_MODE).toMatch(/completion check before judgment[\s\S]{0,260}complete the missing resolution without posting again/i)
   })
 
   test("top-level PR comment replies also use a heredoc body", () => {

--- a/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test"
-import { execFileSync } from "child_process"
+import { spawnSync } from "child_process"
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import path from "path"
@@ -16,6 +16,43 @@ const tempDirs: string[] = []
 afterAll(() => {
   for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true })
 })
+
+function fakeGhFixture() {
+  const dir = mkdtempSync(path.join(tmpdir(), "ce-reply-"))
+  tempDirs.push(dir)
+  const capture = path.join(dir, "args.txt")
+  const fakeGh = path.join(dir, "gh")
+  writeFileSync(fakeGh, `#!/usr/bin/env bash
+printf 'CALL\\0' >> ${JSON.stringify(capture)}
+printf '%s\\0' "$@" >> ${JSON.stringify(capture)}
+case "$*" in
+  *"/replies"*)
+    printf '%s\\n' '{"id":2002,"html_url":"https://github.com/o/r/pull/42#discussion_r2002","pull_request_review_id":3003}'
+    ;;
+  *"/reviews"*)
+    if [ "$FAKE_PENDING_REVIEW" = "1" ]; then
+      printf '%s\\n' 'pending-review-1'
+    fi
+    ;;
+  *)
+    echo "unexpected gh invocation: $*" >&2
+    exit 1
+    ;;
+esac
+`)
+  chmodSync(fakeGh, 0o755)
+  return { dir, capture }
+}
+
+function readCalls(capture: string): string[][] {
+  const records = readFileSync(capture, "utf8").split("\0").filter(Boolean)
+  const calls: string[][] = []
+  for (const record of records) {
+    if (record === "CALL") calls.push([])
+    else calls.at(-1)!.push(record)
+  }
+  return calls
+}
 
 describe("ce-resolve-pr-feedback reply bodies keep real newlines", () => {
   test("the reply example feeds a quoted heredoc, not echo", () => {
@@ -35,12 +72,15 @@ describe("ce-resolve-pr-feedback reply bodies keep real newlines", () => {
     expect(replyBlock!).not.toContain("\\n")
   })
 
-  test("full mode reads the posted body back and blocks resolve on literal \\n", () => {
+  test("full mode verifies submitted visibility and rechecks pending state before resolve", () => {
     const verifySection = FULL_MODE.slice(
       FULL_MODE.indexOf("scripts/reply-to-pr-thread"),
       FULL_MODE.indexOf("scripts/resolve-pr-thread"),
     )
-    expect(verifySection).toContain("pulls/comments/COMMENT_ID --jq .body")
+    expect(verifySection).toContain("pulls/comments/REPLY_COMMENT_ID")
+    expect(verifySection).toContain("pull_request_review_id")
+    expect(verifySection).toContain("reviews/REVIEW_ID --jq .state")
+    expect(verifySection).toContain(".pending_review // empty")
     expect(verifySection).toMatch(/`\\n\\n`/)
     expect(verifySection).toMatch(/do not resolve/i)
   })
@@ -52,28 +92,60 @@ describe("ce-resolve-pr-feedback reply bodies keep real newlines", () => {
     expect(commentBlock!).not.toContain("--body \"REPLY_TEXT\"")
   })
 
-  test("reply-to-pr-thread passes stdin through to gh with newlines intact", () => {
-    const dir = mkdtempSync(path.join(tmpdir(), "ce-reply-"))
-    tempDirs.push(dir)
-    const capture = path.join(dir, "args.txt")
-    const fakeGh = path.join(dir, "gh")
-    // Records every argv entry on its own NUL-delimited record so an embedded newline in
-    // the body argument is distinguishable from the separator.
-    writeFileSync(fakeGh, `#!/usr/bin/env bash\nprintf '%s\\0' "$@" > ${JSON.stringify(capture)}\n`)
-    chmodSync(fakeGh, 0o755)
-
+  test("reply-to-pr-thread uses the direct REST reply endpoint and preserves newlines", () => {
+    const { dir, capture } = fakeGhFixture()
     const body = "> reviewer said this\n\nFixed in abc1234 — added the null check."
-    execFileSync("bash", [REPLY_SCRIPT, "PRRT_test"], {
+    const result = spawnSync("bash", [REPLY_SCRIPT, "42", "1001", "o/r"], {
       input: body,
+      encoding: "utf8",
       env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
-      stdio: ["pipe", "ignore", "pipe"],
     })
 
-    const args = readFileSync(capture, "utf8").split("\0")
-    const bodyArg = args.find((a) => a.startsWith("body="))
+    expect(result.status, result.stderr).toBe(0)
+    const calls = readCalls(capture)
+    expect(calls[0]).toEqual([
+      "api",
+      "--method",
+      "POST",
+      "repos/o/r/pulls/42/comments/1001/replies",
+      "-f",
+      `body=${body}`,
+    ])
+    expect(calls[1]).toEqual([
+      "api",
+      "--paginate",
+      "repos/o/r/pulls/42/reviews",
+      "--jq",
+      '.[] | select(.state == "PENDING") | .id',
+    ])
+    const bodyArg = calls[0]!.find((a) => a.startsWith("body="))
     expect(bodyArg).toBe(`body=${body}`)
     expect(bodyArg).toContain("\n\n")
     expect(bodyArg).not.toContain("\\n")
+    expect(calls.flat()).not.toContain("graphql")
+    expect(calls.flat().join(" ")).not.toContain("addPullRequestReviewThreadReply")
+    expect(calls.some((call) => call.includes("resolveReviewThread"))).toBe(false)
+    expect(calls.some((call) => call.includes("/reviews") && call.includes("POST"))).toBe(false)
+  })
+
+  test("reply-to-pr-thread fails closed if a pending review appears after posting", () => {
+    const { dir, capture } = fakeGhFixture()
+    const result = spawnSync("bash", [REPLY_SCRIPT, "42", "1001", "o/r"], {
+      input: "Reply body",
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        FAKE_PENDING_REVIEW: "1",
+      },
+    })
+
+    expect(result.status).toBe(2)
+    expect(result.stderr).toMatch(/pending review appeared after posting/i)
+    const calls = readCalls(capture)
+    expect(calls).toHaveLength(2)
+    expect(calls.flat()).not.toContain("graphql")
+    expect(calls.some((call) => call.includes("resolveReviewThread"))).toBe(false)
   })
 
   test("a body composed with escaped newlines is detectable in what gh would post", () => {

--- a/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
@@ -87,6 +87,13 @@ describe("ce-resolve-pr-feedback reply bodies keep real newlines", () => {
     expect(verifySection).toMatch(/do not resolve/i)
   })
 
+  test("full mode reconciles visible replies and thread resolution independently", () => {
+    expect(FULL_MODE).toMatch(/visible, submitted substantive reply[^.]+authoritative thread resolution/i)
+    expect(FULL_MODE).toMatch(/resolution-pending[\s\S]{0,220}do not repost[^;]+reapply/i)
+    expect(FULL_MODE).toMatch(/only resolution-pending[^.]+skip steps 3-6[^.]+step 7/i)
+    expect(FULL_MODE).toMatch(/verify the existing reply[^.]+re-fetch pending-review state[^.]+resolve without reposting or reapplying/i)
+  })
+
   test("top-level PR comment replies also use a heredoc body", () => {
     const commentBlock = blocks.find((b) => b.includes("gh pr comment"))
     expect(commentBlock).toBeDefined()

--- a/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
+++ b/tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts
@@ -78,7 +78,9 @@ describe("ce-resolve-pr-feedback reply bodies keep real newlines", () => {
       FULL_MODE.indexOf("scripts/resolve-pr-thread"),
     )
     expect(verifySection).toContain("pulls/comments/REPLY_COMMENT_ID")
-    expect(verifySection).toContain("pull_request_review_id")
+    expect(verifySection).toContain("--jq .body")
+    expect(verifySection).toContain("--jq '.pull_request_review_id // empty'")
+    expect(verifySection).not.toContain("--jq '{body, pull_request_review_id}'")
     expect(verifySection).toContain("reviews/REVIEW_ID --jq .state")
     expect(verifySection).toContain(".pending_review // empty")
     expect(verifySection).toMatch(/`\\n\\n`/)


### PR DESCRIPTION
## Summary

Review-thread replies now use GitHub's direct REST reply endpoint, so a successful response cannot leave the message hidden inside the caller's pending review. Thread resolution waits until the stored Markdown is visible, the associated review is submitted, and a fresh pending-review check remains empty.

The fetch helpers expose the root numeric comment ID for REST replies while preserving the GraphQL thread ID for resolution. If a pending review appears after posting, the helper stops without resolving, submitting, or discarding it.

Full and targeted modes now treat a visible submitted reply and authoritative thread resolution as independent completion conditions. A retry that already posted its reply enters the shared resolution-pending path and skips duplicate judgment, fixing, validation, commit, and reply creation.

## Validation

- `bun test tests/skills/ce-resolve-pr-feedback-reply-newlines.test.ts tests/resolve-pr-feedback-pagination.test.ts` - 16 passed, 0 failed
- `bun run test` - 3,430 passed, 0 failed, 15,949 assertions across 139 files
- `bun run release:validate` - passed
- `bun run plugin:validate` - passed
- `git diff --check` - passed

Grok CLI only; Claude was not invoked. A targeted retry probe was intentionally not promoted into the durable behavioral catalog because both historical and current Grok inferred resolution-only behavior; the deterministic shared-path contract is the discriminating regression.

The REST path was also exercised live while resolving this stack's review feedback: every reply read back with real Markdown newlines, every reply review was `COMMENTED`, and fresh pending-review queries remained empty before resolution.

## Security Disclosure

This changes a skill's GitHub API write path. Pull request and root comment IDs are numeric-validated, the reply body remains one quoted `gh api` argument, and the helper uses the existing authenticated `gh` context. No credential, permission, or secret-handling behavior changed.

## Agent Disclosure

- **Model:** Codex CLI · GPT-5
