### PR TITLE
fix(validate-doc-claims): name repo-scoped search base in path-not-found flag

### DIFF
--- a/skills/ce-compound-refresh/scripts/validate-doc-claims.py
+++ b/skills/ce-compound-refresh/scripts/validate-doc-claims.py
@@ -272,12 +272,13 @@ def main(argv: list[str]) -> int:
                 f"{upstream}: stale checkout? Annotate or verify against upstream."
             )
         else:
-            where = (
-                f"working tree or {upstream}" if upstream else "working tree"
-            )
             flags.append(
-                f"FLAG path `{token}`{loc} — not found in {where}. Fix the "
-                "citation, or annotate it as historical (e.g. removed by this fix)."
+                f"FLAG path `{token}`{loc} — not found under {base}"
+                + (f" or {upstream}" if upstream else "")
+                + ". This check only looks in this repository; verify other "
+                "repos or stores before treating the citation as wrong. Fix "
+                "the citation, or annotate it as historical (e.g. removed "
+                "by this fix)."
             )
 
     # --- 2. Cited commit SHAs ----------------------------------------------

--- a/skills/ce-compound/references/grounding-validation.md
+++ b/skills/ce-compound/references/grounding-validation.md
@@ -17,7 +17,7 @@ The script reports flags; you decide each one. Three resolutions — **fix**, **
 
 | Flag | Likely meaning | Resolution |
 |------|----------------|------------|
-| path not found anywhere | Typo, or drafted from memory | Fix the citation or remove the claim |
+| path not found under the search base | Typo, or a real path this repo-scoped check cannot see — another store, or a target the citing sentence itself says is gone | Read that sentence and check stores outside this repository before treating the citation as wrong; then fix it, or annotate it as historical |
 | path missing here, exists at upstream | Stale checkout | Verify the claim against upstream; annotate if the doc implies the file is present locally |
 | path deliberately gone (doc says removed/renamed) | Historical citation | Confirm the surrounding prose marks it as historical ("removed by this fix", "pre-fix state"); add that marker if absent |
 | SHA does not resolve | Fabricated or from another repo | Replace with the PR number, or drop |

--- a/skills/ce-compound/scripts/validate-doc-claims.py
+++ b/skills/ce-compound/scripts/validate-doc-claims.py
@@ -272,12 +272,13 @@ def main(argv: list[str]) -> int:
                 f"{upstream}: stale checkout? Annotate or verify against upstream."
             )
         else:
-            where = (
-                f"working tree or {upstream}" if upstream else "working tree"
-            )
             flags.append(
-                f"FLAG path `{token}`{loc} — not found in {where}. Fix the "
-                "citation, or annotate it as historical (e.g. removed by this fix)."
+                f"FLAG path `{token}`{loc} — not found under {base}"
+                + (f" or {upstream}" if upstream else "")
+                + ". This check only looks in this repository; verify other "
+                "repos or stores before treating the citation as wrong. Fix "
+                "the citation, or annotate it as historical (e.g. removed "
+                "by this fix)."
             )
 
     # --- 2. Cited commit SHAs ----------------------------------------------

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -140,14 +140,18 @@ describe("validate-doc-claims script", () => {
         expect(result.stdout).not.toContain("FLAG")
       })
 
-      test("flags a cited path that exists nowhere", () => {
+      test("flags a cited path that exists nowhere, naming the search base as repo-scoped", () => {
         const docPath = writeRepoDoc(
           "The handler is `src/does-not-exist.ts` in the tree.\n",
         )
         const result = runValidator(skillDir, docPath)
         expect(result.code).toBe(1)
         expect(result.stdout).toContain("FLAG path `src/does-not-exist.ts`")
-        expect(result.stdout).toContain("not found")
+        expect(result.stdout).toContain("not found under ")
+        expect(result.stdout).toContain(path.basename(repo))
+        expect(result.stdout).toContain(
+          "This check only looks in this repository",
+        )
       })
 
       test("classifies a path that only exists upstream as stale-checkout", () => {


### PR DESCRIPTION
## What

`validate-doc-claims.py` flags a cited repo path with "not found in working tree" (or "working tree or `origin/main`") without saying where it looked. An agent reading that flag can't tell "this citation is wrong" from "this citation points somewhere this check did not look" — e.g. a second docs store in another repo on the same machine.

## Fix

Name the search base (repo root, plus the upstream ref when one exists) in the flag text and state the check is repo-scoped:

```
FLAG path `x.md` (line N) — not found under /path/to/repo or origin/main. This
check only looks in this repository; verify other repos or stores before
treating the citation as wrong. Fix the citation, or annotate it as
historical (e.g. removed by this fix).
```

Applied identically to both duplicated copies of the script (`skills/ce-compound/scripts/validate-doc-claims.py` and `skills/ce-compound-refresh/scripts/validate-doc-claims.py`), per the AGENTS.md duplication rule the existing test suite already enforces.

## Scope

Smallest correct fix per the issue: wording only, no cross-repo resolution (out of scope per the issue, tracked separately by #1505).

## Tests

- Updated `tests/doc-claims-validator.test.ts`'s "flags a cited path that exists nowhere" test to assert the new repo-scoped wording (search base + "This check only looks in this repository").
- `bun test tests/doc-claims-validator.test.ts` — 53/53 pass.
- `bun run test` — full suite passes except 5 pre-existing, unrelated timing-flaky tests in `tests/ce-babysit-pr-snapshot.test.ts` / `tests/skills/ce-code-review-cross-model-routes.test.ts`, confirmed failing identically on a clean checkout of upstream `main` before this change.

Ref: #1545
