### PR TITLE
fix(peer-job-runner): keep Windows reap from killing a recycled pid

### DIFF
--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -25,9 +25,11 @@ Job directory (durable state, the source of truth):
     meta.json   identity: skill, run id, label, input digest, start time,
                 worker argv, result path (written at start, before detach)
     pid         supervisor pid + worker pid (written by the supervisor before
-                start returns; its presence marks "detached"). Two fields are
-                platform-conditional, so consumers must use .get(): POSIX adds
-                supervisor_pgid, Windows adds job_name (its job object).
+                start returns; its presence marks "detached"). Platform-
+                conditional fields — consumers must use .get(): POSIX adds
+                supervisor_pgid; Windows adds job_name (its job object) and
+                supervisor_identity / worker_identity (GetProcessTimes guards
+                so a recycled pid is not treated as the original process).
     out.log     worker's combined stdout+stderr (byte growth = liveness)
     reason      terminal detail, written before the status rename so the
                 status file is always the LAST record to land
@@ -106,7 +108,10 @@ POSIX path is behaviorally unchanged:
             handle closes, so a cmd_reap running after the supervisor died
             falls back to a Toolhelp32 snapshot walk; that works because
             Windows never reparents orphans, so a dead pid still appears as
-            th32ParentProcessID on its live children.
+            th32ParentProcessID on its live children. A recycled pid that is
+            now this process (or whose GetProcessTimes identity does not
+            match the pid file) is not the original leader: sweep stale-PPID
+            descendants, do not TerminateProcess the live reused process.
   ownership st_uid == geteuid becomes: the object's owner SID is one this token
             creates objects as (user or default-owner SID), checked on the opened
             handle (GetSecurityInfo) exactly like the POSIX fstat-by-fd check.
@@ -378,6 +383,18 @@ if IS_WINDOWS:
     _kernel32.OpenProcess.argtypes = [
         wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
+    _kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
     _kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
     _kernel32.WaitForSingleObject.restype = wintypes.DWORD
     _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -479,7 +496,58 @@ if IS_WINDOWS:
                 queue.append(child)
         return list(reversed(order))
 
+    def _win_process_identity(pid: int):
+        """Creation time plus image path — analog of `ps -o lstart= -o command=`.
+
+        Creation time is the PID-reuse guard: Windows recycles PIDs aggressively,
+        and a recycled pid always carries a later FILETIME than the worker we
+        recorded. None means unproven (gone or unopenable)."""
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            if not started:
+                return None
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = (buf.value if _kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size)) else "")
+        finally:
+            _kernel32.CloseHandle(handle)
+        return "{} {}".format(started, image)
+
+    def _win_process_start_time(pid: int):
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            return started or None
+        finally:
+            _kernel32.CloseHandle(handle)
+
+    def _win_process_identity_matches(pid: int, recorded) -> bool:
+        if not recorded:
+            return True
+        current = _win_process_identity(pid)
+        return current is not None and current == recorded
+
     def _win_terminate_pid(pid: int) -> bool:
+        if pid <= 0 or pid == os.getpid():
+            return False
         handle = _kernel32.OpenProcess(_PROCESS_TERMINATE, False, pid)
         if not handle:
             return False
@@ -668,7 +736,9 @@ if IS_WINDOWS:
         finally:
             _kernel32.CloseHandle(handle)
 
-    def _win_kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+    def _win_kill_tree(
+        root_pid: int, grace: float, job_name=None, expected_identity=None,
+    ) -> bool:
         """Terminate the worker tree (KTD3). Returns whether the LEADER was
         alive when the kill began -- the reap classification signal -- which is
         independent of how much of the tree we then sweep.
@@ -690,19 +760,41 @@ if IS_WINDOWS:
         fails with ERROR_FILE_NOT_FOUND). So a cmd_reap running after the
         supervisor died cannot use it, and falls back to the snapshot walk --
         which is exactly the dead-leader case, hence deepest-first descendants
-        BEFORE the leader, and never gated on leader liveness."""
-        alive = _win_pid_alive(root_pid)
+        BEFORE the leader, and never gated on leader liveness.
+
+        A live pid at root_pid is not automatically the original leader:
+        Windows recycles PIDs, and cmd_reap is often the next python.exe after
+        the worker exits (the orphan-grandchild smoke). Never terminate this
+        process, and never terminate a live pid whose GetProcessTimes identity
+        does not match the recorded worker. Stale-PPID orphans still show the
+        dead leader as parent; when the pid was reused, skip descendants that
+        started at-or-after the new process (they belong to the reuse, not the
+        original tree)."""
+        self_pid = os.getpid()
+        is_self = root_pid == self_pid
+        alive = (not is_self) and _win_pid_alive(root_pid)
+        recorded_leader = alive and _win_process_identity_matches(
+            root_pid, expected_identity)
         if job_name:
             _win_terminate_job(job_name)
         # Always Toolhelp-sweep after (or without) the job terminate: children
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        reuse_cutoff = None
+        if not recorded_leader and (is_self or alive):
+            reuse_cutoff = _win_process_start_time(root_pid)
         for pid in _win_descendants_deepest_first(root_pid):
+            if pid == self_pid:
+                continue
+            if reuse_cutoff is not None:
+                started = _win_process_start_time(pid)
+                if started is not None and started >= reuse_cutoff:
+                    continue
             _win_terminate_pid(pid)
-        if alive:
+        if recorded_leader:
             _win_terminate_pid(root_pid)
-        return alive
+        return recorded_leader
 
 
 # --- hardened I/O primitives --------------------------------------------------
@@ -1003,14 +1095,16 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         _kill_quiet(pid, sig)
 
 
-def kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:
     """TERM the pid's process group (workers are started as group leaders),
     falling back to a deepest-first tree walk; grace, then KILL survivors.
 
     `job_name` is Windows-only (the worker's job object, the pgid analog) and
-    is ignored on POSIX, where the pgid is derived from the pid itself."""
+    is ignored on POSIX, where the pgid is derived from the pid itself.
+    `expected_identity` is Windows-only (GetProcessTimes identity recorded at
+    start) and is ignored on POSIX."""
     if IS_WINDOWS:
-        return _win_kill_tree(root_pid, grace, job_name)
+        return _win_kill_tree(root_pid, grace, job_name, expected_identity)
     # Do NOT early-return just because the leader pid is dead: killpg targets
     # the pgid, which persists while any group member lives even after the
     # leader exits, so a dead leader can still front a live group we must sweep.
@@ -1525,6 +1619,12 @@ def supervise(job_dir: str, argv, result_path, conf: dict, ack_fd: int) -> None:
             "worker_pid": proc.pid,
         }
         if IS_WINDOWS:
+            sup_ident = _win_process_identity(os.getpid())
+            worker_ident = _win_process_identity(proc.pid)
+            if sup_ident:
+                pid_doc["supervisor_identity"] = sup_ident
+            if worker_ident:
+                pid_doc["worker_identity"] = worker_ident
             # Assign while still suspended, then resume. Record the job only
             # once the worker is actually a member, so a later reap never trusts
             # a name that owns nothing. If assignment fails (job creation denied,
@@ -2060,15 +2160,28 @@ def cmd_reap(args) -> int:
         pid_doc = json.loads(read_owned(os.path.join(job_dir, "pid"), META_READ_CAP))
     except (Unreadable, OSError, ValueError):
         pid_doc = None
-    sup_pid = pid_doc.get("supervisor_pid") if isinstance(pid_doc, dict) else None
-    sup_pgid = pid_doc.get("supervisor_pgid") if isinstance(pid_doc, dict) else None
-    worker_pid = pid_doc.get("worker_pid") if isinstance(pid_doc, dict) else None
+    if not isinstance(pid_doc, dict):
+        pid_doc = {}
+    sup_pid = pid_doc.get("supervisor_pid")
+    sup_pgid = pid_doc.get("supervisor_pgid")
+    worker_pid = pid_doc.get("worker_pid")
     # Windows-only: the worker tree's job object. Named precisely so this
     # process -- which never held the supervisor's handle -- can reopen and
     # terminate the tree even after the worker leader has exited.
-    job_name = pid_doc.get("job_name") if isinstance(pid_doc, dict) else None
+    job_name = pid_doc.get("job_name")
+    worker_identity = pid_doc.get("worker_identity")
+    supervisor_identity = pid_doc.get("supervisor_identity")
 
-    if isinstance(sup_pid, int) and _pid_alive(sup_pid):
+    supervisor_ours = (
+        isinstance(sup_pid, int)
+        and not (IS_WINDOWS and sup_pid == os.getpid())
+        and _pid_alive(sup_pid)
+        and (
+            not IS_WINDOWS
+            or _win_process_identity_matches(sup_pid, supervisor_identity)
+        )
+    )
+    if supervisor_ours:
         # The supervisor owns TERM-grace-KILL and the terminal classification.
         # POSIX signals it (SIGTERM to the group or pid); Windows drops the
         # `.reap` marker the supervisor's loop polls for.
@@ -2107,7 +2220,7 @@ def cmd_reap(args) -> int:
     worker_leader_alive = False
     if isinstance(worker_pid, int):
         worker_leader_alive = kill_tree(
-            worker_pid, min(conf["grace"], 1.0), job_name)
+            worker_pid, min(conf["grace"], 1.0), job_name, worker_identity)
     # A worker can publish its declared result and exit before this fallback runs
     # (e.g. the supervisor died mid-run, then the worker completed cleanly). Honor
     # that result instead of discarding it as died-without-result: read the

--- a/skills/ce-brainstorm/scripts/peer-job-runner.py
+++ b/skills/ce-brainstorm/scripts/peer-job-runner.py
@@ -469,15 +469,11 @@ if IS_WINDOWS:
     _kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
     _kernel32.TerminateProcess.restype = wintypes.BOOL
 
-    def _win_descendants_deepest_first(root_pid: int):
-        """Children before parents, via a process snapshot. This is the direct
-        analog of the POSIX `ps`-based walk and carries the same pid-reuse
-        exposure. It works on an EXITED leader because Windows never reparents
-        orphans: a dead pid still appears as th32ParentProcessID on its live
-        children (unlike POSIX, where orphans are reparented to init)."""
+    def _win_process_children_map():
+        """th32ParentProcessID -> [child pids] from one Toolhelp snapshot."""
         snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
         if not snap or snap == ctypes.c_void_p(-1).value:
-            return []
+            return {}
         children = {}
         try:
             entry = _PROCESSENTRY32W()
@@ -489,6 +485,16 @@ if IS_WINDOWS:
                 more = _kernel32.Process32NextW(snap, ctypes.byref(entry))
         finally:
             _kernel32.CloseHandle(ctypes.c_void_p(snap))
+        return children
+
+    def _win_descendants_deepest_first(root_pid: int, children=None):
+        """Children before parents, via a process snapshot. This is the direct
+        analog of the POSIX `ps`-based walk and carries the same pid-reuse
+        exposure. It works on an EXITED leader because Windows never reparents
+        orphans: a dead pid still appears as th32ParentProcessID on its live
+        children (unlike POSIX, where orphans are reparented to init)."""
+        if children is None:
+            children = _win_process_children_map()
         order, queue = [], [root_pid]
         while queue:
             for child in children.get(queue.pop(0), []):
@@ -767,9 +773,10 @@ if IS_WINDOWS:
         the worker exits (the orphan-grandchild smoke). Never terminate this
         process, and never terminate a live pid whose GetProcessTimes identity
         does not match the recorded worker. Stale-PPID orphans still show the
