### PR TITLE
fix(ce-compound): name search base in repo-scoped path flag

### DIFF
--- a/skills/ce-compound-refresh/scripts/validate-doc-claims.py
+++ b/skills/ce-compound-refresh/scripts/validate-doc-claims.py
@@ -276,8 +276,11 @@ def main(argv: list[str]) -> int:
                 f"working tree or {upstream}" if upstream else "working tree"
             )
             flags.append(
-                f"FLAG path `{token}`{loc} — not found in {where}. Fix the "
-                "citation, or annotate it as historical (e.g. removed by this fix)."
+                f"FLAG path `{token}`{loc} — not found in {where}, under "
+                f"{base}. This check only looks in this repository; check "
+                "other stores before treating the citation as wrong. "
+                "Otherwise, fix the citation, or annotate it as historical "
+                "(e.g. removed by this fix)."
             )
 
     # --- 2. Cited commit SHAs ----------------------------------------------

--- a/skills/ce-compound/scripts/validate-doc-claims.py
+++ b/skills/ce-compound/scripts/validate-doc-claims.py
@@ -276,8 +276,11 @@ def main(argv: list[str]) -> int:
                 f"working tree or {upstream}" if upstream else "working tree"
             )
             flags.append(
-                f"FLAG path `{token}`{loc} — not found in {where}. Fix the "
-                "citation, or annotate it as historical (e.g. removed by this fix)."
+                f"FLAG path `{token}`{loc} — not found in {where}, under "
+                f"{base}. This check only looks in this repository; check "
+                "other stores before treating the citation as wrong. "
+                "Otherwise, fix the citation, or annotate it as historical "
+                "(e.g. removed by this fix)."
             )
 
     # --- 2. Cited commit SHAs ----------------------------------------------

--- a/tests/doc-claims-validator.test.ts
+++ b/tests/doc-claims-validator.test.ts
@@ -1,6 +1,12 @@
 import { beforeAll, describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 
@@ -66,7 +72,7 @@ function mixedShaPrefix(sha: string): string {
 }
 
 beforeAll(() => {
-  repo = mkdtempSync(path.join(tmpdir(), "doc-claims-repo-"))
+  repo = realpathSync(mkdtempSync(path.join(tmpdir(), "doc-claims-repo-")))
   sh(repo, "git", ["init", "-b", "main"])
   sh(repo, "git", ["config", "user.email", "test@example.com"])
   sh(repo, "git", ["config", "user.name", "Test"])
@@ -140,14 +146,20 @@ describe("validate-doc-claims script", () => {
         expect(result.stdout).not.toContain("FLAG")
       })
 
-      test("flags a cited path that exists nowhere", () => {
+      test("flags a cited path that exists nowhere, naming the search base", () => {
         const docPath = writeRepoDoc(
           "The handler is `src/does-not-exist.ts` in the tree.\n",
         )
         const result = runValidator(skillDir, docPath)
         expect(result.code).toBe(1)
         expect(result.stdout).toContain("FLAG path `src/does-not-exist.ts`")
-        expect(result.stdout).toContain("not found")
+        expect(result.stdout).toContain(
+          `not found in working tree or origin/main, under ${repo}`,
+        )
+        expect(result.stdout).toContain(
+          "This check only looks in this repository; check other stores " +
+            "before treating the citation as wrong.",
+        )
       })
 
       test("classifies a path that only exists upstream as stale-checkout", () => {
@@ -176,8 +188,9 @@ describe("validate-doc-claims script", () => {
         )
         const result = runValidator(skillDir, docPath)
         expect(result.code).toBe(1)
-        expect(result.stdout).toContain("FLAG path `src/nonexistent-helper`")
-        expect(result.stdout).toContain("not found")
+        expect(result.stdout).toContain(
+          `not found in working tree or origin/main, under ${repo}`,
+        )
       })
 
       test("ignores placeholder and URL-like tokens", () => {
@@ -345,7 +358,9 @@ describe("validate-doc-claims script", () => {
         expect(result.stdout).toContain(
           "FLAG path `../best-practices/does-not-exist.md`",
         )
-        expect(result.stdout).toContain("not found")
+        expect(result.stdout).toContain(
+          `not found in working tree or origin/main, under ${repo}`,
+        )
       })
 
       test("skips a `../` token that escapes the repository", () => {


### PR DESCRIPTION
Fixes the misleading repo-scoped path validation message from #1545.

## Summary

`validate-doc-claims.py` resolves cited paths against a single repo root. When a citation is unresolvable, the FLAG message said only "not found in working tree" (or "... or origin/main"), with no mention of which repo it searched. That reads as a global "this citation is wrong," which an agent can't distinguish from "this citation points somewhere I didn't look" (e.g. a second solutions store in another repo on the same machine).

## Fix

The FLAG message for the "not found anywhere" case now names the search base and states the check is repo-scoped:

```
FLAG path `x.md` (line N) — not found in working tree, under /path/to/repo.
This check only looks in this repository; check other stores before
treating the citation as wrong. Otherwise, fix the citation, or annotate
it as historical (e.g. removed by this fix).
```

Applied identically to both copies of the script (`skills/ce-compound/scripts/validate-doc-claims.py` and `skills/ce-compound-refresh/scripts/validate-doc-claims.py`), which AGENTS.md requires to stay byte-identical. Confirmed with `diff` after the edit.

The other two flag branches (tracked-at-HEAD, exists-upstream) already name their source (`working tree`, `origin/main` etc.) and are unchanged.

## Tests

Updated `tests/doc-claims-validator.test.ts` assertions for the three "not found" scenarios to check the new wording (repo base path included). Added `realpathSync` on the scratch repo path so the assertion matches the script's own `git rev-parse --show-toplevel` output on macOS (`/tmp` vs `/private/tmp` symlink).

```
bun test tests/doc-claims-validator.test.ts
 53 pass
 0 fail
```

Also ran the full `bun run test` suite. It has pre-existing unrelated failures (timing-sensitive `ce-babysit-pr-snapshot` watcher tests and `ce-code-review-cross-model-routes` peer-idle heuristics) reproducible on a clean `main` checkout without this change — confirmed via `git stash` on the same worktree.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Claude Code
