### PR TITLE
fix(cross-model): drop empty Codex usage files and unblock heartbeat teardown

### DIFF
--- a/skills/ce-brainstorm/scripts/elevation-dispatch.sh
+++ b/skills/ce-brainstorm/scripts/elevation-dispatch.sh
@@ -183,6 +183,10 @@ start_heartbeat() {
   case "$every" in ''|*[!0-9]*) every=60 ;; esac; [ "$every" -lt 1 ] && every=1
   _HEARTBEAT_READY=0
   trap '_HEARTBEAT_READY=1' USR1
+  # Callers restore set +m after launching the peer, so without this the
+  # heartbeat inherits the worker pgid and kill -- -PID cannot reach the sleep.
+  local prev_m; case "$-" in *m*) prev_m=1;; *) prev_m=0;; esac
+  set -m
   ( local t0 n sleeper=""
     trap 'kill "${sleeper:-}" 2>/dev/null || true; exit 0' TERM INT
     kill -USR1 "$parent_pid"
@@ -195,6 +199,7 @@ start_heartbeat() {
       n="$(date +%s)"; log "peer alive ($(( n - t0 ))s elapsed)"
     done ) &
   _HEARTBEAT_PID=$!
+  [ "$prev_m" = 0 ] && set +m
   while [ "$_HEARTBEAT_READY" != 1 ] && kill -0 "$_HEARTBEAT_PID" 2>/dev/null; do sleep 0.01 || true; done
   trap - USR1
 }

--- a/skills/ce-brainstorm/scripts/elevation-dispatch.sh
+++ b/skills/ce-brainstorm/scripts/elevation-dispatch.sh
@@ -200,7 +200,9 @@ start_heartbeat() {
 }
 stop_heartbeat() {
   if [ -n "$_HEARTBEAT_PID" ]; then
-    kill "$_HEARTBEAT_PID" 2>/dev/null || true
+    # Leader-only TERM is deferred until the inner `wait $sleeper` returns, so
+    # the default 60s interval would block this wait. Signal the process group.
+    kill -- -"$_HEARTBEAT_PID" 2>/dev/null || kill "$_HEARTBEAT_PID" 2>/dev/null || true
     wait "$_HEARTBEAT_PID" 2>/dev/null || true
   fi
   _HEARTBEAT_PID=""

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -680,7 +680,9 @@ start_heartbeat() {
 }
 stop_heartbeat() {
   if [ -n "$_HEARTBEAT_PID" ]; then
-    kill "$_HEARTBEAT_PID" 2>/dev/null || true
+    # Leader-only TERM is deferred until the inner `wait $sleeper` returns, so
+    # the default 60s interval would block this wait. Signal the process group.
+    kill -- -"$_HEARTBEAT_PID" 2>/dev/null || kill "$_HEARTBEAT_PID" 2>/dev/null || true
     wait "$_HEARTBEAT_PID" 2>/dev/null || true
   fi
   _HEARTBEAT_PID=""

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -663,6 +663,10 @@ start_heartbeat() {
   case "$every" in ''|*[!0-9]*) every=60 ;; esac; [ "$every" -lt 1 ] && every=1
   _HEARTBEAT_READY=0
   trap '_HEARTBEAT_READY=1' USR1
+  # Callers restore set +m after launching the peer, so without this the
+  # heartbeat inherits the worker pgid and kill -- -PID cannot reach the sleep.
+  local prev_m; case "$-" in *m*) prev_m=1;; *) prev_m=0;; esac
+  set -m
   ( local t0 n sleeper=""
     trap 'kill "${sleeper:-}" 2>/dev/null || true; exit 0' TERM INT
     kill -USR1 "$parent_pid"
@@ -675,6 +679,7 @@ start_heartbeat() {
       n="$(date +%s)"; log "peer alive ($(( n - t0 ))s elapsed)"
     done ) &
   _HEARTBEAT_PID=$!
+  [ "$prev_m" = 0 ] && set +m
   while [ "$_HEARTBEAT_READY" != 1 ] && kill -0 "$_HEARTBEAT_PID" 2>/dev/null; do sleep 0.01 || true; done
   trap - USR1
 }

