### PR TITLE
test(cross-model): give the subprocess-heavy route suites a 30s per-test ceiling

### DIFF
--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { spawnSync } from "node:child_process"
 import {
   mkdtempSync,
@@ -13,6 +13,10 @@ import {
 } from "node:fs"
 import { devNull, tmpdir } from "node:os"
 import path from "node:path"
+
+// These tests spawn bash/python/git subprocesses; on a loaded CI runner they cross the 5s default
+// (2026-08-21, PR #1508: three different tests timed out across two reruns with no related change).
+setDefaultTimeout(30_000)
 
 const tempRoots: string[] = []
 function mkTempRoot(prefix: string): string {

--- a/tests/skills/ce-doc-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-doc-review-cross-model-routes.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { spawnSync } from "node:child_process"
 import {
   mkdtempSync,
@@ -13,6 +13,10 @@ import {
 } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
+
+// These tests spawn bash/python/git subprocesses; on a loaded CI runner they cross the 5s default
+// (2026-08-21, PR #1508: three different tests timed out across two reruns with no related change).
+setDefaultTimeout(30_000)
 
 // Every temp root we create, torn down after the suite so runs don't leak dirs.
 const tempRoots: string[] = []


### PR DESCRIPTION
The two `cross-model-routes` test files spawn `bash`, `python`, and `git` per test but ran under bun's 5 s default timeout, so a loaded runner turned them into failures unrelated to the change under test — on #1508 three different tests in these files timed out across two reruns while the suite took 127 s instead of its usual ~81 s. Each file now calls `setDefaultTimeout(30_000)` at the top, the same ceiling the other subprocess-heavy suites already set. No assertion changes; 129 tests still pass locally.

Related: #1508

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** `Claude Code · claude-fable-5`
