### PR TITLE
fix(ci): absorb the windows _ctypes flake without hiding real failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,9 @@ jobs:
         # mid-suite (DLL init on _ctypes) after earlier tests already passed.
         # Product code cannot recover. Retries are signature-gated: only
         # `DLL load failed while importing _ctypes` is retried; any other
-        # nonzero exit fails this step immediately.
+        # nonzero exit fails this step immediately. A retried attempt's log is
+        # suppressed so a green step never shows failure dumps; the full log
+        # prints on success and on the terminal failure.
         shell: pwsh
         run: |
           $max = 3
@@ -156,11 +158,11 @@ jobs:
             python tests/fixtures/peer-job-runner-windows-smoke.py *> $log
             $code = $LASTEXITCODE
             $text = Get-Content -Raw -ErrorAction SilentlyContinue $log
-            if ($null -ne $text) { Write-Host $text }
-            if ($code -eq 0) { exit 0 }
-            if ($text -notmatch 'DLL load failed while importing _ctypes') { exit $code }
-            Write-Host "Windows smoke failed with known _ctypes flake (attempt $i/$max, exit $code)"
-            if ($i -eq $max) { exit $code }
+            if (($code -eq 0) -or ($text -notmatch 'DLL load failed while importing _ctypes') -or ($i -eq $max)) {
+              if ($null -ne $text) { Write-Host $text }
+              exit $code
+            }
+            Write-Host "Windows smoke hit known _ctypes flake (attempt $i/$max, exit $code); output suppressed, retrying"
             Start-Sleep -Seconds 15
           }
 

