### PR TITLE
fix(ce-work): scrub GIT_INTERNAL_SUPER_PREFIX from inherited git env

### DIFF
--- a/skills/ce-work/scripts/unit_workspace_state.py
+++ b/skills/ce-work/scripts/unit_workspace_state.py
@@ -60,6 +60,10 @@ GIT_LOCAL_ENV_VARS = frozenset({
     "GIT_GRAFT_FILE",
     "GIT_IMPLICIT_WORK_TREE",
     "GIT_INDEX_FILE",
+    # Listed by `git rev-parse --local-env-vars` on git < 2.41 (e.g. Debian
+    # bookworm's 2.39); dropped from the list by newer git. Scrub it so an
+    # inherited value cannot leak into unit verification on old git.
+    "GIT_INTERNAL_SUPER_PREFIX",
     "GIT_NO_REPLACE_OBJECTS",
     "GIT_OBJECT_DIRECTORY",
     "GIT_PREFIX",


### PR DESCRIPTION
## Summary

`ce-work` unit verification no longer breaks on git < 2.41: the inherited-environment scrub list in `unit_workspace_state.py` now also removes `GIT_INTERNAL_SUPER_PREFIX`, so `integrate` returns `UNIT_COMMITTED` instead of `BLOCKED` on the git versions that still report that variable.

The scrub list statically mirrors the output of `git rev-parse --local-env-vars`, and git dropped `GIT_INTERNAL_SUPER_PREFIX` from that output in 2.41 — so a list written against newer git omits it, and on git 2.39 (e.g. Debian bookworm) the inherited value leaked into the verification probe.

Fixes #1563.

## Validation

On Debian bookworm (git 2.39.5), `bun test tests/skills/ce-work-unit-workspace-init.test.ts` fails at "unit and plan-wide verification ignore inherited Git local environment" before this change and passes with it. On git 2.50.1 the variable is not listed by `rev-parse` at all, and the suite passes with and without the change.

## Security Disclosure

No security-relevant changes. The change scrubs one more inherited git environment variable from unit verification, which reduces environment leakage; no new externally visible surface.

## Agent Disclosure

Claude Code · claude-opus-4-8
