### PR TITLE
fix(opencode): support both OpenCode V1 and V2 (#1557)

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -8,7 +8,7 @@ Add Compound Engineering to the `plugin` array in your global or project `openco
 }
 ```
 
-Restart OpenCode after changing the config. The OpenCode plugin registers the Compound Engineering skills directory directly; no Bun installer or generated skill copy is required.
+Restart OpenCode after changing the config. The bundled entrypoint supports both the legacy OpenCode v1 plugin loader and the OpenCode v2 plugin loader, so the same declaration works with either binary. It registers the Compound Engineering skills directly; no Bun installer or generated skill copy is required.
 
 To pin a release, add a tag. Replace `X.Y.Z` with the release you want — see the [releases page](https://github.com/EveryInc/compound-engineering-plugin/releases) for available tags:
 

--- a/.opencode/plugins/compound-engineering.js
+++ b/.opencode/plugins/compound-engineering.js
@@ -1,6 +1,8 @@
 import path from "path"
 import fs from "fs"
 import { fileURLToPath } from "url"
+import { createV1Plugin } from "./compound-engineering/opencode-v1.js"
+import { createV2Setup } from "./compound-engineering/opencode-v2.js"
 
 const pluginDir = path.dirname(fileURLToPath(import.meta.url))
 const skillsDir = path.resolve(pluginDir, "../../skills")
@@ -23,52 +25,50 @@ function parseFrontmatter(content) {
     const pair = line.match(/^([A-Za-z][\w-]*):\s*(.*)$/)
     if (pair) fields[pair[1]] = unquote(pair[2].trim())
   }
-  return fields
+  return {
+    fields,
+    body: content.slice(block[0].length).replace(/^\r?\n/, ""),
+  }
 }
 
 function loadSkills() {
-  const commands = {}
+  const skills = []
   let entries
   try {
     entries = fs.readdirSync(skillsDir)
   } catch {
-    return commands
+    return skills
   }
   for (const entry of entries) {
+    const skillPath = path.join(skillsDir, entry, "SKILL.md")
     let content
     try {
-      content = fs.readFileSync(path.join(skillsDir, entry, "SKILL.md"), "utf8")
+      content = fs.readFileSync(skillPath, "utf8")
     } catch {
       continue
     }
-    const fields = parseFrontmatter(content)
-    if (!fields || !fields.name) continue
-    if (fields["user-invocable"] === "false") continue
-    const command = {
-      template: `Load and execute the \`${fields.name}\` skill.\n\n$ARGUMENTS`,
-    }
-    if (fields.description) command.description = fields.description
-    commands[fields.name] = command
+    const parsed = parseFrontmatter(content)
+    if (!parsed || !parsed.fields.name) continue
+    skills.push({
+      name: parsed.fields.name,
+      description: parsed.fields.description,
+      body: parsed.body,
+      skillPath,
+      suppressed: parsed.fields["user-invocable"] === "false",
+    })
   }
-  return commands
+  return skills
 }
 
-const skillCommands = loadSkills()
+const skills = loadSkills()
 
-export const CompoundEngineeringPlugin = async () => ({
-  config: async (config) => {
-    config.skills = config.skills || {}
-    config.skills.paths = config.skills.paths || []
-    if (!config.skills.paths.includes(skillsDir)) {
-      config.skills.paths.push(skillsDir)
-    }
-    config.command = config.command || {}
-    for (const [name, cmd] of Object.entries(skillCommands)) {
-      if (!(name in config.command)) {
-        config.command[name] = cmd
-      }
-    }
-  },
-})
+const CompoundEngineeringPlugin = createV1Plugin({ skills, skillsDir })
+const setupV2 = createV2Setup(skills)
 
-export default CompoundEngineeringPlugin
+export { CompoundEngineeringPlugin }
+
+export default {
+  id: "compound-engineering",
+  server: CompoundEngineeringPlugin,
+  setup: setupV2,
+}

--- a/.opencode/plugins/compound-engineering/opencode-v1.js
+++ b/.opencode/plugins/compound-engineering/opencode-v1.js
@@ -1,0 +1,20 @@
+export function createV1Plugin({ skills, skillsDir }) {
+  return async () => ({
+    config: async (config) => {
+      config.skills = config.skills || {}
+      config.skills.paths = config.skills.paths || []
+      if (!config.skills.paths.includes(skillsDir)) {
+        config.skills.paths.push(skillsDir)
+      }
+      config.command = config.command || {}
+      for (const skill of skills) {
+        if (skill.suppressed || skill.name in config.command) continue
+        const command = {
+          template: `Load and execute the \`${skill.name}\` skill.\n\n$ARGUMENTS`,
+        }
+        if (skill.description) command.description = skill.description
+        config.command[skill.name] = command
+      }
+    },
+  })
+}

--- a/.opencode/plugins/compound-engineering/opencode-v2.js
+++ b/.opencode/plugins/compound-engineering/opencode-v2.js
@@ -1,0 +1,60 @@
+function v2SkillInfo(skill, slash) {
+  return {
+    name: skill.name,
+    ...(skill.description ? { description: skill.description } : {}),
+    slash,
+    location: skill.skillPath,
+    content: skill.body,
+  }
+}
+
+function v2Skill(skill, slash) {
+  return {
+    id: skill.name,
+    ...v2SkillInfo(skill, slash),
+  }
+}
+
+export function createV2Setup(skills) {
+  return async function setupV2(context) {
+    let commandsRegistered = false
+    const commandTransform = context?.command?.transform
+    const prompt = context?.session?.prompt
+
+    if (typeof commandTransform === "function" && typeof prompt === "function") {
+      await commandTransform((draft) => {
+        if (typeof draft?.add !== "function") return
+        commandsRegistered = true
+        for (const skill of skills) {
+          if (skill.suppressed) continue
+          draft.add({
+            name: skill.name,
+            description: skill.description,
+            execute: async (input) => {
+              const promptInput = input?.prompt ?? {}
+              const attachedSkills = promptInput.skills ?? []
+              const skillAlreadyAttached = attachedSkills.some((attached) => attached.id === skill.name)
+              await prompt({
+                ...promptInput,
+                sessionID: input.sessionID,
+                text: promptInput.text || "",
+                skills: skillAlreadyAttached ? attachedSkills : [...attachedSkills, { id: skill.name }],
+                delivery: input.delivery,
+              })
+            },
+          })
+        }
+      })
+    }
+
+    const skillTransform = context?.skill?.transform
+    if (typeof skillTransform !== "function") return
+
+    await skillTransform((draft) => {
+      if (typeof draft?.add !== "function") return
+      for (const skill of skills) {
+        draft.add(v2Skill(skill, commandsRegistered ? false : !skill.suppressed))
+      }
+    })
+  }
+}

--- a/tests/opencode-plugin-commands.test.ts
+++ b/tests/opencode-plugin-commands.test.ts
@@ -3,6 +3,8 @@ import path from "path"
 import { describe, expect, test } from "bun:test"
 // @ts-expect-error -- plain JS plugin entrypoint, no type declarations
 import { CompoundEngineeringPlugin } from "../.opencode/plugins/compound-engineering.js"
+// @ts-expect-error -- plain JS plugin entrypoint, no type declarations
+import OpenCodePlugin from "../.opencode/plugins/compound-engineering.js"
 import { parseFrontmatter } from "../src/utils/frontmatter"
 
 const skillsDir = path.resolve(import.meta.dir, "../skills")
@@ -11,6 +13,25 @@ type OpenCodeCommand = { template: string; description?: string }
 type OpenCodeConfig = {
   skills?: { paths?: string[] }
   command?: Record<string, OpenCodeCommand>
+}
+
+type V2Command = {
+  name: string
+  description?: string
+  execute: (input: {
+    sessionID: string
+    prompt: { text: string; skills?: Array<{ id: string }> }
+    delivery: string
+  }) => Promise<void>
+}
+
+type V2Skill = {
+  id: string
+  name: string
+  description?: string
+  slash?: boolean
+  location: string
+  content: string
 }
 
 async function applyPlugin(config: OpenCodeConfig = {}): Promise<OpenCodeConfig> {
@@ -37,16 +58,19 @@ const skills = fs
   })
 
 const expectedTemplate = (name: string) => `Load and execute the \`${name}\` skill.\n\n$ARGUMENTS`