--- a/docs/solutions/developer-experience/windows-ctypes-import-flake-signature-gated-retry.md
+++ b/docs/solutions/developer-experience/windows-ctypes-import-flake-signature-gated-retry.md
@@ -1,0 +1,99 @@
+---
+title: "Hosted windows-latest CI intermittently fails `import ctypes` — signature-gated retry, not a blanket retry"
+date: 2026-08-31
+category: developer-experience
+module: "ci (peer-job-runner-windows-smoke.py, .github/workflows/ci.yml)"
+problem_type: test_failure
+component: testing_framework
+symptoms:
+  - "Peer-job-runner Windows smoke CI step fails with dozens of assertion failures from a single flaky launch"
+  - "Freshly spawned Windows Python subprocess raises ImportError: DLL load failed while importing _ctypes: A dynamic link library (DLL) initialization routine failed"
+  - "Failure is intermittent and unrelated to the code under test; reruns of the same commit sometimes pass"
+root_cause: environment_setup
+resolution_type: workflow_improvement
+severity: medium
+tags: [windows, ci, flaky-tests, ctypes, retry, subprocess, peer-job-runner]
+---
+
+# Hosted windows-latest CI intermittently fails `import ctypes` — signature-gated retry, not a blanket retry
+
+## Problem
+
+Hosted `windows-latest` CI Python intermittently fails `import ctypes` with a DLL-init error in freshly spawned subprocesses, killing the "Peer-job-runner Windows smoke" step and forcing full-suite reruns whose failure dumps made an otherwise-green run look broken.
+
+## Symptoms
+
+- Python subprocesses raise `ImportError: DLL load failed while importing _ctypes: A dynamic link library (DLL) initialization routine failed` from `skills/ce-doc-review/scripts/peer-job-runner.py`'s module-level `import ctypes` under `IS_WINDOWS` — a hosted-runner environment fault, not a code path exercised by the test.
+- One flaky launch failed roughly 39 assertions in a single run of `WindowsPeerJobSmoke`, because each `_run()` call spawns a fresh interpreter and any one of them can hit the flake.
+- The step printed the full assertion dump for every attempt, including retried attempts a later attempt made irrelevant, so a healthy retried run was indistinguishable from a real regression at a glance.
+
+## What Didn't Work
+
+- A whole-suite retry alone (rerun `peer-job-runner-windows-smoke.py` up to 3x when the log matched the flake signature) was already in place and was insufficient on its own: a single flaky subprocess launch still failed the entire suite instance (~39 assertions), and the step echoed the failed attempt's full dump even when the very next attempt passed. The old loop did print a one-line flake marker, but only after the full dump.
+
+## Solution
+
+Two retry layers plus dedicated coverage (introduced on branch `tmchow/investigate-ci-failure-pr`, uncommitted as of this writing).
+
+1. `.github/workflows/ci.yml` "Peer-job-runner Windows smoke" step (`shell: pwsh`): a retried flake attempt's log is suppressed and replaced with a one-line marker; the full log prints only on success or the terminal (non-flake or final) failure:
+
+```powershell
+$max = 3
+for ($i = 1; $i -le $max; $i++) {
+  $log = Join-Path $env:TEMP "peer-job-runner-windows-smoke-$i.log"
+  python tests/fixtures/peer-job-runner-windows-smoke.py *> $log
+  $code = $LASTEXITCODE
+  $text = Get-Content -Raw -ErrorAction SilentlyContinue $log
+  if (($code -eq 0) -or ($text -notmatch 'DLL load failed while importing _ctypes') -or ($i -eq $max)) {
+    if ($null -ne $text) { Write-Host $text }
+    exit $code
+  }
+  Write-Host "Windows smoke hit known _ctypes flake (attempt $i/$max, exit $code); output suppressed, retrying"
+  Start-Sleep -Seconds 15
+}
+```
+
+2. `tests/fixtures/peer-job-runner-windows-smoke.py` `WindowsPeerJobSmoke._run`: each individual runner launch retries itself up to 3 times when the exact signature matches, shrinking one flaky launch's blast radius from "whole suite instance fails" to "one subcommand relaunches":
+
+```python
+_CTYPES_FLAKE = "DLL load failed while importing _ctypes"
+
+def _run(self, args, timeout=90):
+    for attempt in range(3):
+        proc = subprocess.run(
+            [sys.executable, RUNNER, *args],
+            env=self.env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if proc.returncode == 0 or self._CTYPES_FLAKE not in (proc.stderr or ""):
+            return proc
+        if attempt < 2:
+            time.sleep(1)
+    return proc
+```
+
+   The relaunch is safe because the runner imports `ctypes` at module top level under `IS_WINDOWS`, so a flaked process dies before any side effect. The CI-level whole-suite retry is deliberately kept as backstop for the same flake occurring inside the detached supervisor process, which this spawn site cannot observe.
+
+3. New platform-independent coverage: `RunRetryGateUnit` (same fixture; `subprocess.run` and `time.sleep` stubbed, a `types.SimpleNamespace` stand-in for the win32-gated smoke case) asserts immediate success, immediate non-flake failure, flake-then-success retry, and three-flake exhaustion; `tests/peer-job-runner-retry-gate.test.ts` probes `python3`/`python`/`py` by execution (not presence) and runs the fixture with the `RunRetryGateUnit` argument, so the retry gate runs in the ordinary `bun run test` suite on every platform.
+
+## Why This Works
+
+The root cause is a hosted `windows-latest` runner environment fault in Python's `_ctypes` DLL initialization on process spawn, not a defect in the runner or the tests. Because the failure is a launch-time crash at import, before the process does anything, there is no partial state and relaunching is safe. Gating every retry — both layers — on the exact substring `DLL load failed while importing _ctypes` preserves gate fidelity: any other nonzero exit (real assertion failure, timeout, different exception) fails immediately on the first attempt with no retry and no output suppression, so the mechanism cannot mask an actual regression.
+
+## Prevention
+
+- Signature-gate any CI retry on the exact known-flake text, never on "nonzero exit" generically — a broad retry silently hides real failures.
+- Suppress a retried attempt's noisy output, but always print one visible line recording the attempt number and the suppression, so flake frequency stays observable in green runs.
+- Per-spawn retry is safe only when the failure is a crash at process launch before any side effect; the pattern does not generalize to failures after partial work.
+- Keep an outer whole-run retry alongside an inner per-spawn retry when the outer scope can observe failures the inner site cannot (here: the detached supervisor).
+- Retry logic embedded in a platform-gated fixture needs separate platform-independent tests, or its branches run nowhere deterministically.
+- Residual risks accepted deliberately: the substring gate delays (up to 3 attempts) rather than masks a real failure whose text contains the phrase; if the upstream error wording drifts, the gate silently reverts to zero retries (loud immediate failure, but no retry) until a human updates the signature; hangs are not retried — they fail via the normal timeout.
+
+## Related Issues
+
+- `docs/solutions/architecture-patterns/posix-process-supervision-on-native-windows.md` — same module and native-Windows workstream; that doc covers the POSIX-to-Windows primitive port, this one the hosted-runner CI flake found while smoking it.
+- `docs/solutions/conventions/resolve-python-interpreter-not-python3.md` — same Windows-support workstream; interpreter resolution, a different layer.
+- `docs/solutions/developer-experience/windows-crlf-checkout-breaks-newline-anchored-tests.md` — same "diagnose the Windows CI artifact before blaming source" framing, distinct root cause.
+- `docs/solutions/skill-design/dispatch-script-failure-degrade-outcome-not-boundary.md` — the general principle behind the gating: a retry/fallback must not weaken the boundary the mechanism enforces.