-        dead leader as parent; when the pid was reused, skip descendants that
-        started at-or-after the new process (they belong to the reuse, not the
-        original tree)."""
+        dead leader as parent. When the pid was reused, the start-time cutoff
+        applies only to *direct* children of that pid (the new process's own
+        children vs stale-PPID orphans). A pre-reuse child's full subtree is
+        still original-tree work, including descendants spawned after reuse."""
         self_pid = os.getpid()
         is_self = root_pid == self_pid
         alive = (not is_self) and _win_pid_alive(root_pid)
@@ -781,16 +788,23 @@ if IS_WINDOWS:
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        children_map = _win_process_children_map()
         reuse_cutoff = None
         if not recorded_leader and (is_self or alive):
             reuse_cutoff = _win_process_start_time(root_pid)
-        for pid in _win_descendants_deepest_first(root_pid):
+        if reuse_cutoff is not None:
+            def _predates_reuse(pid):
+                started = _win_process_start_time(pid)
+                return started is None or started < reuse_cutoff
+            kill_set = _pre_reuse_descendant_pids(
+                root_pid, children_map, _predates_reuse, self_pid)
+        else:
+            kill_set = None
+        for pid in _win_descendants_deepest_first(root_pid, children_map):
             if pid == self_pid:
                 continue
-            if reuse_cutoff is not None:
-                started = _win_process_start_time(pid)
-                if started is not None and started >= reuse_cutoff:
-                    continue
+            if kill_set is not None and pid not in kill_set:
+                continue
             _win_terminate_pid(pid)
         if recorded_leader:
             _win_terminate_pid(root_pid)
@@ -1093,6 +1107,34 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         for descendant in _descendants_deepest_first(pid):
             _kill_quiet(descendant, sig)
         _kill_quiet(pid, sig)
+
+
+def _pre_reuse_descendant_pids(root_pid, children, predates_reuse, skip_pid=None):
+    """Direct children that predate a recycled leader pid, plus each of those
+    children's full subtree.
+
+    Toolhelp still lists the original tree under a dead pid as parent, mixed
+    with the new process's own children. The start-time cutoff applies only to
+    direct children. A pre-reuse child's later descendants stay original-tree
+    work even if they started after the reuse.
+    """
+    keep = set()
+    queue = []
+    for child in children.get(root_pid, []):
+        if skip_pid is not None and child == skip_pid:
+            continue
+        if not predates_reuse(child):
+            continue
+        queue.append(child)
+    while queue:
+        pid = queue.pop(0)
+        if skip_pid is not None and pid == skip_pid:
+            continue
+        if pid in keep:
+            continue
+        keep.add(pid)
+        queue.extend(children.get(pid, []))
+    return keep
 
 
 def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -25,9 +25,11 @@ Job directory (durable state, the source of truth):
     meta.json   identity: skill, run id, label, input digest, start time,
                 worker argv, result path (written at start, before detach)
     pid         supervisor pid + worker pid (written by the supervisor before
-                start returns; its presence marks "detached"). Two fields are
-                platform-conditional, so consumers must use .get(): POSIX adds
-                supervisor_pgid, Windows adds job_name (its job object).
+                start returns; its presence marks "detached"). Platform-
+                conditional fields — consumers must use .get(): POSIX adds
+                supervisor_pgid; Windows adds job_name (its job object) and
+                supervisor_identity / worker_identity (GetProcessTimes guards
+                so a recycled pid is not treated as the original process).
     out.log     worker's combined stdout+stderr (byte growth = liveness)
     reason      terminal detail, written before the status rename so the
                 status file is always the LAST record to land
@@ -106,7 +108,10 @@ POSIX path is behaviorally unchanged:
             handle closes, so a cmd_reap running after the supervisor died
             falls back to a Toolhelp32 snapshot walk; that works because
             Windows never reparents orphans, so a dead pid still appears as
-            th32ParentProcessID on its live children.
+            th32ParentProcessID on its live children. A recycled pid that is
+            now this process (or whose GetProcessTimes identity does not
+            match the pid file) is not the original leader: sweep stale-PPID
+            descendants, do not TerminateProcess the live reused process.
   ownership st_uid == geteuid becomes: the object's owner SID is one this token
             creates objects as (user or default-owner SID), checked on the opened
             handle (GetSecurityInfo) exactly like the POSIX fstat-by-fd check.
@@ -378,6 +383,18 @@ if IS_WINDOWS:
     _kernel32.OpenProcess.argtypes = [
         wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
+    _kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
     _kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
     _kernel32.WaitForSingleObject.restype = wintypes.DWORD
     _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -479,7 +496,58 @@ if IS_WINDOWS:
                 queue.append(child)
         return list(reversed(order))
 
+    def _win_process_identity(pid: int):
+        """Creation time plus image path — analog of `ps -o lstart= -o command=`.
+
+        Creation time is the PID-reuse guard: Windows recycles PIDs aggressively,
+        and a recycled pid always carries a later FILETIME than the worker we
+        recorded. None means unproven (gone or unopenable)."""
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            if not started:
+                return None
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = (buf.value if _kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size)) else "")
+        finally:
+            _kernel32.CloseHandle(handle)
+        return "{} {}".format(started, image)
+
+    def _win_process_start_time(pid: int):
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            return started or None
+        finally:
+            _kernel32.CloseHandle(handle)
+
+    def _win_process_identity_matches(pid: int, recorded) -> bool:
+        if not recorded:
+            return True
+        current = _win_process_identity(pid)
+        return current is not None and current == recorded
+
     def _win_terminate_pid(pid: int) -> bool:
+        if pid <= 0 or pid == os.getpid():
+            return False
         handle = _kernel32.OpenProcess(_PROCESS_TERMINATE, False, pid)
         if not handle:
             return False
@@ -668,7 +736,9 @@ if IS_WINDOWS:
         finally:
             _kernel32.CloseHandle(handle)
 
-    def _win_kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+    def _win_kill_tree(
+        root_pid: int, grace: float, job_name=None, expected_identity=None,
+    ) -> bool:
         """Terminate the worker tree (KTD3). Returns whether the LEADER was
         alive when the kill began -- the reap classification signal -- which is
         independent of how much of the tree we then sweep.
@@ -690,19 +760,41 @@ if IS_WINDOWS:
         fails with ERROR_FILE_NOT_FOUND). So a cmd_reap running after the
         supervisor died cannot use it, and falls back to the snapshot walk --
         which is exactly the dead-leader case, hence deepest-first descendants
-        BEFORE the leader, and never gated on leader liveness."""
-        alive = _win_pid_alive(root_pid)
+        BEFORE the leader, and never gated on leader liveness.
+
+        A live pid at root_pid is not automatically the original leader:
+        Windows recycles PIDs, and cmd_reap is often the next python.exe after
+        the worker exits (the orphan-grandchild smoke). Never terminate this
+        process, and never terminate a live pid whose GetProcessTimes identity
+        does not match the recorded worker. Stale-PPID orphans still show the
+        dead leader as parent; when the pid was reused, skip descendants that
+        started at-or-after the new process (they belong to the reuse, not the
+        original tree)."""
+        self_pid = os.getpid()
+        is_self = root_pid == self_pid
+        alive = (not is_self) and _win_pid_alive(root_pid)
+        recorded_leader = alive and _win_process_identity_matches(
+            root_pid, expected_identity)
         if job_name:
             _win_terminate_job(job_name)
         # Always Toolhelp-sweep after (or without) the job terminate: children
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        reuse_cutoff = None
+        if not recorded_leader and (is_self or alive):
+            reuse_cutoff = _win_process_start_time(root_pid)
         for pid in _win_descendants_deepest_first(root_pid):
+            if pid == self_pid:
+                continue
+            if reuse_cutoff is not None:
+                started = _win_process_start_time(pid)
+                if started is not None and started >= reuse_cutoff:
+                    continue
             _win_terminate_pid(pid)
-        if alive:
+        if recorded_leader:
             _win_terminate_pid(root_pid)
-        return alive
+        return recorded_leader
 
 
 # --- hardened I/O primitives --------------------------------------------------
@@ -1003,14 +1095,16 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         _kill_quiet(pid, sig)
 
 
-def kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:
     """TERM the pid's process group (workers are started as group leaders),
     falling back to a deepest-first tree walk; grace, then KILL survivors.
 
     `job_name` is Windows-only (the worker's job object, the pgid analog) and
-    is ignored on POSIX, where the pgid is derived from the pid itself."""
+    is ignored on POSIX, where the pgid is derived from the pid itself.
+    `expected_identity` is Windows-only (GetProcessTimes identity recorded at
+    start) and is ignored on POSIX."""
     if IS_WINDOWS:
-        return _win_kill_tree(root_pid, grace, job_name)
+        return _win_kill_tree(root_pid, grace, job_name, expected_identity)
     # Do NOT early-return just because the leader pid is dead: killpg targets
     # the pgid, which persists while any group member lives even after the
     # leader exits, so a dead leader can still front a live group we must sweep.
@@ -1525,6 +1619,12 @@ def supervise(job_dir: str, argv, result_path, conf: dict, ack_fd: int) -> None:
             "worker_pid": proc.pid,
         }
         if IS_WINDOWS:
+            sup_ident = _win_process_identity(os.getpid())
+            worker_ident = _win_process_identity(proc.pid)
+            if sup_ident:
+                pid_doc["supervisor_identity"] = sup_ident
+            if worker_ident:
+                pid_doc["worker_identity"] = worker_ident
             # Assign while still suspended, then resume. Record the job only
             # once the worker is actually a member, so a later reap never trusts
             # a name that owns nothing. If assignment fails (job creation denied,
@@ -2060,15 +2160,28 @@ def cmd_reap(args) -> int:
         pid_doc = json.loads(read_owned(os.path.join(job_dir, "pid"), META_READ_CAP))
     except (Unreadable, OSError, ValueError):
         pid_doc = None
-    sup_pid = pid_doc.get("supervisor_pid") if isinstance(pid_doc, dict) else None
-    sup_pgid = pid_doc.get("supervisor_pgid") if isinstance(pid_doc, dict) else None
-    worker_pid = pid_doc.get("worker_pid") if isinstance(pid_doc, dict) else None
+    if not isinstance(pid_doc, dict):
+        pid_doc = {}
+    sup_pid = pid_doc.get("supervisor_pid")
+    sup_pgid = pid_doc.get("supervisor_pgid")
+    worker_pid = pid_doc.get("worker_pid")
     # Windows-only: the worker tree's job object. Named precisely so this
     # process -- which never held the supervisor's handle -- can reopen and
     # terminate the tree even after the worker leader has exited.
-    job_name = pid_doc.get("job_name") if isinstance(pid_doc, dict) else None
+    job_name = pid_doc.get("job_name")
+    worker_identity = pid_doc.get("worker_identity")
+    supervisor_identity = pid_doc.get("supervisor_identity")
 
-    if isinstance(sup_pid, int) and _pid_alive(sup_pid):
+    supervisor_ours = (
+        isinstance(sup_pid, int)
+        and not (IS_WINDOWS and sup_pid == os.getpid())
+        and _pid_alive(sup_pid)
+        and (
+            not IS_WINDOWS
+            or _win_process_identity_matches(sup_pid, supervisor_identity)
+        )
+    )
+    if supervisor_ours:
         # The supervisor owns TERM-grace-KILL and the terminal classification.
         # POSIX signals it (SIGTERM to the group or pid); Windows drops the
         # `.reap` marker the supervisor's loop polls for.