+const invocableSkillNames = skills.filter((skill) => !skill.suppressed).map((skill) => skill.name).sort()
 
 describe("opencode plugin skill commands", () => {
+  test("exports both OpenCode plugin contracts", () => {
+    expect(OpenCodePlugin.id).toBe("compound-engineering")
+    expect(typeof OpenCodePlugin.server).toBe("function")
+    expect(typeof OpenCodePlugin.setup).toBe("function")
+  })
+
   test("registers a command for every user-invocable skill", async () => {
     const config = await applyPlugin()
-    const expected = skills
-      .filter((skill) => !skill.suppressed)
-      .map((skill) => skill.name)
-      .sort()
 
-    expect(Object.keys(config.command ?? {}).sort()).toEqual(expected)
+    expect(Object.keys(config.command ?? {}).sort()).toEqual(invocableSkillNames)
   })
 
   test("each command carries a $ARGUMENTS template and the skill description", async () => {
@@ -98,4 +122,46 @@ describe("opencode plugin skill commands", () => {
       expect(dirs.has(name)).toBe(true)
     }
   })
+
+  test("registers v2 commands and embedded skill definitions", async () => {
+    const commands: V2Command[] = []
+    const registeredSkills: V2Skill[] = []
+    const prompts: unknown[] = []
+
+    await OpenCodePlugin.setup({
+      command: {
+        transform: async (callback: (draft: { add: (command: V2Command) => void }) => void) =>
+          callback({ add: (command) => commands.push(command) }),
+      },
+      skill: {
+        transform: async (callback: (draft: { add: (skill: V2Skill) => void }) => void) =>
+          callback({ add: (skill) => registeredSkills.push(skill) }),
+      },
+      session: {
+        prompt: async (input: unknown) => {
+          prompts.push(input)
+        },
+      },
+    })
+
+    expect(commands.map((command) => command.name).sort()).toEqual(invocableSkillNames)
+    expect(registeredSkills.map((skill) => skill.id).sort()).toEqual(skills.map((skill) => skill.name).sort())
+    expect(registeredSkills.every((skill) => skill.slash === false)).toBe(true)
+    expect(registeredSkills.every((skill) => !skill.content.startsWith("---"))).toBe(true)
+
+    const command = commands.find((item) => item.name === "ce-plan")!
+    const existingSkill = { id: "existing-skill" }
+    await command.execute({
+      sessionID: "session",
+      prompt: { text: "extra context", skills: [existingSkill] },
+      delivery: "steer",
+    })
+    expect(prompts[0]).toEqual({
+      sessionID: "session",
+      text: "extra context",
+      skills: [existingSkill, { id: command.name }],
+      delivery: "steer",
+    })
+  })
+
 })


### PR DESCRIPTION
## Summary

The same plugin declaration now supports OpenCode V1 and V2. In OpenCode v2, slash commands attach the selected skill natively and pass command arguments as prompt text, instead of asking the model to issue a separate `Load and execute...` request.

Fixes #1557: [Expand support for both OpenCode v1 and v2](https://github.com/EveryInc/compound-engineering-plugin/issues/1557).

## Design Decisions

- The top-level JavaScript entrypoint stays directly under `.opencode/plugins/`, so OpenCode v1 discovers one plugin while the v1 and v2 implementations remain separate helper modules.
- The v1 config hook adds the bundled skills path and creates slash-command wrappers.
- The v2 setup registers skill definitions through the current `draft.add` API.
- A v2 command such as `/ce-plan add OAuth login` sends `text: "add OAuth login"` and `skills: [{ id: "ce-plan" }]`. Existing prompt attachments are preserved and the selected skill is not duplicated.
- Skill frontmatter is removed before registration while the skill's real location is retained, so OpenCode can resolve supporting files relative to the skill.
- Skills marked non-user-invocable do not receive slash commands.

## New concepts

### Native v2 skill attachments

OpenCode v2 can attach a skill by ID when submitting a prompt. OpenCode then loads the skill content and supporting files from the registered skill location. This keeps the user request separate from the skill instructions and avoids a model-mediated skill-loading turn. Use this pattern when a command is a thin entry point to a registered skill. It is not a copy of the skill body into a command template.

## Validation

- `bun test tests/opencode-plugin-commands.test.ts` - 8 passed.
- `bun run release:validate` - passed.
- `bun run plugin:validate` - passed.
- `git diff --check` - passed.
- OpenCode v1 `1.18.23` - interactive TUI loaded the repository plugin and reached a clean exit (`init count=38`).
- OpenCode v2 `0.0.0-beta-18314` - standalone startup loaded the repository plugin and reached the interactive TUI; native skill-command behavior was manually verified.
- `bun run test` - not completed within 420 seconds; it remained in `tests/skills/ce-work-cross-model-routes.test.ts`.
- `bun run typecheck` and `bun run lint` - not configured in this repository.

## Security Disclosure

The plugin reads bundled `SKILL.md` files and passes their registered locations and content to OpenCode. No new shell execution, credential handling, permission rules, or dependencies were introduced.

## Agent Disclosure

- **Model:** `OpenCode · openai/gpt-5.6-luna`
