### PR TITLE
docs(lfg): align leftover-findings FAQ with PR-body checklist

### DIFF
--- a/docs/guides/lfg.md
+++ b/docs/guides/lfg.md
@@ -211,7 +211,7 @@ No. That is the point of the skill, and why it is the wrong tool for in-the-loop
 The pipeline stops. Non-software tasks, requirements-only leftovers, knowledge-work plans, and invalidating settlement conflicts all halt before implementation.
 
 **Where do leftover review findings go?**
-Not into the PR description. They are filed in the project tracker when possible, and carried in one run-report comment on the PR.
+They are listed as an `## Unapplied review findings` checklist in the PR body for the reviewer to decide on: fix in-branch, dismiss, or file a ticket. `lfg` files tickets itself only when no PR will exist.
 
 **What happens if there is no `origin`?**
 Local commits only. No push, no PR, no CI watch.


### PR DESCRIPTION
Closes #1581.

## What

`docs/guides/lfg.md`'s FAQ entry "Where do leftover review findings go?" still described the pre-#1580 behavior ("Not into the PR description… carried in one run-report comment"), contradicting step 6 of the same page, which #1580 changed to the `## Unapplied review findings` PR-body checklist.

This PR rewrites the FAQ answer to match the post-#1580 design:

> They are listed as an `## Unapplied review findings` checklist in the PR body for the reviewer to decide on: fix in-branch, dismiss, or file a ticket. `lfg` files tickets itself only when no PR will exist.

One line changed, docs only.

## Verification

- `bun test tests/review-skill-contract.test.ts tests/docs-root-literals.test.ts` — 86 pass, 0 fail. Notably, `review-skill-contract.test.ts` asserts the lfg guide no longer contains "run-report comment"; this change removes that stale phrasing.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

Claude Code · claude-opus-4-8