### PR TITLE
fix(ce-setup): detect leftover Codex tool-map sentinels

### DIFF
--- a/docs/install/upgrading.md
+++ b/docs/install/upgrading.md
@@ -62,7 +62,7 @@ Remove the obsolete Compound Engineering Codex tool-map block from my Codex home
 
 1. Check `$CODEX_HOME/AGENTS.md` if CODEX_HOME is set, otherwise `~/.codex/AGENTS.md`. If I use Codex profiles, also check `~/.codex/profiles/*/AGENTS.md`.
 2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` and `<!-- END COMPOUND CODEX TOOL MAP -->`.
-3. If both are present, delete only the span from the BEGIN line through the END line (inclusive), leaving any other user content untouched. Do not edit project/repo AGENTS.md unless those exact sentinels are present there.
+3. Only if a BEGIN line is followed later by an END line (each sentinel occupying its own line), delete the span from that first BEGIN through that later END (inclusive). A stray END before the first BEGIN does not cancel a later ordered pair. Inline mentions of the marker strings are not a block. If no standalone BEGIN has a standalone END after it, leave the file alone. Leave any other user content untouched. Do not edit project/repo AGENTS.md unless those exact sentinels form an ordered pair of lines there.
 4. If the file is empty after the removal, delete the file.
 5. Show a short before/after summary of what you changed (or say the block was already absent). Do not add a replacement tool map.
 ```

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -70,7 +70,7 @@ Also remediate these project issues when the report names them:
 - `.compound-engineering/config.example.yaml` is missing or outdated
 - the health report marks the `ce-work` skill implementation engine unavailable or invalid, detects retired scalar routing keys, or reports malformed dormant `work_engine_preferences`
 - the health report marks `docs_root` invalid (`Invalid docs_root ...`) — CE artifacts will not be written until it is fixed
-- the health report names a **legacy Compound Codex tool map** in `$CODEX_HOME/AGENTS.md` (or a profile copy) — session-level; point at `docs/install/upgrading.md`. Do not rewrite `ce-work` skip phrases in this skill.
+- the health report names a **legacy Compound Codex tool map** in `$CODEX_HOME/AGENTS.md` (or a profile copy) — session-level; follow `references/legacy-codex-tool-map.md` in this skill. Do not rewrite `ce-work` skip phrases in this skill.
 
 If optional tools are missing, do not offer a bulk install. The diagnostic already printed the relevant install command or project URL. Say: "Install optional tools only for the workflows you use."
 

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -70,7 +70,7 @@ Also remediate these project issues when the report names them:
 - `.compound-engineering/config.example.yaml` is missing or outdated
 - the health report marks the `ce-work` skill implementation engine unavailable or invalid, detects retired scalar routing keys, or reports malformed dormant `work_engine_preferences`
 - the health report marks `docs_root` invalid (`Invalid docs_root ...`) — CE artifacts will not be written until it is fixed
-- the health report names a **legacy Compound Codex tool map** in `$CODEX_HOME/AGENTS.md` (or a profile copy) — session-level; follow `references/legacy-codex-tool-map.md` in this skill. Do not rewrite `ce-work` skip phrases in this skill.
+- the health report names a **legacy Compound Codex tool map** in `${CODEX_HOME:-$HOME/.codex}/AGENTS.md` (or a profile copy) — session-level; follow `references/legacy-codex-tool-map.md` in this skill. Do not rewrite `ce-work` skip phrases in this skill.
 
 If optional tools are missing, do not offer a bulk install. The diagnostic already printed the relevant install command or project URL. Say: "Install optional tools only for the workflows you use."
 

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -70,6 +70,7 @@ Also remediate these project issues when the report names them:
 - `.compound-engineering/config.example.yaml` is missing or outdated
 - the health report marks the `ce-work` skill implementation engine unavailable or invalid, detects retired scalar routing keys, or reports malformed dormant `work_engine_preferences`
 - the health report marks `docs_root` invalid (`Invalid docs_root ...`) — CE artifacts will not be written until it is fixed