@@ -2107,7 +2220,7 @@ def cmd_reap(args) -> int:
     worker_leader_alive = False
     if isinstance(worker_pid, int):
         worker_leader_alive = kill_tree(
-            worker_pid, min(conf["grace"], 1.0), job_name)
+            worker_pid, min(conf["grace"], 1.0), job_name, worker_identity)
     # A worker can publish its declared result and exit before this fallback runs
     # (e.g. the supervisor died mid-run, then the worker completed cleanly). Honor
     # that result instead of discarding it as died-without-result: read the

--- a/skills/ce-code-review/scripts/peer-job-runner.py
+++ b/skills/ce-code-review/scripts/peer-job-runner.py
@@ -469,15 +469,11 @@ if IS_WINDOWS:
     _kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
     _kernel32.TerminateProcess.restype = wintypes.BOOL
 
-    def _win_descendants_deepest_first(root_pid: int):
-        """Children before parents, via a process snapshot. This is the direct
-        analog of the POSIX `ps`-based walk and carries the same pid-reuse
-        exposure. It works on an EXITED leader because Windows never reparents
-        orphans: a dead pid still appears as th32ParentProcessID on its live
-        children (unlike POSIX, where orphans are reparented to init)."""
+    def _win_process_children_map():
+        """th32ParentProcessID -> [child pids] from one Toolhelp snapshot."""
         snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
         if not snap or snap == ctypes.c_void_p(-1).value:
-            return []
+            return {}
         children = {}
         try:
             entry = _PROCESSENTRY32W()
@@ -489,6 +485,16 @@ if IS_WINDOWS:
                 more = _kernel32.Process32NextW(snap, ctypes.byref(entry))
         finally:
             _kernel32.CloseHandle(ctypes.c_void_p(snap))
+        return children
+
+    def _win_descendants_deepest_first(root_pid: int, children=None):
+        """Children before parents, via a process snapshot. This is the direct
+        analog of the POSIX `ps`-based walk and carries the same pid-reuse
+        exposure. It works on an EXITED leader because Windows never reparents
+        orphans: a dead pid still appears as th32ParentProcessID on its live
+        children (unlike POSIX, where orphans are reparented to init)."""
+        if children is None:
+            children = _win_process_children_map()
         order, queue = [], [root_pid]
         while queue:
             for child in children.get(queue.pop(0), []):
@@ -767,9 +773,10 @@ if IS_WINDOWS:
         the worker exits (the orphan-grandchild smoke). Never terminate this
         process, and never terminate a live pid whose GetProcessTimes identity
         does not match the recorded worker. Stale-PPID orphans still show the
-        dead leader as parent; when the pid was reused, skip descendants that
-        started at-or-after the new process (they belong to the reuse, not the
-        original tree)."""
+        dead leader as parent. When the pid was reused, the start-time cutoff
+        applies only to *direct* children of that pid (the new process's own
+        children vs stale-PPID orphans). A pre-reuse child's full subtree is
+        still original-tree work, including descendants spawned after reuse."""
         self_pid = os.getpid()
         is_self = root_pid == self_pid
         alive = (not is_self) and _win_pid_alive(root_pid)
@@ -781,16 +788,23 @@ if IS_WINDOWS:
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        children_map = _win_process_children_map()
         reuse_cutoff = None
         if not recorded_leader and (is_self or alive):
             reuse_cutoff = _win_process_start_time(root_pid)
-        for pid in _win_descendants_deepest_first(root_pid):
+        if reuse_cutoff is not None:
+            def _predates_reuse(pid):
+                started = _win_process_start_time(pid)
+                return started is None or started < reuse_cutoff
+            kill_set = _pre_reuse_descendant_pids(
+                root_pid, children_map, _predates_reuse, self_pid)
+        else:
+            kill_set = None
+        for pid in _win_descendants_deepest_first(root_pid, children_map):
             if pid == self_pid:
                 continue
-            if reuse_cutoff is not None:
-                started = _win_process_start_time(pid)
-                if started is not None and started >= reuse_cutoff:
-                    continue
+            if kill_set is not None and pid not in kill_set:
+                continue
             _win_terminate_pid(pid)
         if recorded_leader:
             _win_terminate_pid(root_pid)
@@ -1093,6 +1107,34 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         for descendant in _descendants_deepest_first(pid):
             _kill_quiet(descendant, sig)
         _kill_quiet(pid, sig)
+
+
+def _pre_reuse_descendant_pids(root_pid, children, predates_reuse, skip_pid=None):
+    """Direct children that predate a recycled leader pid, plus each of those
+    children's full subtree.
+
+    Toolhelp still lists the original tree under a dead pid as parent, mixed
+    with the new process's own children. The start-time cutoff applies only to
+    direct children. A pre-reuse child's later descendants stay original-tree
+    work even if they started after the reuse.
+    """
+    keep = set()
+    queue = []
+    for child in children.get(root_pid, []):
+        if skip_pid is not None and child == skip_pid:
+            continue
+        if not predates_reuse(child):
+            continue
+        queue.append(child)
+    while queue:
+        pid = queue.pop(0)
+        if skip_pid is not None and pid == skip_pid:
+            continue
+        if pid in keep:
+            continue
+        keep.add(pid)
+        queue.extend(children.get(pid, []))
+    return keep
 
 
 def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -25,9 +25,11 @@ Job directory (durable state, the source of truth):
     meta.json   identity: skill, run id, label, input digest, start time,
                 worker argv, result path (written at start, before detach)
     pid         supervisor pid + worker pid (written by the supervisor before
-                start returns; its presence marks "detached"). Two fields are
-                platform-conditional, so consumers must use .get(): POSIX adds
-                supervisor_pgid, Windows adds job_name (its job object).
+                start returns; its presence marks "detached"). Platform-
+                conditional fields — consumers must use .get(): POSIX adds
+                supervisor_pgid; Windows adds job_name (its job object) and
+                supervisor_identity / worker_identity (GetProcessTimes guards
+                so a recycled pid is not treated as the original process).
     out.log     worker's combined stdout+stderr (byte growth = liveness)
     reason      terminal detail, written before the status rename so the
                 status file is always the LAST record to land
@@ -106,7 +108,10 @@ POSIX path is behaviorally unchanged:
             handle closes, so a cmd_reap running after the supervisor died
             falls back to a Toolhelp32 snapshot walk; that works because
             Windows never reparents orphans, so a dead pid still appears as
-            th32ParentProcessID on its live children.
+            th32ParentProcessID on its live children. A recycled pid that is
+            now this process (or whose GetProcessTimes identity does not
+            match the pid file) is not the original leader: sweep stale-PPID
+            descendants, do not TerminateProcess the live reused process.
   ownership st_uid == geteuid becomes: the object's owner SID is one this token
             creates objects as (user or default-owner SID), checked on the opened
             handle (GetSecurityInfo) exactly like the POSIX fstat-by-fd check.
@@ -378,6 +383,18 @@ if IS_WINDOWS:
     _kernel32.OpenProcess.argtypes = [
         wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
+    _kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
     _kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
     _kernel32.WaitForSingleObject.restype = wintypes.DWORD
     _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -479,7 +496,58 @@ if IS_WINDOWS:
                 queue.append(child)
         return list(reversed(order))
 
+    def _win_process_identity(pid: int):
+        """Creation time plus image path — analog of `ps -o lstart= -o command=`.
+
+        Creation time is the PID-reuse guard: Windows recycles PIDs aggressively,
+        and a recycled pid always carries a later FILETIME than the worker we
+        recorded. None means unproven (gone or unopenable)."""
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            if not started:
+                return None
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = (buf.value if _kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size)) else "")
+        finally:
+            _kernel32.CloseHandle(handle)
+        return "{} {}".format(started, image)
+
+    def _win_process_start_time(pid: int):
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            return started or None
+        finally:
+            _kernel32.CloseHandle(handle)
+
+    def _win_process_identity_matches(pid: int, recorded) -> bool:
+        if not recorded:
+            return True
+        current = _win_process_identity(pid)
+        return current is not None and current == recorded
+
     def _win_terminate_pid(pid: int) -> bool:
+        if pid <= 0 or pid == os.getpid():
+            return False
         handle = _kernel32.OpenProcess(_PROCESS_TERMINATE, False, pid)
         if not handle:
             return False
@@ -668,7 +736,9 @@ if IS_WINDOWS:
         finally:
             _kernel32.CloseHandle(handle)
 
-    def _win_kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+    def _win_kill_tree(
+        root_pid: int, grace: float, job_name=None, expected_identity=None,
+    ) -> bool:
         """Terminate the worker tree (KTD3). Returns whether the LEADER was
         alive when the kill began -- the reap classification signal -- which is
         independent of how much of the tree we then sweep.
@@ -690,19 +760,41 @@ if IS_WINDOWS:
         fails with ERROR_FILE_NOT_FOUND). So a cmd_reap running after the
         supervisor died cannot use it, and falls back to the snapshot walk --
         which is exactly the dead-leader case, hence deepest-first descendants
-        BEFORE the leader, and never gated on leader liveness."""
-        alive = _win_pid_alive(root_pid)
+        BEFORE the leader, and never gated on leader liveness.
+
+        A live pid at root_pid is not automatically the original leader:
+        Windows recycles PIDs, and cmd_reap is often the next python.exe after
+        the worker exits (the orphan-grandchild smoke). Never terminate this
+        process, and never terminate a live pid whose GetProcessTimes identity
+        does not match the recorded worker. Stale-PPID orphans still show the
+        dead leader as parent; when the pid was reused, skip descendants that
+        started at-or-after the new process (they belong to the reuse, not the
+        original tree)."""
+        self_pid = os.getpid()
+        is_self = root_pid == self_pid
+        alive = (not is_self) and _win_pid_alive(root_pid)
+        recorded_leader = alive and _win_process_identity_matches(
+            root_pid, expected_identity)
         if job_name:
             _win_terminate_job(job_name)
         # Always Toolhelp-sweep after (or without) the job terminate: children
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        reuse_cutoff = None
+        if not recorded_leader and (is_self or alive):
+            reuse_cutoff = _win_process_start_time(root_pid)
         for pid in _win_descendants_deepest_first(root_pid):
+            if pid == self_pid:
+                continue
+            if reuse_cutoff is not None:
+                started = _win_process_start_time(pid)
+                if started is not None and started >= reuse_cutoff:
+                    continue
             _win_terminate_pid(pid)
-        if alive:
+        if recorded_leader:
             _win_terminate_pid(root_pid)
-        return alive
+        return recorded_leader
 
 
 # --- hardened I/O primitives --------------------------------------------------
@@ -1003,14 +1095,16 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         _kill_quiet(pid, sig)
 
 
-def kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:
     """TERM the pid's process group (workers are started as group leaders),
     falling back to a deepest-first tree walk; grace, then KILL survivors.
 
     `job_name` is Windows-only (the worker's job object, the pgid analog) and
-    is ignored on POSIX, where the pgid is derived from the pid itself."""
+    is ignored on POSIX, where the pgid is derived from the pid itself.
+    `expected_identity` is Windows-only (GetProcessTimes identity recorded at
+    start) and is ignored on POSIX."""
     if IS_WINDOWS:
-        return _win_kill_tree(root_pid, grace, job_name)
+        return _win_kill_tree(root_pid, grace, job_name, expected_identity)
     # Do NOT early-return just because the leader pid is dead: killpg targets
     # the pgid, which persists while any group member lives even after the
     # leader exits, so a dead leader can still front a live group we must sweep.
@@ -1525,6 +1619,12 @@ def supervise(job_dir: str, argv, result_path, conf: dict, ack_fd: int) -> None:
             "worker_pid": proc.pid,
         }
         if IS_WINDOWS:
