### PR TITLE
perf(tests): reuse seed git fixtures to cut suite wall time

### DIFF
--- a/tests/ce-code-review-mechanics.test.ts
+++ b/tests/ce-code-review-mechanics.test.ts
@@ -2,7 +2,9 @@ import { mkdtempSync, mkdirSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import path from "path"
 import { spawnSync } from "node:child_process"
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
+
+setDefaultTimeout(20_000)
 
 const SKILL_DIR = path.join(process.cwd(), "skills", "ce-code-review")
 const SCOPE_SCRIPT = path.join(SKILL_DIR, "scripts", "review-scope.py")

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,8 +1,10 @@
-import { afterAll, describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { promises as fs } from "fs"
 import path from "path"
 import os from "os"
 import { materializeClaudePluginFixture } from "./helpers/claude-plugin-fixture"
+
+setDefaultTimeout(20_000)
 
 const fixture = materializeClaudePluginFixture(path.join(import.meta.dir, "fixtures", "sample-plugin"))
 const fixtureRoot = fixture.root

--- a/tests/codex-dev.test.ts
+++ b/tests/codex-dev.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { promises as fs } from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -20,6 +20,8 @@ import {
   type CommandRunner,
   type InstalledPlugin,
 } from "../src/dev/codex-dev"
+
+setDefaultTimeout(20_000)
 
 const tempRoots: string[] = []
 

--- a/tests/plugin-path.test.ts
+++ b/tests/plugin-path.test.ts
@@ -1,8 +1,10 @@
-import { afterAll, describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test"
 import { promises as fs } from "fs"
 import path from "path"
 import os from "os"
 import { materializeClaudePluginFixture } from "./helpers/claude-plugin-fixture"
+
+setDefaultTimeout(20_000)
 
 async function exists(filePath: string): Promise<boolean> {
   try {

--- a/tests/skill-eval-cell/extract.test.ts
+++ b/tests/skill-eval-cell/extract.test.ts
@@ -1,4 +1,6 @@
-import { afterAll, expect, test } from "bun:test"
+import { afterAll, expect, setDefaultTimeout, test } from "bun:test"
+
+setDefaultTimeout(20_000)
 import { spawnSync } from "node:child_process"
 import fs from "node:fs"
 import path from "node:path"

--- a/tests/skill-eval-cell/path-shim.test.ts
+++ b/tests/skill-eval-cell/path-shim.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from "bun:test"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
+
+setDefaultTimeout(20_000)
 import { spawnSync } from "node:child_process"
 import fs from "node:fs"
 import os from "node:os"

--- a/tests/skills/ce-work-cross-model-routes.test.ts
+++ b/tests/skills/ce-work-cross-model-routes.test.ts
@@ -536,7 +536,7 @@ describe("ce-work fixed write routes", () => {
     const quietBin = temp("ce-work-bin-")
     writeFileSync(path.join(quietBin, "claude"), `#!/bin/sh
 cat > '${quiet.capture}/stdin'
-sleep 2
+sleep 1.1
 exit 7
 `)
     chmodSync(path.join(quietBin, "claude"), 0o755)
@@ -898,7 +898,7 @@ printf '%s' '${prefix}${sentinel}${"y".repeat(maxRawBytes)}'
     const bin = temp("ce-work-bin-")
     writeFileSync(path.join(bin, "claude"), `#!/bin/sh
 cat > '${f.capture}/stdin'
-python3 -c 'import sys; sys.stdout.buffer.write(b"x" * 8388608)'
+python3 -c 'import sys; sys.stdout.buffer.write(b"x" * 65536)'
 `)
     chmodSync(path.join(bin, "claude"), 0o755)
 
@@ -906,6 +906,7 @@ python3 -c 'import sys; sys.stdout.buffer.write(b"x" * 8388608)'
       ...process.env,
       PATH: `${bin}:${process.env.PATH}`,
       CE_WORK_MAX_RAW_BYTES: String(maxRawBytes),
+      CE_WORK_ACTIVITY_POLL_SECS: "1",
     })
 
     expect(result.code).toBe(1)

--- a/tests/skills/ce-work-cross-model-routes.test.ts
+++ b/tests/skills/ce-work-cross-model-routes.test.ts
@@ -2,6 +2,7 @@ import { afterAll, describe, expect, setDefaultTimeout, test } from "bun:test"
 import {
   chmodSync,
   copyFileSync,
+  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -33,6 +34,8 @@ const ROUTE_CONTRACTS = {
   "grok-cursor": { target: "grok", harness: "cursor-agent", intermediaries: ["cursor"], model: "cursor-grok-4.6-high", restriction: "adapter-enforced" },
 } as const
 const roots: string[] = []
+const templateRoots: string[] = []
+let seedCanonical: string | null = null
 
 function temp(prefix: string): string {
   const dir = mkdtempSync(path.join(tmpdir(), prefix))
@@ -40,7 +43,27 @@ function temp(prefix: string): string {
   return dir
 }
 
-afterAll(() => roots.forEach((dir) => rmSync(dir, { recursive: true, force: true })))
+afterAll(() => {
+  for (const dir of [...roots, ...templateRoots]) rmSync(dir, { recursive: true, force: true })
+})
+
+function seedCanonicalRepo(): string {
+  if (seedCanonical) return seedCanonical
+  const root = mkdtempSync(path.join(tmpdir(), "ce-work-route-template-"))
+  templateRoots.push(root)
+  const canonical = path.join(root, "canonical")
+  mkdirSync(canonical)
+  mkdirSync(path.join(canonical, "docs", "plans"), { recursive: true })
+  writeFileSync(path.join(canonical, "README.md"), "seed\n")
+  writeFileSync(path.join(canonical, "docs", "plans", "plan.md"), "# Test plan\n")
+  spawnSync("git", ["init", "-q", canonical])
+  spawnSync("git", ["-C", canonical, "config", "user.email", "test@example.com"])
+  spawnSync("git", ["-C", canonical, "config", "user.name", "Test"])
+  spawnSync("git", ["-C", canonical, "add", "."])
+  spawnSync("git", ["-C", canonical, "commit", "-qm", "seed"])
+  seedCanonical = canonical
+  return canonical
+}
 
 function fixture() {
   const root = temp("ce-work-route-")
@@ -48,17 +71,10 @@ function fixture() {
   const packet = path.join(root, "packet.md")
   const capture = path.join(root, "capture")
   const runs = path.join(root, "runs")
-  mkdirSync(canonical)
+  mkdirSync(root, { recursive: true })
   mkdirSync(capture)
   writeFileSync(packet, "Implement U3 only.\n")
-  spawnSync("git", ["init", "-q", canonical])
-  spawnSync("git", ["-C", canonical, "config", "user.email", "test@example.com"])
-  spawnSync("git", ["-C", canonical, "config", "user.name", "Test"])
-  mkdirSync(path.join(canonical, "docs", "plans"), { recursive: true })
-  writeFileSync(path.join(canonical, "README.md"), "seed\n")
-  writeFileSync(path.join(canonical, "docs", "plans", "plan.md"), "# Test plan\n")
-  spawnSync("git", ["-C", canonical, "add", "."])
-  spawnSync("git", ["-C", canonical, "commit", "-qm", "seed"])
+  cpSync(seedCanonicalRepo(), canonical, { recursive: true })
   return {
     root,
     canonical,

--- a/tests/skills/helpers/ce-work-workspace-harness.ts
+++ b/tests/skills/helpers/ce-work-workspace-harness.ts
@@ -1,7 +1,8 @@
-import { afterEach } from "bun:test"
+import { afterAll, afterEach } from "bun:test"
 import { spawnSync } from "node:child_process"
 import {
   chmodSync,
+  cpSync,
   existsSync,
   linkSync,
   mkdtempSync,
@@ -24,6 +25,12 @@ import { createHash } from "node:crypto"
 export const SCRIPT = path.join(__dirname, "../../../skills/ce-work/scripts/unit-workspace.py")
 export const ADAPTER = path.join(__dirname, "../../../skills/ce-work/scripts/cross-model-work.sh")
 const roots: string[] = []
+const templateRoots: string[] = []
+const seedTemplates = new Map<string, { repo: string; digest: string; base: string }>()
+
+afterAll(() => {
+  for (const root of templateRoots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
 
 export function tmp(prefix: string): string {
   const root = mkdtempSync(path.join(tmpdir(), prefix))
@@ -41,8 +48,12 @@ export function git(cwd: string, ...args: string[]): string {
   return sh(cwd, ["git", ...args]).stdout.trim()
 }
 
-export function makeRepo(objectFormat: "sha1" | "sha256" = "sha1"): { repo: string; plan: string; digest: string; base: string } {
-  const repo = path.join(tmp("ce-work-repo-"), "repo")
+function seedTemplate(objectFormat: "sha1" | "sha256"): { repo: string; digest: string; base: string } {
+  const cached = seedTemplates.get(objectFormat)
+  if (cached) return cached
+  const root = mkdtempSync(path.join(tmpdir(), "ce-work-repo-template-"))
+  templateRoots.push(root)
+  const repo = path.join(root, "repo")
   mkdirSync(repo)
   git(repo, "init", `--object-format=${objectFormat}`, "-b", "main")
   git(repo, "config", "user.name", "CE Work Test")
@@ -56,8 +67,26 @@ export function makeRepo(objectFormat: "sha1" | "sha256" = "sha1"): { repo: stri
   writeFileSync(plan, "# Plan\n")
   git(repo, "add", ".")
   git(repo, "commit", "-m", "seed")
-  const digest = createHash("sha256").update(readFileSync(plan)).digest("hex")
-  return { repo, plan, digest, base: git(repo, "rev-parse", "HEAD") }
+  const template = {
+    repo,
+    digest: createHash("sha256").update(readFileSync(plan)).digest("hex"),
+    base: git(repo, "rev-parse", "HEAD"),
+  }
+  seedTemplates.set(objectFormat, template)
+  return template
+}
+
+export function makeRepo(objectFormat: "sha1" | "sha256" = "sha1"): { repo: string; plan: string; digest: string; base: string } {
+  const template = seedTemplate(objectFormat)
+  const repo = path.join(tmp("ce-work-repo-"), "repo")
+  mkdirSync(path.dirname(repo), { recursive: true })
+  cpSync(template.repo, repo, { recursive: true })
+  return {
+    repo,
+    plan: path.join(repo, "docs", "plans", "plan.md"),
+    digest: template.digest,
+    base: template.base,
+  }
 }
 
 export function packetFile(content: string): string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Speed up `bun run test` without skipping tests or pinning a worker count.

**If a local run is ~9 minutes, you are almost certainly running serial `bun test` or a loaded machine.** The package script is already `bun test --parallel`. On GitHub CI, `main` is 126s today, not 9 minutes.

### Results

| Surface | Before | After |
|---|---|---|
| This 4-core cloud VM | 395s, 13 fail (5s default timeouts) | 202s (3 load-flakes that pass in isolation) |
| GitHub CI `Run tests` | 126.10s on `main` | **111.88s**, 3626 pass / 0 fail |

Ideal target was 60s. After the fixture change the suite is pack-bound (~807s of per-file work / 4 cores locally). Further file splits will not get there.

### What changed

1. **Seed-repo copy** — `makeRepo` and the ce-work route fixture copy a cached git repo instead of `git init` + commit on every test. This is what moved CI 126s → 112s and dropped the workspace shards from 100–200s to 36–51s on the slow VM.
2. **Timeouts** — files that flake at bun's 5s default under `--parallel` now declare `setDefaultTimeout(20_000)`.
3. **Oversized-output test** — was paying the adapter's default 15s activity poll. It now polls at 1s and writes 64KiB (still above the 256-byte cap). Isolated 15.6s → 1.7s; full-suite wall is inside noise.

### Why not 60s

Eight files still own most of the work (babysit snapshot, cross-model routes/integration, remaining python/bash/git). Cutting that in half is a later optimize pass (in-process snapshot, concurrent-within-file, integration seed helper) — leftover on the optimize backlog.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Cursor Cloud Agent · cursor-grok-4.6-high-fast

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e2b0ca8-3835-4263-aa2d-78b80fb620a4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e2b0ca8-3835-4263-aa2d-78b80fb620a4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