--- a/tests/fixtures/peer-job-runner-windows-smoke.py
+++ b/tests/fixtures/peer-job-runner-windows-smoke.py
@@ -20,7 +20,9 @@ import subprocess
 import sys
 import tempfile
 import time
+import types
 import unittest
+import unittest.mock
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -81,14 +83,28 @@ class WindowsPeerJobSmoke(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.root, ignore_errors=True)
 
+    # Hosted windows-latest Python intermittently fails `_ctypes` DLL init in a
+    # freshly spawned process. The runner dies at its top-level `import ctypes`,
+    # before any side effect, so relaunching any subcommand is safe. Only this
+    # signature is retried; real failures surface on the first attempt. The CI
+    # step's whole-suite retry remains as backstop for the same flake inside the
+    # detached supervisor, which this spawn site cannot observe.
+    _CTYPES_FLAKE = "DLL load failed while importing _ctypes"
+
     def _run(self, args, timeout=90):
-        return subprocess.run(
-            [sys.executable, RUNNER, *args],
-            env=self.env,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
+        for attempt in range(3):
+            proc = subprocess.run(
+                [sys.executable, RUNNER, *args],
+                env=self.env,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            if proc.returncode == 0 or self._CTYPES_FLAKE not in (proc.stderr or ""):
+                return proc
+            if attempt < 2:
+                time.sleep(1)
+        return proc
 
     def _job_dir(self, job_id: str, skill="ce-doc-review", run_id="run1"):
         return os.path.join(self.root, skill, run_id, "jobs", job_id)
@@ -785,8 +801,77 @@ class WindowsPeerJobSmoke(unittest.TestCase):
         self.assertEqual(json.loads(got.stdout), {"ok": True})
 
 
+class RunRetryGateUnit(unittest.TestCase):
+    """Platform-independent coverage for `_run`'s signature-gated retry.
+
+    The smoke class only ever exercises `_run`'s success path, and it is
+    win32-gated, so without this class the retry/give-up/immediate-fail
+    branches would run nowhere deterministically.
+    """
+
+    def setUp(self):
+        # _run only reads self.env and self._CTYPES_FLAKE, so a stand-in object
+        # avoids driving the smoke class's real filesystem setUp/tearDown.
+        self.case = types.SimpleNamespace(
+            env={}, _CTYPES_FLAKE=WindowsPeerJobSmoke._CTYPES_FLAKE
+        )
+        self.sleeps = []
+        sleep_patcher = unittest.mock.patch.object(time, "sleep", self.sleeps.append)
+        sleep_patcher.start()
+        self.addCleanup(sleep_patcher.stop)
+
+    def _scripted_run(self, outcomes):
+        """Patch subprocess.run to pop one (returncode, stderr) per call."""
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            code, stderr = outcomes.pop(0)
+            return subprocess.CompletedProcess(argv, code, stdout="", stderr=stderr)
+
+        patcher = unittest.mock.patch.object(subprocess, "run", fake_run)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        return calls
+
+    def _run(self, args):
+        return WindowsPeerJobSmoke._run(self.case, args)
+
+    def test_success_returns_first_attempt_without_sleep(self):
+        calls = self._scripted_run([(0, "")])
+        proc = self._run(["status", "job"])
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(self.sleeps, [])
+
+    def test_non_flake_failure_returns_immediately(self):
+        calls = self._scripted_run([(1, "RunnerError: no usable Git Bash")])
+        proc = self._run(["start", "--", "bash"])
+        self.assertEqual(proc.returncode, 1)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(self.sleeps, [])
+
+    def test_flake_then_success_retries(self):
+        flake = f"ImportError: {WindowsPeerJobSmoke._CTYPES_FLAKE}: init failed"
+        calls = self._scripted_run([(1, flake), (0, "")])
+        proc = self._run(["status", "job"])
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(self.sleeps, [1])
+
+    def test_three_flakes_returns_last_failure(self):
+        flake = f"ImportError: {WindowsPeerJobSmoke._CTYPES_FLAKE}: init failed"
+        calls = self._scripted_run([(1, flake), (1, flake), (1, flake)])
+        proc = self._run(["status", "job"])
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn(WindowsPeerJobSmoke._CTYPES_FLAKE, proc.stderr)
+        self.assertEqual(len(calls), 3)
+        self.assertEqual(self.sleeps, [1, 1])
+
+
 if __name__ == "__main__":
     if not IS_WINDOWS:
-        print("skip: peer-job-runner Windows smoke is for win32 only", file=sys.stderr)
-        sys.exit(0)
+        suite = unittest.TestLoader().loadTestsFromTestCase(RunRetryGateUnit)
+        result = unittest.TextTestRunner(verbosity=2).run(suite)
+        sys.exit(0 if result.wasSuccessful() else 1)
     unittest.main(verbosity=2)

--- a/tests/peer-job-runner-retry-gate.test.ts
+++ b/tests/peer-job-runner-retry-gate.test.ts
@@ -1,0 +1,28 @@
+import { spawnSync } from "node:child_process"
+import path from "node:path"
+import { expect, setDefaultTimeout, test } from "bun:test"
+
+// Runs the platform-independent RunRetryGateUnit tests inside the Windows smoke
+// fixture, so the fixture's signature-gated `_run` retry (retry only on the
+// hosted-runner `_ctypes` DLL-init flake, fail immediately on anything else) is
+// exercised on every platform — the smoke class itself is win32-gated and its
+// tests only ever hit `_run`'s success path.
+
+setDefaultTimeout(30_000)
+
+// Probe by execution, not presence: on native Windows `python3` can be the
+// Microsoft Store stub (a real file on PATH that exits non-zero). See
+// docs/solutions/conventions/resolve-python-interpreter-not-python3.md.
+const PYTHON = ["python3", "python", "py"].find(
+  (cand) => spawnSync(cand, ["-c", ""], { encoding: "utf8" }).status === 0,
+)
+if (!PYTHON) throw new Error("no working Python 3 interpreter on PATH (tried python3, python, py)")
+
+test("fixture retry gate: _run retries only on the _ctypes flake signature", () => {
+  const fixture = path.join(process.cwd(), "tests", "fixtures", "peer-job-runner-windows-smoke.py")
+  // The class-name arg keeps win32 runs scoped to the unit class instead of the
+  // full Win32 smoke suite (which CI runs as its own signature-retried step);
+  // the fixture's non-Windows branch runs only that class regardless.
+  const result = spawnSync(PYTHON, [fixture, "RunRetryGateUnit"], { encoding: "utf-8" })
+  expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0)
+})


### PR DESCRIPTION
## Summary

The windows-native smoke step no longer makes a green run look broken or lets one flaky launch fail the whole suite: the known hosted-runner `_ctypes` DLL-init flake is now absorbed at the point it strikes, while any other failure still fails immediately on the first attempt.

Two layers, both gated on the exact `DLL load failed while importing _ctypes` signature:

- The CI step suppresses a retried flake attempt's ~39-assertion dump behind a one-line "output suppressed, retrying" marker. The full log still prints on success and on any terminal failure, so flake frequency stays observable without reading as a regression.
- The fixture's `_run` relaunches an individual runner launch (up to 3x) when it dies with the signature, shrinking the blast radius from "whole suite instance fails, 15s sleep, full rerun" to "one subcommand relaunches after 1s". This is safe because the runner imports `ctypes` at module top level and dies before any side effect; the suite-level retry stays as backstop for the flake inside the detached supervisor, which the spawn site cannot observe.

The retry gate itself was previously exercised nowhere deterministically (the smoke class is win32-gated and only ever hit the success path). New `RunRetryGateUnit` tests stub `subprocess.run` to cover the success, non-flake-immediate-fail, retry, and exhaustion branches, and `tests/peer-job-runner-retry-gate.test.ts` runs them in the ordinary `bun run test` suite on every platform. A solutions doc captures the flake and the retry-design rules.

Validation: full suite green locally (3669 pass, 0 fail, includes the new test); the fixture's unit class passes standalone on POSIX. The Windows-path behavior proves out on this PR's own `windows-native` job.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

Claude Code · claude-fable-5


https://claude.ai/code/session_01UTG4i4nPw18kbcYh2aWUer