+            sup_ident = _win_process_identity(os.getpid())
+            worker_ident = _win_process_identity(proc.pid)
+            if sup_ident:
+                pid_doc["supervisor_identity"] = sup_ident
+            if worker_ident:
+                pid_doc["worker_identity"] = worker_ident
             # Assign while still suspended, then resume. Record the job only
             # once the worker is actually a member, so a later reap never trusts
             # a name that owns nothing. If assignment fails (job creation denied,
@@ -2060,15 +2160,28 @@ def cmd_reap(args) -> int:
         pid_doc = json.loads(read_owned(os.path.join(job_dir, "pid"), META_READ_CAP))
     except (Unreadable, OSError, ValueError):
         pid_doc = None
-    sup_pid = pid_doc.get("supervisor_pid") if isinstance(pid_doc, dict) else None
-    sup_pgid = pid_doc.get("supervisor_pgid") if isinstance(pid_doc, dict) else None
-    worker_pid = pid_doc.get("worker_pid") if isinstance(pid_doc, dict) else None
+    if not isinstance(pid_doc, dict):
+        pid_doc = {}
+    sup_pid = pid_doc.get("supervisor_pid")
+    sup_pgid = pid_doc.get("supervisor_pgid")
+    worker_pid = pid_doc.get("worker_pid")
     # Windows-only: the worker tree's job object. Named precisely so this
     # process -- which never held the supervisor's handle -- can reopen and
     # terminate the tree even after the worker leader has exited.
-    job_name = pid_doc.get("job_name") if isinstance(pid_doc, dict) else None
+    job_name = pid_doc.get("job_name")
+    worker_identity = pid_doc.get("worker_identity")
+    supervisor_identity = pid_doc.get("supervisor_identity")
 
-    if isinstance(sup_pid, int) and _pid_alive(sup_pid):
+    supervisor_ours = (
+        isinstance(sup_pid, int)
+        and not (IS_WINDOWS and sup_pid == os.getpid())
+        and _pid_alive(sup_pid)
+        and (
+            not IS_WINDOWS
+            or _win_process_identity_matches(sup_pid, supervisor_identity)
+        )
+    )
+    if supervisor_ours:
         # The supervisor owns TERM-grace-KILL and the terminal classification.
         # POSIX signals it (SIGTERM to the group or pid); Windows drops the
         # `.reap` marker the supervisor's loop polls for.
@@ -2107,7 +2220,7 @@ def cmd_reap(args) -> int:
     worker_leader_alive = False
     if isinstance(worker_pid, int):
         worker_leader_alive = kill_tree(
-            worker_pid, min(conf["grace"], 1.0), job_name)
+            worker_pid, min(conf["grace"], 1.0), job_name, worker_identity)
     # A worker can publish its declared result and exit before this fallback runs
     # (e.g. the supervisor died mid-run, then the worker completed cleanly). Honor
     # that result instead of discarding it as died-without-result: read the

--- a/skills/ce-doc-review/scripts/peer-job-runner.py
+++ b/skills/ce-doc-review/scripts/peer-job-runner.py
@@ -469,15 +469,11 @@ if IS_WINDOWS:
     _kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
     _kernel32.TerminateProcess.restype = wintypes.BOOL
 
-    def _win_descendants_deepest_first(root_pid: int):
-        """Children before parents, via a process snapshot. This is the direct
-        analog of the POSIX `ps`-based walk and carries the same pid-reuse
-        exposure. It works on an EXITED leader because Windows never reparents
-        orphans: a dead pid still appears as th32ParentProcessID on its live
-        children (unlike POSIX, where orphans are reparented to init)."""
+    def _win_process_children_map():
+        """th32ParentProcessID -> [child pids] from one Toolhelp snapshot."""
         snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
         if not snap or snap == ctypes.c_void_p(-1).value:
-            return []
+            return {}
         children = {}
         try:
             entry = _PROCESSENTRY32W()
@@ -489,6 +485,16 @@ if IS_WINDOWS:
                 more = _kernel32.Process32NextW(snap, ctypes.byref(entry))
         finally:
             _kernel32.CloseHandle(ctypes.c_void_p(snap))
+        return children
+
+    def _win_descendants_deepest_first(root_pid: int, children=None):
+        """Children before parents, via a process snapshot. This is the direct
+        analog of the POSIX `ps`-based walk and carries the same pid-reuse
+        exposure. It works on an EXITED leader because Windows never reparents
+        orphans: a dead pid still appears as th32ParentProcessID on its live
+        children (unlike POSIX, where orphans are reparented to init)."""
+        if children is None:
+            children = _win_process_children_map()
         order, queue = [], [root_pid]
         while queue:
             for child in children.get(queue.pop(0), []):
@@ -767,9 +773,10 @@ if IS_WINDOWS:
         the worker exits (the orphan-grandchild smoke). Never terminate this
         process, and never terminate a live pid whose GetProcessTimes identity
         does not match the recorded worker. Stale-PPID orphans still show the
-        dead leader as parent; when the pid was reused, skip descendants that
-        started at-or-after the new process (they belong to the reuse, not the
-        original tree)."""
+        dead leader as parent. When the pid was reused, the start-time cutoff
+        applies only to *direct* children of that pid (the new process's own
+        children vs stale-PPID orphans). A pre-reuse child's full subtree is
+        still original-tree work, including descendants spawned after reuse."""
         self_pid = os.getpid()
         is_self = root_pid == self_pid
         alive = (not is_self) and _win_pid_alive(root_pid)
@@ -781,16 +788,23 @@ if IS_WINDOWS:
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        children_map = _win_process_children_map()
         reuse_cutoff = None
         if not recorded_leader and (is_self or alive):
             reuse_cutoff = _win_process_start_time(root_pid)
-        for pid in _win_descendants_deepest_first(root_pid):
+        if reuse_cutoff is not None:
+            def _predates_reuse(pid):
+                started = _win_process_start_time(pid)
+                return started is None or started < reuse_cutoff
+            kill_set = _pre_reuse_descendant_pids(
+                root_pid, children_map, _predates_reuse, self_pid)
+        else:
+            kill_set = None
+        for pid in _win_descendants_deepest_first(root_pid, children_map):
             if pid == self_pid:
                 continue
-            if reuse_cutoff is not None:
-                started = _win_process_start_time(pid)
-                if started is not None and started >= reuse_cutoff:
-                    continue
+            if kill_set is not None and pid not in kill_set:
+                continue
             _win_terminate_pid(pid)
         if recorded_leader:
             _win_terminate_pid(root_pid)
@@ -1093,6 +1107,34 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         for descendant in _descendants_deepest_first(pid):
             _kill_quiet(descendant, sig)
         _kill_quiet(pid, sig)
+
+
+def _pre_reuse_descendant_pids(root_pid, children, predates_reuse, skip_pid=None):
+    """Direct children that predate a recycled leader pid, plus each of those
+    children's full subtree.
+
+    Toolhelp still lists the original tree under a dead pid as parent, mixed
+    with the new process's own children. The start-time cutoff applies only to
+    direct children. A pre-reuse child's later descendants stay original-tree
+    work even if they started after the reuse.
+    """
+    keep = set()
+    queue = []
+    for child in children.get(root_pid, []):
+        if skip_pid is not None and child == skip_pid:
+            continue
+        if not predates_reuse(child):
+            continue
+        queue.append(child)
+    while queue:
+        pid = queue.pop(0)
+        if skip_pid is not None and pid == skip_pid:
+            continue
+        if pid in keep:
+            continue
+        keep.add(pid)
+        queue.extend(children.get(pid, []))
+    return keep
 
 
 def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -25,9 +25,11 @@ Job directory (durable state, the source of truth):
     meta.json   identity: skill, run id, label, input digest, start time,
                 worker argv, result path (written at start, before detach)
     pid         supervisor pid + worker pid (written by the supervisor before
-                start returns; its presence marks "detached"). Two fields are
-                platform-conditional, so consumers must use .get(): POSIX adds
-                supervisor_pgid, Windows adds job_name (its job object).
+                start returns; its presence marks "detached"). Platform-
+                conditional fields — consumers must use .get(): POSIX adds
+                supervisor_pgid; Windows adds job_name (its job object) and
+                supervisor_identity / worker_identity (GetProcessTimes guards
+                so a recycled pid is not treated as the original process).
     out.log     worker's combined stdout+stderr (byte growth = liveness)
     reason      terminal detail, written before the status rename so the
                 status file is always the LAST record to land
@@ -106,7 +108,10 @@ POSIX path is behaviorally unchanged:
             handle closes, so a cmd_reap running after the supervisor died
             falls back to a Toolhelp32 snapshot walk; that works because
             Windows never reparents orphans, so a dead pid still appears as
-            th32ParentProcessID on its live children.
+            th32ParentProcessID on its live children. A recycled pid that is
+            now this process (or whose GetProcessTimes identity does not
+            match the pid file) is not the original leader: sweep stale-PPID
+            descendants, do not TerminateProcess the live reused process.
   ownership st_uid == geteuid becomes: the object's owner SID is one this token
             creates objects as (user or default-owner SID), checked on the opened
             handle (GetSecurityInfo) exactly like the POSIX fstat-by-fd check.
@@ -378,6 +383,18 @@ if IS_WINDOWS:
     _kernel32.OpenProcess.argtypes = [
         wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
+    _kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
     _kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
     _kernel32.WaitForSingleObject.restype = wintypes.DWORD
     _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -479,7 +496,58 @@ if IS_WINDOWS:
                 queue.append(child)
         return list(reversed(order))
 
+    def _win_process_identity(pid: int):
+        """Creation time plus image path — analog of `ps -o lstart= -o command=`.
+
+        Creation time is the PID-reuse guard: Windows recycles PIDs aggressively,
+        and a recycled pid always carries a later FILETIME than the worker we
+        recorded. None means unproven (gone or unopenable)."""
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            if not started:
+                return None
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = (buf.value if _kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size)) else "")
+        finally:
+            _kernel32.CloseHandle(handle)
+        return "{} {}".format(started, image)
+
+    def _win_process_start_time(pid: int):
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            return started or None
+        finally:
+            _kernel32.CloseHandle(handle)
+
+    def _win_process_identity_matches(pid: int, recorded) -> bool:
+        if not recorded:
+            return True
+        current = _win_process_identity(pid)
+        return current is not None and current == recorded
+
     def _win_terminate_pid(pid: int) -> bool:
+        if pid <= 0 or pid == os.getpid():
+            return False
         handle = _kernel32.OpenProcess(_PROCESS_TERMINATE, False, pid)
         if not handle:
             return False
@@ -668,7 +736,9 @@ if IS_WINDOWS:
         finally:
             _kernel32.CloseHandle(handle)
 
