### PR TITLE
fix(codex): reconcile config-only plugin installs

### DIFF
--- a/docs/solutions/developer-experience/codex-local-skill-development-workflow.md
+++ b/docs/solutions/developer-experience/codex-local-skill-development-workflow.md
@@ -1,6 +1,7 @@
 ---
 title: "Codex local skill development from any worktree"
 date: 2026-07-16
+last_updated: 2026-08-31
 category: developer-experience
 module: codex-local-development
 problem_type: developer_experience
@@ -23,20 +24,21 @@ tags:
   - skill-symlink
   - plugin-cache
   - installation-modes
+  - config-reconciliation
 ---
 
 # Codex local skill development from any worktree
 
 ## Context
 
-Compound Engineering development needs two different Codex experiences: a fast loop against the exact files in the current checkout, and a production-like loop against the released marketplace plugin. Treating a checkout as a marketplace does not provide the first experience. The repository's marketplace entry points at the co-located plugin root, so `codex plugin marketplace add "$PWD"` followed by `codex plugin add compound-engineering@compound-engineering-plugin` installs a cached copy of that checkout. Later edits are not live, and the Codex manifest remains at a release-owned version such as `3.20.0` while branch contents change, so version equality cannot establish which files were loaded.
+Compound Engineering development needs two different Codex experiences: a fast loop against the exact files in the current checkout, and a production-like loop against the released marketplace plugin. Treating a checkout as a marketplace does not provide the first experience. The repository's marketplace entry points at the co-located plugin root, so `codex plugin marketplace add "$PWD"` followed by `codex plugin add compound-engineering@compound-engineering-plugin` installs a cached copy of that checkout. Later edits are not live, and the Codex manifest remains at its release-owned version while branch contents change, so version equality cannot establish which files were loaded.
 
 There are two distinct contracts to keep straight:
 
 - The official Codex skill documentation describes user-installed skills under `$HOME/.agents/skills`, and the plugin documentation defines a local marketplace `source.path` relative to that marketplace's root. For a personal marketplace rooted at the home directory, a dot-relative checkout path therefore starts from `$HOME`, not from the directory containing `.agents/plugins/marketplace.json`. See [Build skills](https://learn.chatgpt.com/docs/build-skills) and [Build plugins](https://learn.chatgpt.com/docs/build-plugins).
 - The Codex CLI 0.144.5 behavior tested during this implementation adds useful but version-specific detail: plugin installations are copied into a cache; running `codex plugin add` again refreshes that cache even when the manifest version is unchanged, so remove/re-add is not inherently required; direct skill sources are live and edits are detected; and nested symlink collections under `$CODEX_HOME/skills` are discovered. Those observations are empirical compatibility findings, not broader guarantees from the official documentation.
 
-Cursor does not need this workaround. Its agent CLI accepts the checkout directly with `cursor-agent --plugin-dir "$PWD"`, which is also the repository's documented local-development command (`README.md:474-478`).
+Cursor does not need this workaround. Its agent CLI accepts the checkout directly with `cursor-agent --plugin-dir "$PWD"`, which is also the repository's documented local-development command (`docs/development.md:28-32`).
 
 ## Guidance
 