--- a/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
+++ b/skills/ce-code-review/scripts/cross-model-adversarial-review.sh
@@ -1036,6 +1036,9 @@ attempt_route() {
       cp "$PEERLOG" "$RUN_DIR/adversarial-codex-events.jsonl" 2>/dev/null || true
       jq -s '[.[] | select(.type == "turn.completed") | .usage] | last // empty' "$PEERLOG" \
         > "$RUN_DIR/adversarial-codex-usage.json" 2>/dev/null || true
+      # Redirect + `// empty` would leave a zero-byte file when no turn.completed
+      # exists; json.load then fails (#1531). Keep the artifact only if non-empty.
+      [ -s "$RUN_DIR/adversarial-codex-usage.json" ] || rm -f "$RUN_DIR/adversarial-codex-usage.json"
       if [ "$RUN_SUCCEEDED" = true ] && out_missing_or_invalid; then
         recover_findings_json "$PEERLOG" "$RAW_OUT" && log "recovered codex JSON from stdout (-o file unavailable)"
       fi

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -657,7 +657,9 @@ start_heartbeat() {
 }
 stop_heartbeat() {
   if [ -n "$_HEARTBEAT_PID" ]; then
-    kill "$_HEARTBEAT_PID" 2>/dev/null || true
+    # Leader-only TERM is deferred until the inner `wait $sleeper` returns, so
+    # the default 60s interval would block this wait. Signal the process group.
+    kill -- -"$_HEARTBEAT_PID" 2>/dev/null || kill "$_HEARTBEAT_PID" 2>/dev/null || true
     wait "$_HEARTBEAT_PID" 2>/dev/null || true
   fi
   _HEARTBEAT_PID=""

--- a/skills/ce-doc-review/scripts/cross-model-doc-review.sh
+++ b/skills/ce-doc-review/scripts/cross-model-doc-review.sh
@@ -640,6 +640,10 @@ start_heartbeat() {
   case "$every" in ''|*[!0-9]*) every=60 ;; esac; [ "$every" -lt 1 ] && every=1
   _HEARTBEAT_READY=0
   trap '_HEARTBEAT_READY=1' USR1
+  # Callers restore set +m after launching the peer, so without this the
+  # heartbeat inherits the worker pgid and kill -- -PID cannot reach the sleep.
+  local prev_m; case "$-" in *m*) prev_m=1;; *) prev_m=0;; esac
+  set -m
   ( local t0 n sleeper=""
     trap 'kill "${sleeper:-}" 2>/dev/null || true; exit 0' TERM INT
     kill -USR1 "$parent_pid"
@@ -652,6 +656,7 @@ start_heartbeat() {
       n="$(date +%s)"; log "peer alive ($(( n - t0 ))s elapsed)"
     done ) &
   _HEARTBEAT_PID=$!
+  [ "$prev_m" = 0 ] && set +m
   while [ "$_HEARTBEAT_READY" != 1 ] && kill -0 "$_HEARTBEAT_PID" 2>/dev/null; do sleep 0.01 || true; done
   trap - USR1
 }

--- a/skills/ce-plan/scripts/elevation-dispatch.sh
+++ b/skills/ce-plan/scripts/elevation-dispatch.sh
@@ -183,6 +183,10 @@ start_heartbeat() {
   case "$every" in ''|*[!0-9]*) every=60 ;; esac; [ "$every" -lt 1 ] && every=1
   _HEARTBEAT_READY=0
   trap '_HEARTBEAT_READY=1' USR1
+  # Callers restore set +m after launching the peer, so without this the
+  # heartbeat inherits the worker pgid and kill -- -PID cannot reach the sleep.
+  local prev_m; case "$-" in *m*) prev_m=1;; *) prev_m=0;; esac
+  set -m
   ( local t0 n sleeper=""
     trap 'kill "${sleeper:-}" 2>/dev/null || true; exit 0' TERM INT
     kill -USR1 "$parent_pid"
@@ -195,6 +199,7 @@ start_heartbeat() {
       n="$(date +%s)"; log "peer alive ($(( n - t0 ))s elapsed)"
     done ) &
   _HEARTBEAT_PID=$!
+  [ "$prev_m" = 0 ] && set +m
   while [ "$_HEARTBEAT_READY" != 1 ] && kill -0 "$_HEARTBEAT_PID" 2>/dev/null; do sleep 0.01 || true; done
   trap - USR1
 }

