### PR TITLE
fix(config): probe optional config.local.yaml before Read

### DIFF
--- a/skills/ce-brainstorm/SKILL.md
+++ b/skills/ce-brainstorm/SKILL.md
@@ -36,7 +36,7 @@ Resolve `<root>` the first time you compose or read a `<root>/` path, never earl
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-code-review/references/cross-model-review.md
+++ b/skills/ce-code-review/references/cross-model-review.md
@@ -32,7 +32,7 @@ Cursor is the one identity self-knowledge cannot complete, because the harness d
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-commit-push-pr/references/compose.md
+++ b/skills/ce-commit-push-pr/references/compose.md
@@ -14,7 +14,7 @@
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-doc-review/references/cross-model-review.md
+++ b/skills/ce-doc-review/references/cross-model-review.md
@@ -31,7 +31,7 @@ Cursor is the one identity self-knowledge cannot complete, because the harness d
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-ideate/SKILL.md
+++ b/skills/ce-ideate/SKILL.md
@@ -49,7 +49,7 @@ Read `references/output-mode.md` whenever a format is resolved. The read is requ
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-plan/references/output-mode.md
+++ b/skills/ce-plan/references/output-mode.md
@@ -35,7 +35,7 @@ Output mode is **exclusive** — a plan is written as either markdown (`.md`) OR
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-product-pulse/SKILL.md
+++ b/skills/ce-product-pulse/SKILL.md
@@ -57,7 +57,7 @@ This skill writes pulse reports under `<root>/pulse-reports/`. Resolve `<root>` 
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-promote/references/spiral-cli.md
+++ b/skills/ce-promote/references/spiral-cli.md
@@ -26,7 +26,7 @@ When Spiral is unauthed or absent, offer setup once. First check the opt-out so 
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-sweep/SKILL.md
+++ b/skills/ce-sweep/SKILL.md
@@ -57,7 +57,7 @@ Swept feedback lives under `<root>/feedback-sweep/`. Resolve `<root>` the first 
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/skills/ce-work/references/execution-engines.md
+++ b/skills/ce-work/references/execution-engines.md
@@ -42,7 +42,7 @@ When the target resolves to the current host's default execution route and no di
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->

--- a/tests/config-layers-rule-parity.test.ts
+++ b/tests/config-layers-rule-parity.test.ts
@@ -64,6 +64,8 @@ describe("config-layers rule shared-asset parity", () => {
     expect(block).toContain("invalid value continues to the next layer")
     expect(block).toContain("including an empty list or map")
     expect(block).toContain("Do not** use this rule for `docs_root`")
+    expect(block).toContain("Confirm each file exists")
+    expect(block).toContain("do not Read a missing path")
   })
 
   test("cross-model peer resolution continues past an invalid local scalar", async () => {

--- a/tests/fixtures/ce-config-layers-rule.md
+++ b/tests/fixtures/ce-config-layers-rule.md
@@ -1,7 +1,7 @@
 <!-- ce-config-layers:start -->
 **Resolve ordinary CE yaml keys from the two repo files.**
 
-- **Read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Missing files are skipped. Gitignore does not change resolution.
+- **Probe then read** `<repo-root>/.compound-engineering/config.local.yaml`, then `config.yaml` (`<repo-root>` = `git rev-parse --show-toplevel`). Confirm each file exists (`Glob` or `test -f`) before Read. When a file is absent, skip it and continue — do not Read a missing path. Gitignore does not change resolution.
 - **Win** with the first active (non-commented) value. For scalars, empty is unset; an invalid value continues to the next layer, then the skill default. For lists and maps, a present key — including an empty list or map — replaces the whole key.
 - **Do not** use this rule for `docs_root` — that key is `config.yaml` only.
 <!-- ce-config-layers:end -->


### PR DESCRIPTION
Skills that resolve ordinary CE yaml keys used to say **Read** `config.local.yaml` then skip if missing. Models still issued Read, which fails in unconfigured repos (one phantom tool error per skill run).

The shared `ce-config-layers` block now says probe existence (`Glob` / `test -f`) first and do not Read a missing path. Behavior with a present file is unchanged. No new config schema.

Fixes #1593

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Hermes Agent · grok-4.6