+- the health report names a **legacy Compound Codex tool map** in `$CODEX_HOME/AGENTS.md` (or a profile copy) — session-level; point at `docs/install/upgrading.md`. Do not rewrite `ce-work` skip phrases in this skill.
 
 If optional tools are missing, do not offer a bulk install. The diagnostic already printed the relevant install command or project URL. Say: "Install optional tools only for the workflows you use."
 

--- a/skills/ce-setup/references/legacy-codex-tool-map.md
+++ b/skills/ce-setup/references/legacy-codex-tool-map.md
@@ -18,9 +18,10 @@ the main thread. Native plugin install does **not** add this block.
    `~/.codex/profiles/*/AGENTS.md`.
 2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->`
    and `<!-- END COMPOUND CODEX TOOL MAP -->`.
-3. Only if a BEGIN is followed later by its END, delete the span from
-   that BEGIN through that END (inclusive). If END appears first, leave
-   the file alone — there is no ordered block to remove. Leave any other
+3. Only if a BEGIN is followed later by an END, delete the span from
+   that first BEGIN through that later END (inclusive). A stray END
+   before the first BEGIN does not cancel a later ordered pair. If no
+   BEGIN has an END after it, leave the file alone. Leave any other
    user content untouched. Do not edit project/repo `AGENTS.md` unless
    those exact sentinels form an ordered pair there.
 4. If the file is empty after the removal, delete the file.

--- a/skills/ce-setup/references/legacy-codex-tool-map.md
+++ b/skills/ce-setup/references/legacy-codex-tool-map.md
@@ -1,0 +1,30 @@
+# Remove the retired Compound Codex tool map
+
+The Bun-era convert/install path could insert a managed block into
+global Codex instructions:
+
+`<!-- BEGIN COMPOUND CODEX TOOL MAP -->` … `<!-- END COMPOUND CODEX TOOL MAP -->`
+
+in `$CODEX_HOME/AGENTS.md` (default `~/.codex/AGENTS.md`) and in named
+profile copies under `~/.codex/profiles/*/AGENTS.md`.
+
+That Claude-compat map is obsolete — CE skills name Codex tools inline —
+and one line incorrectly told Codex to collapse subagent dispatch onto
+the main thread. Native plugin install does **not** add this block.
+
+## Safe removal
+
+1. Check `$CODEX_HOME/AGENTS.md` if `CODEX_HOME` is set, otherwise
+   `~/.codex/AGENTS.md`. Also check `~/.codex/profiles/*/AGENTS.md`.
+2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->`
+   and `<!-- END COMPOUND CODEX TOOL MAP -->`.
+3. If both are present, delete only the span from the BEGIN line through
+   the END line (inclusive). Leave any other user content untouched. Do
+   not edit project/repo `AGENTS.md` unless those exact sentinels are
+   present there.
+4. If the file is empty after the removal, delete the file.
+5. Show a short before/after of what changed (or say the block was
+   already absent). Do not add a replacement tool map.
+
+This file ships with the `ce-setup` skill so marketplace/converted
+installs still have the procedure without the repo `docs/` tree.

--- a/skills/ce-setup/references/legacy-codex-tool-map.md
+++ b/skills/ce-setup/references/legacy-codex-tool-map.md
@@ -5,7 +5,7 @@ global Codex instructions:
 
 `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` … `<!-- END COMPOUND CODEX TOOL MAP -->`
 
-in `$CODEX_HOME/AGENTS.md` (default `~/.codex/AGENTS.md`) and in named
+in `${CODEX_HOME:-$HOME/.codex}/AGENTS.md` and in named
 profile copies under `~/.codex/profiles/*/AGENTS.md`.
 
 That Claude-compat map is obsolete — CE skills name Codex tools inline —
@@ -14,8 +14,8 @@ the main thread. Native plugin install does **not** add this block.
 
 ## Safe removal
 