-    def _win_kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+    def _win_kill_tree(
+        root_pid: int, grace: float, job_name=None, expected_identity=None,
+    ) -> bool:
         """Terminate the worker tree (KTD3). Returns whether the LEADER was
         alive when the kill began -- the reap classification signal -- which is
         independent of how much of the tree we then sweep.
@@ -690,19 +760,41 @@ if IS_WINDOWS:
         fails with ERROR_FILE_NOT_FOUND). So a cmd_reap running after the
         supervisor died cannot use it, and falls back to the snapshot walk --
         which is exactly the dead-leader case, hence deepest-first descendants
-        BEFORE the leader, and never gated on leader liveness."""
-        alive = _win_pid_alive(root_pid)
+        BEFORE the leader, and never gated on leader liveness.
+
+        A live pid at root_pid is not automatically the original leader:
+        Windows recycles PIDs, and cmd_reap is often the next python.exe after
+        the worker exits (the orphan-grandchild smoke). Never terminate this
+        process, and never terminate a live pid whose GetProcessTimes identity
+        does not match the recorded worker. Stale-PPID orphans still show the
+        dead leader as parent; when the pid was reused, skip descendants that
+        started at-or-after the new process (they belong to the reuse, not the
+        original tree)."""
+        self_pid = os.getpid()
+        is_self = root_pid == self_pid
+        alive = (not is_self) and _win_pid_alive(root_pid)
+        recorded_leader = alive and _win_process_identity_matches(
+            root_pid, expected_identity)
         if job_name:
             _win_terminate_job(job_name)
         # Always Toolhelp-sweep after (or without) the job terminate: children
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        reuse_cutoff = None
+        if not recorded_leader and (is_self or alive):
+            reuse_cutoff = _win_process_start_time(root_pid)
         for pid in _win_descendants_deepest_first(root_pid):
+            if pid == self_pid:
+                continue
+            if reuse_cutoff is not None:
+                started = _win_process_start_time(pid)
+                if started is not None and started >= reuse_cutoff:
+                    continue
             _win_terminate_pid(pid)
-        if alive:
+        if recorded_leader:
             _win_terminate_pid(root_pid)
-        return alive
+        return recorded_leader
 
 
 # --- hardened I/O primitives --------------------------------------------------
@@ -1003,14 +1095,16 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         _kill_quiet(pid, sig)
 
 
-def kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:
     """TERM the pid's process group (workers are started as group leaders),
     falling back to a deepest-first tree walk; grace, then KILL survivors.
 
     `job_name` is Windows-only (the worker's job object, the pgid analog) and
-    is ignored on POSIX, where the pgid is derived from the pid itself."""
+    is ignored on POSIX, where the pgid is derived from the pid itself.
+    `expected_identity` is Windows-only (GetProcessTimes identity recorded at
+    start) and is ignored on POSIX."""
     if IS_WINDOWS:
-        return _win_kill_tree(root_pid, grace, job_name)
+        return _win_kill_tree(root_pid, grace, job_name, expected_identity)
     # Do NOT early-return just because the leader pid is dead: killpg targets
     # the pgid, which persists while any group member lives even after the
     # leader exits, so a dead leader can still front a live group we must sweep.
@@ -1525,6 +1619,12 @@ def supervise(job_dir: str, argv, result_path, conf: dict, ack_fd: int) -> None:
             "worker_pid": proc.pid,
         }
         if IS_WINDOWS:
+            sup_ident = _win_process_identity(os.getpid())
+            worker_ident = _win_process_identity(proc.pid)
+            if sup_ident:
+                pid_doc["supervisor_identity"] = sup_ident
+            if worker_ident:
+                pid_doc["worker_identity"] = worker_ident
             # Assign while still suspended, then resume. Record the job only
             # once the worker is actually a member, so a later reap never trusts
             # a name that owns nothing. If assignment fails (job creation denied,
@@ -2060,15 +2160,28 @@ def cmd_reap(args) -> int:
         pid_doc = json.loads(read_owned(os.path.join(job_dir, "pid"), META_READ_CAP))
     except (Unreadable, OSError, ValueError):
         pid_doc = None
-    sup_pid = pid_doc.get("supervisor_pid") if isinstance(pid_doc, dict) else None
-    sup_pgid = pid_doc.get("supervisor_pgid") if isinstance(pid_doc, dict) else None
-    worker_pid = pid_doc.get("worker_pid") if isinstance(pid_doc, dict) else None
+    if not isinstance(pid_doc, dict):
+        pid_doc = {}
+    sup_pid = pid_doc.get("supervisor_pid")
+    sup_pgid = pid_doc.get("supervisor_pgid")
+    worker_pid = pid_doc.get("worker_pid")
     # Windows-only: the worker tree's job object. Named precisely so this
     # process -- which never held the supervisor's handle -- can reopen and
     # terminate the tree even after the worker leader has exited.
-    job_name = pid_doc.get("job_name") if isinstance(pid_doc, dict) else None
+    job_name = pid_doc.get("job_name")
+    worker_identity = pid_doc.get("worker_identity")
+    supervisor_identity = pid_doc.get("supervisor_identity")
 
-    if isinstance(sup_pid, int) and _pid_alive(sup_pid):
+    supervisor_ours = (
+        isinstance(sup_pid, int)
+        and not (IS_WINDOWS and sup_pid == os.getpid())
+        and _pid_alive(sup_pid)
+        and (
+            not IS_WINDOWS
+            or _win_process_identity_matches(sup_pid, supervisor_identity)
+        )
+    )
+    if supervisor_ours:
         # The supervisor owns TERM-grace-KILL and the terminal classification.
         # POSIX signals it (SIGTERM to the group or pid); Windows drops the
         # `.reap` marker the supervisor's loop polls for.
@@ -2107,7 +2220,7 @@ def cmd_reap(args) -> int:
     worker_leader_alive = False
     if isinstance(worker_pid, int):
         worker_leader_alive = kill_tree(
-            worker_pid, min(conf["grace"], 1.0), job_name)
+            worker_pid, min(conf["grace"], 1.0), job_name, worker_identity)
     # A worker can publish its declared result and exit before this fallback runs
     # (e.g. the supervisor died mid-run, then the worker completed cleanly). Honor
     # that result instead of discarding it as died-without-result: read the

--- a/skills/ce-plan/scripts/peer-job-runner.py
+++ b/skills/ce-plan/scripts/peer-job-runner.py
@@ -469,15 +469,11 @@ if IS_WINDOWS:
     _kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
     _kernel32.TerminateProcess.restype = wintypes.BOOL
 
-    def _win_descendants_deepest_first(root_pid: int):
-        """Children before parents, via a process snapshot. This is the direct
-        analog of the POSIX `ps`-based walk and carries the same pid-reuse
-        exposure. It works on an EXITED leader because Windows never reparents
-        orphans: a dead pid still appears as th32ParentProcessID on its live
-        children (unlike POSIX, where orphans are reparented to init)."""
+    def _win_process_children_map():
+        """th32ParentProcessID -> [child pids] from one Toolhelp snapshot."""
         snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
         if not snap or snap == ctypes.c_void_p(-1).value:
-            return []
+            return {}
         children = {}
         try:
             entry = _PROCESSENTRY32W()
@@ -489,6 +485,16 @@ if IS_WINDOWS:
                 more = _kernel32.Process32NextW(snap, ctypes.byref(entry))
         finally:
             _kernel32.CloseHandle(ctypes.c_void_p(snap))
+        return children
+
+    def _win_descendants_deepest_first(root_pid: int, children=None):
+        """Children before parents, via a process snapshot. This is the direct
+        analog of the POSIX `ps`-based walk and carries the same pid-reuse
+        exposure. It works on an EXITED leader because Windows never reparents
+        orphans: a dead pid still appears as th32ParentProcessID on its live
+        children (unlike POSIX, where orphans are reparented to init)."""
+        if children is None:
+            children = _win_process_children_map()
         order, queue = [], [root_pid]
         while queue:
             for child in children.get(queue.pop(0), []):
@@ -767,9 +773,10 @@ if IS_WINDOWS:
         the worker exits (the orphan-grandchild smoke). Never terminate this
         process, and never terminate a live pid whose GetProcessTimes identity
         does not match the recorded worker. Stale-PPID orphans still show the
-        dead leader as parent; when the pid was reused, skip descendants that
-        started at-or-after the new process (they belong to the reuse, not the
-        original tree)."""
+        dead leader as parent. When the pid was reused, the start-time cutoff
+        applies only to *direct* children of that pid (the new process's own
+        children vs stale-PPID orphans). A pre-reuse child's full subtree is
+        still original-tree work, including descendants spawned after reuse."""
         self_pid = os.getpid()
         is_self = root_pid == self_pid
         alive = (not is_self) and _win_pid_alive(root_pid)
@@ -781,16 +788,23 @@ if IS_WINDOWS:
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        children_map = _win_process_children_map()
         reuse_cutoff = None
         if not recorded_leader and (is_self or alive):
             reuse_cutoff = _win_process_start_time(root_pid)
-        for pid in _win_descendants_deepest_first(root_pid):
+        if reuse_cutoff is not None:
+            def _predates_reuse(pid):
+                started = _win_process_start_time(pid)
+                return started is None or started < reuse_cutoff
+            kill_set = _pre_reuse_descendant_pids(
+                root_pid, children_map, _predates_reuse, self_pid)
+        else:
+            kill_set = None
+        for pid in _win_descendants_deepest_first(root_pid, children_map):
             if pid == self_pid:
                 continue
-            if reuse_cutoff is not None:
-                started = _win_process_start_time(pid)
-                if started is not None and started >= reuse_cutoff:
-                    continue
+            if kill_set is not None and pid not in kill_set:
+                continue
             _win_terminate_pid(pid)
         if recorded_leader:
             _win_terminate_pid(root_pid)
@@ -1093,6 +1107,34 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         for descendant in _descendants_deepest_first(pid):
             _kill_quiet(descendant, sig)
         _kill_quiet(pid, sig)
+
+
+def _pre_reuse_descendant_pids(root_pid, children, predates_reuse, skip_pid=None):
+    """Direct children that predate a recycled leader pid, plus each of those
+    children's full subtree.
+
+    Toolhelp still lists the original tree under a dead pid as parent, mixed
+    with the new process's own children. The start-time cutoff applies only to
+    direct children. A pre-reuse child's later descendants stay original-tree
+    work even if they started after the reuse.
+    """
+    keep = set()
+    queue = []
+    for child in children.get(root_pid, []):
+        if skip_pid is not None and child == skip_pid:
+            continue
+        if not predates_reuse(child):
+            continue
+        queue.append(child)
+    while queue:
+        pid = queue.pop(0)
+        if skip_pid is not None and pid == skip_pid:
+            continue
+        if pid in keep:
+            continue
+        keep.add(pid)
+        queue.extend(children.get(pid, []))
+    return keep
 
 
 def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -25,9 +25,11 @@ Job directory (durable state, the source of truth):
     meta.json   identity: skill, run id, label, input digest, start time,
                 worker argv, result path (written at start, before detach)
     pid         supervisor pid + worker pid (written by the supervisor before
-                start returns; its presence marks "detached"). Two fields are
-                platform-conditional, so consumers must use .get(): POSIX adds
-                supervisor_pgid, Windows adds job_name (its job object).
+                start returns; its presence marks "detached"). Platform-
+                conditional fields — consumers must use .get(): POSIX adds
+                supervisor_pgid; Windows adds job_name (its job object) and
+                supervisor_identity / worker_identity (GetProcessTimes guards
+                so a recycled pid is not treated as the original process).
     out.log     worker's combined stdout+stderr (byte growth = liveness)
     reason      terminal detail, written before the status rename so the
                 status file is always the LAST record to land
@@ -106,7 +108,10 @@ POSIX path is behaviorally unchanged:
             handle closes, so a cmd_reap running after the supervisor died
             falls back to a Toolhelp32 snapshot walk; that works because
             Windows never reparents orphans, so a dead pid still appears as
