### PR TITLE
fix(ce-code-review): stop the reviewer template from embedding the diff twice

### DIFF
--- a/skills/ce-code-review/references/subagent-template.md
+++ b/skills/ce-code-review/references/subagent-template.md
@@ -183,7 +183,7 @@ Changed files: {file_list}
 Diff:
 {diff}
 
-(For a large staged review, `{file_list}` and `{diff}` may be **file paths** rather than inline content. When a value above is a path, Read that file to get the full list/diff before reviewing — never treat the path string itself as the content to review.)
+(The `Changed files:` and `Diff:` values above are either inline content or, for a large staged review, a single file path each. Inline content is authoritative: review it as given. A lone file path is not the content — Read that file to get the full list/diff before reviewing.)
 </review-context>
 ```
 

--- a/tests/review-skill-contract.test.ts
+++ b/tests/review-skill-contract.test.ts
@@ -1531,3 +1531,24 @@ describe("testing-reviewer contract", () => {
     expect(content).toContain("Non-behavioral changes")
   })
 })
+
+describe("ce-code-review dispatch templates", () => {
+  // #1509: a placeholder named in the template's prose gets filled like a slot, so
+  // `{diff}` in the closing note re-emitted the whole diff into every reviewer prompt.
+  // Each placeholder may appear only once inside the fenced template, as its slot.
+  test("the reviewer template names each placeholder once, as a slot", async () => {
+    const content = await readRepoFile(
+      "skills/ce-code-review/references/subagent-template.md",
+    )
+    // The template fence nests a ```json example, so bound it by the heading that follows it.
+    const fenced = content.match(/^```\n[\s\S]*?^```\n\n## Variable Reference/m)?.[0]
+    expect(fenced).toBeDefined()
+    const counts = new Map<string, number>()
+    for (const m of fenced!.matchAll(/\{([a-z_]+)\}/g)) {
+      counts.set(m[1], (counts.get(m[1]) ?? 0) + 1)
+    }
+    for (const name of ["file_list", "diff"]) {
+      expect(counts.get(name)).toBe(1)
+    }
+  })
+})


### PR DESCRIPTION
Every `ce-code-review` reviewer prompt carried the changed-file list and the full diff twice, then ended with a note telling the reviewer that inline content "may be file paths" to Read from disk. The closing note of the template's `<review-context>` block named `{file_list}` and `{diff}` in slot syntax, so prompt assembly filled them a second time; the reporter measured the second copy at 33% of a nine-reviewer run's payload, and one reviewer stopped to verify the contradiction. The note now refers to the `Changed files:` and `Diff:` labels the reviewer actually sees after substitution and states the condition: inline content is authoritative, a lone staged path is Read. This matches the shape the validator template already used.

A contract test pins each placeholder to exactly one occurrence inside the fenced template, so a future mention of `{diff}` in the note fails `bun run test`.

Fixes #1509

## Validation

`bun run test` (3540 pass), `bun run release:validate` clean. The new test fails on the old template line and passes on the new one.

Fresh-agent eval of the reviewer subagent, read-only, against a throwaway repo with a 2-file diff. Prompts were assembled from the real template (pre = `main`, post = this branch) by filling every `{slot}`; the pre prompt reproduces the bug (diff present twice). Three arms on Claude (`claude -p`) and Codex (`codex exec --sandbox read-only`):

| Arm | Claude | Codex |
|---|---|---|
| pre, inline diff | Reviewed inline diff; absorbed the false note silently (no path reads, no contradiction reported) | Same; re-derived the diff from `git diff` rather than trusting the prompt |
| post, inline diff | Reviewed inline diff; no path reads | Same; also re-derived from git and ran a node probe |
| post, staged paths | First tool calls: Read `diff.txt`, Read `files.txt`, then reviewed | First command: `sed` both staged files, then reviewed |

No regression on either host; the staged-path instruction still fires on both. The strong tiers absorbed the old contradiction rather than acting on it (matching 8 of 9 reviewers in the report), so this eval shows the fix holds rather than a before/after flip; the reporter's `testing` reviewer that halted to verify is the observed failure the rewrite removes.

## Security Disclosure
No security-relevant changes.

## Agent Disclosure
- **Model:** `Claude Code · claude-fable-5`

https://claude.ai/code/session_012uPY9QcVF4ueBgrpegPcvC
