### PR TITLE
fix(ce-commit): make the stage-and-commit example PowerShell-safe

### DIFF
--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -43,16 +43,14 @@ Treat this as a snapshot. Re-read branch and staged set immediately before commi
    - Good: `Fix double-submit on checkout`
    - Good: `Add per-subscription mute (U3)`
 
-6. **Stage and commit** — stage **named files only** (never `git add -A` or `git add .`). Honor `exclude:<paths>` when the invocation carries it: those files stay uncommitted no matter what else changed; say in the report that they were left out. Prefer one shell call per commit group:
+6. **Stage and commit** — stage **named files only** (never `git add -A` or `git add .`). Honor `exclude:<paths>` when the invocation carries it: those files stay uncommitted no matter what else changed; say in the report that they were left out. Stage, then commit, each as its own call per commit group:
 
 ```bash
-git add file1 file2 file3 && git commit -m "$(cat <<'EOF'
-type(scope): subject line here
-
-Optional body when the why is not obvious from the subject.
-EOF
-)" -- file1 file2 file3
+git add file1 file2 file3
+git commit -m "type(scope): subject line here" -m "Optional body when the why is not obvious from the subject." -- file1 file2 file3
 ```
+
+Each `-m` after the first adds a blank-line-separated body paragraph, so a multi-line message needs no heredoc.
 
 The trailing path list on `git commit` is load-bearing: a bare `git commit` takes the whole index, so anything already staged before this run (a caller's `exclude:` paths, or work the user staged and did not name) would ride into the commit. Naming the paths commits exactly the group and leaves other index entries alone.
 

--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -53,7 +53,7 @@ git add file1 file2 file3
 git commit -F <message-file> -- file1 file2 file3
 ```
 
-`-F` takes the message bytes as written: a `$`, quotes, or a multi-line body commit exactly as authored under any shell, with no quoting rules to satisfy.
+No shell parses the message with `-F`: a `$`, quotes, backticks, or a multi-line body pass through literally under any shell, with no quoting rules to satisfy. Git's normal whitespace cleanup still applies (trailing spaces trimmed, blank-line runs collapsed), which is fine for a commit message.
 
 The trailing path list on `git commit` is load-bearing: a bare `git commit` takes the whole index, so anything already staged before this run (a caller's `exclude:` paths, or work the user staged and did not name) would ride into the commit. Naming the paths commits exactly the group and leaves other index entries alone.
 

--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -47,6 +47,9 @@ Treat this as a snapshot. Re-read branch and staged set immediately before commi
 
 ```bash
 git add file1 file2 file3
+```
+
+```bash
 git commit -F <message-file> -- file1 file2 file3
 ```
 

--- a/skills/ce-commit/SKILL.md
+++ b/skills/ce-commit/SKILL.md
@@ -43,14 +43,14 @@ Treat this as a snapshot. Re-read branch and staged set immediately before commi
    - Good: `Fix double-submit on checkout`
    - Good: `Add per-subscription mute (U3)`
 
-6. **Stage and commit** — stage **named files only** (never `git add -A` or `git add .`). Honor `exclude:<paths>` when the invocation carries it: those files stay uncommitted no matter what else changed; say in the report that they were left out. Stage, then commit, each as its own call per commit group:
+6. **Stage and commit** — stage **named files only** (never `git add -A` or `git add .`). Honor `exclude:<paths>` when the invocation carries it: those files stay uncommitted no matter what else changed; say in the report that they were left out. Write the full message — subject line, blank line, optional body — to a file outside the repo with your file-write tool, then stage and commit as two calls per commit group:
 
 ```bash
 git add file1 file2 file3
-git commit -m "type(scope): subject line here" -m "Optional body when the why is not obvious from the subject." -- file1 file2 file3
+git commit -F <message-file> -- file1 file2 file3
 ```
 
-Each `-m` after the first adds a blank-line-separated body paragraph, so a multi-line message needs no heredoc.
+`-F` takes the message bytes as written: a `$`, quotes, or a multi-line body commit exactly as authored under any shell, with no quoting rules to satisfy.
 
 The trailing path list on `git commit` is load-bearing: a bare `git commit` takes the whole index, so anything already staged before this run (a caller's `exclude:` paths, or work the user staged and did not name) would ride into the commit. Naming the paths commits exactly the group and leaves other index entries alone.
 

--- a/tests/ce-commit-contract.test.ts
+++ b/tests/ce-commit-contract.test.ts
@@ -45,7 +45,7 @@ describe("ce-commit contract", () => {
     expect(content).toMatch(/never `git add -A` or `git add \.`/)
     expect(content).toContain("named files")
     expect(content).toContain("git add file1 file2 file3")
-    expect(content).toContain('git commit -m "type(scope): subject line here"')
+    expect(content).toContain("git commit -F <message-file>")
     expect(content).toContain("-- file1 file2 file3")
   })
 

--- a/tests/ce-commit-contract.test.ts
+++ b/tests/ce-commit-contract.test.ts
@@ -45,7 +45,8 @@ describe("ce-commit contract", () => {
     expect(content).toMatch(/never `git add -A` or `git add \.`/)
     expect(content).toContain("named files")
     expect(content).toContain("git add file1 file2 file3")
-    expect(content).toContain("<<'EOF'")
+    expect(content).toContain('git commit -m "type(scope): subject line here"')
+    expect(content).toContain("-- file1 file2 file3")
   })
 
   test("defaults fix over feat and leads messages with outcome", async () => {


### PR DESCRIPTION
Closes #1586.

The Context rule forbids joining commands with `&&` / `$(...)` because that syntax fails under Windows PowerShell — and step 6's example used both, plus a heredoc. On pwsh it's a parse error, so an agent on a PowerShell-shelled harness fails right at the commit step.

The fix: write the message to a file with the agent's file-write tool, then `git add` and `git commit -F <message-file> -- <files>` as two plain argv-only calls. `-F` keeps the message bytes exact — which is the property the quoted heredoc existed for. The contract test asserting the heredoc now asserts the `-F` fence.

## Alternatives considered

Every shell has a heredoc-like form; none holds across both shells:

- **Multiple `-m` flags** (my first push): parses everywhere, but double-quoted `-m` interpolates on *both* shells — `git commit -m "fix: handle $PRICE"` commits `fix: handle ` under PowerShell and bash, and Codex's review showed `$(printf injected)` goes further: command execution, not just corruption.
- **PowerShell here-strings** (`@'…'@`): the native heredoc on Windows, including PowerShell 5.1 — but bash doesn't parse them (the `@`s land in the message). Mirror image of `<<'EOF'`.
- **A multi-line single-quoted argument**: parses and stays literal in both shells, and respects the argv-only rule — but apostrophe escaping diverges (impossible inside bash `'…'`, doubled as `''` in PowerShell), and English prose hits apostrophes constantly (`don't`, `user's`), so it fails often and differently per shell.

`-F` is the one form with no shell parsing of the message at all.

## Validation

- Reproduced the old fence's parse error verbatim on pwsh 7 / Windows 11.
- Verified `-F` commits a message containing `$`, quotes, blank lines and bullets byte-exact under PowerShell and bash, and reproduced the `-m` $-corruption above.
- `bun test tests/ce-commit-contract.test.ts tests/skill-shell-safety.test.ts tests/skill-conventions.test.ts`: 286 pass; `bun run release:validate` passes. The full suite fails identically on unmodified `main` in my Windows environment, so I'm leaning on CI for it.

## Security Disclosure

Changes a shell example in a skill: removes command chaining and `$()` from the canonical commit command and moves the message into a file read by `git commit -F`; no new commands introduced.

## Agent Disclosure

- **Model:** `Claude Code · claude-fable-5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)