-1. Check `$CODEX_HOME/AGENTS.md` if `CODEX_HOME` is set, otherwise
-   `~/.codex/AGENTS.md`. Also check `~/.codex/profiles/*/AGENTS.md`.
+1. Check `${CODEX_HOME:-$HOME/.codex}/AGENTS.md`. Also check
+   `~/.codex/profiles/*/AGENTS.md`.
 2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->`
    and `<!-- END COMPOUND CODEX TOOL MAP -->`.
 3. Only if a BEGIN is followed later by its END, delete the span from

--- a/skills/ce-setup/references/legacy-codex-tool-map.md
+++ b/skills/ce-setup/references/legacy-codex-tool-map.md
@@ -18,10 +18,11 @@ the main thread. Native plugin install does **not** add this block.
    `~/.codex/AGENTS.md`. Also check `~/.codex/profiles/*/AGENTS.md`.
 2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->`
    and `<!-- END COMPOUND CODEX TOOL MAP -->`.
-3. If both are present, delete only the span from the BEGIN line through
-   the END line (inclusive). Leave any other user content untouched. Do
-   not edit project/repo `AGENTS.md` unless those exact sentinels are
-   present there.
+3. Only if a BEGIN is followed later by its END, delete the span from
+   that BEGIN through that END (inclusive). If END appears first, leave
+   the file alone — there is no ordered block to remove. Leave any other
+   user content untouched. Do not edit project/repo `AGENTS.md` unless
+   those exact sentinels form an ordered pair there.
 4. If the file is empty after the removal, delete the file.
 5. Show a short before/after of what changed (or say the block was
    already absent). Do not add a replacement tool map.

--- a/skills/ce-setup/references/legacy-codex-tool-map.md
+++ b/skills/ce-setup/references/legacy-codex-tool-map.md
@@ -18,12 +18,14 @@ the main thread. Native plugin install does **not** add this block.
    `~/.codex/profiles/*/AGENTS.md`.
 2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->`
    and `<!-- END COMPOUND CODEX TOOL MAP -->`.