-            th32ParentProcessID on its live children.
+            th32ParentProcessID on its live children. A recycled pid that is
+            now this process (or whose GetProcessTimes identity does not
+            match the pid file) is not the original leader: sweep stale-PPID
+            descendants, do not TerminateProcess the live reused process.
   ownership st_uid == geteuid becomes: the object's owner SID is one this token
             creates objects as (user or default-owner SID), checked on the opened
             handle (GetSecurityInfo) exactly like the POSIX fstat-by-fd check.
@@ -378,6 +383,18 @@ if IS_WINDOWS:
     _kernel32.OpenProcess.argtypes = [
         wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
+    _kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
     _kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
     _kernel32.WaitForSingleObject.restype = wintypes.DWORD
     _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -479,7 +496,58 @@ if IS_WINDOWS:
                 queue.append(child)
         return list(reversed(order))
 
+    def _win_process_identity(pid: int):
+        """Creation time plus image path — analog of `ps -o lstart= -o command=`.
+
+        Creation time is the PID-reuse guard: Windows recycles PIDs aggressively,
+        and a recycled pid always carries a later FILETIME than the worker we
+        recorded. None means unproven (gone or unopenable)."""
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            if not started:
+                return None
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = (buf.value if _kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size)) else "")
+        finally:
+            _kernel32.CloseHandle(handle)
+        return "{} {}".format(started, image)
+
+    def _win_process_start_time(pid: int):
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            return started or None
+        finally:
+            _kernel32.CloseHandle(handle)
+
+    def _win_process_identity_matches(pid: int, recorded) -> bool:
+        if not recorded:
+            return True
+        current = _win_process_identity(pid)
+        return current is not None and current == recorded
+
     def _win_terminate_pid(pid: int) -> bool:
+        if pid <= 0 or pid == os.getpid():
+            return False
         handle = _kernel32.OpenProcess(_PROCESS_TERMINATE, False, pid)
         if not handle:
             return False
@@ -668,7 +736,9 @@ if IS_WINDOWS:
         finally:
             _kernel32.CloseHandle(handle)
 
-    def _win_kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+    def _win_kill_tree(
+        root_pid: int, grace: float, job_name=None, expected_identity=None,
+    ) -> bool:
         """Terminate the worker tree (KTD3). Returns whether the LEADER was
         alive when the kill began -- the reap classification signal -- which is
         independent of how much of the tree we then sweep.
@@ -690,19 +760,41 @@ if IS_WINDOWS:
         fails with ERROR_FILE_NOT_FOUND). So a cmd_reap running after the
         supervisor died cannot use it, and falls back to the snapshot walk --
         which is exactly the dead-leader case, hence deepest-first descendants
-        BEFORE the leader, and never gated on leader liveness."""
-        alive = _win_pid_alive(root_pid)
+        BEFORE the leader, and never gated on leader liveness.
+
+        A live pid at root_pid is not automatically the original leader:
+        Windows recycles PIDs, and cmd_reap is often the next python.exe after
+        the worker exits (the orphan-grandchild smoke). Never terminate this
+        process, and never terminate a live pid whose GetProcessTimes identity
+        does not match the recorded worker. Stale-PPID orphans still show the
+        dead leader as parent; when the pid was reused, skip descendants that
+        started at-or-after the new process (they belong to the reuse, not the
+        original tree)."""
+        self_pid = os.getpid()
+        is_self = root_pid == self_pid
+        alive = (not is_self) and _win_pid_alive(root_pid)
+        recorded_leader = alive and _win_process_identity_matches(
+            root_pid, expected_identity)
         if job_name:
             _win_terminate_job(job_name)
         # Always Toolhelp-sweep after (or without) the job terminate: children
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        reuse_cutoff = None
+        if not recorded_leader and (is_self or alive):
+            reuse_cutoff = _win_process_start_time(root_pid)
         for pid in _win_descendants_deepest_first(root_pid):
+            if pid == self_pid:
+                continue
+            if reuse_cutoff is not None:
+                started = _win_process_start_time(pid)
+                if started is not None and started >= reuse_cutoff:
+                    continue
             _win_terminate_pid(pid)
-        if alive:
+        if recorded_leader:
             _win_terminate_pid(root_pid)
-        return alive
+        return recorded_leader
 
 
 # --- hardened I/O primitives --------------------------------------------------
@@ -1003,14 +1095,16 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         _kill_quiet(pid, sig)
 
 
-def kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:
     """TERM the pid's process group (workers are started as group leaders),
     falling back to a deepest-first tree walk; grace, then KILL survivors.
 
     `job_name` is Windows-only (the worker's job object, the pgid analog) and
-    is ignored on POSIX, where the pgid is derived from the pid itself."""
+    is ignored on POSIX, where the pgid is derived from the pid itself.
+    `expected_identity` is Windows-only (GetProcessTimes identity recorded at
+    start) and is ignored on POSIX."""
     if IS_WINDOWS:
-        return _win_kill_tree(root_pid, grace, job_name)
+        return _win_kill_tree(root_pid, grace, job_name, expected_identity)
     # Do NOT early-return just because the leader pid is dead: killpg targets
     # the pgid, which persists while any group member lives even after the
     # leader exits, so a dead leader can still front a live group we must sweep.
@@ -1525,6 +1619,12 @@ def supervise(job_dir: str, argv, result_path, conf: dict, ack_fd: int) -> None:
             "worker_pid": proc.pid,
         }
         if IS_WINDOWS:
+            sup_ident = _win_process_identity(os.getpid())
+            worker_ident = _win_process_identity(proc.pid)
+            if sup_ident:
+                pid_doc["supervisor_identity"] = sup_ident
+            if worker_ident:
+                pid_doc["worker_identity"] = worker_ident
             # Assign while still suspended, then resume. Record the job only
             # once the worker is actually a member, so a later reap never trusts
             # a name that owns nothing. If assignment fails (job creation denied,
@@ -2060,15 +2160,28 @@ def cmd_reap(args) -> int:
         pid_doc = json.loads(read_owned(os.path.join(job_dir, "pid"), META_READ_CAP))
     except (Unreadable, OSError, ValueError):
         pid_doc = None
-    sup_pid = pid_doc.get("supervisor_pid") if isinstance(pid_doc, dict) else None
-    sup_pgid = pid_doc.get("supervisor_pgid") if isinstance(pid_doc, dict) else None
-    worker_pid = pid_doc.get("worker_pid") if isinstance(pid_doc, dict) else None
+    if not isinstance(pid_doc, dict):
+        pid_doc = {}
+    sup_pid = pid_doc.get("supervisor_pid")
+    sup_pgid = pid_doc.get("supervisor_pgid")
+    worker_pid = pid_doc.get("worker_pid")
     # Windows-only: the worker tree's job object. Named precisely so this
     # process -- which never held the supervisor's handle -- can reopen and
     # terminate the tree even after the worker leader has exited.
-    job_name = pid_doc.get("job_name") if isinstance(pid_doc, dict) else None
+    job_name = pid_doc.get("job_name")
+    worker_identity = pid_doc.get("worker_identity")
+    supervisor_identity = pid_doc.get("supervisor_identity")
 
-    if isinstance(sup_pid, int) and _pid_alive(sup_pid):
+    supervisor_ours = (
+        isinstance(sup_pid, int)
+        and not (IS_WINDOWS and sup_pid == os.getpid())
+        and _pid_alive(sup_pid)
+        and (
+            not IS_WINDOWS
+            or _win_process_identity_matches(sup_pid, supervisor_identity)
+        )
+    )
+    if supervisor_ours:
         # The supervisor owns TERM-grace-KILL and the terminal classification.
         # POSIX signals it (SIGTERM to the group or pid); Windows drops the
         # `.reap` marker the supervisor's loop polls for.
@@ -2107,7 +2220,7 @@ def cmd_reap(args) -> int:
     worker_leader_alive = False
     if isinstance(worker_pid, int):
         worker_leader_alive = kill_tree(
-            worker_pid, min(conf["grace"], 1.0), job_name)
+            worker_pid, min(conf["grace"], 1.0), job_name, worker_identity)
     # A worker can publish its declared result and exit before this fallback runs
     # (e.g. the supervisor died mid-run, then the worker completed cleanly). Honor
     # that result instead of discarding it as died-without-result: read the

--- a/skills/ce-pov/scripts/peer-job-runner.py
+++ b/skills/ce-pov/scripts/peer-job-runner.py
@@ -469,15 +469,11 @@ if IS_WINDOWS:
     _kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
     _kernel32.TerminateProcess.restype = wintypes.BOOL
 
-    def _win_descendants_deepest_first(root_pid: int):
-        """Children before parents, via a process snapshot. This is the direct
-        analog of the POSIX `ps`-based walk and carries the same pid-reuse
-        exposure. It works on an EXITED leader because Windows never reparents
-        orphans: a dead pid still appears as th32ParentProcessID on its live
-        children (unlike POSIX, where orphans are reparented to init)."""
+    def _win_process_children_map():
+        """th32ParentProcessID -> [child pids] from one Toolhelp snapshot."""
         snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
         if not snap or snap == ctypes.c_void_p(-1).value:
-            return []
+            return {}
         children = {}
         try:
             entry = _PROCESSENTRY32W()
@@ -489,6 +485,16 @@ if IS_WINDOWS:
                 more = _kernel32.Process32NextW(snap, ctypes.byref(entry))
         finally:
             _kernel32.CloseHandle(ctypes.c_void_p(snap))
+        return children
+
+    def _win_descendants_deepest_first(root_pid: int, children=None):
+        """Children before parents, via a process snapshot. This is the direct
+        analog of the POSIX `ps`-based walk and carries the same pid-reuse
+        exposure. It works on an EXITED leader because Windows never reparents
+        orphans: a dead pid still appears as th32ParentProcessID on its live
+        children (unlike POSIX, where orphans are reparented to init)."""
+        if children is None:
+            children = _win_process_children_map()
         order, queue = [], [root_pid]
         while queue:
             for child in children.get(queue.pop(0), []):
@@ -767,9 +773,10 @@ if IS_WINDOWS:
         the worker exits (the orphan-grandchild smoke). Never terminate this
         process, and never terminate a live pid whose GetProcessTimes identity
         does not match the recorded worker. Stale-PPID orphans still show the
-        dead leader as parent; when the pid was reused, skip descendants that
-        started at-or-after the new process (they belong to the reuse, not the
-        original tree)."""
+        dead leader as parent. When the pid was reused, the start-time cutoff
+        applies only to *direct* children of that pid (the new process's own
+        children vs stale-PPID orphans). A pre-reuse child's full subtree is
+        still original-tree work, including descendants spawned after reuse."""
         self_pid = os.getpid()
         is_self = root_pid == self_pid
         alive = (not is_self) and _win_pid_alive(root_pid)
@@ -781,16 +788,23 @@ if IS_WINDOWS:
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        children_map = _win_process_children_map()
         reuse_cutoff = None
         if not recorded_leader and (is_self or alive):
             reuse_cutoff = _win_process_start_time(root_pid)
-        for pid in _win_descendants_deepest_first(root_pid):
+        if reuse_cutoff is not None:
+            def _predates_reuse(pid):
+                started = _win_process_start_time(pid)
+                return started is None or started < reuse_cutoff
+            kill_set = _pre_reuse_descendant_pids(
+                root_pid, children_map, _predates_reuse, self_pid)
+        else:
+            kill_set = None
+        for pid in _win_descendants_deepest_first(root_pid, children_map):
             if pid == self_pid:
                 continue