--- a/skills/ce-plan/scripts/elevation-dispatch.sh
+++ b/skills/ce-plan/scripts/elevation-dispatch.sh
@@ -200,7 +200,9 @@ start_heartbeat() {
 }
 stop_heartbeat() {
   if [ -n "$_HEARTBEAT_PID" ]; then
-    kill "$_HEARTBEAT_PID" 2>/dev/null || true
+    # Leader-only TERM is deferred until the inner `wait $sleeper` returns, so
+    # the default 60s interval would block this wait. Signal the process group.
+    kill -- -"$_HEARTBEAT_PID" 2>/dev/null || kill "$_HEARTBEAT_PID" 2>/dev/null || true
     wait "$_HEARTBEAT_PID" 2>/dev/null || true
   fi
   _HEARTBEAT_PID=""

--- a/skills/ce-pov/scripts/cross-model-pov.sh
+++ b/skills/ce-pov/scripts/cross-model-pov.sh
@@ -552,6 +552,10 @@ start_heartbeat() {
   case "$every" in ''|*[!0-9]*) every=60 ;; esac; [ "$every" -lt 1 ] && every=1
   _HEARTBEAT_READY=0
   trap '_HEARTBEAT_READY=1' USR1
+  # Callers restore set +m after launching the peer, so without this the
+  # heartbeat inherits the worker pgid and kill -- -PID cannot reach the sleep.
+  local prev_m; case "$-" in *m*) prev_m=1;; *) prev_m=0;; esac
+  set -m
   ( local t0 n sleeper=""
     trap 'kill "${sleeper:-}" 2>/dev/null || true; exit 0' TERM INT
     kill -USR1 "$parent_pid"
@@ -564,6 +568,7 @@ start_heartbeat() {
       n="$(date +%s)"; log "peer alive ($(( n - t0 ))s elapsed)"
     done ) &
   _HEARTBEAT_PID=$!
+  [ "$prev_m" = 0 ] && set +m
   while [ "$_HEARTBEAT_READY" != 1 ] && kill -0 "$_HEARTBEAT_PID" 2>/dev/null; do sleep 0.01 || true; done
   trap - USR1
 }

--- a/skills/ce-pov/scripts/cross-model-pov.sh
+++ b/skills/ce-pov/scripts/cross-model-pov.sh
@@ -569,7 +569,9 @@ start_heartbeat() {
 }
 stop_heartbeat() {
   if [ -n "$_HEARTBEAT_PID" ]; then
-    kill "$_HEARTBEAT_PID" 2>/dev/null || true
+    # Leader-only TERM is deferred until the inner `wait $sleeper` returns, so
+    # the default 60s interval would block this wait. Signal the process group.
+    kill -- -"$_HEARTBEAT_PID" 2>/dev/null || kill "$_HEARTBEAT_PID" 2>/dev/null || true
     wait "$_HEARTBEAT_PID" 2>/dev/null || true
   fi
   _HEARTBEAT_PID=""

--- a/tests/peer-job-runner-parity.test.ts
+++ b/tests/peer-job-runner-parity.test.ts
@@ -64,5 +64,8 @@ describe("peer-job-runner shared-asset parity", () => {
     // Leader-only TERM is deferred across `wait $sleeper`; the group signal
     // unblocks stop_heartbeat (CI 20s timeout on SIGTERM / failed grok).
     expect(kernels[0]).toContain('kill -- -"$_HEARTBEAT_PID"')
+    // Heartbeat must be its own process group even after callers set +m.
+    expect(kernels[0]).toContain("local prev_m")
+    expect(kernels[0]).toContain("[ \"$prev_m\" = 0 ] && set +m")
   })
 })