@@ -56,29 +58,31 @@ bun run codex:dev -- remote
 bun run codex:dev -- remove
 ```
 
-The package script delegates to the dedicated Bun entrypoint (`package.json:18-20`), and that entrypoint returns the workflow exit code while formatting failures consistently (`scripts/codex-dev.ts:1-7`). `local` and `refresh` take the same reconciliation path; `status` is read-only; `remote` restores the official marketplace-backed plugin; and `remove` clears both supported Compound Engineering installation surfaces (`src/dev/codex-dev.ts:663-699`).
+The package script delegates to the dedicated Bun entrypoint (`package.json:18-20`), and that entrypoint returns the workflow exit code while formatting failures consistently (`scripts/codex-dev.ts:1-7`). `local` and `refresh` take the same reconciliation path; `status` is read-only; `remote` restores the official marketplace-backed plugin; and `remove` clears both supported Compound Engineering installation surfaces (`src/dev/codex-dev.ts:701-737`).
 
 The workflow derives provenance instead of encoding a developer-specific path. It asks Git for the invoking repository root, resolves that path, validates both the package and Codex plugin identities, and requires the manifest's skills entry to resolve to this repository's `skills/` directory (`src/dev/codex-dev.ts:122-140`, `src/dev/codex-dev.ts:171-183`). It records the Git directory, common Git directory, branch, HEAD, and porcelain status, which allows `status` to distinguish primary and linked worktrees and report modified and untracked files (`src/dev/codex-dev.ts:184-228`). Arguments are passed as arrays to `Bun.spawn`, so paths containing spaces are not reconstructed through shell interpolation (`src/dev/codex-dev.ts:19-32`).
 
-The active Codex profile is part of the target. The workflow uses the inherited `CODEX_HOME`, falling back to `$HOME/.codex`, and places only the named collection beneath that profile's `skills` directory (`src/dev/codex-dev.ts:210-220`). Launch Codex with the same `CODEX_HOME` used for the switch command.
+The active Codex profile is part of the target. The workflow uses the inherited `CODEX_HOME`, falling back to `$HOME/.codex`, and places only the named collection beneath that profile's `skills` directory (`src/dev/codex-dev.ts:211-229`). Launch Codex with the same `CODEX_HOME` used for the switch command. In the Orca setup observed during this fix, each account had its own Codex home, so the relevant `config.toml` was under that resolved profile rather than `~/.codex/config.toml`.
 
 Local mode is intentionally skill-only. Before linking anything, repository validation refuses manifests that add apps, hooks, or MCP servers, and also refuses a default hook manifest, because a skills symlink could not reproduce those runtime components (`src/dev/codex-dev.ts:132-153`). The link points at the whole current `skills/` directory, so tracked edits, uncommitted edits, and newly created untracked skill directories are all represented without copying; the workflow enumerates directories containing `SKILL.md` directly from that tree (`src/dev/codex-dev.ts:156-169`, `src/dev/codex-dev.ts:210-213`).
 
 Local activation is conservative about user state. It refuses to overwrite a regular file or directory, an unrelated symlink, or a broken symlink at the managed path (`src/dev/codex-dev.ts:232-275`). Link creation is exclusive. Removal and retargeting atomically move the current entry into a unique same-parent recovery directory, validate the stable moved entry, and delete it only when its raw symlink target matches the inspected target. An unexpected entry is restored exclusively or retained at a reported recovery path instead of being overwritten or deleted (`src/dev/codex-dev.ts:278-400`). The workflow never recursively deletes the target or neighboring skills (`src/dev/codex-dev.ts:417-430`).
 
-Avoid mixed installations. Codex plugin discovery filters all installed Compound Engineering IDs, not just the official one (`src/dev/codex-dev.ts:449-458`). `local` first activates the link, removes every detected Compound Engineering plugin through `codex plugin remove`, verifies that the resulting mode is local, and restores the prior link state if plugin removal or verification fails (`src/dev/codex-dev.ts:519-540`). Status explicitly classifies a valid link plus any installed Compound Engineering plugin as `mixed`. Link collisions and broken or unrelated links are `drifted`; without a valid local link, unexpected plugin IDs or source mismatches are also `drifted` (`src/dev/codex-dev.ts:479-506`).
+Avoid mixed installations. Codex plugin discovery filters all installed Compound Engineering IDs, not just the official one (`src/dev/codex-dev.ts:450-458`). In the observed Orca/Codex state, an enabled official plugin remained in the active profile's `config.toml` while `codex plugin list --available --json` omitted it. The workflow therefore parses the resolved `$CODEX_HOME/config.toml` independently (`src/dev/codex-dev.ts:461-473`). Status classifies a valid link plus either an inventoried plugin or that hidden enabled configuration as `mixed`; a hidden configuration without the local link is `drifted`, not `absent` (`src/dev/codex-dev.ts:495-523`).
 
-Returning to production-like behavior is verification-first. `remote` confirms that the named official marketplace is either absent or Git-backed by the expected repository, upgrades it, adds the official plugin, and verifies that exactly one enabled plugin reports the expected plugin ID and marketplace provenance before unlinking local skills (`src/dev/codex-dev.ts:464-477`, `src/dev/codex-dev.ts:543-607`). The co-located plugin source is local within that Git-fetched marketplace snapshot; the verifier also accepts the former Git plugin source so existing installations remain classifiable during the transition. If installation fails before verification, the local symlink remains available. `remove` similarly removes only detected Compound Engineering plugin IDs and the exact managed link, then verifies the `absent` state (`src/dev/codex-dev.ts:609-621`).
+`local` first activates the link, removes every detected Compound Engineering plugin, and also removes the official plugin ID when configuration shows it enabled even if inventory omitted it. It then verifies that the resulting mode is local and restores the prior link state if plugin removal or verification fails (`src/dev/codex-dev.ts:526-575`). `remove` uses the same reconciliation path before verifying the absent state (`src/dev/codex-dev.ts:644-655`). This makes cleanup depend on the union of the two observable state sources instead of trusting a lossy inventory response.
 
-Start a new Codex session after changing between local, remote, and absent modes. For ordinary edits while already in local mode, Codex CLI 0.144.5 empirically observes the live symlinked files, so no reinstall is normally needed; restart only if a change is not visible. The command prints that distinction after every mutating operation (`src/dev/codex-dev.ts:693-697`).
+Returning to production-like behavior is verification-first. `remote` confirms that the named official marketplace is either absent or Git-backed by the expected repository, upgrades it, adds the official plugin, and verifies that exactly one enabled plugin reports the expected plugin ID and marketplace provenance before unlinking local skills (`src/dev/codex-dev.ts:578-641`). The co-located plugin source is local within that Git-fetched marketplace snapshot; the verifier also accepts the former Git plugin source so existing installations remain classifiable during the transition. If installation fails before verification, the local symlink remains available. `remove` similarly removes only supported Compound Engineering installation state and the exact managed link, then verifies the `absent` state (`src/dev/codex-dev.ts:644-655`).
+
+Start a new Codex session after changing between local, remote, and absent modes. For ordinary edits while already in local mode, Codex CLI 0.144.5 empirically observes the live symlinked files, so no reinstall is normally needed; restart only if a change is not visible. The command prints that distinction after every mutating operation (`src/dev/codex-dev.ts:731-735`).
 
 ## Why This Matters
 
 A marketplace installation and a live development source solve different problems. A marketplace exercises catalog resolution, plugin installation, cache population, and the released user path. A symlink exercises the exact branch or worktree being edited. Conflating them makes a successful local test ambiguous: the manifest version may match while the cache contains an older checkout or released-marketplace snapshot.
 
-The fixed collection name provides a stable ownership boundary without a separate manifest of copied skills. Provenance lives in the symlink target and the Git metadata printed by `status`: Codex home, source checkout, primary or linked worktree, branch, commit, dirty counts, skill inventory, linked target, and whether it matches the invoking checkout (`src/dev/codex-dev.ts:623-650`). This makes uncommitted and untracked experiments visible while still making it obvious which worktree is supplying them.
+The fixed collection name provides a stable ownership boundary without a separate manifest of copied skills. Provenance lives in the symlink target and the Git metadata printed by `status`: Codex home, source checkout, primary or linked worktree, branch, commit, dirty counts, skill inventory, linked target, and whether it matches the invoking checkout (`src/dev/codex-dev.ts:658-678`). This makes uncommitted and untracked experiments visible while still making it obvious which worktree is supplying them.
 
-The explicit local/remote state machine also prevents a subtler failure: both surfaces can be enabled at once. Without reconciliation, duplicate skill names may come from a live directory and a cached plugin simultaneously. Classifying that condition as `mixed`, returning a non-zero exit for mixed or drifted states, and providing deterministic repair commands makes the unsafe state visible rather than relying on a developer to remember which installation they last touched (`src/dev/codex-dev.ts:623-699`).
+The explicit local/remote state machine also prevents a subtler failure: both surfaces can be enabled at once. Without reconciliation, duplicate skill names may come from a live directory and a cached plugin simultaneously. Classifying that condition as `mixed`, returning a non-zero exit for mixed or drifted states, and providing deterministic repair modes in the workflow makes the unsafe state visible rather than relying on a developer to remember which installation they last touched (`src/dev/codex-dev.ts:508-520`, `src/dev/codex-dev.ts:731-737`).
 
 Finally, preserving the official marketplace while local mode is active makes switching cheap. Local work does not require editing a personal marketplace catalog, and remote mode can refresh and verify the normal installation when a developer wants to reproduce the released user experience. Unrelated marketplace entries and unrelated user skills stay outside the workflow's ownership boundary.
 
@@ -86,13 +90,13 @@ Finally, preserving the official marketplace while local mode is active makes sw
 
 Use `local` when developing or evaluating Compound Engineering skill content from a checkout, feature branch, detached worktree, or dirty working tree. Run it from anywhere inside the intended repository; repository discovery resolves the top level, and the selected `skills/` directory becomes the link target (`src/dev/codex-dev.ts:171-183`, `src/dev/codex-dev.ts:215-229`).
 
-Use `refresh` when the worktree is already linked but a plugin was installed accidentally or the state otherwise needs reconciliation. It is an idempotent alias for `local`, not a file-copy refresh (`src/dev/codex-dev.ts:677-681`). Ordinary local edits already flow through the live link.
+Use `refresh` when the worktree is already linked but a plugin was installed accidentally or the state otherwise needs reconciliation. It is an idempotent alias for `local`, not a file-copy refresh (`src/dev/codex-dev.ts:715-719`). Ordinary local edits already flow through the live link.
 
-Use `status` before testing when provenance matters, after changing worktrees, or whenever duplicate or stale behavior is suspected. It reads the managed link and Codex plugin list, reports `local`, `remote`, `mixed`, `drifted`, or `absent`, and does not execute an installation transition (`src/dev/codex-dev.ts:479-506`, `src/dev/codex-dev.ts:688-690`).
+Use `status` before testing when provenance matters, after changing worktrees, or whenever duplicate or stale behavior is suspected. It reads the managed link, Codex plugin inventory, and the resolved profile's `config.toml`; reports `local`, `remote`, `mixed`, `drifted`, or `absent`; and does not execute an installation transition (`src/dev/codex-dev.ts:495-523`, `src/dev/codex-dev.ts:680-695`, `src/dev/codex-dev.ts:726-728`). When configuration enables the official plugin but inventory omits it, status prints that discrepancy explicitly.
 
-Use `remote` before release validation or any test intended to simulate a normal marketplace user. This path exercises the official Git marketplace and verifies the marketplace-backed installed plugin before removing the local development link (`src/dev/codex-dev.ts:576-607`).
+Use `remote` before release validation or any test intended to simulate a normal marketplace user. This path exercises the official Git marketplace and verifies the marketplace-backed installed plugin before removing the local development link (`src/dev/codex-dev.ts:611-641`).
 
-Use `remove` when neither the local collection nor a Compound Engineering plugin should remain in the active profile. It is not a repository cleanup command and does not alter the worktree (`src/dev/codex-dev.ts:609-621`).
+Use `remove` when neither the local collection nor a Compound Engineering plugin should remain in the active profile. It is not a repository cleanup command and does not alter the worktree (`src/dev/codex-dev.ts:644-655`).
 
 Do not use the symlink workflow if the Codex manifest gains apps, hooks, or MCP servers, or if the default hook manifest appears; the built-in guard deliberately stops rather than silently testing an incomplete plugin (`src/dev/codex-dev.ts:132-153`). At that point, extend the development workflow to represent those components or test through a full plugin installation.
 
@@ -133,7 +137,7 @@ Codex home: /Users/developer/.codex
 Source checkout: /path/to/compound-engineering-plugin-feature
 Worktree: linked worktree
 Branch: feat/local-dev
-Commit: <40-character HEAD SHA>
+Commit: <HEAD object ID>
 Working tree: 2 modified, 1 untracked
 Linked skills: /path/to/compound-engineering-plugin-feature/skills
 Matches this checkout: yes
@@ -152,7 +156,7 @@ Switch to the released-user path, then begin a fresh Codex session:
 bun run codex:dev -- remote
 ```
 
