### PR TITLE
fix(ce-setup): detect the retired Codex tool map

### DIFF
--- a/docs/install/upgrading.md
+++ b/docs/install/upgrading.md
@@ -60,11 +60,10 @@ Paste this into Codex (or any agent with access to your home directory) to remov
 ```text
 Remove the obsolete Compound Engineering Codex tool-map block from my Codex home AGENTS.md.
 
-1. Check `$CODEX_HOME/AGENTS.md` if CODEX_HOME is set, otherwise `~/.codex/AGENTS.md`. If I use Codex profiles, also check `~/.codex/profiles/*/AGENTS.md`.
-2. Look for the exact sentinels `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` and `<!-- END COMPOUND CODEX TOOL MAP -->`.
-3. If both are present, delete only the span from the BEGIN line through the END line (inclusive), leaving any other user content untouched. Do not edit project/repo AGENTS.md unless those exact sentinels are present there.
-4. If the file is empty after the removal, delete the file.
-5. Show a short before/after summary of what you changed (or say the block was already absent). Do not add a replacement tool map.
+1. Check `$CODEX_HOME/AGENTS.md` if CODEX_HOME is set, otherwise `~/.codex/AGENTS.md`.
+2. Delete the managed block: the line `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` through the next line `<!-- END COMPOUND CODEX TOOL MAP -->`. If that pair is not present as two whole lines in that order, the block is not there -- change nothing.
+3. Leave the rest of the file untouched, and delete the file if nothing is left. Do not add a replacement tool map, and do not edit project/repo AGENTS.md.
+4. Show a short before/after summary of what you changed (or say the block was already absent).
 ```
 
 Re-running the Bun convert/install CLI for Codex also strips the block if it is still present; it no longer inserts it.

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -63,6 +63,8 @@ After the health report, decide Phase 2 from writable-checkout availability:
 - If this session has no writable checkout, but the user named a repository and the harness exposes a remote repo-work surface with a writable checkout, run Phase 2 on that surface instead and report the remote repo-local fixes in Phase 3.
 - Otherwise skip Phase 2 and go to Phase 3, saying repo-local writes were skipped because no writable checkout is available.
 
+If the report names a legacy Compound Codex tool map, offer to remove it following `references/legacy-codex-tool-map.md` from this skill's directory. That block lives in the user's Codex home, not the checkout, so the offer stands whether or not Phase 2 runs.
+
 Also remediate these project issues when the report names them:
 
 - obsolete `compound-engineering.local.md`

--- a/skills/ce-setup/SKILL.md
+++ b/skills/ce-setup/SKILL.md
@@ -90,8 +90,8 @@ Display a brief summary:
 ```text
 ✅ Compound Engineering setup complete
 
-Fixed:     <repo-local fixes applied, or none>
-Skipped:   <repo-local fixes declined, or none>
+Fixed:     <fixes applied, or none>
+Skipped:   <fixes declined, or none>
 Optional:  <missing optional tools, or all available>
 
 Run `<rendered invocation>` anytime to re-check.

--- a/skills/ce-setup/references/legacy-codex-tool-map.md
+++ b/skills/ce-setup/references/legacy-codex-tool-map.md
@@ -1,0 +1,15 @@
+# Remove the retired Compound Codex tool map
+
+The Bun-era `convert` / `install --to codex` path inserted a managed block into the global Codex instructions file:
+
+`<!-- BEGIN COMPOUND CODEX TOOL MAP -->` … `<!-- END COMPOUND CODEX TOOL MAP -->`
+
+in `${CODEX_HOME:-$HOME/.codex}/AGENTS.md`. That Claude-compat map is obsolete — CE skills name Codex tools inline — and one of its lines told Codex to collapse subagent dispatch onto the main thread. Native plugin install does not add it, and re-running the Bun CLI for Codex strips it.
+
+## Removal
+
+Delete the managed block from that file: the line `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` through the next line `<!-- END COMPOUND CODEX TOOL MAP -->`. If that pair is not present as two whole lines in that order, the block is not there — change nothing.
+
+Leave the rest of the file untouched, and delete the file if nothing is left. Do not add a replacement map, and do not touch a project or repo `AGENTS.md`: the Bun installer only ever wrote the Codex home file.
+
+Show the user a short before/after of what changed, or say the block was already absent.

--- a/skills/ce-setup/references/repo-fixes.md
+++ b/skills/ce-setup/references/repo-fixes.md
@@ -10,6 +10,7 @@ When the bundled `scripts/check-health` is unavailable, perform these checks by 
 4. Check whether `.compound-engineering/config.yaml` exists.
 5. Check whether `.compound-engineering/config.local.yaml` exists and, if it does, whether `git check-ignore -q .compound-engineering/config.local.yaml` succeeds.
 6. Compare `.compound-engineering/config.example.yaml` with `references/config-template.yaml` when the template is readable; otherwise report that the example refresh must be done manually.
+7. Report a legacy Compound Codex tool map when `${CODEX_HOME:-$HOME/.codex}/AGENTS.md` contains a standalone `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` line followed by a standalone `<!-- END COMPOUND CODEX TOOL MAP -->` line.
 
 This file is read at two points: from Step 2 whenever the bundled health script is unavailable, for the inline equivalent above; and before any Phase 2 write, once Step 3 has decided that a writable checkout exists and which reported issues need remediation. Ask with the blocking question tool named in SKILL.md. Maintaining the generated example files is the work this phase does on its own — Step 5's refresh and its removal of the superseded `config.local.example.yaml`. Every change to a user-owned file is offered and applied only if the user approves.
 

--- a/skills/ce-setup/scripts/check-health
+++ b/skills/ce-setup/scripts/check-health
@@ -289,6 +289,23 @@ read_work_engine_preferences() {
 has_brew=$(command -v brew >/dev/null 2>&1 && echo "yes" || echo "no")
 in_repo=$(git rev-parse --is-inside-work-tree >/dev/null 2>&1 && echo "yes" || echo "no")
 
+# Retired Bun-era Codex tool map (#1099). The block is present only when a
+# standalone BEGIN line is followed by a standalone END line.
+has_codex_tool_map() {
+  awk '
+    { sub(/\r$/, "") }
+    $0 == "<!-- BEGIN COMPOUND CODEX TOOL MAP -->" { seen = 1 }
+    seen && $0 == "<!-- END COMPOUND CODEX TOOL MAP -->" { found = 1; exit }
+    END { exit found ? 0 : 1 }
+  ' "$1"
+}
+
+codex_agents_file="${CODEX_HOME:-$HOME/.codex}/AGENTS.md"
+legacy_codex_map="no"
+if [ -f "$codex_agents_file" ] && has_codex_tool_map "$codex_agents_file"; then
+  legacy_codex_map="yes"
+fi
+
 # =====================================================
 #  Check optional capabilities
 # =====================================================
@@ -528,6 +545,13 @@ for result in "${results[@]}"; do
   fi
 done
 
+if [ "$legacy_codex_map" = "yes" ]; then
+  section "Codex instructions"
+  warn "Legacy Compound Codex tool map in ${codex_agents_file}"
+  detail "Retired block from a pre-native Bun install; one line tells Codex to collapse subagent dispatch."
+  detail "Remove it -- see this skill's references/legacy-codex-tool-map.md"
+fi
+
 if [ "$in_repo" = "yes" ]; then
   section "Project config"
 
@@ -621,6 +645,10 @@ if [ "$project_issues" -eq 0 ]; then
   echo " ✅  Project config healthy. Optional capabilities available: ${capability_ok}/${capability_total}"
 else
   echo " ⚠️   ${project_issues} project issue(s) found. Optional capabilities available: ${capability_ok}/${capability_total}"
+fi
+
+if [ "$legacy_codex_map" = "yes" ]; then
+  echo "     Environment: the legacy Codex tool map above still needs attention."
 fi
 
 if [ "$capability_missing" -gt 0 ]; then

--- a/tests/skills/ce-setup-check-health.test.ts
+++ b/tests/skills/ce-setup-check-health.test.ts
@@ -24,6 +24,8 @@ async function runCheckHealth(cwd: string, pathValue: string): Promise<RunResult
       ...process.env,
       HOME: cwd,
       PATH: pathValue,
+      // A host CODEX_HOME would otherwise decide what the tool-map scan reads.
+      CODEX_HOME: path.join(cwd, ".codex"),
     },
     stderr: "pipe",
     stdout: "pipe",
@@ -51,6 +53,50 @@ async function initConfiguredRepo(root: string, localConfig: string): Promise<vo
 }
 
 describe("ce-setup check-health", () => {
+  async function runWithCodexAgents(contents: string): Promise<RunResult> {
+    const root = await mkdtemp(path.join(os.tmpdir(), "ce-setup-health-codex-"))
+    try {
+      await initGitRepo(root)
+      await mkdir(path.join(root, ".codex"), { recursive: true })
+      await writeFile(path.join(root, ".codex", "AGENTS.md"), contents)
+      return await runCheckHealth(root, "/usr/bin:/bin")
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  }
+
+  test("reports the legacy Codex tool map and keeps the verdict from reading all-clear", async () => {
+    const result = await runWithCodexAgents(
+      [
+        "my notes",
+        "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+        "Task (subagent dispatch): run sequentially in main thread",
+        "<!-- END COMPOUND CODEX TOOL MAP -->",
+        "",
+      ].join("\n"),
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("Legacy Compound Codex tool map in")
+    expect(result.stdout).toContain("references/legacy-codex-tool-map.md")
+    expect(result.stdout).toContain("legacy Codex tool map above still needs attention")
+  })
+
+  test("reports no tool map without an ordered pair of standalone sentinel lines", async () => {
+    const result = await runWithCodexAgents(
+      [
+        "The retired map used `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` to `<!-- END COMPOUND CODEX TOOL MAP -->` inline.",
+        "<!-- END COMPOUND CODEX TOOL MAP -->",
+        "my notes",
+        "<!-- BEGIN COMPOUND CODEX TOOL MAP -->",
+        "",
+      ].join("\n"),
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).not.toContain("Legacy Compound Codex tool map")
+  })
+
   test("does not require temporary-file-backed here-strings", async () => {
     const script = await readFile(checkHealthScript, "utf8")
 


### PR DESCRIPTION
Replaces #1570 (closed). Addresses the detection half of #1559; see "What this does not fix" below.

## Summary

`check-health` never looked at the Codex home instructions file, so an install still carrying the retired `<!-- BEGIN COMPOUND CODEX TOOL MAP -->` block reported a clean environment. The Bun-era installer wrote that block; `ca474429b` strips it only when someone re-runs the Bun CLI, so anyone who moved to the native marketplace install keeps it indefinitely with nothing surfacing it.

The check now scans `${CODEX_HOME:-$HOME/.codex}/AGENTS.md`, reports the block alongside the other diagnostics, and adds a line to the verdict so the report does not read as all-clear while it stands. `ce-setup` offers the removal from a skill-local reference.

## Design decisions

**Detection is one condition, not a set of cases.** The block is present when a standalone BEGIN sentinel line is followed by a standalone END sentinel line. That single condition decides every case #1570 accumulated over its review rounds — inline mentions of both markers in prose, a stray END before the first BEGIN, END/BEGIN/END — in six lines of `awk` rather than ~50 lines of branching. Verified against all of them plus CRLF line endings and a missing file.

**No change to `src/utils/codex-agents.ts`.** #1570 also tightened `removeCodexAgentsToolMapBlock` to match. The Bun writer (`buildCodexAgentsBlock`) always emitted sentinels on their own lines, so no file that stripper will ever see is affected. Leaving shipped CLI behavior alone.

**The remediation is session-level, so it sits outside the Phase 2 gate.** Phase 2 is skipped when there is no writable checkout — which is the reported scenario. The offer is stated where that decision is made rather than in the repo-local project-issues list.

**Dropped `~/.codex/profiles/*/AGENTS.md`.** Codex resolves user instructions from `$CODEX_HOME/AGENTS.md` (falling back to `$HOME/.codex`); profiles are `[profiles.<name>]` tables in `config.toml` selected with `codex -p`, not directories with their own `AGENTS.md`. That path entered the docs as a hedge in #1118. Removed from the upgrade guide too.

## Validation

- `bun run test` — 3647 pass, 0 fail
- `bun run release:validate` — in sync
- Script behavior verified directly against six fixtures: valid block, inline prose mention, reversed pair, stray END then a valid pair, no sentinels, no file, and CRLF. Runs under bash 3.2 (macOS default).

### Skill eval

`bun run test:skill-eval-cell -- --skill ce-setup --read-only`, Claude and Codex, prompted with real `check-health` output. Two scenarios; the pre arm ran against #1570's tree.

| Scenario | Arm | Claude | Codex |
|---|---|---|---|
| Report names the tool map, no writable checkout | pre (#1570) | offered removal | offered removal |
| Report names the tool map, no writable checkout | post | offered removal | offered removal |
| Report names the tool map, writable checkout | post | offered removal **and** Phase 2 fixes | offered removal **and** Phase 2 fixes |

**Both arms offered the removal on both hosts**, so the placement change is a correctness-of-representation fix, not a demonstrated routing fix — recording that plainly rather than claiming a behavior win. The writable-checkout row is there because moving the bullet out of the Phase 2 list could have dropped one side or the other; neither host dropped either.

What the eval did discriminate is what reaches the user. The pre arm relayed the accumulated edge-case rules into the user-facing instructions ("a stray END before the first BEGIN doesn't count", "inline mentions of those strings are not a block") and — on both hosts — told the user to also check `~/.codex/profiles/*/AGENTS.md`, a directory that does not exist. The post arm gave one condition and one path.

## What this does not fix

This does not close #1559. The failure that issue reports is `ce-work` emitting `Code review: skipped (ce-code-review unavailable)` with the reason "no callable ce-code-review runner in the current harness" — which is not one of the states that gate enumerates (`skills/ce-work/references/shipping-workflow.md:41`: dispatch unavailable, unauthenticated, hard-capped, or a `failed`/`degraded`/`skipped` return). Detection does not touch that. Leaving #1559 open for it.

## Credit

The gap, and the `CODEX_HOME` fixture isolation kept here, are from @saurabhkagent-lab's work in #1570.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

## Security Disclosure

The health check reads one additional file, `${CODEX_HOME:-$HOME/.codex}/AGENTS.md`, and only when it exists. It is read-only — `awk` matches two exact literal lines and the script never writes to it. The path comes from an environment variable already trusted by the surrounding script and is quoted at every use. Removal remains a user-approved action performed by the agent, not by this script. No other security-relevant changes.

## Agent Disclosure

- **Model:** Claude Code · claude-opus-5[1m]