--- a/tests/peer-job-runner-parity.test.ts
+++ b/tests/peer-job-runner-parity.test.ts
@@ -61,5 +61,8 @@ describe("peer-job-runner shared-asset parity", () => {
     expect(kernels[0]).toContain('wait "$sleeper" 2>/dev/null || exit 0')
     expect(kernels[0]).toContain('kill -USR1 "$parent_pid"')
     expect(kernels[0]).toContain('while [ "$_HEARTBEAT_READY" != 1 ]')
+    // Leader-only TERM is deferred across `wait $sleeper`; the group signal
+    // unblocks stop_heartbeat (CI 20s timeout on SIGTERM / failed grok).
+    expect(kernels[0]).toContain('kill -- -"$_HEARTBEAT_PID"')
   })
 })

--- a/tests/skills/ce-code-review-cross-model-routes.test.ts
+++ b/tests/skills/ce-code-review-cross-model-routes.test.ts
@@ -1608,7 +1608,42 @@ describe("cross-model-adversarial-review normalization", () => {
     expect(out.cross_model_route).toBe("codex")
     expect(out.model_requested).toBe("gpt-5.6-luna")
     expect(out.model_actual).toBe("unverified")
+    // Recover-from-stdout has no turn.completed; usage must be absent, not a
+    // zero-byte file that json.load rejects (#1531).
+    expect(r.files).not.toContain("adversarial-codex-usage.json")
   }, 20_000) // the codex liveness poll sleeps in 5s slices even for a fast stub
+
+  test("codex usage artifact is the last turn.completed usage object", () => {
+    const review = JSON.stringify({
+      reviewer: "adversarial",
+      findings: [],
+      residual_risks: [],
+      testing_gaps: [],
+    })
+    const { env } = sandbox(
+      ["codex"],
+      `#!/bin/sh
+out=''
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = '-o' ]; then out="$2"; shift 2; else shift; fi
+done
+cat >/dev/null
+printf '%s' '${review}' > "$out"
+printf '%s\\n%s\\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}' '{"type":"turn.completed","usage":{"input_tokens":12,"cached_input_tokens":4,"output_tokens":3}}'
+`,
+    )
+    const runDir = makeRunDir()
+    const r = run(["claude", "codex", "HEAD", runDir], runDir, env)
+    expect(r.files).toContain("adversarial-codex.json")
+    expect(r.files).toContain("adversarial-codex-usage.json")
+    expect(
+      JSON.parse(readFileSync(path.join(runDir, "adversarial-codex-usage.json"), "utf8")),
+    ).toEqual({
+      input_tokens: 12,
+      cached_input_tokens: 4,
+      output_tokens: 3,
+    })
+  }, 20_000)
 
   test("codex stdout recovery is string-aware — an in-string brace does not let a draft object win", () => {
     // A brace-counting scanner desyncs on the real answer's in-string "{" (quoted

--- a/tests/skills/ce-pov-cross-model-routes.test.ts
+++ b/tests/skills/ce-pov-cross-model-routes.test.ts
@@ -15,7 +15,7 @@ import {
 import { tmpdir } from "node:os"
 import path from "node:path"
 
-setDefaultTimeout(20_000)
+setDefaultTimeout(30_000)
 
 const roots: string[] = []
 function temp(prefix: string): string {


### PR DESCRIPTION
A Codex peer run that never emits `turn.completed` used to leave a zero-byte `adversarial-codex-usage.json`. Downstream `json.load` then failed, so token cost went unrecorded. The artifact is now either valid usage JSON or absent.

The same PR also unblocks peer-worker shutdown. `stop_heartbeat` used to SIGTERM only the heartbeat leader, and Bash deferred that trap until the inner 60s `sleep` finished — CI then hit the 20s test timeout. Teardown now signals the heartbeat process group, and `start_heartbeat` enables job control around its own spawn so that group actually exists after callers restore `set +m`.

Fixes #1531.

## Security Disclosure
No security-relevant changes.

## Agent Disclosure
- **Model:** Grok Build · grok-4.6

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