-3. Only if a BEGIN is followed later by an END, delete the span from
-   that first BEGIN through that later END (inclusive). A stray END
-   before the first BEGIN does not cancel a later ordered pair. If no
-   BEGIN has an END after it, leave the file alone. Leave any other
-   user content untouched. Do not edit project/repo `AGENTS.md` unless
-   those exact sentinels form an ordered pair there.
+3. Only if a BEGIN line is followed later by an END line (each sentinel
+   occupying its own line), delete the span from that first BEGIN through
+   that later END (inclusive). A stray END before the first BEGIN does
+   not cancel a later ordered pair. Inline mentions of the marker strings
+   are not a block. If no standalone BEGIN has a standalone END after it,
+   leave the file alone. Leave any other user content untouched. Do not
+   edit project/repo `AGENTS.md` unless those exact sentinels form an
+   ordered pair of lines there.
 4. If the file is empty after the removal, delete the file.
 5. Show a short before/after of what changed (or say the block was
    already absent). Do not add a replacement tool map.

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -318,8 +318,8 @@ scan_codex_profile_tree() {
 scan_codex_agents_file "$codex_home/AGENTS.md"
 scan_codex_profile_tree "$codex_home"
 # Named profiles live under ~/.codex even when CODEX_HOME points at an active profile.
+# Do not scan inactive ~/.codex/AGENTS.md — that file is not the current session.
 if [ "$codex_home" != "$default_codex_home" ]; then
-  scan_codex_agents_file "$default_codex_home/AGENTS.md"
   scan_codex_profile_tree "$default_codex_home"
 fi
 

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -295,16 +295,18 @@ CODEX_TOOL_MAP_END="<!-- END COMPOUND CODEX TOOL MAP -->"
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 default_codex_home="$HOME/.codex"
 legacy_codex_map_files=()
-# Ordered pair only: first BEGIN must precede first END (same contract as
-# removeCodexAgentsToolMapBlock). Independent grep would treat END-then-BEGIN
-# as removable even though no safe span exists.
+# Ordered pair: first BEGIN must have an END after it (same contract as
+# removeCodexAgentsToolMapBlock). A stray earlier END must not hide a later
+# removable block (END then BEGIN then END). Independent grep would treat
+# END-then-BEGIN with no later END as removable even though no safe span exists.
 has_ordered_codex_tool_map() {
   awk -v s="$CODEX_TOOL_MAP_START" -v e="$CODEX_TOOL_MAP_END" '
     { buf = buf $0 "\n" }
     END {
       si = index(buf, s)
-      ei = index(buf, e)
-      exit (si > 0 && ei > 0 && ei > si) ? 0 : 1
+      if (si == 0) exit 1
+      rest = substr(buf, si + length(s))
+      exit (index(rest, e) > 0) ? 0 : 1
     }
   ' "$1"
 }

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -295,19 +295,18 @@ CODEX_TOOL_MAP_END="<!-- END COMPOUND CODEX TOOL MAP -->"
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 default_codex_home="$HOME/.codex"
 legacy_codex_map_files=()
-# Ordered pair: first BEGIN must have an END after it (same contract as
+# Ordered pair of standalone sentinel lines (same contract as
 # removeCodexAgentsToolMapBlock). A stray earlier END must not hide a later
-# removable block (END then BEGIN then END). Independent grep would treat
-# END-then-BEGIN with no later END as removable even though no safe span exists.
+# removable block. Inline mentions of both marker strings are not a block.
 has_ordered_codex_tool_map() {
   awk -v s="$CODEX_TOOL_MAP_START" -v e="$CODEX_TOOL_MAP_END" '
-    { buf = buf $0 "\n" }
-    END {
-      si = index(buf, s)
-      if (si == 0) exit 1
-      rest = substr(buf, si + length(s))
-      exit (index(rest, e) > 0) ? 0 : 1
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line == s) seen = 1
+      if (seen && line == e) found = 1
     }
+    END { exit found ? 0 : 1 }
   ' "$1"
 }
 scan_codex_agents_file() {

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -289,6 +289,25 @@ read_work_engine_preferences() {
 has_brew=$(command -v brew >/dev/null 2>&1 && echo "yes" || echo "no")
 in_repo=$(git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo "yes" || echo "no")
 
+# Retired Bun-era Codex tool map (#1099 / #1559). Exact sentinels from docs/install/upgrading.md.
+CODEX_TOOL_MAP_START="<!-- BEGIN COMPOUND CODEX TOOL MAP -->"
+CODEX_TOOL_MAP_END="<!-- END COMPOUND CODEX TOOL MAP -->"
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+legacy_codex_map_files=()
+scan_codex_agents_file() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  if grep -F -q -- "$CODEX_TOOL_MAP_START" "$f" && grep -F -q -- "$CODEX_TOOL_MAP_END" "$f"; then
+    legacy_codex_map_files+=("$f")
+  fi
+}
+scan_codex_agents_file "$codex_home/AGENTS.md"
+if [ -d "$codex_home/profiles" ]; then
+  for f in "$codex_home/profiles"/*/AGENTS.md; do
+    scan_codex_agents_file "$f"
+  done
+fi
+
 # =====================================================
 #  Check optional capabilities
 # =====================================================
@@ -625,6 +644,16 @@ fi
 
 if [ "$capability_missing" -gt 0 ]; then
   echo "     Missing optional tools do not block setup; install them only for the workflows you use."
+fi
+
+if [ "${#legacy_codex_map_files[@]}" -gt 0 ]; then
+  echo ""
+  section "Codex instructions"
+  for f in "${legacy_codex_map_files[@]}"; do
+    warn "Legacy Compound Codex tool map still present in $f"
+  done
+  detail "This retired block can make Codex skip ce-code-review as if no runner exists."
+  detail "Remove only the BEGIN/END COMPOUND CODEX TOOL MAP span — see docs/install/upgrading.md"
 fi
 
 echo ""

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -293,19 +293,34 @@ in_repo=$(git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo "yes" || e
 CODEX_TOOL_MAP_START="<!-- BEGIN COMPOUND CODEX TOOL MAP -->"
 CODEX_TOOL_MAP_END="<!-- END COMPOUND CODEX TOOL MAP -->"
 codex_home="${CODEX_HOME:-$HOME/.codex}"
+default_codex_home="$HOME/.codex"
 legacy_codex_map_files=()
 scan_codex_agents_file() {
   local f="$1"
+  local existing
   [ -f "$f" ] || return 0
+  for existing in "${legacy_codex_map_files[@]}"; do
+    [ "$existing" = "$f" ] && return 0
+  done
   if grep -F -q -- "$CODEX_TOOL_MAP_START" "$f" && grep -F -q -- "$CODEX_TOOL_MAP_END" "$f"; then
     legacy_codex_map_files+=("$f")
   fi
 }
-scan_codex_agents_file "$codex_home/AGENTS.md"
-if [ -d "$codex_home/profiles" ]; then
-  for f in "$codex_home/profiles"/*/AGENTS.md; do
+scan_codex_profile_tree() {
+  local root="$1"
+  local f
+  [ -d "$root/profiles" ] || return 0
+  for f in "$root/profiles"/*/AGENTS.md; do
+    [ -f "$f" ] || continue
     scan_codex_agents_file "$f"
   done
+}
+scan_codex_agents_file "$codex_home/AGENTS.md"
+scan_codex_profile_tree "$codex_home"
+# Named profiles live under ~/.codex even when CODEX_HOME points at an active profile.
+if [ "$codex_home" != "$default_codex_home" ]; then
+  scan_codex_agents_file "$default_codex_home/AGENTS.md"
+  scan_codex_profile_tree "$default_codex_home"
 fi
 
 # =====================================================

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -668,7 +668,7 @@ if [ "${#legacy_codex_map_files[@]}" -gt 0 ]; then
     warn "Legacy Compound Codex tool map still present in $f"
   done
   detail "This retired block can make Codex skip ce-code-review as if no runner exists."
-  detail "Remove only the BEGIN/END COMPOUND CODEX TOOL MAP span — see docs/install/upgrading.md"
+  detail "Remove only the BEGIN/END COMPOUND CODEX TOOL MAP span — see this skill's references/legacy-codex-tool-map.md"
 fi
 
 echo ""

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -295,6 +295,19 @@ CODEX_TOOL_MAP_END="<!-- END COMPOUND CODEX TOOL MAP -->"
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 default_codex_home="$HOME/.codex"
 legacy_codex_map_files=()
+# Ordered pair only: first BEGIN must precede first END (same contract as
+# removeCodexAgentsToolMapBlock). Independent grep would treat END-then-BEGIN
+# as removable even though no safe span exists.
+has_ordered_codex_tool_map() {
+  awk -v s="$CODEX_TOOL_MAP_START" -v e="$CODEX_TOOL_MAP_END" '
+    { buf = buf $0 "\n" }
+    END {
+      si = index(buf, s)
+      ei = index(buf, e)
+      exit (si > 0 && ei > 0 && ei > si) ? 0 : 1
+    }
+  ' "$1"
+}
 scan_codex_agents_file() {
   local f="$1"
   local existing
@@ -302,7 +315,7 @@ scan_codex_agents_file() {
   for existing in "${legacy_codex_map_files[@]}"; do
     [ "$existing" = "$f" ] && return 0
   done
-  if grep -F -q -- "$CODEX_TOOL_MAP_START" "$f" && grep -F -q -- "$CODEX_TOOL_MAP_END" "$f"; then
+  if has_ordered_codex_tool_map "$f"; then
     legacy_codex_map_files+=("$f")
   fi
 }

--- a/src/utils/codex-agents.ts
+++ b/src/utils/codex-agents.ts
@@ -34,12 +34,32 @@ export async function stripCodexAgentsToolMap(codexHome: string): Promise<void> 
 }
 
 /** Pure strip helper — exported for tests. */
+function indexOfStandaloneLine(haystack: string, needle: string, fromIndex = 0): number {
+  let pos = fromIndex
+  while (pos <= haystack.length) {
+    const i = haystack.indexOf(needle, pos)
+    if (i === -1) {
+      return -1
+    }
+    const beforeOk = i === 0 || haystack[i - 1] === "\n"
+    const after = i + needle.length
+    const afterOk =
+      after === haystack.length || haystack[after] === "\n" || haystack.startsWith("\r\n", after)
+    if (beforeOk && afterOk) {
+      return i
+    }
+    pos = i + 1
+  }
+  return -1
+}
+
 export function removeCodexAgentsToolMapBlock(existing: string): string {
-  const startIndex = existing.indexOf(CODEX_AGENTS_BLOCK_START)
+  const startIndex = indexOfStandaloneLine(existing, CODEX_AGENTS_BLOCK_START)
   if (startIndex === -1) {
     return existing
   }
-  const endIndex = existing.indexOf(
+  const endIndex = indexOfStandaloneLine(
+    existing,
     CODEX_AGENTS_BLOCK_END,
     startIndex + CODEX_AGENTS_BLOCK_START.length,
   )

--- a/src/utils/codex-agents.ts
+++ b/src/utils/codex-agents.ts
@@ -36,9 +36,14 @@ export async function stripCodexAgentsToolMap(codexHome: string): Promise<void> 
 /** Pure strip helper — exported for tests. */
 export function removeCodexAgentsToolMapBlock(existing: string): string {
   const startIndex = existing.indexOf(CODEX_AGENTS_BLOCK_START)
-  const endIndex = existing.indexOf(CODEX_AGENTS_BLOCK_END)
-
-  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+  if (startIndex === -1) {
+    return existing
+  }
+  const endIndex = existing.indexOf(
+    CODEX_AGENTS_BLOCK_END,
+    startIndex + CODEX_AGENTS_BLOCK_START.length,
+  )
+  if (endIndex === -1) {
     return existing
   }
 

--- a/tests/codex-agents.test.ts
+++ b/tests/codex-agents.test.ts
@@ -70,6 +70,15 @@ describe("removeCodexAgentsToolMapBlock", () => {
     )
   })
 
+  test("leaves inline documentation of both sentinels unchanged", () => {
+    const input = [
+      "keep this",
+      `The retired map used \`${CODEX_AGENTS_BLOCK_START}\` … \`${CODEX_AGENTS_BLOCK_END}\` inline.`,
+      "",
+    ].join("\n")
+    expect(removeCodexAgentsToolMapBlock(input)).toBe(input)
+  })
+
   test("leaves END-then-BEGIN without a later END unchanged", () => {
     const input = [
       "keep this",

--- a/tests/codex-agents.test.ts
+++ b/tests/codex-agents.test.ts
@@ -48,6 +48,39 @@ describe("removeCodexAgentsToolMapBlock", () => {
     expect(result).not.toContain("old managed content")
   })
 
+  test("strips a later ordered pair after a stray earlier END", () => {
+    const input = [
+      "keep this",
+      CODEX_AGENTS_BLOCK_END,
+      "user-owned notes",
+      CODEX_AGENTS_BLOCK_START,
+      "legacy map",
+      CODEX_AGENTS_BLOCK_END,
+      "",
+    ].join("\n")
+
+    const result = removeCodexAgentsToolMapBlock(input)
+    expect(result).toContain("keep this")
+    expect(result).toContain("user-owned notes")
+    expect(result).toContain(CODEX_AGENTS_BLOCK_END)
+    expect(result).not.toContain(CODEX_AGENTS_BLOCK_START)
+    expect(result).not.toContain("legacy map")
+    expect(result.indexOf(CODEX_AGENTS_BLOCK_END)).toBe(
+      input.indexOf(CODEX_AGENTS_BLOCK_END),
+    )
+  })
+
+  test("leaves END-then-BEGIN without a later END unchanged", () => {
+    const input = [
+      "keep this",
+      CODEX_AGENTS_BLOCK_END,
+      "user-owned notes",
+      CODEX_AGENTS_BLOCK_START,
+      "",
+    ].join("\n")
+    expect(removeCodexAgentsToolMapBlock(input)).toBe(input)
+  })
+
   test("returns empty string when the file is only the managed block", () => {
     const input = [CODEX_AGENTS_BLOCK_START, "only this", CODEX_AGENTS_BLOCK_END].join("\n")
     expect(removeCodexAgentsToolMapBlock(input)).toBe("")

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -128,6 +128,31 @@ describe("ce-setup check-health", () => {
     }
   })
 
+  test("does not warn on inactive ~/.codex/AGENTS.md when CODEX_HOME is a custom home", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+    try {
+      await initGitRepo(root)
+      const customHome = path.join(root, "custom-codex")
+      await mkdir(customHome, { recursive: true })
+      await writeFile(path.join(customHome, "AGENTS.md"), "# active profile, no map\n")
+      await mkdir(path.join(root, ".codex"), { recursive: true })
+      await writeFile(
+        path.join(root, ".codex", "AGENTS.md"),
+        [
+          "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+          "Task (subagent dispatch) / Subagent / Parallel: run sequentially in main thread",
+          "<!-- END COMPOUND CODEX TOOL MAP -->",
+          "",
+        ].join("\n"),
+      )
+      const result = await runCheckHealth(root, "/usr/bin:/bin", { CODEX_HOME: customHome })
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).not.toContain("Legacy Compound Codex tool map still present")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("advertises agent-browser only for its current consumers", async () => {
     const [script, setupDocs, polishSkill, polishRun, polishDocs] = await Promise.all([
       readFile(checkHealthScript, "utf8"),

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -127,6 +127,27 @@ describe("ce-setup check-health", () => {
     }
   })
 
+  test("does not warn when both sentinels appear inline in prose", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+    try {
+      await initGitRepo(root)
+      await mkdir(path.join(root, ".codex"), { recursive: true })
+      await writeFile(
+        path.join(root, ".codex", "AGENTS.md"),
+        [
+          "keep this",
+          "The retired map used `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` … `<!-- END COMPOUND CODEX TOOL MAP -->` inline.",
+          "",
+        ].join("\n"),
+      )
+      const result = await runCheckHealth(root, "/usr/bin:/bin")
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).not.toContain("Legacy Compound Codex tool map still present")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("does not warn when END sentinel precedes BEGIN (no ordered span)", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
     try {

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -102,6 +102,31 @@ describe("ce-setup check-health", () => {
     }
   })
 
+  test("warns when a stray earlier END precedes a later ordered BEGIN/END pair", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+    try {
+      await initGitRepo(root)
+      await mkdir(path.join(root, ".codex"), { recursive: true })
+      await writeFile(
+        path.join(root, ".codex", "AGENTS.md"),
+        [
+          "keep this",
+          "<!-- END COMPOUND CODEX TOOL MAP -->",
+          "user-owned notes",
+          "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+          "Task (subagent dispatch) / Subagent / Parallel: run sequentially in main thread",
+          "<!-- END COMPOUND CODEX TOOL MAP -->",
+          "",
+        ].join("\n"),
+      )
+      const result = await runCheckHealth(root, "/usr/bin:/bin")
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain("Legacy Compound Codex tool map still present")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("does not warn when END sentinel precedes BEGIN (no ordered span)", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
     try {

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -82,7 +82,7 @@ describe("ce-setup check-health", () => {
       const result = await runCheckHealth(root, "/usr/bin:/bin")
       expect(result.exitCode).toBe(0)
       expect(result.stdout).toContain("Legacy Compound Codex tool map still present")
-      expect(result.stdout).toContain("docs/install/upgrading.md")
+      expect(result.stdout).toContain("references/legacy-codex-tool-map.md")
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -122,7 +122,7 @@ describe("ce-setup check-health", () => {
       const result = await runCheckHealth(root, "/usr/bin:/bin", { CODEX_HOME: customHome })
       expect(result.exitCode).toBe(0)
       expect(result.stdout).toContain("Legacy Compound Codex tool map still present")
-      expect(result.stdout).toContain("docs/install/upgrading.md")
+      expect(result.stdout).toContain("references/legacy-codex-tool-map.md")
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -102,6 +102,29 @@ describe("ce-setup check-health", () => {
     }
   })
 
+  test("does not warn when END sentinel precedes BEGIN (no ordered span)", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+    try {
+      await initGitRepo(root)
+      await mkdir(path.join(root, ".codex"), { recursive: true })
+      await writeFile(
+        path.join(root, ".codex", "AGENTS.md"),
+        [
+          "keep this",
+          "<!-- END COMPOUND CODEX TOOL MAP -->",
+          "user-owned notes",
+          "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+          "",
+        ].join("\n"),
+      )
+      const result = await runCheckHealth(root, "/usr/bin:/bin")
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).not.toContain("Legacy Compound Codex tool map still present")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("still finds named-profile copies under ~/.codex when CODEX_HOME is elsewhere", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
     try {

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -17,13 +17,20 @@ type RunResult = {
   stderr: string
 }
 
-async function runCheckHealth(cwd: string, pathValue: string): Promise<RunResult> {
+async function runCheckHealth(
+  cwd: string,
+  pathValue: string,
+  extraEnv: Record<string, string> = {},
+): Promise<RunResult> {
   const proc = Bun.spawn(["bash", checkHealthScript], {
     cwd,
     env: {
       ...process.env,
       HOME: cwd,
       PATH: pathValue,
+      // Isolate from the host Codex install (CI/dev machines often set CODEX_HOME).
+      CODEX_HOME: path.join(cwd, ".codex"),
+      ...extraEnv,
     },
     stderr: "pipe",
     stdout: "pipe",
@@ -90,6 +97,32 @@ describe("ce-setup check-health", () => {
       const result = await runCheckHealth(root, "/usr/bin:/bin")
       expect(result.exitCode).toBe(0)
       expect(result.stdout).not.toContain("Legacy Compound Codex tool map still present")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("still finds named-profile copies under ~/.codex when CODEX_HOME is elsewhere", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+    try {
+      await initGitRepo(root)
+      const customHome = path.join(root, "custom-codex")
+      await mkdir(customHome, { recursive: true })
+      await writeFile(path.join(customHome, "AGENTS.md"), "# active profile, no map\n")
+      await mkdir(path.join(root, ".codex", "profiles", "work"), { recursive: true })
+      await writeFile(
+        path.join(root, ".codex", "profiles", "work", "AGENTS.md"),
+        [
+          "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+          "Task (subagent dispatch) / Subagent / Parallel: run sequentially in main thread",
+          "<!-- END COMPOUND CODEX TOOL MAP -->",
+          "",
+        ].join("\n"),
+      )
+      const result = await runCheckHealth(root, "/usr/bin:/bin", { CODEX_HOME: customHome })
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain("Legacy Compound Codex tool map still present")
+      expect(result.stdout).toContain("docs/install/upgrading.md")
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -57,6 +57,44 @@ describe("ce-setup check-health", () => {
     expect(script).not.toMatch(/<<<\s/)
   })
 
+  test("reports the legacy Codex tool map when both sentinels are present", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+    try {
+      await initGitRepo(root)
+      await mkdir(path.join(root, ".codex"), { recursive: true })
+      await writeFile(
+        path.join(root, ".codex", "AGENTS.md"),
+        [
+          "keep this",
+          "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+          "Task (subagent dispatch) / Subagent / Parallel: run sequentially in main thread",
+          "<!-- END COMPOUND CODEX TOOL MAP -->",
+          "",
+        ].join("\n"),
+      )
+      const result = await runCheckHealth(root, "/usr/bin:/bin")
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toContain("Legacy Compound Codex tool map still present")
+      expect(result.stdout).toContain("docs/install/upgrading.md")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("does not warn when Codex AGENTS.md has no tool-map sentinels", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-"))
+    try {
+      await initGitRepo(root)
+      await mkdir(path.join(root, ".codex"), { recursive: true })
+      await writeFile(path.join(root, ".codex", "AGENTS.md"), "# user instructions\n")
+      const result = await runCheckHealth(root, "/usr/bin:/bin")
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).not.toContain("Legacy Compound Codex tool map still present")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   test("advertises agent-browser only for its current consumers", async () => {
     const [script, setupDocs, polishSkill, polishRun, polishDocs] = await Promise.all([
       readFile(checkHealthScript, "utf8"),


### PR DESCRIPTION
## Summary

`ce-setup` reported a healthy Codex environment even when the retired `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` block remained in `$CODEX_HOME/AGENTS.md`. That mapping is known to make Codex skip `ce-code-review`.

`check-health` now scans `$CODEX_HOME/AGENTS.md` and profile copies for both sentinels and points at `docs/install/upgrading.md`. Out of scope: changing `ce-work` skip phrases or auto-stripping the file.

## Validation

- `bun test tests/skills/ce-setup-check-health.test.ts` — 57 pass
- `bun run release:validate` — in sync

Closes #1559

## Security Disclosure

No security-relevant changes. The check only reads AGENTS.md for exact sentinels.

## Agent Disclosure

- **Model:** Hermes Agent · grok-4.6
