### PR TITLE
docs: add session guidance for same-session, compact, or fresh start

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ After installing, run `/ce-setup` in any project. It reports optional tool capab
 
 Starting from a bug instead of a feature? Use [`/ce-debug`](docs/skills/ce-debug.md). Not sure what to build yet? Start with [`/ce-ideate`](docs/skills/ce-ideate.md).
 
+## Session guidance
+
+The loop produces durable artifacts at each step — plan documents, commits, and review reports — so you rarely need to protect in-session context by hand. Use the artifact as the checkpoint, not the conversation:
+
+- **Stay in the same session** while you're inside one step (planning, or one `/ce-work` implementation pass). The model has the context it needs; clearing it early just forces a re-read of the same files.
+- **Compact** when a session has run long (large diffs, many tool calls, or you're approaching the host's context limit) but you're still mid-step and want to keep recent decisions in view. Compact after a plan is written or a `/ce-code-review` pass completes, not mid-edit.
+- **Start a fresh session** at a durable handoff point — after a plan is committed, after code is committed and pushed, or after a review report lands — so the next step starts from the artifact on disk instead of a long transcript. `/ce-plan`, `/ce-work`, and `/ce-code-review` all read prior artifacts back in, so a new session loses no information a completed step already wrote down. Use [`/ce-handoff`](docs/skills/ce-handoff.md) to hand off mid-step work that has no artifact yet.
+
+`/lfg` chains brainstorm through PR without asking, so this guidance mainly applies when you're running loop steps by hand.
+
 ## Skills at a glance
 
 33 skills, grouped by what they are for. The full catalog, with a page per skill and how each one chains into the others, is in **[docs/skills](docs/skills/README.md)**.


### PR DESCRIPTION
## Summary

Adds a "Session guidance" section to the README explaining when Compound Engineering users should stay in the same session, compact context, or start a fresh session — anchored to the loop's durable handoff points (a committed plan, pushed code, or a landed review report) rather than session duration alone.

Addresses the request in #884: users running long sessions (especially with 1M context) weren't sure when to compact, clear, or continue, and the docs didn't call out that each loop step's artifact is itself the safe checkpoint.

## Validation

- `bun run release:validate` — pass
- `bun run plugin:validate` — pass (marketplace + plugin manifest)
- `bun test tests/release-metadata.test.ts tests/skill-conventions.test.ts` — 304 pass, 0 fail (README-consistency and skill-convention suites)
- `bun run test` (full suite) — 3615 pass / 12 fail; the 12 failures are pre-existing timing-sensitive cross-model-routing and PR-watcher subprocess tests unrelated to this docs-only change (no source/skill files touched).

## Security Disclosure

No security-relevant changes. This is a documentation-only change to `README.md` — no shell/exec, path handling, converters, credentials, or dependencies touched.

## Agent Disclosure

- **Model:** Claude Code · Claude (this harness does not expose an exact model identifier in-session; family only)