-This upgrades the `compound-engineering-plugin` marketplace, ensures `compound-engineering@compound-engineering-plugin` is the sole enabled Compound Engineering plugin, verifies its official marketplace provenance, and only then unlinks `compound-engineering-local` (`src/dev/codex-dev.ts:548-607`).
+This upgrades the `compound-engineering-plugin` marketplace, ensures `compound-engineering@compound-engineering-plugin` is the sole enabled Compound Engineering plugin, verifies its official marketplace provenance, and only then unlinks `compound-engineering-local` (`src/dev/codex-dev.ts:583-641`).
 
 Remove either supported installation without touching other skills:
 

--- a/src/dev/codex-dev.ts
+++ b/src/dev/codex-dev.ts
@@ -81,6 +81,7 @@ export interface CodexDevStatus {
   collection: LocalCollectionState
   localTarget?: string
   localMatchesCheckout: boolean
+  officialPluginConfigured: boolean
 }
 
 const OFFICIAL_PLUGIN_ID = "compound-engineering@compound-engineering-plugin"
@@ -457,6 +458,21 @@ async function listCompoundEngineeringPlugins(
   )
 }
 
+async function isOfficialPluginConfigured(context: CodexDevContext): Promise<boolean> {
+  const configPath = path.join(context.codexHome, "config.toml")
+  try {
+    const config = Bun.TOML.parse(await fs.readFile(configPath, "utf8")) as {
+      plugins?: Record<string, { enabled?: unknown }>
+    }
+    return config.plugins?.[OFFICIAL_PLUGIN_ID]?.enabled === true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false
+    throw new Error(
+      `Could not inspect ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}
+
 function normalizedGitUrl(value: string | undefined): string | undefined {
   return value?.replace(/\.git\/?$/, "").replace(/\/$/, "").toLowerCase()
 }
@@ -480,9 +496,10 @@ export async function inspectCodexDevStatus(
   context: CodexDevContext,
   runner: CommandRunner = new BunCommandRunner(),
 ): Promise<CodexDevStatus> {
-  const [collection, plugins] = await Promise.all([
+  const [collection, plugins, officialPluginConfigured] = await Promise.all([
     inspectLocalCollection(context),
     listCompoundEngineeringPlugins(context, runner),
+    isOfficialPluginConfigured(context),
   ])
   const localTarget = collection.kind === "valid" ? collection.resolvedTarget : undefined
   const localMatchesCheckout =
@@ -491,11 +508,11 @@ export async function inspectCodexDevStatus(
   let mode: CodexDevMode
   if (collection.kind === "collision" || collection.kind === "broken" || collection.kind === "unrelated") {
     mode = "drifted"
-  } else if (collection.kind === "valid" && plugins.length > 0) {
+  } else if (collection.kind === "valid" && (plugins.length > 0 || officialPluginConfigured)) {
     mode = "mixed"
   } else if (collection.kind === "valid") {
     mode = localMatchesCheckout ? "local" : "drifted"
-  } else if (plugins.length === 0) {
+  } else if (plugins.length === 0 && !officialPluginConfigured) {
     mode = "absent"
   } else if (plugins.length === 1 && isOfficialMarketplacePlugin(plugins[0]!)) {
     mode = "remote"
@@ -503,7 +520,7 @@ export async function inspectCodexDevStatus(
     mode = "drifted"
   }
 
-  return { mode, plugins, collection, localTarget, localMatchesCheckout }
+  return { mode, plugins, collection, localTarget, localMatchesCheckout, officialPluginConfigured }
 }
 
 async function removePlugins(
@@ -514,6 +531,24 @@ async function removePlugins(
   for (const plugin of plugins) {
     await runCodex(context, runner, ["plugin", "remove", plugin.pluginId, "--json"])
   }
+}
+
+async function removeLocalPluginConflicts(
+  context: CodexDevContext,
+  runner: CommandRunner,
+  plugins: InstalledPlugin[],
+): Promise<void> {
+  if (
+    plugins.some((plugin) => plugin.pluginId === OFFICIAL_PLUGIN_ID) ||
+    (await isOfficialPluginConfigured(context))
+  ) {
+    await runCodex(context, runner, ["plugin", "remove", OFFICIAL_PLUGIN_ID, "--json"])
+  }
+  await removePlugins(
+    context,
+    runner,
+    plugins.filter((plugin) => plugin.pluginId !== OFFICIAL_PLUGIN_ID),
+  )
 }
 
 export async function switchToLocal(
@@ -528,7 +563,7 @@ export async function switchToLocal(
   await activateLocalCollection(context)
   try {
     const plugins = await listCompoundEngineeringPlugins(context, runner)
-    await removePlugins(context, runner, plugins)
+    await removeLocalPluginConflicts(context, runner, plugins)
     const status = await inspectCodexDevStatus(context, runner)
     if (status.mode !== "local") {
       throw new Error(`Could not verify local Codex development mode (reported ${status.mode})`)
@@ -611,7 +646,7 @@ export async function removeCodexDevInstallation(
   runner: CommandRunner = new BunCommandRunner(),
 ): Promise<CodexDevStatus> {
   const plugins = await listCompoundEngineeringPlugins(context, runner)
-  await removePlugins(context, runner, plugins)
+  await removeLocalPluginConflicts(context, runner, plugins)
   await removeLocalCollection(context)
   const status = await inspectCodexDevStatus(context, runner)
   if (status.mode !== "absent") {
@@ -647,6 +682,9 @@ function statusLines(context: CodexDevContext, status: CodexDevStatus): string[]
     lines.push(
       `Plugin: ${plugin.pluginId} (${plugin.enabled ? "enabled" : "disabled"}, version ${plugin.version ?? "unknown"}, ${source})`,
     )
+  }
+  if (status.officialPluginConfigured && !status.plugins.some((plugin) => plugin.pluginId === OFFICIAL_PLUGIN_ID)) {
+    lines.push(`Plugin config: ${OFFICIAL_PLUGIN_ID} (enabled, omitted from codex plugin list)`)
   }
   if (status.mode === "mixed") {
     lines.push("Action required: both local skills and a Compound Engineering plugin are enabled.")

--- a/tests/codex-dev.test.ts
+++ b/tests/codex-dev.test.ts
@@ -113,6 +113,7 @@ class StatefulCodexRunner implements CommandRunner {
   failAdd = false
   failRemove: string | null = null
   beforeFailedRemove?: () => Promise<void>
+  afterRemove?: (pluginId: string) => Promise<void>
 
   constructor(plugins: InstalledPlugin[] = [], marketplaces: typeof officialMarketplace[] = []) {
     this.plugins = [...plugins]
@@ -135,6 +136,7 @@ class StatefulCodexRunner implements CommandRunner {
         return { exitCode: 1, stdout: "", stderr: "remove failed" }
       }
       this.plugins = this.plugins.filter((entry) => entry.pluginId !== args[2])
+      await this.afterRemove?.(args[2]!)
       return { exitCode: 0, stdout: "{}", stderr: "" }
     }
     if (joined === "plugin marketplace add EveryInc/compound-engineering-plugin --json") {
@@ -459,6 +461,43 @@ describe("Codex development installation transitions", () => {
     expect(runner.calls.filter((call) => call[1] === "plugin" && call[2] === "remove")).toEqual([
       ["codex", "plugin", "remove", "compound-engineering@compound-engineering-plugin", "--json"],
       ["codex", "plugin", "remove", "compound-engineering@personal", "--json"],
+    ])
+  })
+
+  test("status reports mixed mode when Codex config enables an unlisted official plugin", async () => {
+    const context = await makeContext()
+    await activateLocalCollection(context)
+    await fs.writeFile(
+      path.join(context.codexHome, "config.toml"),
+      '[plugins."compound-engineering@compound-engineering-plugin"]\nenabled = true\n',
+    )
+
+    expect((await inspectCodexDevStatus(context, new StatefulCodexRunner())).mode).toBe("mixed")
+  })
+
+  test("local mode removes an official plugin enabled in config but omitted from plugin list", async () => {
+    const context = await makeContext()
+    const configPath = path.join(context.codexHome, "config.toml")
+    await fs.writeFile(
+      configPath,
+      '[plugins."compound-engineering@compound-engineering-plugin"]\nenabled = true\n',
+    )
+    const runner = new StatefulCodexRunner()
+    runner.afterRemove = async (pluginId) => {
+      if (pluginId === "compound-engineering@compound-engineering-plugin") {
+        await fs.writeFile(configPath, "")
+      }
+    }
+
+    const status = await switchToLocal(context, runner)
+
+    expect(status.mode).toBe("local")
+    expect(runner.calls).toContainEqual([
+      "codex",
+      "plugin",
+      "remove",
+      "compound-engineering@compound-engineering-plugin",
+      "--json",
     ])
   })
 


### PR DESCRIPTION
## Summary

- Reconcile Codex's plugin inventory with the active profile's `config.toml`, so an enabled official plugin cannot hide behind an incomplete `codex plugin list` response.
- Report local-plus-config state as `mixed`, config-only state as `drifted`, and remove the official plugin ID during local/remove reconciliation even when inventory omits it.
- Cover the observed Orca account-scoped `CODEX_HOME` behavior with regression tests and update the Codex local-development solution note.

## Validation

- `bun test tests/codex-dev.test.ts` (28 pass)
- `bun run test` in a clean clone (3,658 pass, 0 fail)
- `bunx tsc --noEmit`
- `bun run release:validate`
- Live `bun run codex:dev -- status` against the Orca account profile reports `mixed` and identifies the config-only plugin discrepancy

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

The bulk of this work was completed by Orca Codex · GPT-5.
