### PR TITLE
docs(readme): add session guidance for same, compact, or fresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ After installing, run `/ce-setup` in any project. It reports optional tool capab
 
 Starting from a bug instead of a feature? Use [`/ce-debug`](docs/guides/ce-debug.md). Not sure what to build yet? Start with [`/ce-ideate`](docs/guides/ce-ideate.md).
 
+## Session guidance
+
+When you run loop steps by hand, treat on-disk artifacts as the checkpoint — not the chat transcript.
+
+- **Stay in the same session** while you are inside one step (for example one `/ce-plan` or one `/ce-work` pass). Clearing mid-step only forces a re-read of the same files.
+- **Compact** when the session is long (large diffs, many tool calls, or you are near the host context limit) but you are still mid-step. Compact after a plan file is written or after commits land, not in the middle of an edit.
+- **Start a fresh session** at a durable handoff: a plan in `docs/plans/`, code that is committed (and pushed when you have a remote), or a `docs/solutions/` note from `/ce-compound`. `/ce-work` reads the plan file; it does not need the planning transcript. A `/ce-code-review` report is a per-run artifact — do not assume a new session will recover it unless you kept the path.
+
+For mid-step work that has no artifact yet, use [`/ce-handoff`](docs/guides/ce-handoff.md), then `/ce-handoff resume <path>` in the next session. `/lfg` chains brainstorm through PR without asking, so this section mainly applies when you run steps yourself.
+
 ## Skills at a glance
 
 33 skills, grouped by what they are for. The full catalog, with a page per skill and how each one chains into the others, is in **[docs/guides](docs/guides/README.md)**.

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -277,6 +277,21 @@ describe("release metadata", () => {
     expect(stated.map(Number)).toEqual([skillCount, skillCount, skillCount])
   })
 
+  test("README session guidance pins stay/compact/fresh without claiming review reports reload", async () => {
+    const readme = await Bun.file(path.join(process.cwd(), "README.md")).text()
+    const start = readme.indexOf("## Session guidance")
+    const end = readme.indexOf("## Skills at a glance")
+    expect(start).toBeGreaterThan(0)
+    expect(end).toBeGreaterThan(start)
+    const section = readme.slice(start, end)
+    expect(section).toMatch(/\*\*Stay in the same session\*\*/)
+    expect(section).toMatch(/\*\*Compact\*\*/)
+    expect(section).toMatch(/\*\*Start a fresh session\*\*/)
+    expect(section).toMatch(/ce-handoff/)
+    expect(section).toMatch(/per-run artifact/)
+    expect(section).not.toMatch(/\/ce-plan`, `\/ce-work`, and `\/ce-code-review` all read prior artifacts/)
+  })
+
   // Hosts install the repo's skills/ tree as the plugin payload. A sibling
   // directory without SKILL.md (the #1551 catalog landing under skills/guides)
   // ships user docs with every install. The catalog lives in docs/guides/.


### PR DESCRIPTION
#884 asked when to stay in a session, compact, or start clean. Closed PR #1544 tried this and was not merged; this is a new patch, not a resurrection.

The earlier draft said `/ce-plan`, `/ce-work`, and `/ce-code-review` all read prior artifacts back in. That overstated review reports: they are per-run, and `ce-compound` does not take them as inputs. This section:

- Stay in-session mid-step
- Compact when long but still mid-step
- Fresh session from durable files (`docs/plans/`, commits, `docs/solutions/`)
- Explicitly: review reports do not auto-reload
- Mid-step with no artifact → `/ce-handoff`
- `/lfg` already chains without asking

Does not add agent auto-suggest-next-step behavior.

Closes #884

## Validation

- `bun test tests/release-metadata.test.ts` — 45 pass
- Sabotage: dropping the "per-run artifact" sentence fails the new contract test; restoring it passes

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Hermes Agent · grok-4.6