-            if reuse_cutoff is not None:
-                started = _win_process_start_time(pid)
-                if started is not None and started >= reuse_cutoff:
-                    continue
+            if kill_set is not None and pid not in kill_set:
+                continue
             _win_terminate_pid(pid)
         if recorded_leader:
             _win_terminate_pid(root_pid)
@@ -1093,6 +1107,34 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         for descendant in _descendants_deepest_first(pid):
             _kill_quiet(descendant, sig)
         _kill_quiet(pid, sig)
+
+
+def _pre_reuse_descendant_pids(root_pid, children, predates_reuse, skip_pid=None):
+    """Direct children that predate a recycled leader pid, plus each of those
+    children's full subtree.
+
+    Toolhelp still lists the original tree under a dead pid as parent, mixed
+    with the new process's own children. The start-time cutoff applies only to
+    direct children. A pre-reuse child's later descendants stay original-tree
+    work even if they started after the reuse.
+    """
+    keep = set()
+    queue = []
+    for child in children.get(root_pid, []):
+        if skip_pid is not None and child == skip_pid:
+            continue
+        if not predates_reuse(child):
+            continue
+        queue.append(child)
+    while queue:
+        pid = queue.pop(0)
+        if skip_pid is not None and pid == skip_pid:
+            continue
+        if pid in keep:
+            continue
+        keep.add(pid)
+        queue.extend(children.get(pid, []))
+    return keep
 
 
 def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -25,9 +25,11 @@ Job directory (durable state, the source of truth):
     meta.json   identity: skill, run id, label, input digest, start time,
                 worker argv, result path (written at start, before detach)
     pid         supervisor pid + worker pid (written by the supervisor before
-                start returns; its presence marks "detached"). Two fields are
-                platform-conditional, so consumers must use .get(): POSIX adds
-                supervisor_pgid, Windows adds job_name (its job object).
+                start returns; its presence marks "detached"). Platform-
+                conditional fields — consumers must use .get(): POSIX adds
+                supervisor_pgid; Windows adds job_name (its job object) and
+                supervisor_identity / worker_identity (GetProcessTimes guards
+                so a recycled pid is not treated as the original process).
     out.log     worker's combined stdout+stderr (byte growth = liveness)
     reason      terminal detail, written before the status rename so the
                 status file is always the LAST record to land
@@ -106,7 +108,10 @@ POSIX path is behaviorally unchanged:
             handle closes, so a cmd_reap running after the supervisor died
             falls back to a Toolhelp32 snapshot walk; that works because
             Windows never reparents orphans, so a dead pid still appears as
-            th32ParentProcessID on its live children.
+            th32ParentProcessID on its live children. A recycled pid that is
+            now this process (or whose GetProcessTimes identity does not
+            match the pid file) is not the original leader: sweep stale-PPID
+            descendants, do not TerminateProcess the live reused process.
   ownership st_uid == geteuid becomes: the object's owner SID is one this token
             creates objects as (user or default-owner SID), checked on the opened
             handle (GetSecurityInfo) exactly like the POSIX fstat-by-fd check.
@@ -378,6 +383,18 @@ if IS_WINDOWS:
     _kernel32.OpenProcess.argtypes = [
         wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
     _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.GetProcessTimes.argtypes = [
+        wintypes.HANDLE,
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+        ctypes.POINTER(wintypes.FILETIME),
+    ]
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
+    _kernel32.QueryFullProcessImageNameW.argtypes = [
+        wintypes.HANDLE, wintypes.DWORD, wintypes.LPWSTR,
+        ctypes.POINTER(wintypes.DWORD)]
+    _kernel32.QueryFullProcessImageNameW.restype = wintypes.BOOL
     _kernel32.WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
     _kernel32.WaitForSingleObject.restype = wintypes.DWORD
     _kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
@@ -479,7 +496,58 @@ if IS_WINDOWS:
                 queue.append(child)
         return list(reversed(order))
 
+    def _win_process_identity(pid: int):
+        """Creation time plus image path — analog of `ps -o lstart= -o command=`.
+
+        Creation time is the PID-reuse guard: Windows recycles PIDs aggressively,
+        and a recycled pid always carries a later FILETIME than the worker we
+        recorded. None means unproven (gone or unopenable)."""
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            if not started:
+                return None
+            size = wintypes.DWORD(32768)
+            buf = ctypes.create_unicode_buffer(size.value)
+            image = (buf.value if _kernel32.QueryFullProcessImageNameW(
+                handle, 0, buf, ctypes.byref(size)) else "")
+        finally:
+            _kernel32.CloseHandle(handle)
+        return "{} {}".format(started, image)
+
+    def _win_process_start_time(pid: int):
+        handle = _kernel32.OpenProcess(
+            _PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if not handle:
+            return None
+        try:
+            created, exited, kernel, user = (wintypes.FILETIME() for _ in range(4))
+            if not _kernel32.GetProcessTimes(
+                    handle, ctypes.byref(created), ctypes.byref(exited),
+                    ctypes.byref(kernel), ctypes.byref(user)):
+                return None
+            started = (created.dwHighDateTime << 32) | created.dwLowDateTime
+            return started or None
+        finally:
+            _kernel32.CloseHandle(handle)
+
+    def _win_process_identity_matches(pid: int, recorded) -> bool:
+        if not recorded:
+            return True
+        current = _win_process_identity(pid)
+        return current is not None and current == recorded
+
     def _win_terminate_pid(pid: int) -> bool:
+        if pid <= 0 or pid == os.getpid():
+            return False
         handle = _kernel32.OpenProcess(_PROCESS_TERMINATE, False, pid)
         if not handle:
             return False
@@ -668,7 +736,9 @@ if IS_WINDOWS:
         finally:
             _kernel32.CloseHandle(handle)
 
-    def _win_kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+    def _win_kill_tree(
+        root_pid: int, grace: float, job_name=None, expected_identity=None,
+    ) -> bool:
         """Terminate the worker tree (KTD3). Returns whether the LEADER was
         alive when the kill began -- the reap classification signal -- which is
         independent of how much of the tree we then sweep.
@@ -690,19 +760,41 @@ if IS_WINDOWS:
         fails with ERROR_FILE_NOT_FOUND). So a cmd_reap running after the
         supervisor died cannot use it, and falls back to the snapshot walk --
         which is exactly the dead-leader case, hence deepest-first descendants
-        BEFORE the leader, and never gated on leader liveness."""
-        alive = _win_pid_alive(root_pid)
+        BEFORE the leader, and never gated on leader liveness.
+
+        A live pid at root_pid is not automatically the original leader:
+        Windows recycles PIDs, and cmd_reap is often the next python.exe after
+        the worker exits (the orphan-grandchild smoke). Never terminate this
+        process, and never terminate a live pid whose GetProcessTimes identity
+        does not match the recorded worker. Stale-PPID orphans still show the
+        dead leader as parent; when the pid was reused, skip descendants that
+        started at-or-after the new process (they belong to the reuse, not the
+        original tree)."""
+        self_pid = os.getpid()
+        is_self = root_pid == self_pid
+        alive = (not is_self) and _win_pid_alive(root_pid)
+        recorded_leader = alive and _win_process_identity_matches(
+            root_pid, expected_identity)
         if job_name:
             _win_terminate_job(job_name)
         # Always Toolhelp-sweep after (or without) the job terminate: children
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        reuse_cutoff = None
+        if not recorded_leader and (is_self or alive):
+            reuse_cutoff = _win_process_start_time(root_pid)
         for pid in _win_descendants_deepest_first(root_pid):
+            if pid == self_pid:
+                continue
+            if reuse_cutoff is not None:
+                started = _win_process_start_time(pid)
+                if started is not None and started >= reuse_cutoff:
+                    continue
             _win_terminate_pid(pid)
-        if alive:
+        if recorded_leader:
             _win_terminate_pid(root_pid)
-        return alive
+        return recorded_leader
 
 
 # --- hardened I/O primitives --------------------------------------------------
@@ -1003,14 +1095,16 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         _kill_quiet(pid, sig)
 
 
-def kill_tree(root_pid: int, grace: float, job_name=None) -> bool:
+def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:
     """TERM the pid's process group (workers are started as group leaders),
     falling back to a deepest-first tree walk; grace, then KILL survivors.
 
     `job_name` is Windows-only (the worker's job object, the pgid analog) and
-    is ignored on POSIX, where the pgid is derived from the pid itself."""
+    is ignored on POSIX, where the pgid is derived from the pid itself.
+    `expected_identity` is Windows-only (GetProcessTimes identity recorded at
+    start) and is ignored on POSIX."""
     if IS_WINDOWS:
-        return _win_kill_tree(root_pid, grace, job_name)
+        return _win_kill_tree(root_pid, grace, job_name, expected_identity)
     # Do NOT early-return just because the leader pid is dead: killpg targets
     # the pgid, which persists while any group member lives even after the
     # leader exits, so a dead leader can still front a live group we must sweep.
@@ -1525,6 +1619,12 @@ def supervise(job_dir: str, argv, result_path, conf: dict, ack_fd: int) -> None:
             "worker_pid": proc.pid,
         }
         if IS_WINDOWS:
+            sup_ident = _win_process_identity(os.getpid())
+            worker_ident = _win_process_identity(proc.pid)
+            if sup_ident:
+                pid_doc["supervisor_identity"] = sup_ident
+            if worker_ident:
+                pid_doc["worker_identity"] = worker_ident
             # Assign while still suspended, then resume. Record the job only
             # once the worker is actually a member, so a later reap never trusts
             # a name that owns nothing. If assignment fails (job creation denied,
@@ -2060,15 +2160,28 @@ def cmd_reap(args) -> int:
         pid_doc = json.loads(read_owned(os.path.join(job_dir, "pid"), META_READ_CAP))
     except (Unreadable, OSError, ValueError):
         pid_doc = None
-    sup_pid = pid_doc.get("supervisor_pid") if isinstance(pid_doc, dict) else None
-    sup_pgid = pid_doc.get("supervisor_pgid") if isinstance(pid_doc, dict) else None
-    worker_pid = pid_doc.get("worker_pid") if isinstance(pid_doc, dict) else None
+    if not isinstance(pid_doc, dict):
+        pid_doc = {}
+    sup_pid = pid_doc.get("supervisor_pid")
+    sup_pgid = pid_doc.get("supervisor_pgid")
+    worker_pid = pid_doc.get("worker_pid")
     # Windows-only: the worker tree's job object. Named precisely so this
     # process -- which never held the supervisor's handle -- can reopen and
     # terminate the tree even after the worker leader has exited.
-    job_name = pid_doc.get("job_name") if isinstance(pid_doc, dict) else None
+    job_name = pid_doc.get("job_name")
+    worker_identity = pid_doc.get("worker_identity")
+    supervisor_identity = pid_doc.get("supervisor_identity")
 
-    if isinstance(sup_pid, int) and _pid_alive(sup_pid):
+    supervisor_ours = (
+        isinstance(sup_pid, int)
+        and not (IS_WINDOWS and sup_pid == os.getpid())
+        and _pid_alive(sup_pid)
+        and (
+            not IS_WINDOWS
+            or _win_process_identity_matches(sup_pid, supervisor_identity)
+        )
+    )
+    if supervisor_ours:
         # The supervisor owns TERM-grace-KILL and the terminal classification.
         # POSIX signals it (SIGTERM to the group or pid); Windows drops the
         # `.reap` marker the supervisor's loop polls for.
@@ -2107,7 +2220,7 @@ def cmd_reap(args) -> int:
     worker_leader_alive = False
     if isinstance(worker_pid, int):
         worker_leader_alive = kill_tree(
-            worker_pid, min(conf["grace"], 1.0), job_name)
+            worker_pid, min(conf["grace"], 1.0), job_name, worker_identity)
     # A worker can publish its declared result and exit before this fallback runs
     # (e.g. the supervisor died mid-run, then the worker completed cleanly). Honor
     # that result instead of discarding it as died-without-result: read the

--- a/skills/ce-work/scripts/peer-job-runner.py
+++ b/skills/ce-work/scripts/peer-job-runner.py
@@ -469,15 +469,11 @@ if IS_WINDOWS:
     _kernel32.TerminateProcess.argtypes = [wintypes.HANDLE, wintypes.UINT]
     _kernel32.TerminateProcess.restype = wintypes.BOOL
 
-    def _win_descendants_deepest_first(root_pid: int):
-        """Children before parents, via a process snapshot. This is the direct
-        analog of the POSIX `ps`-based walk and carries the same pid-reuse
-        exposure. It works on an EXITED leader because Windows never reparents
-        orphans: a dead pid still appears as th32ParentProcessID on its live
-        children (unlike POSIX, where orphans are reparented to init)."""
+    def _win_process_children_map():
+        """th32ParentProcessID -> [child pids] from one Toolhelp snapshot."""
         snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
         if not snap or snap == ctypes.c_void_p(-1).value:
-            return []
+            return {}
         children = {}
         try:
             entry = _PROCESSENTRY32W()
@@ -489,6 +485,16 @@ if IS_WINDOWS:
                 more = _kernel32.Process32NextW(snap, ctypes.byref(entry))
         finally:
             _kernel32.CloseHandle(ctypes.c_void_p(snap))
+        return children
+
+    def _win_descendants_deepest_first(root_pid: int, children=None):
+        """Children before parents, via a process snapshot. This is the direct
+        analog of the POSIX `ps`-based walk and carries the same pid-reuse
+        exposure. It works on an EXITED leader because Windows never reparents
+        orphans: a dead pid still appears as th32ParentProcessID on its live
+        children (unlike POSIX, where orphans are reparented to init)."""
+        if children is None:
+            children = _win_process_children_map()
         order, queue = [], [root_pid]
         while queue:
             for child in children.get(queue.pop(0), []):
@@ -767,9 +773,10 @@ if IS_WINDOWS:
         the worker exits (the orphan-grandchild smoke). Never terminate this
         process, and never terminate a live pid whose GetProcessTimes identity
         does not match the recorded worker. Stale-PPID orphans still show the
-        dead leader as parent; when the pid was reused, skip descendants that
-        started at-or-after the new process (they belong to the reuse, not the
-        original tree)."""
+        dead leader as parent. When the pid was reused, the start-time cutoff
+        applies only to *direct* children of that pid (the new process's own
+        children vs stale-PPID orphans). A pre-reuse child's full subtree is
+        still original-tree work, including descendants spawned after reuse."""
         self_pid = os.getpid()
         is_self = root_pid == self_pid
         alive = (not is_self) and _win_pid_alive(root_pid)
@@ -781,16 +788,23 @@ if IS_WINDOWS:
         # that raced outside the job before AssignProcessToJobObject completed
         # are not members, and TerminateJobObject alone would leave them.
         # CREATE_SUSPENDED closes that spawn race; this remains the belt.
+        children_map = _win_process_children_map()
         reuse_cutoff = None
         if not recorded_leader and (is_self or alive):
             reuse_cutoff = _win_process_start_time(root_pid)
-        for pid in _win_descendants_deepest_first(root_pid):
+        if reuse_cutoff is not None:
+            def _predates_reuse(pid):
+                started = _win_process_start_time(pid)
+                return started is None or started < reuse_cutoff
+            kill_set = _pre_reuse_descendant_pids(
+                root_pid, children_map, _predates_reuse, self_pid)
+        else:
+            kill_set = None
+        for pid in _win_descendants_deepest_first(root_pid, children_map):
             if pid == self_pid:
                 continue
-            if reuse_cutoff is not None:
-                started = _win_process_start_time(pid)
-                if started is not None and started >= reuse_cutoff:
-                    continue
+            if kill_set is not None and pid not in kill_set:
+                continue
             _win_terminate_pid(pid)
         if recorded_leader:
             _win_terminate_pid(root_pid)
@@ -1093,6 +1107,34 @@ def _signal_group_or_tree(pid: int, sig: int) -> None:
         for descendant in _descendants_deepest_first(pid):
             _kill_quiet(descendant, sig)
         _kill_quiet(pid, sig)
+
+
+def _pre_reuse_descendant_pids(root_pid, children, predates_reuse, skip_pid=None):
+    """Direct children that predate a recycled leader pid, plus each of those
+    children's full subtree.
+
+    Toolhelp still lists the original tree under a dead pid as parent, mixed
+    with the new process's own children. The start-time cutoff applies only to
+    direct children. A pre-reuse child's later descendants stay original-tree
+    work even if they started after the reuse.
+    """
+    keep = set()
+    queue = []
+    for child in children.get(root_pid, []):
+        if skip_pid is not None and child == skip_pid:
+            continue
+        if not predates_reuse(child):
+            continue
+        queue.append(child)
+    while queue:
+        pid = queue.pop(0)
+        if skip_pid is not None and pid == skip_pid:
+            continue
+        if pid in keep:
+            continue
+        keep.add(pid)
+        queue.extend(children.get(pid, []))
+    return keep
 
 
 def kill_tree(root_pid: int, grace: float, job_name=None, expected_identity=None) -> bool:

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -1187,5 +1187,67 @@ class HardDefaultFromCrossModel(unittest.TestCase):
             self.assertEqual(MOD.cfg()["hard"], 2030.0)
 
 
+class WindowsKillTreePidReuse(unittest.TestCase):
+    """cmd_reap after a dead worker must not TerminateProcess a recycled PID.
+
+    Windows recycles PIDs aggressively. test_orphan_grandchild_swept_by_reap
+    kills the supervisor, waits for the worker leader to exit, then starts
+    `reap` — the next python.exe, which can reuse worker_pid. Without a guard,
+    _win_kill_tree sees that pid alive (it is us) and TerminateProcess(handle,
+    1) suicides: exit 1, empty stderr. That is the windows-native flake.
+    """
+
+    @unittest.skipUnless(IS_WINDOWS, "native Windows kill_tree only")
+    def test_terminate_pid_refuses_current_process(self):
+        self.assertFalse(MOD._win_terminate_pid(os.getpid()))
+        self.assertTrue(MOD._pid_alive(os.getpid()))
+
+    @unittest.skipUnless(IS_WINDOWS, "native Windows kill_tree only")
+    def test_kill_tree_of_current_pid_does_not_terminate_self(self):
+        alive = MOD._win_kill_tree(os.getpid(), 0.0)
+        self.assertFalse(alive)
+        self.assertTrue(MOD._pid_alive(os.getpid()))
+
+    @unittest.skipUnless(IS_WINDOWS, "native Windows kill_tree only")
+    def test_cmd_reap_does_not_suicide_when_worker_pid_is_self(self):
+        root = tempfile.mkdtemp(prefix="peer-reap-self-")
+        job_dir = os.path.join(root, "job")
+        os.mkdir(job_dir, 0o700)
+        with open(os.path.join(job_dir, "pid"), "w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "supervisor_pid": 0,
+                    "worker_pid": os.getpid(),
+                },
+                f,
+            )
+        with open(os.path.join(job_dir, "meta.json"), "w", encoding="utf-8") as f:
+            json.dump(
+                {"job_id": "job", "skill": "ce-doc-review", "run_id": "run1"},
+                f,
+            )
+        code, _out, err = run_main(["reap", job_dir])
+        self.assertEqual(code, 0, err)
+        self.assertTrue(MOD._pid_alive(os.getpid()))
+        with open(os.path.join(job_dir, "status"), encoding="utf-8") as f:
+            self.assertEqual(f.read().strip(), "died-without-result")
+
+    @unittest.skipUnless(IS_WINDOWS, "native Windows identity probe only")
+    def test_process_identity_is_stable_and_differs_across_processes(self):
+        mine = MOD._win_process_identity(os.getpid())
+        self.assertIsNotNone(mine)
+        self.assertEqual(mine, MOD._win_process_identity(os.getpid()))
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(30)"],
+        )
+        try:
+            other = MOD._win_process_identity(child.pid)
+            self.assertIsNotNone(other)
+            self.assertNotEqual(other, mine)
+        finally:
+            child.kill()
+            child.wait(timeout=5)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/fixtures/peer-job-runner-unit.py
+++ b/tests/fixtures/peer-job-runner-unit.py
@@ -1187,6 +1187,28 @@ class HardDefaultFromCrossModel(unittest.TestCase):
             self.assertEqual(MOD.cfg()["hard"], 2030.0)
 
 
+class PreReuseDescendantPids(unittest.TestCase):
+    """Cutoff on a recycled leader pid applies only to its direct children."""
+
+    def test_keeps_late_descendants_of_a_pre_reuse_child(self):
+        # root 10 was recycled. 20 is an original-tree child; 21 is spawned by
+        # 20 after reuse; 30/31 belong to the new process at pid 10.
+        children = {10: [20, 30], 20: [21], 30: [31]}
+        keep = MOD._pre_reuse_descendant_pids(10, children, lambda pid: pid == 20)
+        self.assertEqual(keep, {20, 21})
+
+    def test_unproven_start_keeps_the_direct_child_and_subtree(self):
+        children = {1: [2], 2: [3]}
+        keep = MOD._pre_reuse_descendant_pids(1, children, lambda _pid: True)
+        self.assertEqual(keep, {2, 3})
+
+    def test_skips_self_in_a_pre_reuse_subtree(self):
+        children = {1: [2], 2: [99]}
+        keep = MOD._pre_reuse_descendant_pids(
+            1, children, lambda _pid: True, skip_pid=99)
+        self.assertEqual(keep, {2})
+
+
 class WindowsKillTreePidReuse(unittest.TestCase):
     """cmd_reap after a dead worker must not TerminateProcess a recycled PID.
 


### PR DESCRIPTION
Windows `reap` after a dead worker no longer `TerminateProcess`s a process that reused the worker PID. That was the `windows-native` flake on `test_orphan_grandchild_swept_by_reap`: empty stderr, exit 1.

The supervisor is gone, so the named Job Object is not reopenable. The Toolhelp fallback then treated a live PID as the original leader. On GitHub-hosted Windows, the next `python.exe` is often `reap` itself.

## Validation

- `python3 tests/fixtures/peer-job-runner-unit.py` — 76 pass, 4 Windows-only tests skipped on macOS
- `bun test tests/peer-job-runner-parity.test.ts` — six runner copies stay byte-identical
- `bun test tests/skills/peer-job-runner.test.ts` — POSIX lifecycle, including dead-leader reap
- Native Windows smoke will run on this PR's `windows-native` job. It cannot be reproduced on macOS.

Related: #1248, #1384, #1534

## Security Disclosure

`TerminateProcess` on Windows is now refused for the current PID and for a live PID whose `GetProcessTimes` identity does not match the pid file. That closes a recycled-PID kill of an unrelated process. Residual risk: a pid file from before this change has no identity field, so only the self-PID guard applies.

## Agent Disclosure

- **Model:** Grok Build · grok-4.6

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
