### PR TITLE
docs(guides): edit pass over guides

### DIFF
--- a/docs/guides/ce-babysit-pr.md
+++ b/docs/guides/ce-babysit-pr.md
@@ -2,13 +2,11 @@
 
 > Watch an open GitHub PR and keep it moving toward merge-ready. Report when it *looks* ready. Land only if you asked.
 
-`ce-babysit-pr` is the **post-open watch**. It is a git-workflow skill, not a core-loop step. After `/ce-commit-push-pr` opens a PR, this skill watches three streams (review comments, CI, base-branch movement) until the PR looks ready, is blocked, hits a budget, or is merged/closed.
+`ce-babysit-pr` is the post-open watch. It is a git-workflow skill, not a core-loop step. After `/ce-commit-push-pr` opens a PR, this skill watches three streams (review comments, CI, base-branch movement) until the PR looks ready, is blocked, hits a budget, or is merged or closed.
 
-It is a conductor. It does **not** fix comments or diagnose CI itself. Comments go to `/ce-resolve-pr-feedback`. Real CI failures go to `/ce-debug`. This skill owns the loop, the order, dedup across ticks, the settle window, bounded branch maintenance, and the stop.
+It is a conductor. It does not fix comments or diagnose CI itself. Comments go to `/ce-resolve-pr-feedback`. Real CI failures go to `/ce-debug`. This skill owns the loop, the order, dedup across ticks, the settle window, bounded branch maintenance, and the stop. `/ce-resolve-pr-feedback` by contrast is a one-pass "fix the comments now" skill. Use that when you want a single round you watch. Use this when you want the PR driven over time.
 
-That is the contrast with `/ce-resolve-pr-feedback`, which is a one-pass "fix the comments now" skill. Use that when you want a single round you watch. Use this when you want the PR driven over time.
-
-**Posture** sets the scope. Default is `target` (the named PR only). On a confirmed managed stack you can choose `stack-ready` (advance upstack as soon as a layer has nothing actionable — even while its CI is still running — with lower layers kept under probe; no merge) or `stack-land` (same walk, plus `gh stack merge` of the bottom-most open **settled** prefix). **Settled is not merged.** A layer can look ready and still be OPEN.
+Posture sets the scope. Default is `target`, the named PR only. On a confirmed managed stack you can choose `stack-ready` (advance upstack as soon as a layer has nothing actionable, even while its CI is still running, with lower layers kept under probe; no merge) or `stack-land` (same walk, plus `gh stack merge` of the bottom-most open settled prefix). Settled is not merged. A layer can look ready and still be OPEN.
 
 It cannot promise merge-readiness. A reviewer can still comment later. Required checks can change. Under `target` and `stack-ready`, you merge. Selecting `stack-land` *is* land authorization for that managed prefix.
 
@@ -74,14 +72,14 @@ Hand-babysitting, or a naive loop, usually fails in the same ways:
 
 Each tick is stateless and resumable from disk. The harness only has to wake the agent when something changed.
 
-- **Comments first.** New review threads and non-thread comments are handled before CI. After that pass, if a commit was pushed, the old CI failure is against a dead SHA and is skipped
-- **Delegation.** `/ce-resolve-pr-feedback` for comments, `/ce-debug` for real failures (once per new signature). The only inline CI work is a cheap flaky-vs-real split
-- **Consumption-only branch currency.** The base is merged or updated into the PR only when the snapshot emits a `branch_currency` item (`BEHIND` via GitHub's update-branch endpoint, `DIRTY` via an exact-base local repair) and only after it is claimed; ordinary base movement on a CLEAN PR, a sibling merging, or someone saying "update the branch" never triggers one. A disputable conflict becomes a sticky `needs-human`; an unrequested base merge on the head is flagged as a defect
-- **Settle window.** "Looks ready" needs GitHub `CLEAN`, no open feedback, no parked `needs-human`, and enough quiet time. A started-but-unfinished review waits at least 15 quiet minutes and at most 30
-- **In-session watch by default.** `pr-snapshot watch` polls with no agent tokens and prints `BABYSIT_WAKE` only on an actionable change. If the harness cannot background-and-wake, the skill runs one checkpoint tick and prints the resume command
-- **Posture for confirmed managed stacks.** `target` stops at the named PR. `stack-ready` continues upstack without merging. `stack-land` continues and lands the settled prefix
+- Comments first. New review threads and non-thread comments get handled before CI. If that pass pushed a commit, the old CI failure sits on a dead SHA and gets skipped
+- Delegation. `/ce-resolve-pr-feedback` for comments, `/ce-debug` for real failures (once per new signature). The only inline CI work is a cheap flaky-vs-real split
+- Consumption-only branch currency. The base gets merged or updated into the PR only when the snapshot emits a `branch_currency` item (`BEHIND` via GitHub's update-branch endpoint, `DIRTY` via an exact-base local repair) and only after it is claimed. Ordinary base movement on a CLEAN PR, a sibling merging, or someone saying "update the branch" never triggers one. A disputable conflict becomes a sticky `needs-human`; an unrequested base merge on the head gets flagged as a defect
+- Settle window. "Looks ready" needs GitHub `CLEAN`, no open feedback, no parked `needs-human`, and enough quiet time. A started-but-unfinished review waits at least 15 quiet minutes and at most 30
+- In-session watch by default. `pr-snapshot watch` polls with no agent tokens and prints `BABYSIT_WAKE` only on an actionable change. If the harness cannot background-and-wake, the skill runs one checkpoint tick and prints the resume command
+- Posture for confirmed managed stacks. `target` stops at the named PR. `stack-ready` continues upstack without merging. `stack-land` continues and lands the settled prefix
 
-A `needs-human` item blocks the ready call. It does **not** end the watch. New comments and CI still get handled.
+A `needs-human` item blocks the ready call. It does not end the watch. New comments and CI still get handled.
 
 ---
 
@@ -89,19 +87,19 @@ A `needs-human` item blocks the ready call. It does **not** end the watch. New c
 
 ### Comments before CI, then drop the stale SHA
 
-Within a tick: terminal check, then comments, then re-check the head SHA, then CI only if that SHA did not move. A CI fix is never applied against a pre-comment commit.
+Within a tick: terminal check, then comments, then re-check the head SHA, then CI only if that SHA did not move. A CI fix never lands against a pre-comment commit.
 
-The same rule applies to a review that is still running. Already-posted comments are handled immediately; a review in flight only withholds the "looks ready" call.
+The same rule applies to a review that is still running. Already-posted comments get handled immediately; a review in flight only withholds the "looks ready" call.
 
 ### One tick, any driver
 
 State lives under `/tmp/compound-engineering-<effective-uid>/ce-babysit-pr/<host>-<owner>-<repo>-<pr>/` (under `$TMPDIR/compound-engineering-<effective-uid>/` instead when `/tmp` cannot host a writable private root, as in a sandbox that only allowlists `$TMPDIR`). A later invoke, a checkpoint resume, or a durable scheduler all drive the same tick. That is why the skill can run in a CLI session or fall back in a GUI harness that cannot keep a background wait.
 
-Default budget is **8 hours of active watch time** (laptop-sleep gaps are excluded). A **3-calendar-day** wall-clock backstop caps every run. You can pass a shorter duration at invoke.
+Default budget is 8 hours of active watch time; laptop-sleep gaps do not count. A 3-calendar-day wall-clock backstop caps every run. You can pass a shorter duration at invoke.
 
 ### Looks ready is a cooling-off judgment
 
-Ready is not "CI is green." GitHub must report the PR mergeable against the current base, the attention set must be empty, and the quiet window (5 minutes by default) must have elapsed. Then the skill judges separately whether a review is still on its way, from what the current head shows — a reviewer that announced itself earns a bounded extra wait until something it produced accounts for the review it announced, whatever that output concluded. An unrelated check from the same app finishing is not that. Even then the summary says "looks ready, your call" or "cautiously looks ready."
+Ready is not "CI is green." GitHub must report the PR mergeable against the current base, the attention set must be empty, and the quiet window (5 minutes by default) must have elapsed. Then the skill judges separately whether a review is still on its way, from what the current head shows. A reviewer that announced itself earns a bounded extra wait until something it produced accounts for the review it announced, whatever that output concluded. An unrelated check from the same app finishing is not that. Even then the summary says "looks ready, your call" or "cautiously looks ready."
 
 When a fork PR's CI is waiting on maintainer approval, the skill drains review for a bounded window (5, 15, or 30 minutes) and then hands back. It never approves the workflow run. Pipeline mode returns that blocker immediately.
 
@@ -121,9 +119,9 @@ A just-landed `MERGED` under `stack-land` is a layer transition, not the end of 
 
 ## Why All This Machinery
 
-Much simpler PR-watch skills exist — a page of prose that polls `gh pr checks`, fixes comments, and stops after a few rounds. If a strong model can reason from a goal statement, why does this skill carry a ~3,500-line snapshot engine and a directory of references?
+Much simpler PR-watch skills exist, a page of prose that polls `gh pr checks`, fixes comments, and stops after a few rounds. If a strong model can reason from a goal statement, why does this skill carry a ~3,500-line snapshot engine and a directory of references?
 
-The short answer: the prose here *is* the goal statement — the always-loaded body is about 60 lines. The engine holds the parts that prose has already failed at in production. The split is deliberate and documented: **the engine reports what is observable and cheap to establish; the agent decides what those observations mean** (see `docs/solutions/skill-design/liveness-judgment-belongs-to-the-agent.md`, which records the one time a judgment leaked into the engine and had to be deleted).
+Because the prose here *is* the goal statement. The always-loaded body is about 60 lines. The engine holds the parts that prose has already failed at in production. The split is deliberate and documented: the engine reports what is observable and cheap to establish, and the agent decides what those observations mean (see `docs/solutions/skill-design/liveness-judgment-belongs-to-the-agent.md`, which records the one time a judgment leaked into the engine and had to be deleted).
 
 Each major piece of the engine exists because a specific failure happened without it:
 
@@ -137,9 +135,9 @@ Each major piece of the engine exists because a specific failure happened withou
 | Trajectory / non-convergence evidence | A fix loop that oscillates (A fixed, B appears, A returns) looks like progress from inside any single tick. Session history is lossy across compaction, so the evidence has to live on disk |
 | Stack topology via the host's manager probe | Advancing or landing the wrong layer of a stack; only a confirmed manager probe activates stack posture |
 
-Simpler skills do not solve these problems — they export them. A bounded "3 rounds then stop" cap is a budget the user enforces by re-invoking; "poll until all reviewers are finished" with no definition of finished hangs on a reviewer that announces itself and never signals completion (the exact bug fixed here in #1606/#1611); and a watcher with no comment-trust rule will follow instructions planted in PR comments, a concretely exploited injection class.
+Simpler skills do not solve these problems. They export them. A bounded "3 rounds then stop" cap is a budget the user enforces by re-invoking. "Poll until all reviewers are finished" with no definition of finished hangs on a reviewer that announces itself and never signals completion, the exact bug fixed here in #1606/#1611. And a watcher with no comment-trust rule will follow instructions planted in PR comments, a concretely exploited injection class.
 
-The machinery still has to pay rent. When a piece turns out to encode a judgment rather than an observation, it gets deleted — #1611 removed a nine-function review-liveness detector and replaced it with a stated goal in `settle.md`. The direction of travel is thinner prose over a boring, observable-facts engine, not fewer facts.
+The machinery still has to pay rent. When a piece turns out to encode a judgment rather than an observation, it gets deleted. #1611 removed a nine-function review-liveness detector and replaced it with a stated goal in `settle.md`. The direction of travel is thinner prose over a boring, observable-facts engine, not fewer facts.
 
 ---
 

--- a/docs/guides/ce-brainstorm.md
+++ b/docs/guides/ce-brainstorm.md
@@ -2,9 +2,9 @@
 
 > Think through what something should become, one question at a time, then write a right-sized requirements-only unified plan.
 
-`ce-brainstorm` is the **definition** skill. Use it when you have a direction and the open question is "what does this need to be?" It asks one question per turn, pressure-tests premises against named gap lenses, lays out 2-3 concrete approaches before recommending one, and, for software, writes a requirements-only unified plan so planning does not invent product behavior.
+`ce-brainstorm` is the **definition** skill. Use it when you have a direction and the open question is "what does this need to be?" It asks one question per turn, pressure-tests your premises, lays out 2-3 concrete approaches before recommending one, and, for software, writes a requirements-only unified plan so planning does not have to invent product behavior.
 
-It runs on software features, on non-software topics (events, business decisions, travel, naming briefs), and on work in between. Software runs write the requirements-only unified plan. Non-software runs stay in facilitation mode: a chat synthesis, then an optional handoff to `ce-plan` for a domain-appropriate plan.
+It handles software features, non-software topics (events, business decisions, travel, naming briefs), and everything between. Software runs write the plan file. Non-software runs stay in facilitation mode: a chat synthesis, then an optional handoff to `ce-plan`.
 
 This is the middle step in the compound-engineering ideation chain. Skip it when you already have requirements, or when you do not yet have a direction:
 
@@ -17,7 +17,7 @@ This is the middle step in the compound-engineering ideation chain. Skip it when
 
 It is also a common standalone entry when the question is not "how do I do it?" but "what am I actually doing, and is that the right shape?"
 
-It does not render a verdict. If the request is a whether-to-adopt decision on a named external candidate (a technology, library, pattern, platform, or architecture, judged against this project), the skill offers `/ce-pov` instead of scoping work you have not committed to. That is an offer, not a silent switch. Open-ended design with no single candidate stays here.
+It does not render verdicts. If you ask whether to adopt a named external candidate (a technology, library, platform, or architecture judged against this project), it offers `/ce-pov` instead of scoping work you have not committed to. That is an offer, not a silent switch. Open-ended design with no single candidate stays here.
 
 ---
 
@@ -28,7 +28,7 @@ It does not render a verdict. If the request is a whether-to-adopt decision on a
 | What does it do? | Collaborative dialogue to clarify scope, pressure-test premises, explore approaches, and write a requirements-only unified plan |
 | When to use it | Vague feature ideas, multiple plausible directions, unclear scope, work in unfamiliar territory, non-software decisions |
 | What it produces | Software: a requirements-only unified plan in `docs/plans/` with `artifact_readiness: requirements-only` and R/A/F/AE IDs. Non-software: chat synthesis, optional save, optional Proof publish, optional handoff to `ce-plan`. Lightweight alignment can skip the doc. |
-| What's next | Software: create the implementation plan (`ce-plan`, recommended), ship autonomously with `lfg`, pressure-test the requirements or prototype a remaining feel-question, open an HTML artifact in the browser, or keep asking. Non-software: create a plan, save the summary, publish to Proof, or stop. |
+| What's next | Software: `ce-plan` (recommended), ship autonomously with `lfg`, pressure-test or prototype, or keep asking. Non-software: create a plan, save the summary, publish to Proof, or stop. |
 
 ---
 
@@ -40,7 +40,7 @@ An empty invoke asks what to explore. A path to an existing requirements-only pl
 # Ask what to explore, then start the dialogue
 /ce-brainstorm
 
-# Shape an ambitious feature or project before committing to a plan
+# Shape an ambitious feature before committing to a plan
 /ce-brainstorm design a self-serve migration platform for enterprise customers
 
 # Turn a rough feature idea into a requirements artifact
@@ -49,82 +49,59 @@ An empty invoke asks what to explore. A path to an existing requirements-only pl
 # Explore a problem without prescribing the solution up front
 /ce-brainstorm support agents get paged overnight for non-urgent events
 
-# Resume or continue an existing requirements-only plan instead of starting a duplicate
+# Resume an existing requirements-only plan instead of starting a duplicate
 /ce-brainstorm docs/plans/2026-08-10-feat-notification-mute-plan.md
 
 # Name an ideate survivor already in this conversation. Its tagged basis,
-# rationale, and tradeoffs travel with it (same as picking "Brainstorm one idea")
+# rationale, and tradeoffs travel with it
 /ce-brainstorm the per-channel mute idea
 
-# Brainstorm non-software work with the same one-question discipline
+# Non-software work, same one-question discipline
 /ce-brainstorm plan a two-day customer advisory workshop
 
-# Unfamiliar territory: offer a blindspot map before questioning that area
+# Unfamiliar territory: offers a blindspot map before questioning that area
 /ce-brainstorm I know nothing about color grading but need a review workflow for it
 
-# Verdict-shaped: offer ce-pov rather than scoping an adoption you have not made
+# Verdict-shaped: offers ce-pov instead
 /ce-brainstorm should we adopt Biome in this repo?
 
-# Ask for a self-contained HTML artifact in plain language
-/ce-brainstorm add account-level notification settings and make the artifact a self-contained HTML page
-
-# Equivalent shorthand when a repeatable automation needs it
+# Ask for a self-contained HTML artifact, in plain language or shorthand
+/ce-brainstorm add account-level notification settings and make the artifact HTML
 /ce-brainstorm add account-level notification settings output:html
 
 # Keep the session on your usual model; generate the approaches on a named one
 /ce-brainstorm add account-level notification settings, use fable
 ```
 
-Use `ce-ideate` when you do not yet have a direction. Use `ce-pov` when the candidates are already named and you need a verdict. Use `ce-plan` when the product shape is already settled.
+Use `ce-ideate` when you do not yet have a direction. Use `ce-pov` when the candidates are already named and you need a verdict. Use `ce-plan` when the product shape is settled.
 
 ---
 
-## The Problem
+## The problem
 
-Going straight from a vague idea to implementation produces:
+Going straight from a vague idea to implementation produces work that solves the wrong problem, scope creep because boundaries were never written down, and plans that re-litigate product decisions every time someone touches them. The requirements end up either over-ceremonial PRDs nobody updates or one-line briefs that planning fills in by guessing.
 
-- Work that solves the wrong problem, because nobody pressure-tested the premise
-- Scope creep, because boundaries were never written down
-- Plans that re-litigate product decisions every time someone touches them
-- Requirements that are either over-ceremonial PRDs nobody updates, or one-line briefs that planning has to fill in by guessing
+A typical "let's brainstorm" with an AI has shape problems too. It asks five questions in one message; you answer two and the rest get lost. It picks one approach immediately instead of showing alternatives. It bakes implementation into product discussion. The output is conversation, not an artifact you can hand off.
 
-A typical "let's brainstorm" with an AI has shape problems too. It asks five questions in one message; you answer two and the rest get lost. It picks one approach immediately instead of showing alternatives. It bakes implementation into product discussion. The output is conversation, not a handoff-able artifact.
-
-## The Solution
-
-`ce-brainstorm` runs a structured conversation that can end in a durable artifact:
-
-- One question per turn, defaulting to the platform's blocking question tool
-- Facts the environment can answer are looked up, not asked; a running lookup does not stall independent questions
-- User terms or system-behavior claims that conflict with existing `CONCEPTS.md` or verified code are challenged when they would change a product decision
-- Ceremony matched to the work: Lightweight, Standard, Deep, or Deep-product
-- Named gap lenses on premises before approaches are generated
-- An opt-in blindspot pass when you do not know the territory well enough to weigh options
-- A background grounding scout that gathers verbatim repo evidence while you answer the opening questions
-- 2-3 concrete approaches with tradeoffs, then a stated recommendation
-- Opt-in visual probes for decisions that are faster to judge as rough sketches than as prose
-- An optional `ce-prototype` offer when committing an approach would be expensive to unravel and neither talk nor a cheap sketch can settle it
-- A Synthesis Summary as the last cheap moment to correct scope before a doc lands
-- Fresh-context claim verification of the doc's repo claims before it lands
-- One coherent work unit per artifact
-- A Ready for Planning Check that repairs completeness, consistency, focus, and planning-readiness before handoff
-- A right-sized Product Contract inside a unified plan, with stable R/A/F/AE identifiers that flow into planning
+`ce-brainstorm` fixes both. The conversation is structured (one question per turn, gap lenses before approaches, alternatives before a recommendation), and it can end in a durable artifact with stable identifiers that planning consumes directly.
 
 ---
 
-## What Makes It Novel
+## What makes it novel
 
 ### 1. One question at a time
 
-Stacking several questions in one message produces diluted answers. `ce-brainstorm` asks one question per turn and defaults to the platform's blocking question tool with single-select options when natural choices exist. Free-text is always available. It also asks only decisions: if the repo, the grounding dossier, or another reachable source can settle the answer, it looks that up instead of putting it to you. A lookup in flight does not stall questions that do not depend on it. When your wording conflicts with existing `CONCEPTS.md` or with verified code in a way that would change a product decision, it surfaces that conflict before treating the wording as settled. It does not create `CONCEPTS.md`; glossary writes still land after the plan.
+Stacking several questions in one message dilutes the answers. `ce-brainstorm` asks one per turn, defaulting to the platform's blocking question tool with single-select options when natural choices exist. Free-text is always available.
+
+It also asks only decisions. If the repo, the grounding dossier, or another reachable source can settle a question, it looks that up instead of putting it to you, and a lookup in flight does not stall questions that don't depend on it. When your wording conflicts with existing `CONCEPTS.md` or with verified code in a way that would change a product decision, it surfaces the conflict before treating the wording as settled.
 
 ### 2. Ceremony scales with the work
 
-Lightweight covers small, well-bounded ideas and ends in chat: a paragraph naming what is being built, the one or two decisions made, and where they go next — no file, no grounding scout, no approach generation. A file is written only when the dialogue produced a decision a downstream consumer needs in IDed form, or you ask for one. Standard handles ordinary features with some decisions. Deep adds probes for cross-cutting work. Deep-product also has to establish product shape (actors, core outcome, positioning, durability) rather than inherit it.
+Four tiers. Lightweight covers small, well-bounded ideas and ends in chat: a paragraph naming what is being built and the one or two decisions made. No file, no grounding scout, no approach generation. A file is written only when the dialogue produced a decision a downstream consumer needs in IDed form, or you ask for one. Standard handles ordinary features. Deep adds probes for cross-cutting work. Deep-product also has to establish product shape (actors, core outcome, positioning, durability) rather than inherit it.
 
 ### 3. Named gap lenses, then approaches
 
-Before generating approaches, the skill scans the opening for rigor gaps and probes only the ones that are present:
+Before generating approaches, the skill scans your opening for rigor gaps and probes only the ones actually present:
 
 - Evidence: "users want X" with no observable behavior behind it
 - Specificity: the beneficiary is abstract, so design will invent who they are
@@ -132,47 +109,43 @@ Before generating approaches, the skill scans the opening for rigor gaps and pro
 - Attachment: a specific solution shape is already being treated as the thing being built
 - Durability (Deep-product only): value rests on a current state of the world that may shift
 
-These probes fire as prose, not menus. A 4-option menu would tell you which kinds of evidence count. Prose forces a real observation.
+These probes fire as prose, not menus. A 4-option menu would tell you which kinds of evidence count; prose forces a real observation.
 
-Phase 2 then surfaces 2-3 concrete approaches, including at least one non-obvious angle (inversion, constraint removal, or cross-domain analogy). Approaches sit at mechanism or product-shape granularity, not architecture. Architecture on thin research belongs in `ce-plan`. Approaches are shown before the recommendation so you see the alternatives first.
+Phase 2 then surfaces 2-3 concrete approaches, including at least one non-obvious angle (inversion, constraint removal, or cross-domain analogy). Approaches sit at mechanism or product-shape granularity, not architecture. Architecture on thin research belongs in `ce-plan`. You see the alternatives before the recommendation.
 
 ### 4. Visual probes, then prototype when a sketch is not enough
 
-When a decision is spatial, behavioral, or visual, the skill can offer a rough local visual probe. Those probes are disposable sketches for product feedback, display-only. You respond in chat. A decision a rough sketch cannot settle (finish or motion), or one a sketch was built for and failed to settle, routes to `ce-prototype` instead.
+When a decision is spatial, behavioral, or visual, the skill can offer a rough local visual probe. Probes are disposable, display-only sketches; you respond in chat. A decision a rough sketch cannot settle (finish or motion), or one a sketch was built for and failed to settle, routes to `ce-prototype` instead.
 
 ### 5. Synthesis, identifiers, and a last check before handoff
 
-Before writing the doc, the skill emits a scoping synthesis: what is being built, the trade-offs the dialogue produced, what was deferred, and any genuine forks. Lightweight runs that asked no blocking questions compress this to a single forward-looking sentence. Standard, Deep, and any run that asked a blocking question get the full synthesis and an explicit confirmation gate, including a richly pre-loaded opener that needed no dialogue.
+Before writing the doc, the skill emits a scoping synthesis: what is being built, the trade-offs the dialogue produced, what was deferred, and any genuine forks. This is the last cheap moment to correct scope. Lightweight runs that asked no blocking questions compress it to one forward-looking sentence; everything else gets the full synthesis and an explicit confirmation gate.
 
-The Product Contract carries R-IDs (Requirements), A-IDs (Actors), F-IDs (Key Flows), and AE-IDs (Acceptance Examples). `ce-plan` traces every implementation unit and test scenario back to them. Origin scope boundaries, including "Outside this product's identity", flow through unchanged.
+The Product Contract carries R-IDs (Requirements), A-IDs (Actors), F-IDs (Key Flows), and AE-IDs (Acceptance Examples). `ce-plan` traces every implementation unit and test scenario back to them. Scope boundaries flow through unchanged. Requirements describe expected behavior from the user's perspective, not libraries, schemas, endpoints, or file layouts, unless the brainstorm itself is about a technical decision. A decision you examined and chose during the dialogue lands as a labeled Key Decision and is not re-asked; `ce-plan` inherits the label.
 
-Requirements describe expected behavior from the user's perspective. They do not describe libraries, schemas, endpoints, file layouts, or code structure unless the brainstorm itself is about a technical decision.
-
-A decision you examined and chose during the dialogue lands as a labeled Key Decision (`session-settled: user-directed` or `user-approved`) and is not re-asked. `ce-plan` inherits the label.
-
-On Standard and Deep software runs, a cheap scout gathers a grounding dossier (verbatim quotes with `file:line` pointers) while you answer the first question. Before the plan is written, a verifier that never saw the dialogue checks the Product Contract's repo claims. Refuted claims are corrected; unverifiable ones become explicit assumptions. The dossier path is handed to `ce-plan`.
+On Standard and Deep software runs, a cheap scout gathers a grounding dossier (verbatim quotes with `file:line` pointers) while you answer the first question. Before the plan lands, a verifier that never saw the dialogue checks the Product Contract's repo claims. Refuted claims get corrected; unverifiable ones become explicit assumptions. The dossier path is handed to `ce-plan`.
 
 ### 6. Blindspot pass and non-software facilitation
 
-When you flag unfamiliarity, or consecutive answers show you cannot weigh the options, the skill offers a blindspot pass before questioning that territory further: a map of 3-7 decisions and hazards, each with why it matters, the realistic options, and a recommended default. You pick which to walk through. The rest take defaults recorded as explicit assumptions. This works on both software and non-software routes.
+When you flag unfamiliarity, or consecutive answers show you cannot weigh the options, the skill offers a blindspot pass before questioning that territory further: a map of 3-7 decisions and hazards, each with why it matters, the realistic options, and a recommended default. You pick which to walk through; the rest take defaults recorded as explicit assumptions. Works on both software and non-software routes.
 
 Non-software work uses a domain-agnostic facilitator with the same one-question discipline. It does not write a software unified-plan artifact.
 
 ---
 
-## Quick Example
+## Quick example
 
-You start with "I want to add a way for users to pause notifications." The skill classifies the work as Standard and sends a cheap background scout for repo evidence while you answer the first question.
+You start with "I want to add a way for users to pause notifications." The skill classifies the work as Standard and sends a background scout for repo evidence while you answer the first question.
 
-The pressure test finds a specificity gap (who are these "users"?) and an attachment gap ("pause" is already a solution shape). It probes both as prose, one at a time. You name the actual pain (support gets pinged at 3 AM for non-urgent stuff) and the smallest version that would solve it.
+The pressure test finds a specificity gap (who are these "users"?) and an attachment gap ("pause" is already a solution shape). It probes both as prose, one at a time. You name the actual pain: support gets pinged at 3 AM for non-urgent stuff.
 
-Three approaches surface: per-notification-type mute with TTL, a global do-not-disturb schedule, mute on the rule rather than the channel. Tradeoffs and a recommendation follow. The Synthesis Summary reads back the shape ("per-channel mute on notification rules, 24h preset for the 3 AM support pings"), the trade-offs (per-channel over per-user, mute lives on the rule), what is deferred (presence-based mute, quiet-hours schedules), and a call-out about the rule-delete loss path. You confirm and add a 24h preset.
+Three approaches surface: per-notification-type mute with TTL, a global do-not-disturb schedule, mute on the rule rather than the channel. Tradeoffs and a recommendation follow. The synthesis reads back the shape ("per-channel mute on notification rules, 24h preset for the 3 AM support pings"), the trade-offs, what is deferred (presence-based mute, quiet-hours schedules), and a call-out about the rule-delete loss path. You confirm and add a 24h preset.
 
-A requirements-only unified plan is written under `docs/plans/`. The Phase 4 menu then offers: create the implementation plan with `ce-plan` (recommended), ship autonomously with `lfg`, pressure-test the requirements or prototype a remaining feel-question, open the file if it is HTML, or keep asking clarifying questions.
+A requirements-only unified plan lands under `docs/plans/`. The Phase 4 menu then offers: create the implementation plan with `ce-plan` (recommended), ship autonomously with `lfg`, pressure-test the requirements or prototype a remaining feel-question, open the file if it is HTML, or keep asking clarifying questions.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Reach for `ce-brainstorm` when:
 
@@ -183,7 +156,7 @@ Reach for `ce-brainstorm` when:
 - You have to scope work in territory you do not know (the blindspot pass maps the decision surface first)
 - The topic is not software (naming, events, roadmap choices)
 
-Skip `ce-brainstorm` when:
+Skip it when:
 
 - You do not yet know what to work on → `/ce-ideate`
 - Requirements are already specified (a PRD exists, the issue is detailed) → `/ce-plan`
@@ -193,7 +166,7 @@ Skip `ce-brainstorm` when:
 
 ---
 
-## Use as Part of the Chained Workflow
+## Use as part of the chained workflow
 
 ```text
 /ce-ideate          (optional: discover candidate directions)
@@ -207,20 +180,19 @@ Skip `ce-brainstorm` when:
 /ce-plan
    |  enriches the same plan to implementation-ready
    |  R-IDs flow into Requirements; A/F/AE-IDs trace into units and tests
-   |  origin scope boundaries are preserved
    v
 /ce-work
 ```
 
-When `ce-plan` loads with a requirements-only unified plan, it does not re-litigate product behavior. The Product Contract is authoritative. Plan-time decisions are about execution guardrails, not what is being built.
+When `ce-plan` loads a requirements-only unified plan, it does not re-litigate product behavior. The Product Contract is authoritative; plan-time decisions are about execution guardrails, not what is being built.
 
 In a repo, acting on an ideate survivor always comes here, not to `ce-plan`. `ce-plan` wants a brainstorm-grounded Product Contract.
 
 ---
 
-## Use Standalone
+## Use standalone
 
-Many teams skip `ce-ideate` (they already know what to explore). Some also stop here and treat the brainstorm as the thinking artifact, then plan later.
+Many teams skip `ce-ideate` because they already know what to explore. Some also stop here and treat the brainstorm as the thinking artifact, then plan later.
 
 - Feature briefs: turn a vague idea into a stable artifact for stakeholders or new contributors
 - Onboarding existing work: the feature is in flight but the rationale was never written down
@@ -228,9 +200,7 @@ Many teams skip `ce-ideate` (they already know what to explore). Some also stop 
 - Strategic decisions: Deep-product surfaces durability and adjacent-product risks
 - Non-software: name a product, plan an event, decide a roadmap
 
-The software Phase 4 menu offers planning, autonomous ship with `lfg` (when a unified plan exists and no blockers remain), document review or a prototype, an HTML open-in-browser option, or more questions. There is no skip-to-`ce-work` from this menu. Non-software wrap-up offers `ce-plan`, save the summary, publish to Proof, or stop.
-
-If a related requirements-only plan already exists, the skill offers to resume it instead of starting a duplicate.
+There is no skip-to-`ce-work` from the Phase 4 menu; software next steps go through `ce-plan` or `lfg` (which plans first). If a related requirements-only plan already exists, the skill offers to resume it instead of starting a duplicate.
 
 ---
 
@@ -244,7 +214,7 @@ If a related requirements-only plan already exists, the skill offers to resume i
 | Existing requirements-only plan path, legacy `*-requirements.md` path, or matching topic | Resume offer |
 | Ideate survivor already in this conversation | Loads with that idea's tagged basis, rationale, and tradeoffs |
 | Verdict-shaped prompt (`should we adopt X`) | Offers `ce-pov`; decline and the brainstorm continues |
-| `output:html` | Write the requirements-only unified plan as a single self-contained HTML file instead of markdown. Exclusive: the artifact is `.md` or `.html`, never both. Default is markdown. Set `brainstorm_output: html` in CE config (`config.local.yaml` then `config.yaml`) to make HTML the default. Pipeline mode (LFG, `disable-model-invocation`) always forces markdown. See the [configuration reference](./configuration.md). |
+| `output:html` | Write the plan as a single self-contained HTML file instead of markdown. Exclusive: the artifact is `.md` or `.html`, never both. Set `brainstorm_output: html` in CE config (`config.local.yaml` then `config.yaml`) to make HTML the default. Pipeline mode (LFG, `disable-model-invocation`) always forces markdown. See the [configuration reference](./configuration.md). |
 | `use fable` / `have opus generate these` | Elevate only approach generation to that model. Also settable as `brainstorm_model: <model>` in CE config. A prompt request overrides the config key. |
 
 ---
@@ -255,30 +225,24 @@ If a related requirements-only plan already exists, the skill offers to resume i
 Stacking three questions per turn produces diluted answers. People pick the easy one and the rest get lost. One question per turn produces sharper answers and usually converges faster.
 
 **Why does it pressure-test my premise? I just want to brainstorm.**
-The named gap lenses catch the usual ways feature briefs fail downstream. They fire only when the gap is actually present. A concrete, well-framed prompt can earn zero probes.
+The gap lenses catch the usual ways feature briefs fail downstream. They fire only when the gap is actually present. A concrete, well-framed prompt can earn zero probes.
 
 **Can I skip the requirements-only plan?**
-Yes. The Lightweight tier and the announce-mode fast path support that. If you only need brief alignment, no doc is written. The `lfg` menu option is hidden when there is no artifact, because `lfg` cannot prompt for the missing file.
-
-**What if I already have a PRD or detailed GitHub issue?**
-Skip `ce-brainstorm` and go to `/ce-plan`. The plan skill consumes any kind of input.
+Yes. If you only need brief alignment, the Lightweight tier ends in chat and no doc is written. The `lfg` menu option is hidden when there is no artifact, because `lfg` cannot prompt for the missing file.
 
 **What does "Inferred" mean in the synthesis?**
-The agent composes an internal three-bucket draft (Stated / Inferred / Out of scope) before presenting the scoping synthesis. Inferred items are bets that fill dialogue gaps. Those that survive the keep test surface as call-outs; the rest dissolve into the Product Contract when you confirm.
-
-**Does it work for non-software topics?**
-Yes. A domain-agnostic facilitator keeps the one-question discipline. The wrap-up can hand the synthesis to `ce-plan`, save a summary, or publish to Proof. It does not write a software unified-plan artifact.
+The agent composes an internal three-bucket draft (Stated / Inferred / Out of scope) before presenting the synthesis. Inferred items are bets that fill dialogue gaps. Those that survive the keep test surface as call-outs; the rest dissolve into the Product Contract when you confirm.
 
 **Can I go straight to `ce-work` from here?**
-Not from the Phase 4 menu. Software next steps are `ce-plan` or `lfg` (which plans first). Skip-to-build is not offered here, even for Lightweight scope.
+Not from the Phase 4 menu. Software next steps are `ce-plan` or `lfg` (which plans first). Skip-to-build is not offered, even for Lightweight scope.
 
 ---
 
 ## Model elevation
 
-When you want a specific model for the heavy reasoning step, `ce-brainstorm` can generate approaches on that model instead of your session model. Only approach generation is dispatched, with read access so it can verify its brief. The rest of the skill stays on your session model. Name a model in the prompt (`use fable`, `have opus generate these`), or set `brainstorm_model: <model>` in CE config (`config.local.yaml` then `config.yaml`). A prompt request overrides the config key.
+When you want a specific model for the heavy reasoning step, `ce-brainstorm` can generate approaches on that model instead of your session model. Only approach generation is dispatched, with read access so it can verify its brief; the rest of the skill stays on your session model. Name a model in the prompt (`use fable`, `have opus generate these`), or set `brainstorm_model: <model>` in CE config.
 
-This works on any harness. The host serves the chosen model natively where it can, otherwise it invokes the Claude CLI (which must be installed and authenticated), otherwise it runs the step on your session model and says which precondition was unmet. Setting `brainstorm_model` therefore takes effect in every harness you run `ce-brainstorm` in, not just Claude Code.
+This works on any harness. The host serves the chosen model natively where it can, otherwise it invokes the Claude CLI (which must be installed and authenticated), otherwise it runs the step on your session model and says which precondition was unmet.
 
 ---
 

--- a/docs/guides/ce-code-review.md
+++ b/docs/guides/ce-code-review.md
@@ -1,16 +1,16 @@
 # `ce-code-review`
 
-> Structured code review: risk-selected personas, confidence-gated findings, and a merge/dedup report.
+> Structured code review: risk-selected reviewer personas, confidence-gated findings, one merged report.
 
-`ce-code-review` is the on-demand **findings** skill for a diff. It analyzes a PR, a named branch, or the current checkout, selects reviewer personas for what was actually touched, dispatches them, then merges and deduplicates their findings into one report. Each finding carries a severity (P0-P3), an autofix class (`gated_auto`, `manual`, `advisory`) that signals follow-up shape, and an owner.
+`ce-code-review` produces findings on a diff. Point it at a PR, a named branch, or the current checkout. It picks reviewer personas that fit what actually changed, dispatches them in parallel, then merges and deduplicates their findings into one report. Each finding carries a severity (P0-P3), an autofix class (`gated_auto`, `manual`, `advisory`) that describes the follow-up shape, and an owner.
 
-Review is report-only by default. Local fixes require `apply:local` or an explicit request to apply this review's findings. `mode:agent` always reports and leaves mutation to the caller.
+Review is report-only by default. Local fixes need `apply:local` or an explicit request to apply this review's findings. `mode:agent` always reports and leaves mutation to the caller.
 
 What it enforces is yours to set. Write a rule in a `CODING_STANDARDS.md` file in your repository and the review checks against it from then on (see [Repo-owned review criteria](#repo-owned-review-criteria)).
 
 It is not a verdict on a document (`ce-pov`), not findings on a planning doc (`ce-doc-review`), and not an investigation of broken behavior (`ce-debug`).
 
-`ce-work` invokes it as the portable review path before shipping. `ce-optimize` and `ce-debug` also call it on the diffs they produce. You can invoke it directly any time you want a structured review.
+`ce-work` invokes it as the portable review path before shipping. `ce-optimize` and `ce-debug` also call it on the diffs they produce. You can invoke it directly any time.
 
 ---
 
@@ -27,8 +27,6 @@ It is not a verdict on a document (`ce-pov`), not findings on a planning doc (`c
 ---
 
 ## Example invocations
-
-Current branch, a PR without checkout, a named branch, a base ref, a plan, JSON for a caller, or an explicit local apply. "Quick" defers to the harness-native reviewer.
 
 ```text
 # Review the current branch. Base comes from origin/HEAD or PR metadata.
@@ -65,55 +63,36 @@ Current branch, a PR without checkout, a named branch, a base ref, a plan, JSON 
 /ce-code-review give this branch a quick review
 ```
 
-Do not combine `base:` with a PR or branch target. Do not combine `apply:local` with `mode:agent`. Conflicting mode or grouping flags stop with an error.
+Do not combine `base:` with a PR or branch target, or `apply:local` with `mode:agent`. Conflicting mode or grouping flags stop with an error.
 
 ---
 
-## The Problem
+## Why not a generalist review prompt
 
-Generalist code review prompts collapse in predictable ways:
+Generalist review prompts fail in predictable ways. They produce "consider adding tests" without naming what to test. They give security feedback on a doc-only change and performance feedback on a typo fix. Every finding reads as critical, and a speculative "could be a bug" looks identical to a verified defect. The findings land in chat with no record and no fix queue. And a reviewer that mutates a shared checkout while another agent runs tests produces undefined outcomes.
 
-- Surface-level findings ("consider adding tests") without naming what to test
-- Wrong findings for the diff: security feedback on a doc-only change, performance feedback on a typo fix
-- No severity calibration. Every finding is presented as critical
-- No confidence calibration. Speculative "could be a bug" looks identical to a verified defect
-- One pass at one model's reasoning
-- Findings end up in chat with no record and no fix queue
-- Mutating a shared checkout while another agent runs tests produces undefined outcomes
-
-## The Solution
-
-`ce-code-review` runs review as a pipeline with explicit gates:
-
-- Diff-aware persona selection. Correctness always runs. Every other reviewer is gated by the surface actually touched
-- Parallel persona dispatch, bounded to the harness's active-subagent limit
-- Confidence-gated synthesis. Findings merge, dedupe, promote on cross-persona agreement, and route by autofix class
-- Severity (P0-P3) and autofix class are orthogonal: urgency vs follow-up shape
-- Separate presentation and authority. Default markdown and `mode:agent` JSON are report-only. `apply:local` grants local mutation
-- Quick-review short-circuit. A "quick", "fast", or "light" request defers to the harness-native `/review`
+`ce-code-review` runs review as a pipeline with explicit gates. Persona selection follows the diff: correctness always runs, every other reviewer is gated by the surface actually touched. Personas dispatch in parallel, bounded to the harness's active-subagent limit. Synthesis merges, dedupes, promotes confidence on cross-persona agreement, and routes by autofix class. Severity and autofix class stay orthogonal (urgency vs follow-up shape). Presentation and authority stay separate: the markdown report and `mode:agent` JSON are report-only; `apply:local` grants local mutation. A "quick", "fast", or "light" request skips all of this and defers to the harness-native `/review`.
 
 ---
 
-## What Makes It Novel
+## Diff-aware persona selection
 
-### Diff-aware persona selection
-
-A small low-risk change runs correctness (and project-standards if applicable files exist). A Rails auth feature with migrations adds the relevant domain lenses. The skill decides which personas fit the diff:
+A small low-risk change runs correctness (and project-standards if applicable files exist). A Rails auth feature with migrations adds the relevant domain lenses. The roster:
 
 - **Always-on:** `correctness-reviewer`
 - **Standards:** `project-standards-reviewer` only when at least one criteria file governs a changed file (see [Repo-owned review criteria](#repo-owned-review-criteria))
-- **Generic conditional:** testing for changed tests/harnesses or meaningful runtime behavior with no corresponding test work; maintainability for large or structural work; agent-native for agent-facing surfaces; learnings only when an existing `docs/solutions/` corpus has plausible matches
+- **Generic conditional:** testing for changed tests/harnesses or meaningful runtime behavior with no corresponding test work; maintainability for large or structural work; agent-native for agent-facing files; learnings only when an existing `docs/solutions/` corpus has plausible matches
 - **Cross-cutting conditional:** security, performance, API contract, data migrations, reliability, adversarial, previous-comments. Each selected only when the diff touches its concern
 - **Stack-specific:** Julik frontend races, Swift/iOS. Only when the matching runtime domain is touched
 - **CE conditional:** `deployment-verification-agent` for risky migration diffs. Schema drift and migration safety live on the `data-migration` persona
 
-Persona selection is agent judgment, not keyword matching. Instruction-prose files (Markdown skills, JSON schemas) are product code but skip runtime-focused reviewers. The exception is a **silent-pass verification mechanism** (a CI/CD gate, build/deploy step, coverage/lint gate, or test harness/mock that could mask production): even as a small config diff it gets the adversarial lens, because its risk is fidelity (going green while the real thing is red), not blast radius.
+Selection is agent judgment, not keyword matching. Instruction-prose files (Markdown skills, JSON schemas) are product code but skip runtime-focused reviewers. The exception is a silent-pass verification mechanism (a CI/CD gate, build/deploy step, coverage/lint gate, or test harness/mock that could mask production): even as a small config diff it gets the adversarial lens, because its risk is going green while the real thing is red, not blast radius.
 
 When you pass a PR number or URL, trivial automated PRs (lockfile bumps, chore version increments) are skipped. Draft PRs are reviewed normally.
 
 `depth:auto` (the default) collapses a 1-39-line, low-risk, code-only diff to a lite roster. `depth:full` disables that path so the full always-on roster runs regardless of size. Neither token invents irrelevant domains.
 
-### Repo-owned review criteria
+## Repo-owned review criteria
 
 Everything else the skill checks is what we ship. This is the part you own.
 
@@ -129,37 +108,35 @@ Put a `CODING_STANDARDS.md` in your repository, write the rules your team actual
 Four things worth knowing:
 
 - **Placement scopes it.** A file at the repo root governs the whole checkout. One at `skills/CODING_STANDARDS.md` governs only what is under `skills/`. Several can apply to the same file at once.
-- **Any format works.** Prose, bullets, tables, nested headings, with or without frontmatter. The content is the contract; there is no schema to satisfy and no identifiers to assign. A paragraph of plain English is a valid rules file.
+- **Any format works.** Prose, bullets, tables, nested headings, with or without frontmatter. The content is the contract. A paragraph of plain English is a valid rules file.
 - **It replaces the instruction file as criteria, per changed file.** `CLAUDE.md` and `AGENTS.md` remain the criteria for any changed file that no `CODING_STANDARDS.md` governs, so a repo that has never written one keeps the review it already had. No file is ever graded against both kinds, and the report names the fallback in Coverage when it supplies the criteria.
 - **It can grow.** An instruction file is loaded into every agent's context on every turn, so it stays short and rules get cut for space. A criteria file is read once, by one reviewer, at review time. That is the reason to keep enforceable rules here rather than in `AGENTS.md`: this file has room, and adding to it costs nothing until review runs.
 
 That last point is what makes review strictness compound. Notice a mistake worth preventing, write the rule down, and every review after that catches it.
 
----
+## Cross-model adversarial pass
 
-### Cross-model adversarial pass
-
-When adversarial is selected and the working tree is the reviewed head (current branch, or a PR whose local tree already matches the PR head), the adversarial lens runs through **one different model provider than the host** in a separate read-only process. A started peer **replaces** the in-process `adversarial` persona. They never both receive the same brief. The in-process persona runs if the peer cannot start, or if the started peer returns only session-quota or auth-context failure — in that case the next announced different-family peer is tried when one is eligible, otherwise the local persona covers the lens. An exact provider-overload 529 gets one same-route retry; repeated overload, another stubborn transient rate limit, or max-turn exhaustion falls back locally without an unbounded retry loop. Remote PR or branch diffs stay on the in-process persona, because that reviewer can inspect the fetched refs.
+When adversarial is selected and the working tree is the reviewed head (current branch, or a PR whose local tree already matches the PR head), the adversarial lens runs through one model provider different from the host, in a separate read-only process. A started peer replaces the in-process `adversarial` persona; they never both receive the same brief. The in-process persona runs if the peer cannot start, or if the started peer returns only session-quota or auth-context failure. In that case the next announced different-family peer is tried when one is eligible, otherwise the local persona covers the lens. An exact provider-overload 529 gets one same-route retry; repeated overload, another stubborn transient rate limit, or max-turn exhaustion falls back locally without an unbounded retry loop. Remote PR or branch diffs stay on the in-process persona, because that reviewer can inspect the fetched refs.
 
 Agreement between the peer and another in-process reviewer is a strong promotion signal in synthesis.
 
-`cross_model_review_mode: off` in CE config keeps this pass from running at all — no peer is resolved and nothing leaves the host; the in-process reviewers cover the lens and Coverage says the pass was disabled by checkout config. A direct request in conversation for a peer overrides it for one run. Which target runs the peer is auto-chosen and overridable: conversation, `cross_model_peer:` in CE config, active project instructions, then `codex → claude → grok → composer`. `Cursor` means `cursor-agent` using its configured default/Auto model. `Composer` means a Composer model through Cursor. `Grok` binds the native grok CLI when it is installed; Grok through Cursor is a different route, used when asked or when the grok CLI is missing and Cursor is allowed. Cursor Auto does not count as independent agreement unless its serving family is verified different from the host. `cross_model_model:` and `cross_model_effort:` in CE config pin that target's model (e.g. `fable` for claude or `gpt-5.6-sol` for codex, or a namespace-qualified codex id such as `openai.gpt-5.6-sol` when that CLI routes through a non-default `model_provider`) and reasoning effort; a value the peer cannot honor skips the pass with a stated reason rather than substituting. See the [configuration reference](./configuration.md).
+`cross_model_review_mode: off` in CE config keeps this pass from running at all. No peer is resolved and nothing leaves the host; the in-process reviewers cover the lens and Coverage says the pass was disabled by checkout config. A direct request in conversation for a peer overrides it for one run. The peer target is auto-chosen and overridable, in priority order: conversation, `cross_model_peer:` in CE config, active project instructions, then `codex → claude → grok → composer`. `Cursor` means `cursor-agent` using its configured default/Auto model. `Composer` means a Composer model through Cursor. `Grok` binds the native grok CLI when it is installed; Grok through Cursor is a different route, used when asked or when the grok CLI is missing and Cursor is allowed. Cursor Auto does not count as independent agreement unless its serving family is verified different from the host. `cross_model_model:` and `cross_model_effort:` in CE config pin that target's model (e.g. `fable` for claude or `gpt-5.6-sol` for codex, or a namespace-qualified codex id such as `openai.gpt-5.6-sol` when that CLI routes through a non-default `model_provider`) and reasoning effort; a value the peer cannot honor skips the pass with a stated reason rather than substituting. See the [configuration reference](./configuration.md).
 
-**Prerequisite: a peer agent CLI.** The pass drives a read-only *agent* CLI (`codex`, `claude`, `grok`, `cursor-agent`, or `opencode`) so the peer can inspect the tree itself; a bare `OPENAI_API_KEY`, Anthropic key, or Gemini key does not enable it. Peers are discovered on `PATH`, plus the CLI bundled inside the Codex desktop app (`ChatGPT.app/Contents/Resources/codex` since the July 2026 app merger, or `Codex.app/…` on older installs; the app does not link it onto `PATH`). Gemini has no standalone peer target — it participates only through Cursor when `cursor-agent` attests a Gemini serving family. With no peer CLI installed the skill runs the in-process adversarial reviewer and reports "cross-model pass: not run"; the skip reason names what to install.
+The prerequisite is a peer agent CLI. The pass drives a read-only agent CLI (`codex`, `claude`, `grok`, `cursor-agent`, or `opencode`) so the peer can inspect the tree itself; a bare `OPENAI_API_KEY`, Anthropic key, or Gemini key does not enable it. Peers are discovered on `PATH`, plus the CLI bundled inside the Codex desktop app (`ChatGPT.app/Contents/Resources/codex` since the July 2026 app merger, or `Codex.app/…` on older installs; the app does not link it onto `PATH`). Gemini has no standalone peer target; it participates only through Cursor when `cursor-agent` attests a Gemini serving family. With no peer CLI installed the skill runs the in-process adversarial reviewer and reports "cross-model pass: not run"; the skip reason names what to install.
 
-This shares the provider/route kernel with `ce-doc-review` but keeps a narrower product scope: adversarial-only, diff/work-tree delivery, not doc-review's judgment trio or whole-doc sweep.
+This shares the provider/route kernel with `ce-doc-review` but keeps a narrower scope: adversarial-only, diff/work-tree delivery, not doc-review's judgment trio or whole-doc sweep.
 
-### Severity and autofix class are orthogonal
+## Severity and autofix class are orthogonal
 
-Severity answers **urgency** (P0 = critical breakage, P3 = user discretion). Autofix class is **signal** about follow-up shape, not apply permission:
+Severity answers urgency (P0 = critical breakage, P3 = user discretion). Autofix class describes follow-up shape, not apply permission:
 
-- `gated_auto` → a concrete `suggested_fix` exists. A clear candidate to apply
-- `manual` → actionable work that needs design input or a handoff
-- `advisory` → report-only (learnings, rollout notes, residual risk)
+- `gated_auto`: a concrete `suggested_fix` exists. A clear candidate to apply
+- `manual`: actionable work that needs design input or a handoff
+- `advisory`: report-only (learnings, rollout notes, residual risk)
 
 Synthesis owns the final route. Persona-provided routing metadata is input. Disagreements default to the more conservative route. Whether a finding actually gets applied is a judgment call after apply authority exists.
 
-### Presentation and apply authority are separate
+## Presentation and apply authority are separate
 
 | Mode | When | Behavior |
 |------|------|----------|
@@ -167,13 +144,13 @@ Synthesis owns the final route. Persona-provided routing metadata is input. Disa
 | **`mode:agent`** | `mode:agent` (alias `mode:headless`) | One JSON object. Report-only. The caller applies findings. `mode:non-interactive` is not this alias (fail closed if passed) |
 | **Explicit local apply** | `apply:local`, or an explicit ask to apply/fix this review's findings | Keeps markdown presentation. May apply verified fixes and commit them when the pre-review tree was clean. Never pushes |
 
-The skill never switches branches. A PR or branch argument selects review *scope* (diffed without checkout), not permission to mutate. Explicit local apply edits the current checkout in place. To review the current checkout against another ref, pass `base:<ref>`.
+The skill never switches branches. A PR or branch argument selects review scope (diffed without checkout), not permission to mutate. Explicit local apply edits the current checkout in place. To review the current checkout against another ref, pass `base:<ref>`.
 
-### Quick-review short-circuit
+## Quick-review short-circuit
 
 When you ask for a "quick", "fast", or "light" review, the skill defers to the harness-native code review (for example `/review` in Claude Code) instead of dispatching the multi-agent pipeline. `mode:agent` bypasses the short-circuit and always runs the full pipeline.
 
-### Synthesis, grouping, and plan checks
+## Synthesis, grouping, and plan checks
 
 After reviewers return, synthesis validates each finding, anchors it to the actual diff, deduplicates across personas, promotes confidence on agreement, resolves contradictions, and routes by autofix class. The output is one report with calibrated severity, evidence quotes, and explicit ownership.
 
@@ -189,7 +166,7 @@ Callers such as `/ce-work` read the Actionable Findings summary (or the JSON `ac
 
 ---
 
-## Quick Example
+## Quick example
 
 You invoke `/ce-code-review` on a feature branch with a Rails auth change that includes a database migration.
 
@@ -203,7 +180,7 @@ You can then apply selected findings yourself, hand the JSON report to `/ce-work
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Use `ce-code-review` when:
 
@@ -213,9 +190,9 @@ Use `ce-code-review` when:
 - You explicitly want a deeper, multi-persona pass ("review this thoroughly", or `depth:full`)
 - Another skill is calling it (`/ce-work` before shipping, `/ce-optimize` on the cumulative optimization diff, `/ce-debug` after a non-trivial fix)
 
-Skip `ce-code-review` when:
+Skip it when:
 
-- You want a quick light review. Ask for "quick review" and the short-circuit defers to the harness-native `/review`
+- You want a light review. Ask for "quick review" and the short-circuit defers to the harness-native `/review`
 - The change is a typo, formatting, or a small dependency bump. The lite roster is enough
 - You want findings on a planning document → `/ce-doc-review`
 - You want a holistic take on a plan, not a diff review → `/ce-pov`
@@ -223,7 +200,7 @@ Skip `ce-code-review` when:
 
 ---
 
-## Use as Part of the Workflow
+## Use as part of the workflow
 
 `ce-code-review` is the portable review path other skills call:
 
@@ -231,9 +208,7 @@ Skip `ce-code-review` when:
 - **`/ce-optimize`** runs it against the cumulative optimization-branch diff before merging
 - **`/ce-debug`** runs it on a non-trivial fix, scoped so it does not wander into unrelated branch work
 
----
-
-## Use Standalone
+## Use standalone
 
 - **Current branch (report-only):** `/ce-code-review`
 - **Current branch and apply verified findings:** `/ce-code-review apply:local`
@@ -273,13 +248,13 @@ Use it when it is the right tool. The quick-review short-circuit defers to it ex
 Agent judgment over the actual diff, not keyword matching. Correctness runs for every multi-agent review. Project-standards runs when a criteria file governs at least one changed file. Generic, cross-cutting, and stack-specific personas are added only when their concern is present. Production-file presence alone and non-behavioral edits do not select testing. A silent-pass verification mechanism gets adversarial (and the cross-model pass, when the tree is local) regardless of size.
 
 **What's the difference between default, `mode:agent`, and `apply:local`?**
-Default is a human-facing markdown report and is report-only. `mode:agent` is the same pipeline serialized as one JSON object for a caller. It is always report-only. `apply:local` is separate authority for the markdown run to apply verified findings locally. `mode:headless` is a deprecated alias for `mode:agent`. `mode:non-interactive` means "suppress prompts" in other CE skills and is not valid here.
+Default is a human-facing markdown report and is report-only. `mode:agent` is the same pipeline serialized as one JSON object for a caller, always report-only. `apply:local` is separate authority for the markdown run to apply verified findings locally. `mode:headless` is a deprecated alias for `mode:agent`. `mode:non-interactive` means "suppress prompts" in other CE skills and is not valid here.
 
 **What's the difference between this and `ce-doc-review`'s cross-model pass?**
-Same independence system (host attestation, multi-provider selection, read-only peer CLI). Different lens policy: code-review runs **adversarial only**, and a started peer replaces the in-process adversarial persona. Doc-review runs a judgment trio plus a whole-doc sweep alongside the in-process reviewers. Code-review peers review the work tree/diff in place. Doc-review embeds the document into a more isolated scratch.
+Same independence system (host attestation, multi-provider selection, read-only peer CLI). Different lens policy: code-review runs adversarial only, and a started peer replaces the in-process adversarial persona. Doc-review runs a judgment trio plus a whole-doc sweep alongside the in-process reviewers. Code-review peers review the work tree/diff in place. Doc-review embeds the document into a more isolated scratch.
 
 **Why does it never switch the checkout?**
-The skill never runs `git checkout` or `git switch`. Passing a PR or branch selects review *scope*, not permission to mutate the tree. Explicit local apply may edit the current checkout, but it never switches branches. To review the current checkout against a different ref, pass `base:<ref>`.
+The skill never runs `git checkout` or `git switch`. Passing a PR or branch selects review scope, not permission to mutate the tree. Explicit local apply may edit the current checkout, but it never switches branches. To review the current checkout against a different ref, pass `base:<ref>`.
 
 **Can it run concurrently with browser tests?**
 Bare and `mode:agent` reviews are report-only and safe alongside concurrent tests. An explicitly authorized local-apply run may mutate the working tree, so avoid using it against a checkout another agent is actively using.
@@ -289,7 +264,7 @@ No. The skill is coupled to git, code reviewers, and PR contexts. For docs (requ
 
 ---
 
-## See Also
+## See also
 
 - [`ce-work`](./ce-work.md): primary upstream caller. Invokes this skill before shipping
 - [`ce-doc-review`](./ce-doc-review.md): sibling skill for documents, not code

--- a/docs/guides/ce-commit-push-pr.md
+++ b/docs/guides/ce-commit-push-pr.md
@@ -2,13 +2,11 @@
 
 > Commit, push, and open a PR. Or rewrite an existing PR description. Or print a description and leave git alone.
 
-`ce-commit-push-pr` is the **shipping** skill. It is a git-workflow tool, not a core-loop step. Use it when the code is already written and you want a PR, or when you only want the description.
+`ce-commit-push-pr` is the shipping skill. It is a git-workflow tool, not a core-loop step. Reach for it when the code is written and you want a PR, or when you only want the description.
 
-Three modes cover that range: full workflow, description update on an existing PR, and description-only generation. Descriptions cover the **full PR commit range**, not just the working-tree diff at invoke time. After a new PR (or new commits on an open one), the skill hands off to `/ce-babysit-pr` by default.
+It runs in one of three modes: the full ship, a description rewrite on an existing PR, or a printed description with no git side effects. Descriptions always cover the full PR commit range, not just whatever is uncommitted when you invoke it. After a new PR or new commits on an open one, it hands off to `/ce-babysit-pr` unless you opt out.
 
-It never runs `git add -A`. Distinct file groups can become separate commits. Related work references keep close-vs-link intent. PR bodies go through a temp file (`--body-file`), not a stdin pipe that can succeed with an empty body.
-
-`/ce-commit` is the local-only sibling: same commit pass, no push, no PR.
+`/ce-commit` is the local-only sibling. Same commit pass, no push, no PR.
 
 ---
 
@@ -19,13 +17,13 @@ It never runs `git add -A`. Distinct file groups can become separate commits. Re
 | What does it do? | Commits, pushes, and opens a PR; or rewrites an existing description; or prints a description without touching git |
 | When to use it | You want a PR, a refreshed description, or a draft body for a branch |
 | What it produces | An open PR URL, an updated description, or a printed body |
-| What's next | Hands off to [`/ce-babysit-pr`](./ce-babysit-pr.md) by default (`babysit:off` or `auto_babysit: false` to skip). You merge when babysit reports ready. A clear **stack** request submits via `gh stack` and babysits the bottom open non-draft PR with `posture:stack-ready` (or `stack-land` when land intent is explicit). |
+| What's next | Hands off to [`/ce-babysit-pr`](./ce-babysit-pr.md) by default (`babysit:off` or `auto_babysit: false` to skip). You merge when babysit reports ready. A clear stack request submits via `gh stack` and babysits the bottom open non-draft PR. |
 
 ---
 
 ## Example invocations
 
-Empty invoke is the full ship. Phrasing picks description-only vs rewrite. A PR URL or number alone is description-only. Stack language is opt-in.
+An empty invoke is the full ship. Your phrasing picks description-only vs rewrite. A PR URL or number alone is description-only. Stacks are opt-in.
 
 ```text
 # Commit, push, open a PR, then start /ce-babysit-pr
@@ -63,8 +61,8 @@ Empty invoke is the full ship. Phrasing picks description-only vs rewrite. A PR 
 
 - A one-line fix and a large refactor get the same Summary / Test Plan / Notes template
 - `git add -A` picks up `.env` files, build artifacts, and generated files
-- The description only covers the working-tree diff, and misses commits already on the branch
-- Issue and tracker references get dropped, or a magic word closes work the PR does not resolve
+- The description only covers the working-tree diff and misses commits already on the branch
+- Issue references get dropped, or a magic word closes work the PR does not resolve
 - `--body` via stdin can return a URL while the body is empty (`gh` still exits 0)
 - The commit lands on the default branch, on detached HEAD, or against a stale base
 
@@ -72,31 +70,23 @@ Empty invoke is the full ship. Phrasing picks description-only vs rewrite. A PR 
 
 The skill picks a mode, then runs only that path:
 
-- **Full workflow** (default): commit pending work, push, and open a PR (or push onto the one that already exists)
-- **Description update**: rewrite an existing PR body without a commit or push
-- **Description-only**: print a body. Apply only if you ask.
+- Full workflow (default): commit pending work, push, and open a PR, or push onto the one that already exists
+- Description update: rewrite an existing PR body without a commit or push
+- Description-only: print a body. Apply only if you ask.
 
-On the full path it stages named files, splits distinct concerns at file level (2-3 max), and routes detached HEAD / default-branch / missing-upstream cases before it pushes. Every body is written to a temp file and passed with `--body-file <path>`. Descriptions read the full PR range. Related-work preflight classifies each tracker ID as closing, non-closing, or uncertain.
+On the full path it stages named files, splits distinct concerns at file level (2-3 commits max), and routes detached HEAD, default-branch, and missing-upstream cases before it pushes. Every body goes through a temp file and `--body-file <path>`. Descriptions read the full PR range. A related-work preflight classifies each tracker ID as closing, non-closing, or uncertain. If it guesses the wrong mode, say so in the next prompt (`just write the description, don't apply it`).
 
 ---
 
-## What Makes It Novel
+## How it behaves
 
-### Three modes, not one forced ship
+### Descriptions sized to the change
 
-- **Full workflow** for "ship this" / "create a PR" / "commit push PR"
-- **Description update** for "refresh" / "rewrite" / "update the PR description"
-- **Description-only** for "draft a PR description", "describe this PR", or a PR URL/number alone
-
-If the detected mode is wrong, say so in the next prompt (`just write the description, don't apply it`).
-
-### Descriptions sized to the change, over the full range
-
-There is no fixed template. A typo can be one or two sentences. A large refactor gets motivation, decisions, a test plan, evidence, and risks. The composition pass reads every commit in the PR, not just the uncommitted diff.
+There is no fixed template. A typo fix can be one or two sentences. A large refactor gets motivation, decisions, a test plan, evidence, and risks. The composition pass reads every commit in the PR, not just the uncommitted diff. A project PR template still sets the structural floor.
 
 ### Named-file commits, then a branch decision tree
 
-Same commit rules as `/ce-commit`: no `git add -A`, file-level splits only, convention from context then history then conventional commits (`fix:` when `fix:` and `feat:` both fit). A known plan unit ID is appended to the subject in parentheses (`(U3)` for unit 3) when it is already in hand for that commit.
+Same commit rules as `/ce-commit`: never `git add -A`, splits at file level only, convention from context, then recent history, then conventional commits (`fix:` wins when `fix:` and `feat:` both fit). A plan unit ID already in hand gets appended to the subject in parentheses (`(U3)` for unit 3).
 
 Branch routing is explicit:
 
@@ -107,25 +97,25 @@ Branch routing is explicit:
 - Feature branch, all pushed, no open PR -> skip commit/push, open the PR
 - Feature branch, all pushed, open PR -> report up to date, then ask about a rewrite
 
-### Body-file, related refs, and an existing-PR preview
+### Body files, related refs, and the rewrite preview
 
-Bodies go through a quoted heredoc into a temp file. The skill does not use `--body-file -`, stdin pipes, or `--body "$(cat ...)"`.
+Bodies go through a quoted heredoc into a temp file. The skill does not use `--body-file -`, stdin pipes, or `--body "$(cat ...)"`, because those can hand `gh` an empty body that still returns a URL.
 
-Before composing, it scans the prompt, branch name, full commit messages, existing body, PR template, plan notes, and visible IDs. GitHub Issues get `Fixes #123` only when the PR targets the default branch and truly resolves the issue. Linear uses `Fixes ENG-123` or `Related to ENG-123` in the description, not a comment. Unknown trackers get a neutral link.
+Before composing, it scans the prompt, branch name, full commit messages, existing body, PR template, plan notes, and visible IDs. A GitHub issue gets `Fixes #123` only when the PR targets the default branch and actually resolves the issue. Linear gets `Fixes ENG-123` or `Related to ENG-123` in the description, not a comment. An unknown tracker gets a neutral link.
 
 A rewrite previews the new title, the first two sentences of the Summary, and the body line count, then asks before `gh pr edit`. Decline and you can send focus text for another draft.
 
 ### Concept teaching, branding, and the babysit handoff
 
-When the change introduces a concept that is new to this repo (checked against the **base** ref, not the working tree), the body can gain a `## New concepts` section. Most PRs should not have one. Turn it off with `pr_teaching_section: false`. `pr_teaching_archive: true` (or `archive:on`) writes the explainer under the CE artifact root and links it.
+When the change introduces a concept new to this repo (checked against the base ref, not the working tree), the body can gain a `## New concepts` section. Most PRs should not have one. Turn it off with `pr_teaching_section: false`. `pr_teaching_archive: true` (or `archive:on`) writes the explainer under the CE artifact root and links it.
 
-New PRs get the Compound Engineering badge only with `branding:on` or an explicit ask. Existing rewrites keep whatever branding is already there.
+New PRs get the Compound Engineering badge only with `branding:on` or an explicit ask. Rewrites keep whatever branding is already there.
 
-After a newly created PR, a successful stack submit, or new commits on an open PR, the run is not done until `/ce-babysit-pr` starts. Pass `babysit:off` to skip. `babysit:continuous` / `babysit:checkpoint` force that babysit mode. `auto_babysit: false` in CE config (`config.local.yaml` then `config.yaml`) is the standing opt-out. Description-only, description-update, `mode:pipeline` (except after a stack submit), non-GitHub remotes, a draft this run created, and a head you cannot push all skip the handoff. Fork PRs are fine when you can push the head.
+After a newly created PR, a successful stack submit, or new commits on an open PR, the run is not done until `/ce-babysit-pr` starts. `babysit:off` skips it; `babysit:continuous` and `babysit:checkpoint` force that mode. `auto_babysit: false` in CE config (`config.local.yaml` then `config.yaml`) is the standing opt-out. Description-only, description-update, `mode:pipeline` (except after a stack submit), non-GitHub remotes, a draft this run created, and a head you cannot push all skip the handoff. Fork PRs are fine when you can push the head.
 
 ### Opt-in stacks
 
-Stacks are never the default and are never suggested for a one-line fix. An explicit request is required intent: it is not rewritten as a single PR with a custom `--base`. The skill probes for `gh stack`. A named parent PR is classified by number. It reuses a confirmed topology, or (for completed work) builds the smallest useful linear layers, then submits with `gh stack submit --auto --open` and babysits the **bottom open non-draft** PR. Default posture is `stack-ready`. `stack-land` only when you asked to land or merge when green. Ambiguous review boundaries ask first. `mode:pipeline` returns the proposed topology as a residual instead of guessing.
+Stacks are never the default and never get suggested for a one-line fix. An explicit request is required intent, so it is not rewritten as a single PR with a custom `--base`. The skill probes for `gh stack`, classifies a named parent PR by number, reuses a confirmed topology, or (for completed work) builds the smallest useful linear layers, then submits with `gh stack submit --auto --open` and babysits the bottom open non-draft PR. Default posture is `stack-ready`; `stack-land` only when you asked to land or merge when green. Ambiguous review boundaries ask first. `mode:pipeline` returns the proposed topology as a residual instead of guessing.
 
 ---
 
@@ -146,7 +136,7 @@ Use `ce-commit-push-pr` when:
 - The code is written and you want commits plus a PR
 - An existing PR description is stale and you want it rewritten
 - You want a printed description without committing or pushing
-- You explicitly want a **PR stack** and `gh stack` is available
+- You explicitly want a PR stack and `gh stack` is available
 
 Skip it when:
 
@@ -168,18 +158,7 @@ On-demand shipping. Not a required ideation-chain stage.
 /ce-commit ->  /ce-commit-push-pr     (if you committed first, then decide to ship)
 ```
 
-`/lfg` and `/ce-work` call this with `branding:on` when they own the ship — unless the project's instructions name their own shipping process, which then runs instead. You can also invoke it on a branch you already finished by hand.
-
----
-
-## Use Standalone
-
-- **Full ship** from a feature branch: `/ce-commit-push-pr`
-- **Skip babysit**: `/ce-commit-push-pr babysit:off`
-- **Refresh a description**: `/ce-commit-push-pr update the PR description`
-- **Print only**: `/ce-commit-push-pr draft a PR description for this branch`
-- **Another PR's range**: `/ce-commit-push-pr <PR URL>`
-- **Stack**: `/ce-commit-push-pr stack this on top of PR #123`
+`/lfg` and `/ce-work` call this with `branding:on` when they own the ship, unless the project's instructions name their own shipping process, which then runs instead. You can also invoke it on a branch you already finished by hand.
 
 ---
 
@@ -197,7 +176,7 @@ On-demand shipping. Not a required ideation-chain stage.
 | `babysit:continuous` / `babysit:checkpoint` | Force that babysit mode (also watches a draft this run created) |
 | `mode:pipeline` | Non-interactive. Existing-PR rewrite defaults to no, except in description-update mode, which applies. |
 | `archive:on\|off` | Per-run override of `pr_teaching_archive` |
-| `branding:on\|off` | Add or omit generic Compound Engineering branding on a **new** PR. Omission defaults off. Rewrites keep current branding. |
+| `branding:on\|off` | Add or omit Compound Engineering branding on a new PR. Off unless asked. Rewrites keep current branding. |
 
 See the [configuration reference](./configuration.md) for `pr_teaching_section`, `pr_teaching_archive`, and `auto_babysit`.
 
@@ -206,19 +185,19 @@ See the [configuration reference](./configuration.md) for `pr_teaching_section`,
 ## FAQ
 
 **Why not a fixed PR template?**
-A one-line fix does not need a test-plan heading. A large refactor does. Adaptive composition matches the description to the change. A project PR template still sets the structural floor.
+A one-line fix does not need a test-plan heading. A large refactor does. The description matches the change; a project PR template still sets the structural floor.
 
 **Why `--body-file` instead of `--body`?**
 Stdin wrappers can produce an empty body while `gh` exits 0 and returns a URL. A quoted temp file keeps `$VAR`, backticks, and literal `EOF` from expanding.
 
 **Description-only vs description update?**
-Description-only prints and stops (no `gh pr edit`, no commit, no push). Description update finds the open PR, previews, asks, then applies with `gh pr edit`. A URL or number **alone** is description-only.
+Description-only prints and stops. No `gh pr edit`, no commit, no push. Description update finds the open PR, previews, asks, then applies with `gh pr edit`. A URL or number alone is description-only.
 
 **Does it follow a non-conventional commit style?**
 Yes. Project conventions in context, then recent history, then conventional commits. Ambiguous `fix:` vs `feat:` defaults to `fix:`.
 
 **Does it skip hooks or signing?**
-The commit command does not pass `--no-verify` or `--no-gpg-sign`. Your git config and hooks run as usual.
+No. The commit command does not pass `--no-verify` or `--no-gpg-sign`. Your git config and hooks run as usual.
 
 **Can I open a draft PR?**
 Not as a flag on the full workflow. Use description-only, then `gh pr create --draft --title "..." --body-file "..."`. Stack submit uses `--auto --open` so layers are ready for babysit, not drafts.

--- a/docs/guides/ce-commit.md
+++ b/docs/guides/ce-commit.md
@@ -2,7 +2,7 @@
 
 > Make local git commit(s) from the working tree. No push, no PR.
 
-`ce-commit` is a **git-workflow** skill, not a core-loop step. Use it when you want changes saved on the current branch and nothing else. It reads the repo's commit convention, stages named files only, and splits into separate commits when the files fall into distinct concerns.
+`ce-commit` is a **git-workflow** skill, not a core-loop step. Use it when you want changes saved on the current branch and nothing else. It reads the repo's commit convention, stages files by name, and splits into separate commits when the files fall into distinct concerns.
 
 It is the local-only sibling of `/ce-commit-push-pr`. That skill ships a PR. This one stops after the commit.
 
@@ -21,7 +21,7 @@ It is the local-only sibling of `/ce-commit-push-pr`. That skill ships a PR. Thi
 
 ## Example invocations
 
-Most prompts are a hint for the subject or the file grouping. There is no mode flag. An empty invoke is the common case.
+The prompt, if any, is a hint for the subject or the file grouping. There is no mode flag. An empty invoke is the common case.
 
 ```text
 # Current work, local only. On main or detached HEAD, create a feature branch first.
@@ -53,37 +53,13 @@ A rushed commit often does one of these:
 
 `ce-commit` treats commit creation as a short, fixed pass:
 
-- Convention comes from project instructions already in context, then the last 10 commits, then conventional commits
-- Files are staged by name. Never `git add -A` or `git add .`
-- Distinct concerns become separate commits at file level only (2-3 max, no `git add -p`). Ambiguous grouping stays one commit
-- Detached HEAD or the default branch gets a feature branch first, with no prompt
-- The subject is imperative and names what is now possible or fixed. A body is added only when the why is not obvious. When a plan unit ID is already in hand for that commit, that U-ID is appended in parentheses (`(U3)` for unit 3)
+- **Convention comes from the repo.** Project instructions already in context win, then a clear pattern in the last 10 commits (conventional commits, ticket prefixes, emoji prefixes), then conventional commits (`type(scope): description`) as the fallback. Under conventional commits, when `fix:` and `feat:` both fit it defaults to `fix:`. You can override.
+- **Files are staged by name.** An explicit `git add file1 file2 file3`, never `git add -A` or `git add .`. That keeps credentials, `dist/` output, and untracked notes out of the commit. An `exclude:<paths>` in the invocation keeps those files uncommitted and the report says so.
+- **Splits stay at the file boundary.** Two or three distinct concerns become separate commits (a data-layer change in one directory, a UI change in another). `git add -p` is out of scope. When the grouping is unclear, one commit is correct.
+- **Unsafe HEAD gets a branch.** On detached HEAD or the default branch, it creates a feature branch from the change content and continues there, without asking. It does not leave the only copy of the work somewhere it can be lost.
+- **The subject names the outcome.** Imperative, states what is now possible or fixed. A body appears only when the why is not obvious. When a plan unit ID is already in hand for the commit, it is appended in parentheses (`(U3)` for unit 3).
 
----
-
-## What Makes It Novel
-
-### Convention before the message
-
-The skill matches the repo rather than forcing a house style:
-
-1. Project conventions already in context
-2. A clear pattern in the last 10 commits (conventional commits, ticket prefixes, emoji prefixes)
-3. Conventional commits as fallback: `type(scope): description`
-
-When conventional commits are in use and both `fix:` and `feat:` fit, it defaults to `fix:` (a change that remedies broken or missing behavior, even if it adds code). You can override.
-
-### Named files only
-
-It stages an explicit list (`git add file1 file2 file3`). That keeps `.env` credentials, `dist/` / `.next/` output, generated files, and untracked notes out of the commit.
-
-### File-level splits only
-
-If the changed files group into two or three distinct concerns (a data-layer change in one directory, a UI change in another), it makes separate commits. Splits stay at the file boundary. `git add -p` is out of scope. When the grouping is unclear, one commit is correct.
-
-### Feature branch when HEAD is unsafe
-
-On detached HEAD, or on `main` / `master` / the resolved default, it creates a feature branch from the change content and continues there. It does not ask, and it does not leave the only copy of the work on detached HEAD or the default branch.
+The message goes to git via a file (`git commit -F`), so quotes, backticks, and multi-line bodies pass through literally with no shell quoting to get wrong.
 
 ---
 
@@ -121,7 +97,7 @@ Use `ce-commit` when:
 Skip it when:
 
 - You also want a push and a PR -> `/ce-commit-push-pr`
-- You need hunk-level splits -> `git add -p` yourself; this skill is file-level
+- You need hunk-level splits -> `git add -p` yourself, then invoke this skill; agent-driven interactive staging is easy to get wrong, so the skill stays at file level
 - There is nothing to commit. The skill reports that and stops.
 
 ---
@@ -147,27 +123,11 @@ Skip it when:
 |----------|--------|
 | _(empty)_ | Commit current changes on this branch. Creates a feature branch first if HEAD is detached or on the default. |
 | `<hint>` | Natural-language steer for the subject or which files to group, e.g. `commit the auth changes` |
+| `exclude:<paths>` | Leave those files uncommitted no matter what else changed |
 
 No mode flags. No push. No PR.
 
----
-
-## FAQ
-
-**Why not `git add -A`?**
-It sweeps in files you did not mean to commit. Staging by name keeps secrets and junk out.
-
-**Why no hunk-level splitting?**
-`git add -p` is interactive and easy to get wrong in an agent flow. Distinct concerns usually already sit in different files. If you need hunks, do that yourself, then invoke this skill.
-
-**What if the repo does not use conventional commits?**
-Project instructions win, then recent history. Conventional commits are only the fallback.
-
-**Why a feature branch on the default or on detached HEAD?**
-A default-branch commit fights PR workflow and branch protection. A detached HEAD commit is easy to lose. Creating a feature branch is the same safe default `/ce-commit-push-pr` uses.
-
-**What if I want the PR after all?**
-Run `/ce-commit-push-pr`. It will see the commits already made and continue from there.
+Wanting the PR after all is not a restart: run `/ce-commit-push-pr` and it continues from the commits already made.
 
 ---
 

--- a/docs/guides/ce-compound-refresh.md
+++ b/docs/guides/ce-compound-refresh.md
@@ -2,9 +2,9 @@
 
 > Maintain `docs/solutions/` over time: review existing learnings against the current codebase, then update, consolidate, replace, or delete the ones that drifted.
 
-`ce-compound-refresh` is the **maintenance** skill for the knowledge store. `ce-compound` captures a new learning. This skill keeps the existing set honest as code moves. It is not a step in `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work`. Those skills read `docs/solutions/` as grounding. This one is how that folder stays trustworthy.
+`ce-compound-refresh` is the **maintenance** skill for the knowledge store. `ce-compound` captures a new learning; this skill keeps the existing set honest as code moves. It is not a step in `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work`. Those skills read `docs/solutions/` as grounding. This one is how that folder stays worth reading.
 
-As the repo changes, paths move, recommended fixes become anti-patterns, and two docs on the same problem start to disagree. Without a periodic pass, the store misleads more than it helps.
+As a repo changes, paths move, recommended fixes become anti-patterns, and two docs on the same problem start to disagree. Without a periodic pass, the store misleads more than it helps.
 
 ```text
 /ce-compound                 /ce-compound-refresh
@@ -32,7 +32,7 @@ Capture a new learning       Review the existing set
 
 ## Example invocations
 
-A scope hint is a category directory, filename slug, module, or keyword. Empty is a broad sweep. `mode:non-interactive` applies unambiguous edits and reports the rest.
+A scope hint is a category directory, filename slug, module, or keyword. Prefer one: an unscoped run has to triage the whole store first.
 
 ```text
 # Review learnings for one module or topic
@@ -47,17 +47,20 @@ A scope hint is a category directory, filename slug, module, or keyword. Empty i
 # Pattern-doc topic
 /ce-compound-refresh critical-patterns
 
-# No hint: triage the whole store, then start at the highest-impact cluster. Interactive asks before going deep.
+# No hint: triage the whole store, then start at the highest-impact cluster.
+# Interactive asks before going deep.
 /ce-compound-refresh
 
-# Apply unambiguous maintenance without questions. Ambiguous docs are marked stale. On the default branch this opens a PR.
+# Apply unambiguous maintenance without questions. Ambiguous docs are marked
+# stale. On the default branch this opens a PR.
 /ce-compound-refresh authentication mode:non-interactive
 
-# Build a repo-wide CONCEPTS.md glossary. Interactive asks whether you meant a refresh instead.
+# Build a repo-wide CONCEPTS.md glossary. Interactive asks whether you meant
+# a refresh instead.
 /ce-compound-refresh create a CONCEPTS.md
 ```
 
-Prefer a topic, module, category, or filename. An unscoped run has to triage everything first.
+With no hint, the skill clusters the store and recommends a starting area. Interactive confirms that area; non-interactive processes every cluster in impact order. A hint that matches nothing asks you to clarify (interactive) or reports the miss and exits (non-interactive). An empty store tells you to run `ce-compound` first.
 
 ---
 
@@ -76,15 +79,15 @@ Future agents (and humans) then take advice that no longer applies. The store ma
 
 ## The Solution
 
-`ce-compound-refresh` is a structured review with five outcomes:
+A structured review with five outcomes per doc:
 
-- **Keep**: accurate and useful. No edit. No review breadcrumb.
+- **Keep**: accurate and useful. No edit, no review breadcrumb.
 - **Update**: the solution is still right; references drifted. Fix in place, including relocating a doc whose directory and frontmatter category clearly disagree.
 - **Consolidate**: two docs overlap. Merge unique content into the canonical one and delete the other. The inverse, **Split**, breaks one multi-problem doc into focused successors when the fragments have independent retrieval value.
 - **Replace**: the old guidance is now misleading. Write a successor, then delete the old file.
-- **Delete**: the code and the problem domain are gone, and inbound citations are absent or decorative. Git history is the archive. There is no `_archived/` destination.
+- **Delete**: the code and the problem domain are gone, and inbound citations are absent or decorative. Git history is the archive; there is no `_archived/` destination.
 
-It investigates each doc against the tree, then looks at the set (overlap, supersession, contradictions), then classifies, then executes. Interactive mode asks only on genuine judgment calls. Non-interactive applies the safe subset and marks the rest stale.
+The skill investigates each doc against the tree, then looks at the set (overlap, supersession, contradictions), then classifies and executes. Interactive mode asks only on genuine judgment calls. Non-interactive applies the safe subset and marks the rest stale.
 
 ---
 
@@ -92,29 +95,29 @@ It investigates each doc against the tree, then looks at the set (overlap, super
 
 ### Five outcomes, not "is this still right?"
 
-Each doc gets a specific action and an evidence bar. Age alone is not staleness. Typos and wording are not a reason to edit. When current-mechanics claims disagree with the code, the doc changes. Independently supported guidance is classified from its governing evidence instead: if the implementation stops satisfying it, preserve the guidance and report the conflict as a potential product regression. The skill never edits or adjudicates product code.
+Each doc gets a specific action and an evidence bar. Age alone is not staleness, and typos are not a reason to edit. When a doc's claims about current mechanics disagree with the code, the doc changes. Guidance with independent support is different: if the implementation stops satisfying it, the skill preserves the guidance and reports the conflict as a potential product regression. It never edits or adjudicates product code.
 
 ### Two modes
 
 **Interactive** (default) applies Keep, Update, and obvious Consolidate directly. It asks before a Replace, a Split, a Delete that fails the auto-delete gate, or a Consolidate whose canonical doc is not obvious.
 
-**Non-interactive** never pauses. It applies Keep, Update, Consolidate, gated auto-Delete, and Replace when the evidence is enough. Ambiguous cases get `status: stale`, `stale_reason`, and `stale_date` in frontmatter. Relocations auto-apply only under a four-condition gate; otherwise they are recommended. Splits are always recommend-only. The report splits into Applied (writes that succeeded) and Recommended (writes that failed, plus everything that never runs unattended).
+**Non-interactive** never pauses. It applies Keep, Update, Consolidate, gated auto-Delete, and Replace when the evidence is enough. Ambiguous cases get `status: stale`, `stale_reason`, and `stale_date` in frontmatter. Relocations auto-apply only under a four-condition gate; Splits are always recommend-only. The report separates Applied (writes that succeeded) from Recommended (writes that failed, plus everything that never runs unattended).
 
 ### Set-level problems
 
-After the per-doc pass, the skill looks for overlap, a newer doc that subsumes an older one, and contradictions between docs. Contradictions outrank individual drift. For a knowledge-track learning, it also compares any guidance file the learning names (a skill's `SKILL.md`, a runbook, a root instruction file) for a conflicting order or rule on the same procedure — only guidance the learning names, never a search — and reports a wrong guidance file rather than editing it. Category-shape notes (a directory that mixes unrelated themes, a near-empty category) are report-only. It never renames categories or invents new ones.
+After the per-doc pass, the skill looks for overlap, a newer doc that subsumes an older one, and contradictions between docs. Contradictions outrank individual drift. For a knowledge-track learning, it also compares any guidance file the learning names (a skill's `SKILL.md`, a runbook, a root instruction file) for a conflicting order or rule on the same procedure. Only guidance the learning names, never a search, and a wrong guidance file is reported, not edited. Category-shape notes (a directory that mixes unrelated themes, a near-empty category) are report-only. It never renames categories or invents new ones.
 
 ### Delete is conservative
 
-Auto-delete requires all three: the implementation that lived in this repo is gone (or a successor already states the same guidance); the problem domain is gone; inbound markdown citations are absent or decorative. A doc that never pointed at in-repo code never auto-deletes. A citation that the other doc depends on is a Replace or Keep signal, not a cleanup task.
+Auto-delete requires all three: the implementation that lived in this repo is gone (or a successor already states the same guidance); the problem domain is gone; inbound markdown citations are absent or decorative. A doc that never pointed at in-repo code never auto-deletes. A citation another doc depends on is a Replace or Keep signal, not a cleanup task.
 
 If the current approach cannot be documented from a file scan, the doc is marked stale rather than guessed into a replacement. The recommendation is `/ce-compound` the next time you work in that area.
 
 ### Vocabulary and findability
 
-After the doc actions, the skill reconciles domain terms with `CONCEPTS.md` at the repo root (creates it when enough terms qualify). That pass is silent in both modes.
+After the doc actions, the skill reconciles domain terms with `CONCEPTS.md` at the repo root (creating it when enough terms qualify). That pass is silent in both modes.
 
-Every run also checks whether the project's instruction files would lead an agent to `docs/solutions/`. Interactive mode proposes the smallest addition and asks before editing. Non-interactive only recommends it. The same check runs for `CONCEPTS.md` when that file exists.
+Every run also checks whether the project's instruction files would lead an agent to `docs/solutions/`. Interactive mode proposes the smallest addition and asks before editing; non-interactive only recommends it. The same check runs for `CONCEPTS.md` when that file exists.
 
 ---
 
@@ -126,11 +129,9 @@ The skill finds five learnings and two pattern docs that match via directory, fr
 
 Investigation: three still name files that moved (`auth_token.rb` → `session_token.rb`). One is fully superseded by a newer doc. One is still accurate. One pattern doc generalizes a rule the rename broke. Set analysis then shows two learnings covering the same auth-error problem; the newer one is broader.
 
-Classification: three Updates (rename the references), one Consolidate (merge the older error doc into the newer and delete the older), one Keep, one Replace (the pattern). The successor is written, then the old pattern file is deleted.
+Classification: three Updates (rename the references), one Consolidate (merge the older error doc into the newer and delete the older), one Keep, one Replace (the pattern doc gets a successor, then the old file is deleted).
 
-Interactive mode confirms the consolidation if the canonical choice is not obvious. Other actions apply directly. If you are on a feature branch, the recommended close is a separate commit of only the refresh files.
-
-The printed report lists every doc, the outcome, the evidence, and what was done.
+Interactive mode confirms the consolidation if the canonical choice is not obvious; other actions apply directly. On a feature branch, the recommended close is a separate commit of only the refresh files. The printed report lists every doc, the outcome, the evidence, and what was done.
 
 ---
 
@@ -144,11 +145,11 @@ Reach for `ce-compound-refresh` when:
 - You want a periodic hygiene pass (for example quarterly), preferably scoped
 - You want a repo-wide `CONCEPTS.md` seeded from the declared domain model
 
-Skip `ce-compound-refresh` when:
+Skip it when:
 
 - You have not seen any drift. Broad sweeps without evidence produce churn.
 - The docs are recent and that area of the codebase has not moved
-- You are mid debug or mid build. Capture first with `/ce-compound`. Refresh later.
+- You are mid debug or mid build. Capture first with `/ce-compound`; refresh later.
 
 ---
 
@@ -161,20 +162,6 @@ This skill is the maintenance counterpart to `/ce-compound`. It is not on the id
 - **Pre-release**: a pass so documented learnings match what is shipping
 
 `ce-compound` adds docs. `ce-compound-refresh` keeps the set lean. Without the second skill, the first eventually clutters.
-
----
-
-## Use Standalone
-
-- Specific file: `/ce-compound-refresh plugin-versioning-requirements`
-- Module or keyword: `/ce-compound-refresh payments`
-- Category: `/ce-compound-refresh performance-issues`
-- Pattern topic: `/ce-compound-refresh critical-patterns`
-- Non-interactive: `/ce-compound-refresh auth mode:non-interactive`
-- Repo-wide glossary: `/ce-compound-refresh create a CONCEPTS.md` (or `build the concept map`)
-- Broad sweep (rare): `/ce-compound-refresh`
-
-With no hint, the skill clusters the store and recommends a starting area before deep investigation. Interactive confirms that area. Non-interactive processes every cluster in impact order. A hint that matches nothing asks you to clarify (interactive) or reports the miss and exits (non-interactive). An empty store tells you to run `ce-compound` first.
 
 ---
 
@@ -201,7 +188,7 @@ On the default branch, non-interactive commits on a named branch and attempts a 
 Update fixes drift and keeps the recommended solution (renamed file, moved class, broken link, unambiguous misfile). Replace rewrites the guidance because the recommended approach changed. If you would rewrite the solution section, that is Replace.
 
 **What happens when code and guidance disagree?**
-Current-mechanics claims follow the code. Independently supported guidance follows its governing evidence; if the implementation no longer satisfies it, the skill preserves the guidance and reports a potential product regression without editing or adjudicating product code.
+Claims about current mechanics follow the code. Guidance with independent support follows its governing evidence; if the implementation no longer satisfies it, the skill preserves the guidance and reports a potential product regression without touching product code.
 
 **When should I use non-interactive mode?**
 Periodic or large-scope runs where stopping on every question is impractical. Ambiguous cases are marked stale, so the report is something a human can review.
@@ -216,7 +203,7 @@ Archive folders accumulate and pollute search. `git log --diff-filter=D -- docs/
 Only the safe subset. Unambiguous misfilings can move with inbound-link rewrites. One multi-problem doc can be split (always recommend-only when unattended). Catalog README rows update when a listed doc is removed or renamed. Renaming categories or inventing new ones is never automated.
 
 **Does it treat pattern docs differently?**
-Same five outcomes, different evidence. Keep means the supporting learnings still back the rule. Replace means the generalization is now wrong, and the successor is based on the refreshed learnings, not a new invention.
+Same five outcomes, different evidence. Keep means the supporting learnings still back the rule. Replace means the generalization is now wrong, and the successor is built from the refreshed learnings, not invented fresh.
 
 **What does a CONCEPTS.md run do?**
 It seeds the project's core domain nouns into a repo-root glossary. A normal refresh also accretes terms from the docs in scope and will create `CONCEPTS.md` if enough terms qualify. The explicit bootstrap is the only repo-wide seed.

--- a/docs/guides/ce-compound.md
+++ b/docs/guides/ce-compound.md
@@ -1,10 +1,10 @@
 # `ce-compound`
 
-> Document a recently solved problem so the next encounter takes minutes instead of hours. Knowledge compounds.
+> Document a recently solved problem so the next encounter takes minutes instead of hours.
 
-`ce-compound` is the **knowledge-capture** skill. After you solve a non-trivial problem, it writes a structured doc to `docs/solutions/` covering symptoms, root cause, what did not work, the working solution, and prevention. Future runs of `ce-plan` and `ce-ideate` consult this folder as institutional memory, so the same investigation does not have to happen twice.
+`ce-compound` is the knowledge-capture skill. After you solve a non-trivial problem, it writes a structured doc to `docs/solutions/` covering symptoms, root cause, what did not work, the working solution, and prevention. `ce-plan` and `ce-ideate` read that folder as institutional memory, so the same investigation does not happen twice.
 
-The compound-engineering ideation chain is `/ce-ideate` -> `/ce-brainstorm` -> `/ce-plan` -> `/ce-work`. `ce-compound` is the **closing loop**. Captured at the end of a debugging or build session, the doc feeds back upstream as grounding. The first time you solve "N+1 query in brief generation" takes 30 minutes of research. The second time, you find the doc and the fix takes 2 minutes.
+It closes the loop on the `/ce-ideate` -> `/ce-brainstorm` -> `/ce-plan` -> `/ce-work` chain. The first time you solve "N+1 query in brief generation" costs 30 minutes of research. The second time, someone finds the doc and the fix takes 2 minutes.
 
 It is optional. Skip it for typos, one-line fixes, and purely mechanical work.
 
@@ -42,43 +42,35 @@ An empty invoke captures the most recent verified fix from this conversation. A 
 /ce-compound mode:non-interactive depth:full the verified caching fix
 ```
 
-One learning per run. If the session produced several distinct learnings, invoke the skill once per learning. A standalone "bootstrap CONCEPTS.md" request is redirected to `ce-compound-refresh`. Use non-interactive mode only when the caller should own any follow-up decisions. Ordinary interactive capture can still ask before changing project guidance.
+One learning per run. If the session produced several distinct learnings, invoke the skill once per learning. A standalone "bootstrap CONCEPTS.md" request gets redirected to `ce-compound-refresh`. Use non-interactive mode only when the caller should own any follow-up decisions. Ordinary interactive capture can still ask before changing project guidance.
 
 ---
 
-## The Problem
+## The problem
 
-Most teams solve the same problem twice, sometimes with the same person, because the first solution lives in conversation, chat history, or a teammate's head. Common failure shapes:
+Most teams solve the same problem twice, sometimes with the same person, because the first solution lives in chat history or a teammate's head. The usual ways it goes wrong:
 
-- Solution lives in chat: Slack thread, Linear comment, agent transcript; gone in a week
-- Documented but undiscoverable: written to a wiki nobody searches, or `docs/solutions/` exists but agents do not know to check it
-- Rewritten when re-encountered: a slightly different doc gets created for the same problem, and now there are two that will drift
-- No anti-patterns captured: what did not work is the most expensive part of the investigation, and it is the first thing to disappear
-- Captured at session-end clutter, not session-end clarity: the doc gets written when context is already faded
+- The solution lives in a Slack thread, a Linear comment, or an agent transcript. Gone in a week.
+- It gets documented but nobody finds it. A wiki nobody searches, or a `docs/solutions/` folder agents do not know to check.
+- A slightly different doc gets created for the same problem, and now there are two that drift apart.
+- The anti-patterns disappear first. What did not work was the most expensive part of the investigation, and it never gets written down.
+- Capture waits until the end of the session, when the context has already faded.
 
-## The Solution
-
-`ce-compound` runs as a structured capture flow at the moment context is freshest:
-
-- Two modes: Full (parallel subagents for cross-referencing and duplicate detection) and Lightweight (single-pass, faster)
-- Bug track and knowledge track produce different section structures matched to the doc type
-- An overlap check decides whether to update an existing doc rather than create a duplicate
-- A discoverability check ensures the project's instruction file surfaces `docs/solutions/` so future agents find it (interactive Full asks consent before editing; non-interactive and lightweight report or tip only)
-- Specialized post-review can enhance the doc: performance, security, data-integrity, and read-only simplification checks review the drafted learning without mutating product code
+`ce-compound` runs the capture at the moment context is freshest. Two modes (Full runs parallel subagents for cross-referencing and duplicate detection; Lightweight is single-pass). An overlap check decides whether to update an existing doc rather than create a duplicate. A discoverability check makes sure the project's instruction file points future agents at `docs/solutions/`. Bug-track and knowledge-track docs get different section structures. Specialized post-review (performance, security, data integrity, read-only simplification) can look over the drafted learning without touching product code.
 
 ---
 
-## What Makes It Novel
+## How it works
 
 ### Two modes, agent-selected
 
-**Full mode** runs three research subagents in parallel (Context Analyzer, Solution Extractor, Related Docs Finder), plus an automatic session-history probe across Claude Code, Codex, Cursor, Pi, and oh-my-pi (omp). It cross-references existing docs, detects duplicates, and runs specialized reviews.
+Full mode runs three research subagents in parallel (Context Analyzer, Solution Extractor, Related Docs Finder), plus an automatic session-history probe across Claude Code, Codex, Cursor, Pi, and oh-my-pi (omp). It cross-references existing docs, detects duplicates, and runs specialized reviews.
 
-**Lightweight mode** writes the same solution-doc artifact type in a single pass, with no subagents or cross-referencing. It skips overlap detection, session-history research, and semantic grounding validation.
+Lightweight mode writes the same doc type in a single pass. No subagents, no overlap detection, no session-history research, no semantic grounding validation.
 
-**The skill picks the mode itself. It does not ask.** Full is the default. Lightweight is chosen only under real context pressure (session near its limit, or a trivial fix where cross-referencing adds nothing). Those are conditions the agent can observe and you cannot. The skill states which mode it ran, and why, on the first line of its output. If it guessed wrong, re-running is a cheap correction.
+The skill picks the mode itself and does not ask. Full is the default. Lightweight only fires under real context pressure: the session is near its limit, or the fix is trivial enough that cross-referencing adds nothing. Those are conditions the agent can observe and you cannot. The first line of its output says which mode ran and why. If it guessed wrong, re-run it.
 
-Automations can select the same tradeoff without a prompt: `mode:non-interactive depth:lightweight` runs the single-pass workflow; `mode:non-interactive depth:full` runs the complete workflow, including its automatic session-history probe. Bare `mode:non-interactive` (and the deprecated alias `mode:headless`) remains Full by default. Depth is non-interactive-only. A depth flag without non-interactive intent, an unknown value, or conflicting depth flags fails explicitly.
+Automations select the same tradeoff without a prompt. `mode:non-interactive depth:lightweight` runs the single-pass workflow; `mode:non-interactive depth:full` runs the complete workflow including the session-history probe. Bare `mode:non-interactive` (and the deprecated alias `mode:headless`) is Full by default. Depth is non-interactive-only. A depth flag without non-interactive intent, an unknown value, or conflicting depth flags fails explicitly.
 
 ### Bug track vs knowledge track
 
@@ -89,7 +81,7 @@ The skill classifies the work from `problem_type`:
 
 The track determines section order and frontmatter fields.
 
-`problem_type`, `severity`, and `resolution_type` are closed enums. `component` and `root_cause` are open vocabulary, and the category directories are a default layout: when `docs/solutions/` already holds learnings, the classifier samples their frontmatter and directory names and reuses what the corpus already uses for the area, falling back to the schema's suggested values and default mapping only for an empty corpus or an uncovered area. Repos with their own documentation vocabulary keep it, so their existing retrieval still finds the new doc.
+`problem_type`, `severity`, and `resolution_type` are closed enums. `component` and `root_cause` are open vocabulary, and the category directories are a default layout, not a mandate. When `docs/solutions/` already holds learnings, the classifier samples their frontmatter and directory names and reuses what the corpus already uses for the area. It falls back to the schema's suggested values only for an empty corpus or an uncovered area. Repos with their own documentation vocabulary keep it, so their existing retrieval still finds the new doc.
 
 ### Overlap, discoverability, and grounding
 
@@ -101,42 +93,42 @@ The Related Docs Finder scores overlap with existing `docs/solutions/` content a
 
 Every run also checks whether the project's instruction file (`AGENTS.md` or `CLAUDE.md`) would lead a future agent to discover `docs/solutions/`. If not, interactive Full proposes the smallest addition that surfaces the knowledge store, asks for consent, and applies it. Non-interactive reports `Instruction-file edit: gap noted, not applied` without editing. Lightweight tips only.
 
-Before the doc compounds, claims are checked against the tree. A deterministic script checks cited repo paths, commit SHAs, relative links, and dangling scaffold (flags are adjudicated, not auto-failed). Then a read-only validator subagent (Full mode, including non-interactive Full) verifies code-behavior claims by quoting the defining source line, and merge-state claims against remote truth. Lightweight keeps the deterministic check and skips the validator subagent.
+Before the doc compounds, its claims get checked against the tree. A deterministic script checks cited repo paths, commit SHAs, relative links, and dangling scaffold (flags are adjudicated, not auto-failed). Then a read-only validator subagent (Full mode, including non-interactive Full) verifies code-behavior claims by quoting the defining source line, and merge-state claims against remote truth. Lightweight keeps the deterministic check and skips the validator subagent.
 
 ### Session history, refresh, and auto-invoke
 
-Full mode always runs a cheap two-stage session-history probe. A discovery+metadata pass runs in parallel with the research subagents. Claude sessions are listed from `~/.claude/projects/` (or `CLAUDE_CONFIG_DIR/projects` when that env var is set) and kept when the recorded `cwd` is the repo root, a parent of it, or a path inside it — including sessions started from a parent directory. Codex sessions come from `~/.codex/sessions/` (or `CODEX_HOME/sessions` when set) plus `~/.agents/sessions/`. It escalates to extraction and synthesis only when a candidate session clears a relevance bar (current-branch match or at least two topic-keyword hits). On a hit, findings fold into "What Didn't Work" (bug track) or "Context" (knowledge track). Lightweight skips this entirely.
+Full mode always runs a cheap two-stage session-history probe. A discovery-and-metadata pass runs in parallel with the research subagents. It lists Claude sessions from `~/.claude/projects/` (or `CLAUDE_CONFIG_DIR/projects` when that env var is set) and keeps the ones whose recorded `cwd` is the repo root, a parent of it, or a path inside it, so sessions started from a parent directory count. Codex sessions come from `~/.codex/sessions/` (or `CODEX_HOME/sessions` when set) plus `~/.agents/sessions/`. It escalates to extraction and synthesis only when a candidate session clears a relevance bar: current-branch match or at least two topic-keyword hits. On a hit, findings fold into "What Didn't Work" (bug track) or "Context" (knowledge track). Lightweight skips all of this.
 
-After capturing the new learning, `ce-compound` checks whether it should invoke `/ce-compound-refresh` on a narrow scope hint. It does not default to running refresh. Only when the new learning suggests a specific older doc may now be stale.
+After capturing the new learning, `ce-compound` checks whether the learning suggests a specific older doc may now be stale. Only then does it recommend or invoke `/ce-compound-refresh`, with a narrow scope hint. It does not run refresh by default.
 
-Phrases like "that worked", "it's fixed", "working now", "problem solved" auto-invoke the skill so capture happens while context is fresh. You can also override with `/ce-compound [context]`.
+Phrases like "that worked", "it's fixed", "working now", "problem solved" auto-invoke the skill so capture happens while context is fresh. `/ce-compound [context]` overrides.
 
 ---
 
-## Quick Example
+## Quick example
 
 You've just spent 45 minutes debugging an N+1 query in the brief-generation flow. You confirm the fix works and say "that worked, ship it."
 
-`ce-compound` auto-invokes (or you call it explicitly). With plenty of context left, it picks Full mode and notes "Ran Full mode." at the top of its output. No prompt.
+`ce-compound` auto-invokes. With plenty of context left, it picks Full mode and notes "Ran Full mode." at the top of its output. No prompt.
 
 Three subagents dispatch in parallel. Context Analyzer classifies the work as `performance_issue` (bug track) and proposes the filename and category. Solution Extractor structures the fix with before/after code. Related Docs Finder reports moderate overlap with an older doc on a different N+1 case. Alongside them, the session-history probe scans recent sessions; none clear the relevance bar, so it records "no relevant prior sessions."
 
-The orchestrator assembles the doc, validates frontmatter, and writes `docs/solutions/performance-issues/n-plus-one-brief-generation.md`. Grounding validation then runs: the mechanical script confirms every cited path and SHA resolves, and the validator subagent quotes the defining source line behind the doc's claim about the ORM's default batching behavior. The discoverability check finds `AGENTS.md` does not mention `docs/solutions/`, proposes a one-line addition to the existing directory listing, and applies it after you confirm.
+The orchestrator assembles the doc, validates frontmatter, and writes `docs/solutions/performance-issues/n-plus-one-brief-generation.md`. Grounding validation runs next: the mechanical script confirms every cited path and SHA resolves, and the validator subagent quotes the source line behind the doc's claim about the ORM's default batching behavior. The discoverability check finds `AGENTS.md` does not mention `docs/solutions/`, proposes a one-line addition, and applies it after you confirm.
 
-Phase 3 dispatches the local `performance-oracle` prompt and, because the doc includes code examples, performs a read-only simplification check on the drafted examples. Phase 2.5 surfaces a refresh recommendation: the older N+1 doc may benefit from consolidation review. The skill suggests `/ce-compound-refresh n-plus-one` as a narrow scope hint and ends. There is no "What's next?" menu.
+Phase 3 dispatches the local `performance-oracle` prompt and, because the doc includes code examples, runs a read-only simplification check on them. The overlap finding surfaces as a refresh recommendation: the older N+1 doc may benefit from consolidation review, so the skill suggests `/ce-compound-refresh n-plus-one` and ends. There is no "What's next?" menu.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Reach for `ce-compound` when:
 
 - You just solved a non-trivial problem and the context is fresh
 - You say "that worked", "it's fixed", "working now", "problem solved"
 - You are at a natural pause and want to capture the learning before context fades
-- The problem took meaningful investigation (not a typo or one-line fix)
+- The problem took meaningful investigation, not a typo or one-line fix
 
-Skip `ce-compound` when:
+Skip it when:
 
 - The problem is in-progress or the solution is unverified
 - The fix is a trivial typo or obvious error with no generalizable insight
@@ -145,65 +137,46 @@ Skip `ce-compound` when:
 
 ---
 
-## Use as Part of the Workflow
+## Use as part of the workflow
 
-`ce-compound` is the closing loop of multiple workflows. Invoke it after any verified, non-trivial fix. Typical moments:
+`ce-compound` closes out multiple workflows. Invoke it after any verified, non-trivial fix:
 
 - After a successful debug and PR, when the bug is generalizable
 - After shipping, when the work yielded a reusable pattern, convention, or tooling decision
 - Stand-alone, after any non-trivial problem-solving session
 
-The output feeds back into upstream skills:
-
-- `/ce-plan` reads `docs/solutions/` during Phase 1 research
-- `/ce-ideate` reads it as part of grounding
-
-When the new learning suggests an older doc may now be stale, `ce-compound` recommends `/ce-compound-refresh` with a narrow scope hint.
+The output feeds back upstream: `/ce-plan` reads `docs/solutions/` during Phase 1 research, and `/ce-ideate` reads it as grounding. When the new learning suggests an older doc may now be stale, `ce-compound` recommends `/ce-compound-refresh` with a narrow scope hint.
 
 ---
 
-## Use Standalone
+## Make capture automatic
 
-The skill is its own complete cycle:
+The auto-invoke trigger phrases ("that worked", "it's fixed") only fire when you happen to say one of them. If you keep forgetting to capture, add a standing instruction to your agent's instruction file so the agent proposes capture on its own once a fix is verified.
 
-- Just-finished problem: `/ce-compound` (or auto-invoked from "that worked")
-- With context hint: `/ce-compound "the email digest race condition we fixed"`
-- Lightweight on a long session: when context is tight, the skill selects lightweight mode on its own and says so
-- Lower-overhead unattended capture: `/ce-compound mode:non-interactive depth:lightweight "the verified fix"`
-- Full unattended capture: `/ce-compound mode:non-interactive depth:full "the verified fix"` (plain `mode:non-interactive` is equivalent)
+Put it in the repo's `AGENTS.md`/`CLAUDE.md`, or in your global instruction file (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`) to make it apply in every repo. Pick the variant that matches how much of a checkpoint you want.
 
-The auto-invoke triggers happen mid-conversation. You do not need to remember the slash command if you have just confirmed something works.
-
----
-
-## Make Capture Automatic
-
-The auto-invoke trigger phrases ("that worked", "it's fixed") only fire when you happen to say one of them. If you keep forgetting to capture, add a standing instruction to your agent's instruction file so the agent proposes capture on its own once a fix is verified, before it hands the session back to you.
-
-Put it in the repo's `AGENTS.md`/`CLAUDE.md`, or in your global instruction file (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`) to make it apply in every repo. Pick the variant that matches how much of a checkpoint you want:
-
-**Offer first** (the agent asks before capturing):
+Offer first (the agent asks before capturing):
 
 > After a solved, verified problem produces a non-trivial, reusable learning, offer once to invoke the `ce-compound` skill, at the completion checkpoint — when the unit of work is complete — so the learning can ship in the PR that produced it. The deadline is while the learning can still be committed to that PR, whether it is not open yet, already open as a draft, or open and under review. Offer at the checkpoint rather than deferring to that deadline. Only where the repository treats captured learnings as tracked, committed knowledge.
 
-**Run it automatically** (no prompt):
+Run it automatically (no prompt):
 
 > After a solved, verified problem produces a non-trivial, reusable learning, automatically invoke the `ce-compound` skill, passing `mode:non-interactive` as the skill argument. Fire at the completion checkpoint — when the unit of work is complete — so the learning ships in the PR that produced it rather than as a later orphan. The deadline is while the learning can still be committed to that PR, whether it is not open yet, already open as a draft, or open and under review. Capture at the checkpoint rather than deferring to that deadline. Only where the repository treats captured learnings as tracked, committed knowledge.
 
 Use `mode:non-interactive depth:lightweight` instead when the standing workflow accepts reduced research and validation in exchange for a single-pass, no-subagent closure.
 
-Auto-run writes to `docs/solutions/` (and may touch `CONCEPTS.md`) without asking. Non-interactive never edits `AGENTS.md`/`CLAUDE.md`. If discoverability is missing it reports `gap noted, not applied` so a later interactive run can apply it with consent. Passing `mode:non-interactive` as an argument is the explicit form. The skill also honors a clear "run headless / without prompts" request, but the token removes all doubt. Without a non-interactive signal the run stays interactive and can stop for the one-time discoverability-consent prompt.
+Auto-run writes to `docs/solutions/` (and may touch `CONCEPTS.md`) without asking. Non-interactive never edits `AGENTS.md`/`CLAUDE.md`. If discoverability is missing it reports `gap noted, not applied` so a later interactive run can apply it with consent. Passing `mode:non-interactive` as an argument is the explicit form; the skill also honors a clear "run headless / without prompts" request, but the token removes all doubt. Without a non-interactive signal the run stays interactive and can stop for the one-time discoverability-consent prompt.
 
 A few phrases in those standing lines are load-bearing:
 
 - "invoke the `ce-compound` skill", not "run `/ce-compound`": instruction files are read by whatever agent you are using, and the slash-command form is not reliably agent-callable across all of them.
 - "at the completion checkpoint", with the deadline as commit-reachability rather than a PR event: a PR can open early, so any deadline pegged to PR creation is already past by the time the work finishes. Whether the learning can still be committed to the producing PR holds in every case.
-- "non-trivial, reusable learning": the bar is reuse, not effort — an expensive one-off with nothing generalizable does not qualify.
-- "treats captured learnings as tracked, committed knowledge", not a named folder: the real question is whether the repo welcomes generated docs — forks and OSS projects you contribute to often do not. A named path also goes stale, since `docs_root` can move the store.
+- "non-trivial, reusable learning": the bar is reuse, not effort. An expensive one-off with nothing generalizable does not qualify.
+- "treats captured learnings as tracked, committed knowledge", not a named folder: the real question is whether the repo welcomes generated docs. Forks and OSS projects you contribute to often do not, and a named path goes stale since `docs_root` can move the store.
 
 ---
 
-## Output Artifact
+## Output artifact
 
 ```text
 docs/solutions/[category]/[filename].md
@@ -211,9 +184,9 @@ docs/solutions/[category]/[filename].md
 
 That is the default root; the store follows `docs_root` if it is set in `config.yaml`, so on a project that relocates CE artifacts the path is `<docs_root>/solutions/...`. Categories are auto-detected. Bug-track examples: `build-errors/`, `test-failures/`, `runtime-errors/`, `performance-issues/`, `database-issues/`, `security-issues/`, `ui-bugs/`, `integration-issues/`, `logic-errors/`. Knowledge-track examples: `architecture-patterns/`, `design-patterns/`, `tooling-decisions/`, `conventions/`, `workflow-issues/`, `developer-experience/`, `documentation-gaps/`, `best-practices/`.
 
-The doc carries YAML frontmatter (`module`, `tags`, `problem_type`, and so on) for searchability. Validation runs through `scripts/validate-frontmatter.py` to catch silent corruption, and `scripts/validate-doc-claims.py` checks the body's cited paths, SHAs, links, and drafting scaffold against the tree.
+The doc carries YAML frontmatter (`module`, `tags`, `problem_type`, and so on) for searchability. `scripts/validate-frontmatter.py` catches silent corruption, and `scripts/validate-doc-claims.py` checks the body's cited paths, SHAs, links, and drafting scaffold against the tree.
 
-In interactive Full mode, the skill may also produce a small edit to `AGENTS.md`/`CLAUDE.md` if the discoverability check finds the knowledge store is not surfaced and you consent. Non-interactive and lightweight never apply that edit.
+In interactive Full mode, the skill may also make a small edit to `AGENTS.md`/`CLAUDE.md` if the discoverability check finds the knowledge store is not surfaced and you consent. Non-interactive and lightweight never apply that edit.
 
 ---
 
@@ -229,20 +202,20 @@ In interactive Full mode, the skill may also produce a small edit to `AGENTS.md`
 
 Auto-invoke triggers: phrases like "that worked", "it's fixed", "working now", "problem solved" anywhere in conversation.
 
-A standalone request to create or bootstrap `CONCEPTS.md` is redirected to `ce-compound-refresh`. Vocabulary capture here is a side effect of documenting a real learning, scoped to that learning's area.
+A standalone request to create or bootstrap `CONCEPTS.md` gets redirected to `ce-compound-refresh`. Vocabulary capture here is a side effect of documenting a real learning, scoped to that learning's area.
 
 ---
 
 ## FAQ
 
 **Why two modes, and why doesn't it ask me which one?**
-Full mode is for most cases: the parallel subagents catch duplicates, find related docs, and run specialized reviews. Lightweight mode exists for simple fixes or sessions running tight on context. The skill picks between them itself rather than prompting, because the deciding factor (how much context budget is left) is something the agent can see and you cannot. It reports the choice in its output. Re-running is a cheap correction if it guessed wrong.
+Full mode is for most cases: the parallel subagents catch duplicates, find related docs, and run specialized reviews. Lightweight exists for simple fixes or sessions running tight on context. The skill picks between them itself because the deciding factor, how much context budget is left, is something the agent can see and you cannot. It reports the choice in its output. Re-run it if it guessed wrong.
 
 **What's the difference between bug track and knowledge track?**
 Bug track captures incident-level fixes: "X broke, here's why and how we fixed it." Knowledge track captures durable guidance: "this is how we do X here, and why." Bug track has Symptoms / What Didn't Work / Solution. Knowledge track has Context / Guidance / When to Apply.
 
-**Why auto-update docs instead of always creating new?**
-Two docs describing the same problem drift apart. The newer context is fresher, so the skill folds it into the existing doc. The result is one canonical doc that improves over time.
+**Why update existing docs instead of always creating new ones?**
+Two docs describing the same problem drift apart. The newer context is fresher, so the skill folds it into the existing doc. One canonical doc that improves over time.
 
 **Can I capture several learnings in one run?**
 No. Grounding, overlap detection, and cross-referencing assume a single solved problem. Run the skill once per learning, sequentially.
@@ -251,14 +224,14 @@ No. Grounding, overlap detection, and cross-referencing assume a single solved p
 Knowledge track generalizes (conventions, decisions, workflow practices), but the skill assumes a code repo, a `docs/solutions/` directory, and YAML-frontmatter conventions. It is primarily a software-team tool.
 
 **What if I don't want the discoverability edit to AGENTS.md?**
-In interactive Full mode, the skill asks for consent before applying the edit. Decline and the doc still gets written. Non-interactive and lightweight never edit the instruction file; they report or tip the gap instead. The discoverability prompt will not fire if your AGENTS.md already mentions `docs/solutions/`.
+Decline the consent prompt and the doc still gets written. Non-interactive and lightweight never edit the instruction file; they report or tip the gap instead. The prompt will not fire if your AGENTS.md already mentions `docs/solutions/`.
 
 **Is there a "What's next?" menu?**
 No. The skill ends after the summary. Cross-doc maintenance is deferred to `ce-compound-refresh` via the refresh recommendation line.
 
 ---
 
-## See Also
+## See also
 
 - [`ce-compound-refresh`](./ce-compound-refresh.md): maintain `docs/solutions/` over time as the codebase evolves; also owns repo-wide CONCEPTS.md bootstrap
 - [`ce-debug`](./ce-debug.md): a common moment to capture, after a fix is verified

--- a/docs/guides/ce-debug.md
+++ b/docs/guides/ce-debug.md
@@ -2,11 +2,11 @@
 
 > Find the root cause before proposing a fix. Trace the causal chain, refuse symptom-level patches, escalate when stuck.
 
-`ce-debug` is the on-demand **investigation** skill for broken behavior. It refuses to propose a fix until it can explain the full causal chain from trigger to symptom with no gaps. For uncertain links in that chain, it requires a **prediction**: something in a different code path or scenario that must also be true if the link is right. When a prediction is wrong but a fix appears to work, the skill flags it. You found a symptom, not the cause.
+`ce-debug` is the on-demand investigation skill for broken behavior. It refuses to propose a fix until it can explain the full causal chain from trigger to symptom with no gaps. For uncertain links in that chain it requires a prediction, something in a different code path that must also be true if the link is right. When a prediction is wrong but a fix appears to work, the skill flags it: you found a symptom, not the cause.
 
-It right-sizes. Trivial bugs (typos, missing imports, obvious one-line fixes) take a fast path in triage: present the cause, ask Fix / Diagnosis only, then stop. Anything else flows through the full framework. The fix is optional. Diagnosis-only is a first-class outcome. When you do choose a fix, non-trivial diffs can continue through simplify and code review before the PR handoff.
+It right-sizes. Trivial bugs (typos, missing imports, obvious one-line fixes) take a fast path in triage: present the cause, ask Fix / Diagnosis only, then stop. Everything else goes through the full framework. The fix is optional, and diagnosis-only is a first-class outcome. When you do choose a fix, non-trivial diffs continue through simplify and code review before the PR handoff.
 
-It is not a verdict (`ce-pov`), not findings on a document (`ce-doc-review`), and not findings on a diff (`ce-code-review`). Use those when the input is a decision, a planning doc, or a change to review. Use this when something is observably broken — including observably slow: a performance regression's reproduction is a numeric baseline measurement, and the fix is verified by re-measuring, not by reading code.
+It is not a verdict (`ce-pov`), not findings on a document (`ce-doc-review`), and not findings on a diff (`ce-code-review`). Use this when something is observably broken, including observably slow. A performance regression's reproduction is a numeric baseline measurement, and the fix is verified by re-measuring, not by reading code.
 
 `ce-plan` offers this skill when a planning prompt is bug-shaped. Orchestrators such as `ce-babysit-pr` and `lfg` invoke it with `mode:pipeline` to fix convergent CI failures without asking.
 
@@ -17,9 +17,9 @@ It is not a verdict (`ce-pov`), not findings on a document (`ce-doc-review`), an
 | Question | Answer |
 |----------|--------|
 | What does it do? | Investigates a bug (reproduce, trace, root-cause), forms hypotheses with predictions, optionally implements a test-first fix, then polishes and reviews non-trivial fixes |
-| When to use it | Failed tests, error messages, regressions, a reliably slow operation (performance regression), an issue reference from whatever tracker or error monitor you use (GitHub, Linear, Jira, Sentry), "I've been stuck on this for hours" |
+| When to use it | Failed tests, error messages, regressions, a reliably slow operation, an issue reference from your tracker or error monitor (GitHub, Linear, Jira, Sentry), "I've been stuck on this for hours" |
 | What it produces | A debug summary with root cause, recommended tests, and (if you opt in) an applied fix plus post-fix quality notes. Pipeline mode returns structured JSON |
-| What's next | Fix it now, diagnosis only, or rethink the design. After a fix, it commits and — when the branch holds only that fix — opens a PR without asking |
+| What's next | Fix it now, diagnosis only, or rethink the design. After a fix, it commits and, when the branch holds only that fix, opens a PR without asking |
 
 ---
 
@@ -52,7 +52,7 @@ Describe what is observably broken, not the fix you suspect. The skill validates
 
 ## The Problem
 
-Common debugging anti-patterns:
+Debugging fails in predictable ways:
 
 - Shotgun fixes. Change three things at once "to see if it helps." If anything works, you don't know why
 - Symptom-level patches. The bug stops manifesting, but the root cause is still active and surfaces somewhere else later
@@ -62,14 +62,14 @@ Common debugging anti-patterns:
 
 ## The Solution
 
-`ce-debug` runs investigation with explicit gates:
+`ce-debug` runs the investigation with explicit gates:
 
 - Causal chain gate. No fix proposed until the chain is explained end-to-end with no gaps
 - Diagnosis before the choice. The findings block is written in full before the Fix / Diagnosis-only / Rethink question opens
 - Predictions for uncertain links. Something in a different code path that must also be true if the link is right
 - Assumption audit. List "this must be true" beliefs, mark each verified or assumed
 - One change at a time
-- Smart escalation when stuck. Diagnose *why* hypotheses are exhausted
+- Escalation when stuck. Diagnose why hypotheses are exhausted instead of trying variants
 - Test-first fix. Inspect existing tests first, use or strengthen the right test home, verify it fails for the right reason, then implement
 - Post-fix quality tail. For non-trivial fixes, simplify the relevant diff, run a scoped code review, and preserve residuals before shipping
 
@@ -79,68 +79,68 @@ Common debugging anti-patterns:
 
 ### Causal chain gate
 
-The skill does not propose a fix until it can explain the full causal chain from trigger to symptom with no gaps. "Somehow X leads to Y" is a gap.
+The skill does not propose a fix until it can explain the full causal chain from trigger to symptom. "Somehow X leads to Y" is a gap.
 
-The findings block (root cause with file:line references, the proposed fix, the recommended tests, and any related ticket or PR) is written in full before the Fix it now / Diagnosis only / Rethink the design question opens. Blocking-question tools render only their own stem on modal harnesses, so a question fired on "root cause confirmed" alone would leave you choosing with none of the chain on screen.
+The findings block (root cause with file:line references, the proposed fix, the recommended tests, any related ticket or PR) is written in full before the Fix it now / Diagnosis only / Rethink the design question opens. Blocking-question tools render only their own stem on modal harnesses, so a question fired on "root cause confirmed" alone would leave you choosing with none of the chain on screen.
 
 ### Predictions for uncertain links
 
-For each uncertain link, the skill states a **prediction**: something in a different code path or scenario that must also be true if this link is correct. If the prediction is wrong but a fix appears to work, you found a symptom, not the cause. Predictions are not required for obvious links (missing imports, clear null dereference).
+For each uncertain link, the skill states a prediction: something in a different code path or scenario that must also be true if this link is correct. If the prediction is wrong but a fix appears to work, you found a symptom. Obvious links (missing imports, a clear null dereference) don't need predictions.
 
 ### Assumption audit
 
-Before forming hypotheses, the skill enumerates the "this must be true" beliefs the understanding depends on: the framework behaves this way here, this function returns what its name implies, the config loads before this runs, the database is in the state the test implies. Each is marked verified or assumed. Many "wrong hypotheses" are correct hypotheses tested against a wrong assumption.
+Before forming hypotheses, the skill lists the "this must be true" beliefs the understanding depends on: the framework behaves this way here, this function returns what its name implies, the config loads before this runs. Each is marked verified or assumed. Many "wrong hypotheses" are correct hypotheses tested against a wrong assumption.
 
-### Smart escalation when stuck
+### Escalation when stuck
 
-After 2-3 hypotheses are exhausted without confirmation, the skill diagnoses *why*:
+After 2-3 hypotheses are exhausted without confirmation, the skill diagnoses why:
 
-- Hypotheses point to different subsystems → likely an architecture problem. Suggest `/ce-brainstorm`
-- Evidence contradicts itself → wrong mental model. Step back and re-read without assumptions
-- Works locally, fails in CI/prod → environment problem. Focus on env, config, dependencies, timing
-- Fix works but prediction was wrong → symptom fix. The real cause is still active
+- Hypotheses point to different subsystems: likely an architecture problem. Suggest `/ce-brainstorm`
+- Evidence contradicts itself: wrong mental model. Step back and re-read without assumptions
+- Works locally, fails in CI/prod: environment problem. Focus on env, config, dependencies, timing
+- Fix works but prediction was wrong: symptom fix. The real cause is still active
 
-Three failed fix attempts is the same gate: invalidate the current hypothesis before forming a new one. Do not retry variants of the same theory.
+Three failed fix attempts hits the same gate: invalidate the current hypothesis before forming a new one. Don't retry variants of the same theory.
 
 ### Issue tracker integration
 
-When the input references an issue (`#123`, GitHub URL, Linear URL, Jira key, Sentry issue), the skill fetches the full conversation including all comments. Comments frequently contain updated reproduction steps, narrowed scope, prior failed attempts, and pivots to a different suspected root cause.
+When the input references an issue (`#123`, GitHub URL, Linear URL, Jira key, Sentry issue), the skill fetches the full conversation, including all comments. Comments frequently contain updated reproduction steps, narrowed scope, prior failed attempts, and pivots to a different suspected root cause.
 
-Whatever you hand it becomes the **issue of record**: the skill links back to that one and never opens a duplicate for the same bug in another system, even when the repo's own tracker is something else. A Sentry issue counts as much as a Linear ticket. New tickets are only ever filed for a *different* problem found along the way.
+Whatever you hand it becomes the issue of record. The skill links back to that one and never opens a duplicate for the same bug in another system, even when the repo's own tracker is something else. A Sentry issue counts as much as a Linear ticket. New tickets are only ever filed for a different problem found along the way.
 
 ### A dirty tree is a suspect
 
-If you have uncommitted work when you invoke the skill, it treats that as a hypothesis rather than noise — the most common reason to be debugging at all is that your own in-progress edit caused the failure. When the changed files could plausibly reach the failing behavior, it stashes them (`-u`, so untracked files go too), reruns the reproduction, and pops immediately with `--index` so your staging survives. The failure disappearing names your edit as the cause and ends the investigation; the failure persisting rules it out and leaves a clean tree to trace. It never auto-resolves a pop conflict in your work, and it never stashes just to simplify its own shipping route.
+If you have uncommitted work when you invoke the skill, it treats that as a hypothesis rather than noise. The most common reason to be debugging at all is that your own in-progress edit caused the failure. When the changed files could plausibly reach the failing behavior, it stashes them (`-u`, so untracked files go too), reruns the reproduction, and pops immediately with `--index` so your staging survives. If the failure disappears, your edit is the cause and the investigation ends. If it persists, your edit is ruled out and the tree is clean to trace. It never auto-resolves a pop conflict in your work, and it never stashes just to simplify its own shipping route.
 
 ### Test-first fix, then a scoped quality tail
 
-If you opt to fix, the skill first inspects existing tests for the affected behavior. It uses an existing failing test when one already captures the bug, updates or strengthens the existing test that owns the contract, or adds a focused regression test only when no existing test fits. It verifies the failure, applies the smallest root-cause fix, reruns the focused test plus broader checks, then self-reviews the diff.
+If you opt to fix, the skill first inspects existing tests for the affected behavior. It uses an existing failing test when one already captures the bug, updates or strengthens the test that owns the contract, or adds a focused regression test only when nothing fits. It verifies the failure, applies the smallest root-cause fix, reruns the focused test plus broader checks, then self-reviews the diff.
 
-After the fix is green, non-trivial diffs run the same quality tail used by the shipping workflow: simplify first when the diff is large enough to benefit, then review the final fix. Tiny mechanical fixes skip this with a reason. Simplify is always handed an explicit scope of the bug-fix files and never the branch diff, so it cannot reach unrelated work in progress; review is scoped the same way unless the tree was clean enough to prove a diff base is the fix. Files with overlapping pre-existing edits skip file-level simplification. Accepted residual findings are written to a durable sink even when you choose commit-only or stop.
+After the fix is green, non-trivial diffs run the same quality tail as the shipping workflow: simplify first when the diff is large enough to benefit, then review the final fix. Tiny mechanical fixes skip this with a reason. Simplify always gets an explicit scope of the bug-fix files, never the branch diff, so it cannot reach unrelated work in progress. Review is scoped the same way unless the tree was clean enough to prove a diff base is the fix. Files with overlapping pre-existing edits skip file-level simplification. Accepted residual findings are written to a durable sink even when you choose commit-only or stop.
 
 ### Defense-in-depth, and brainstorm when it is not a bug
 
-When the root-cause pattern appears in 3+ other files, or the bug would have been catastrophic in production, the skill considers four defense layers (entry validation, invariant check, environment guard, diagnostic breadcrumb) and applies what fits. For one-off errors with no realistic recurrence, defense-in-depth is skipped.
+When the root-cause pattern appears in 3+ other files, or the bug would have been catastrophic in production, the skill considers four defense layers (entry validation, invariant check, environment guard, diagnostic breadcrumb) and applies what fits. One-off errors with no realistic recurrence skip this.
 
-Concrete signals trigger a `/ce-brainstorm` recommendation rather than a fix: the root cause is a wrong responsibility or interface; the requirements are wrong or incomplete; every fix is a workaround. Size alone does not make something a design problem.
+Concrete signals trigger a `/ce-brainstorm` recommendation rather than a fix: the root cause is a wrong responsibility or interface, the requirements are wrong or incomplete, or every fix is a workaround. Size alone does not make something a design problem.
 
 ### Pipeline mode
 
-`mode:pipeline` (set by `ce-babysit-pr` or `lfg`) runs fully non-interactively. It fixes **convergent** bugs (the code is not meeting its planned or tested intent) and defers **divergent** ones (the "failure" would reverse a deliberate contract or product decision). It does not create branches, does not run the polish/review tail, and returns a structured JSON result (`fixed-and-pushed`, `fixed-not-pushed` when the fix is committed but could not be pushed, `diagnosed-no-fix`, `flaky-infra`, or `needs-human`). A design problem becomes a `needs-human` residual, never a brainstorm handoff.
+`mode:pipeline` (set by `ce-babysit-pr` or `lfg`) runs fully non-interactively. It fixes convergent bugs (the code is not meeting its planned or tested intent) and defers divergent ones (the "failure" would reverse a deliberate contract or product decision). It does not create branches, does not run the polish/review tail, and returns a structured JSON result: `fixed-and-pushed`, `fixed-not-pushed` when the fix is committed but could not be pushed, `diagnosed-no-fix`, `flaky-infra`, or `needs-human`. A design problem becomes a `needs-human` residual, never a brainstorm handoff.
 
 ---
 
 ## Quick Example
 
-You paste a stack trace or a GitHub issue URL. The skill fetches the full issue thread, reproduces the bug locally, and verifies environment sanity (correct branch, dependencies installed, env vars present).
+You paste a GitHub issue URL. The skill fetches the full issue thread, reproduces the bug locally, and checks environment sanity (correct branch, dependencies installed, env vars present).
 
-It traces the code path from the error back upstream, asking "where did this value come from?" until it reaches the point where valid state first became invalid. It performs an assumption audit and flags one belief as unverified.
+It traces the code path from the error back upstream, asking "where did this value come from?" until it reaches the point where valid state first became invalid. The assumption audit flags one belief as unverified.
 
-It forms two hypotheses, ranked by likelihood. The first is testable directly. The second has an uncertain link, so it generates a prediction: if this link is right, a different code path that calls the same function under different conditions should also fail. It tests the prediction.
+It forms two hypotheses, ranked by likelihood. The first is testable directly. The second has an uncertain link, so it generates a prediction: if this link is right, a different code path calling the same function under different conditions should also fail. It tests the prediction.
 
-The prediction holds. The skill presents the root cause with file:line references, the proposed fix, and the specific tests that should be used, updated, strengthened, or added. Then it asks: fix it now, diagnosis only, or rethink the design?
+The prediction holds. The skill presents the root cause with file:line references, the proposed fix, and the specific tests to use, update, strengthen, or add. Then it asks: fix it now, diagnosis only, or rethink the design?
 
-You pick "fix it now." It creates a feature branch (you were on the default branch), inspects the existing tests, updates the right test or adds a focused one, verifies it fails for the right reason, implements the minimal fix, and runs tests. If the fix is non-trivial, it runs simplify before code review, applies clear review findings when the review scope is fix-only, reruns targeted checks, records Post-Fix Quality, and then hands off to `/ce-commit-push-pr`.
+You pick "fix it now." It creates a feature branch (you were on the default branch), updates the right test or adds a focused one, verifies it fails for the right reason, implements the minimal fix, and runs tests. Because the fix is non-trivial, it runs simplify before code review, applies clear review findings when the review scope is fix-only, reruns targeted checks, records Post-Fix Quality, and hands off to `/ce-commit-push-pr`.
 
 ---
 
@@ -158,24 +158,24 @@ Use `ce-debug` when:
 Skip `ce-debug` when:
 
 - You already know the root cause and the fix is obvious. Just fix it, or use `/ce-work` for a small change
-- The "bug" is really a feature decision in disguise → `/ce-brainstorm`
-- The work is implementing something new, not investigating something broken → `/ce-work`
-- You want findings on a diff, not an investigation → `/ce-code-review`
-- You want a verdict on exposure (is this CVE ours?) rather than a live failure → `/ce-pov`
+- The "bug" is really a feature decision in disguise: `/ce-brainstorm`
+- The work is implementing something new, not investigating something broken: `/ce-work`
+- You want findings on a diff, not an investigation: `/ce-code-review`
+- You want a verdict on exposure (is this CVE ours?) rather than a live failure: `/ce-pov`
 
 ---
 
 ## Use as Part of the Workflow
 
-`ce-debug` is an on-demand investigation that other skills can route into:
+`ce-debug` is an on-demand investigation that other skills route into:
 
-- **Offered from `/ce-plan`** when a planning prompt is bug-shaped (error message, "fix the bug where X", regression)
-- **Called from `/ce-babysit-pr` or `lfg`** with `mode:pipeline` on failing jobs
-- **Escalates to `/ce-brainstorm`** when investigation reveals a design problem rather than a logic error
-- **Runs post-fix quality checks** through `/ce-simplify-code` and `/ce-code-review` on non-trivial interactive fixes
-- **Hands off to `/ce-commit-push-pr` with `branding:on`** after a successful fix, without asking permission, when the branch holds only that fix. It previews what it is about to commit so you can interrupt. If the branch also carries unrelated work, or there is no remote, it commits just the fix-owned files locally and pushes nothing. Project instructions that say otherwise (for example "don't open PRs from skills") outrank the default
+- Offered from `/ce-plan` when a planning prompt is bug-shaped (error message, "fix the bug where X", regression)
+- Called from `/ce-babysit-pr` or `lfg` with `mode:pipeline` on failing jobs
+- Escalates to `/ce-brainstorm` when investigation reveals a design problem rather than a logic error
+- Runs post-fix quality checks through `/ce-simplify-code` and `/ce-code-review` on non-trivial interactive fixes
+- Hands off to `/ce-commit-push-pr` with `branding:on` after a successful fix, without asking permission, when the branch holds only that fix. It previews what it is about to commit so you can interrupt. If the branch also carries unrelated work, or there is no remote, it commits just the fix-owned files locally and pushes nothing. Project instructions that say otherwise (for example "don't open PRs from skills") outrank the default
 
-After a PR opens, the skill may offer `/ce-compound` when the lesson is generalizable (a one-sentence insight, a pattern in 3+ locations, or a wrong assumption about a shared dependency). Localized mechanical fixes are skipped so `docs/solutions/` does not fill with one-off entries.
+After a PR opens, the skill may offer `/ce-compound` when the lesson is generalizable: a one-sentence insight, a pattern in 3+ locations, or a wrong assumption about a shared dependency. Localized mechanical fixes are skipped so `docs/solutions/` does not fill with one-off entries.
 
 ---
 
@@ -187,7 +187,7 @@ After a PR opens, the skill may offer `/ce-compound` when the lesson is generali
 - **Linear or Jira ticket:** `/ce-debug ABC-456` or paste the URL
 - **Stuck on something:** `/ce-debug "why is X returning undefined when Y"`
 
-When you only want the diagnosis, pick **Diagnosis only** at the fix-choice gate. The summary is still produced. The test recommendations are part of the diagnosis either way.
+When you only want the diagnosis, pick **Diagnosis only** at the fix-choice gate. The summary is still produced, and the test recommendations are part of the diagnosis either way.
 
 ---
 
@@ -207,10 +207,10 @@ When you only want the diagnosis, pick **Diagnosis only** at the fix-choice gate
 ## FAQ
 
 **Why investigate before fixing?**
-Fixes that are not tied to a clear causal chain often address symptoms rather than the cause. The bug stops manifesting, but the real problem is still active. The causal chain gate is the structural defense against this.
+Fixes not tied to a clear causal chain often address symptoms. The bug stops manifesting, but the real problem is still active. The causal chain gate is the structural defense against this.
 
 **What's the difference between a hypothesis and a prediction?**
-A hypothesis says "I think this is the cause." A prediction says "if my hypothesis is right, then this other thing must also be true." Predictions test the hypothesis against independent evidence. If the prediction is wrong but a fix works, you have found a symptom.
+A hypothesis says "I think this is the cause." A prediction says "if my hypothesis is right, this other thing must also be true." Predictions test the hypothesis against independent evidence.
 
 **When should the skill suggest `/ce-brainstorm`?**
 Only when the bug cannot be properly fixed within the current design: wrong responsibility, wrong interface, requirements gap, or every fix is a workaround. Size alone does not make something a design problem.
@@ -219,9 +219,9 @@ Only when the bug cannot be properly fixed within the current design: wrong resp
 Skip the skill. Go directly to `/ce-work` or just edit the file. `ce-debug` is for cases where the root cause is not obvious or the fix has failed to stick.
 
 **Does it always open a PR?**
-Whenever the branch holds only the fix — the common case, and the one the skill optimizes for. Then it previews the commit and opens a PR without asking: a reviewed fix belongs in a PR, and the preview already gives you a chance to stop it.
+Whenever the branch holds only the fix, which is the common case and the one the skill optimizes for. It previews the commit and opens a PR without asking: a reviewed fix belongs in a PR, and the preview already gives you a chance to stop it.
 
-If the branch also carries unrelated work it does not push, because pushing would publish work you never offered up. It commits just the fix-owned files locally and tells you what it held back, then opens the PR if you ask. The one case where it stops and asks is entanglement — a file the fix had to touch already contained your own edits, so no commit can separate them and every option costs something.
+If the branch also carries unrelated work it does not push, because pushing would publish work you never offered up. It commits just the fix-owned files locally, tells you what it held back, and opens the PR if you ask. The one case where it stops and asks is entanglement: a file the fix had to touch already contained your own edits, so no commit can separate them and every option costs something.
 
 Diagnosis-only stops after the summary. With no remote configured it commits locally. `mode:pipeline` commits and pushes on the current branch and does not open a PR.
 

--- a/docs/guides/ce-doc-review.md
+++ b/docs/guides/ce-doc-review.md
@@ -2,9 +2,9 @@
 
 > Review a requirements or plan document with parallel persona agents, apply mechanical fixes, and route the rest.
 
-`ce-doc-review` is the on-demand **findings** skill for documents. Point it at a requirements-only unified plan, an implementation-ready plan, or a legacy requirements/plan doc. It picks reviewer personas from what the doc actually contains, dispatches them in parallel, applies only full-confidence mechanical fixes in the document's native format, then routes everything else.
+`ce-doc-review` is the findings skill for documents. Point it at a requirements-only unified plan, an implementation-ready plan, or a legacy requirements/plan doc. It picks reviewer personas from what the doc contains, dispatches them in parallel, applies only full-confidence mechanical fixes in the document's native format, then routes everything else to you.
 
-It is the sibling of `/ce-code-review` for the docs side. It is not a verdict. Use `/ce-pov` when you want a holistic take (strengths, risks, bottom line) rather than an issue list. Use `/ce-code-review` for findings on a diff, and `/ce-debug` when something is actually broken.
+It is the sibling of `/ce-code-review` for the docs side, and it is not a verdict. Use `/ce-pov` when you want a holistic take (strengths, risks, bottom line) instead of an issue list. Use `/ce-code-review` for findings on a diff, and `/ce-debug` when something is actually broken.
 
 `ce-brainstorm` and `ce-plan` both invoke it on the artifacts they write. You can also run it on any planning doc on disk.
 
@@ -52,22 +52,22 @@ For HTML, edits preserve the artifact's existing structure and never insert mark
 Document review is harder than code review in specific ways:
 
 - No type checker. A requirements doc can contradict itself with no compiler error
-- No execution. You cannot "run" a plan to see if its scope fits its goals
+- No execution. You cannot run a plan to see if its scope fits its goals
 - A generalist pass says "looks good" and misses the design gap, the security implication, or the unstated scope expansion
 - Product framing, security, design, scope, and feasibility need different lenses. One reviewer prioritizes one
 - Findings lack ownership. "Consider revising" does not say who decides or what to do
-- Rejected findings re-surface because the rejection was never recorded
+- Rejected findings re-surface because nobody recorded the rejection
 
 ## The Solution
 
 `ce-doc-review` runs document review as a pipeline with explicit gates:
 
-- Always-on personas for coherence and feasibility
+- Two personas on every review: coherence and feasibility
 - Conditional personas selected from doc content: product-lens, design-lens, security-lens, scope-guardian, adversarial
 - Parallel persona dispatch with bounded concurrency
-- Synthesis that promotes on cross-persona agreement, resolves contradictions, and routes on confidence and fix class together. Only a mechanical correction at full confidence applies unattended. Everything else that touches meaning is batched into one confirmation. Only a real fork becomes a question
-- Decision primer: round-to-round suppression so rejected findings do not re-surface, and applied findings get verification
-- Four-option interaction over the remaining decisions: per-finding walk-through, auto-resolve with best judgment, append to Open Questions, report-only
+- Synthesis that promotes on cross-persona agreement, resolves contradictions, and routes on confidence and fix class together. Only a mechanical correction at full confidence applies unattended. Everything else that touches meaning goes into one batched confirmation. Only a real fork becomes a question
+- A decision primer that suppresses findings you rejected in earlier rounds and verifies the ones you applied
+- Four options for the remaining decisions: per-finding walk-through, auto-resolve with best judgment, append to Open Questions, report-only
 
 ---
 
@@ -77,7 +77,7 @@ Document review is harder than code review in specific ways:
 
 Conditional personas activate from what the doc says, not keyword matching:
 
-- **product-lens** when the doc stakes an unsettled product position — what to build, why, or what comes first — that a stakeholder could challenge, or the work carries strategic weight; a choice among mechanisms is not a product position
+- **product-lens** when the doc stakes an unsettled product position that a stakeholder could challenge (what to build, why, or what comes first), or the work carries strategic weight. A choice among mechanisms is not a product position
 - **design-lens** when it contains UI/UX references, user flows, or visual design language
 - **security-lens** when it touches auth, public APIs, sensitive data, payments, or third-party trust boundaries
 - **scope-guardian** when it has multiple priority tiers, a large requirement count, or scope-boundary language that looks misaligned
@@ -87,13 +87,13 @@ Conditional personas activate from what the doc says, not keyword matching:
 
 Personas also scope their techniques by doc shape. On plan-shape docs with validated upstream Product Contract provenance, product-lens, adversarial, and scope-guardian suppress premise-level techniques and run only implementation-level checks. On requirements-shape docs they run their full technique set. Feasibility inverts: deep implementability checks on plan-shape docs, a tight "would this direction force a fundamental rework?" check on requirements docs.
 
-Classification happens once from readiness metadata, content-shape signals, frontmatter, R-IDs vs U-IDs, and section structure. Unified artifacts are sliced: a requirements-only plan reviews the Product Contract. An implementation-ready plan reviews Product Contract, Planning Contract, Implementation Units, Verification Contract, and Definition of Done.
+Classification happens once, from readiness metadata, content-shape signals, frontmatter, R-IDs vs U-IDs, and section structure. Unified artifacts are sliced: a requirements-only plan reviews the Product Contract. An implementation-ready plan reviews Product Contract, Planning Contract, Implementation Units, Verification Contract, and Definition of Done.
 
 ### Three surfaces, not a flat list
 
 After personas return, synthesis validates, drops unanchored findings, deduplicates, promotes on agreement, and routes:
 
-- **Applied** (reported): only `safe_auto` at confidence 100. Mechanical corrections. One right answer
+- **Applied** (reported): only `safe_auto` at confidence 100. Mechanical corrections with one right answer
 - **Proposed fixes** (grouped confirmation): everything with a concrete fix that touches meaning, plus obligations the document already entailed. One question over the batch, shown in full first
 - **Decisions**: genuine forks. The question is which remedy, never whether to proceed with something already settled
 - **FYI**: observational items. No question
@@ -111,7 +111,7 @@ Without the evidence snippet, suppression falls back to title-only and either re
 
 ### Four-option interaction
 
-After mechanical fixes land and the grouped confirmation is answered, remaining decisions get one routing question over the whole remaining set:
+After mechanical fixes land and the grouped confirmation is answered, one routing question covers the whole remaining set:
 
 | Option | Effect |
 |--------|--------|
@@ -120,7 +120,7 @@ After mechanical fixes land and the grouped confirmation is answered, remaining 
 | Append to Open Questions | All remaining findings deferred to the doc's `Deferred / Open Questions` section as a batch |
 | Report only | No further edits. Report stays in chat |
 
-The walk-through itself supports an "auto-resolve the rest" escape mid-flow. Bulk actions show a preview (section, title, action, brief rationale) before anything lands.
+The walk-through supports an "auto-resolve the rest" escape mid-flow. Bulk actions show a preview (section, title, action, brief rationale) before anything lands.
 
 Each per-finding step prints a terminal block and duplicates What's wrong / Proposed fix / If left as-is into the blocking question, so modal harnesses stay decidable without scrolling.
 
@@ -129,7 +129,7 @@ Each per-finding step prints a terminal block and duplicates What's wrong / Prop
 | Mode | When | Behavior |
 |------|------|----------|
 | **Interactive** | Direct invoke, brainstorm's "Pressure-test the requirements", or `ce-plan`'s "Decide on the review's open items" | Grouped confirmation, routing question, walk-through, bulk-preview confirmations |
-| **Non-interactive** | `mode:non-interactive` (deprecated alias `mode:headless`). Default when `ce-plan` chains the review | Apply full-confidence mechanical corrections silently. Return everything else as structured text. No prompts |
+| **Non-interactive** | `mode:non-interactive` (deprecated alias `mode:headless`). Default when `ce-plan` chains the review | Applies full-confidence mechanical corrections silently. Returns everything else as structured text. No prompts |
 
 Non-interactive requires a path. Without one it errors rather than guessing.
 
@@ -147,11 +147,11 @@ When the **conditional judgment trio** (adversarial, product-lens, security-lens
 
 A single **whole-document sweep** has one different-provider peer review the entire document as a general reviewer, folding in as `whole-doc-<provider>`. On unified plans the focused trio peers are sliced to match their in-process twins. The sweep reads the whole document.
 
-The pass needs a peer *agent* CLI (`codex`, `claude`, `grok`, `cursor-agent`, or `opencode`) — an API key alone does not enable it, and Gemini has no standalone target. Peers are found on `PATH` or inside the Codex desktop app bundle; see the [prerequisite note in `ce-code-review`](./ce-code-review.md#cross-model-adversarial-pass).
+The pass needs a peer *agent* CLI (`codex`, `claude`, `grok`, `cursor-agent`, or `opencode`). An API key alone does not enable it, and Gemini has no standalone target. Peers are found on `PATH` or inside the Codex desktop app bundle; see the [prerequisite note in `ce-code-review`](./ce-code-review.md#cross-model-adversarial-pass).
 
-`cross_model_review_mode: off` in CE config keeps this pass from running at all — no peer is resolved and nothing leaves the host; the in-process reviewers cover the lens and Coverage says the pass was disabled by checkout config. A direct request in conversation for a peer overrides it for one run. Which target runs the peer is auto-chosen and overridable: conversation, `cross_model_peer:` in CE config, active project instructions, then `codex → claude → grok → composer`. `Cursor` means `cursor-agent` using its configured default/Auto model. `Composer` means a Composer model through Cursor. `Grok` binds the native grok CLI when it is installed; Grok through Cursor is a different route, used when asked or when the grok CLI is missing and Cursor is allowed. `cross_model_model:` and `cross_model_effort:` in CE config pin that target's model (e.g. `fable` for claude or `gpt-5.6-sol` for codex, or a namespace-qualified codex id such as `openai.gpt-5.6-sol` when that CLI routes through a non-default `model_provider`) and reasoning effort; a value the peer cannot honor skips the pass with a stated reason rather than substituting. See the [configuration reference](./configuration.md).
+`cross_model_review_mode: off` in CE config keeps this pass from running at all. No peer is resolved and nothing leaves the host; the in-process reviewers cover the lens and Coverage says the pass was disabled by checkout config. A direct request in conversation for a peer overrides it for one run. Which target runs the peer is auto-chosen and overridable: conversation, `cross_model_peer:` in CE config, active project instructions, then `codex → claude → grok → composer`. `Cursor` means `cursor-agent` using its configured default/Auto model. `Composer` means a Composer model through Cursor. `Grok` binds the native grok CLI when it is installed; Grok through Cursor is a different route, used when asked or when the grok CLI is missing and Cursor is allowed. `cross_model_model:` and `cross_model_effort:` in CE config pin that target's model (e.g. `fable` for claude or `gpt-5.6-sol` for codex, or a namespace-qualified codex id such as `openai.gpt-5.6-sol` when that CLI routes through a non-default `model_provider`) and reasoning effort; a value the peer cannot honor skips the pass with a stated reason rather than substituting. See the [configuration reference](./configuration.md).
 
-The pass embeds the document into the peer prompt and sends it to an external provider. `CROSS_MODEL_PEERS` restricts which providers may receive content. Peers are strictly read-only. Failures are non-blocking; an exact provider-overload 529 gets one same-route retry, never an unbounded retry loop. A second target remains opt-in (`CROSS_MODEL_MAX_PEERS=2`).
+The pass embeds the document into the peer prompt and sends it to an external provider. `CROSS_MODEL_PEERS` restricts which providers may receive content. Peers are strictly read-only. Failures never block the review; an exact provider-overload 529 gets one same-route retry, never an unbounded retry loop. A second target remains opt-in (`CROSS_MODEL_MAX_PEERS=2`).
 
 ---
 
@@ -218,7 +218,7 @@ Non-interactive mode without a path errors out rather than guessing.
 ## FAQ
 
 **What's the difference between this and `ce-code-review`?**
-`ce-code-review` reviews diffs (code changes). `ce-doc-review` reviews docs (requirements, plans). Different reviewer personas, different findings shape, different routing. Both share multi-persona dispatch plus synthesis, and both can run a cross-model pass. Lens policy differs: `ce-code-review` runs its adversarial lens cross-model. `ce-doc-review` runs the three-lens judgment trio plus a whole-doc sweep, because doc-review judgment is spread across more lenses.
+`ce-code-review` reviews diffs; `ce-doc-review` reviews requirements and plans, with its own personas, findings shape, and routing. Both share multi-persona dispatch plus synthesis, and both can run a cross-model pass. Lens policy differs: `ce-code-review` runs its adversarial lens cross-model, while `ce-doc-review` runs the three-lens judgment trio plus a whole-doc sweep, because doc-review judgment is spread across more lenses.
 
 **What's the difference between this and `ce-pov`?**
 `ce-pov` gives a holistic take: bottom line, strengths, risks. This skill gives issue-shaped findings and can edit markdown or HTML in place.
@@ -230,16 +230,16 @@ Only the judgment trio (adversarial, product-lens, security-lens) get a dedicate
 Without it, every round re-surfaces the same findings, including ones you already rejected. The primer uses fingerprint plus evidence-snippet matching to suppress rejected findings and verify applied fixes.
 
 **What's "Append to Open Questions" for?**
-For findings you want to address later, not now. They get appended to the doc's visible `Deferred / Open Questions` section in its native format so they survive the session and the next planner or implementer sees them.
+Findings you want to address later, not now. They get appended to the doc's visible `Deferred / Open Questions` section in its native format so they survive the session and the next planner or implementer sees them.
 
 **Why a bulk preview?**
-Mass changes deserve a confirmation step. "Auto-resolve with best judgment" is delegation. The preview shows the changes before they commit so you can cancel.
+"Auto-resolve with best judgment" is delegation, and mass changes deserve a confirmation step. The preview shows the changes before they commit so you can cancel.
 
 **What if a persona times out or fails?**
 The skill proceeds with findings from agents that completed and notes the failure in Coverage. A single agent failure does not block the review.
 
 **Can it review documents other than requirements and plans?**
-The personas are tuned for those two types. Reviewing a learning doc or release note works mechanically, but the persona advice may not be calibrated. For a planning doc this is the right tool. For other types the personas may surface noise.
+The personas are tuned for those two types. Reviewing a learning doc or release note works mechanically, but the persona advice may not be calibrated and may surface noise. For a planning doc this is the right tool.
 
 ---
 

--- a/docs/guides/ce-dogfood.md
+++ b/docs/guides/ce-dogfood.md
@@ -2,11 +2,11 @@
 
 > Hands-off, diff-scoped browser QA of the active branch. Maps the journeys the diff touches, drives them in a real browser, fixes small breakages (with a regression test and a commit), and writes a durable report.
 
-`ce-dogfood` is on-demand **autonomous QA** of what this branch changed versus the trunk. It maps those journeys, exercises them with `agent-browser`, judges correctness and feel (including per-persona paper cuts), fixes what is small and unambiguous, escalates the rest, and leaves a report under `docs/dogfood-reports/`.
+`ce-dogfood` is autonomous QA of what this branch changed versus the trunk. It maps those changes as user journeys, exercises them with `agent-browser`, judges correctness and feel (including per-persona paper cuts), fixes what is small and unambiguous, escalates the rest, and leaves a report under `docs/dogfood-reports/`.
 
-It is diff-scoped, not a whole-app crawl. Once invoked it runs the loop without check-ins, except for external flows (OAuth, real email, payments, SMS) and for resume questions. It edits code and creates commits, so it is manual invocation only.
+It is diff-scoped, not a whole-app crawl. Once invoked it runs without check-ins, except for external flows (OAuth, real email, payments, SMS) and resume questions. It edits code and creates commits, so it is manual invocation only.
 
-It is not `ce-test-browser` (test and report; it fixes only if you pick "fix now"), not `ce-polish` (you drive live UX), and not `ce-simplify-code` (code cleanup with no browser).
+It is not `ce-test-browser` (test and report; fixes only if you pick "fix now"), not `ce-polish` (you drive live UX), and not `ce-simplify-code` (code cleanup, no browser).
 
 ---
 
@@ -16,15 +16,15 @@ It is not `ce-test-browser` (test and report; it fixes only if you pick "fix now
 |----------|--------|
 | What does it do? | Maps the branch diff to user flows, drives them in a browser, auto-fixes small issues, escalates the rest, writes a report |
 | When to use it | Before shipping a branch, when you want a real-browser pass that also fixes what it can |
-| What it produces | `docs/dogfood-reports/<YYYY-MM-DD>-<branch-slug>-dogfood.md`: flows, matrix, fixes, paper cuts, escalations, learnings, verdict. Plus any fix commits |
-| How it differs from `ce-test-browser` | That skill tests and reports. This one also fixes, adds regression tests, commits, judges feel per persona, and keeps a resume-able report |
+| What it produces | `docs/dogfood-reports/<YYYY-MM-DD>-<branch-slug>-dogfood.md`: flows, matrix, fixes, paper cuts, escalations, verdict. Plus any fix commits |
+| How it differs from `ce-test-browser` | That skill tests and reports. This one also fixes, adds regression tests, commits, judges feel per persona, and keeps a resumable report |
 | Invocation | Manual only. Type `/ce-dogfood` |
 
 ---
 
 ## Example invocations
 
-Arguments pick which ref to dogfood and, optionally, which port. Empty runs **in place** on the current branch.
+Arguments pick which ref to dogfood and, optionally, which port. Empty runs in place on the current branch.
 
 ```text
 # Current feature branch, in this checkout. Refuses main/master/the default branch
@@ -61,7 +61,7 @@ A branch can pass review and unit tests and still be broken or rough in the brow
 
 One pass:
 
-- Map each user-visible change as a Mermaid flowchart *before* building the test matrix
+- Map each user-visible change as a Mermaid flowchart before building the test matrix
 - Ground flows in product personas (`STRATEGY.md`, `VISION.md`, persona docs, or one inferred persona)
 - Walk each flow for paper cuts as well as functional failures
 - Auto-fix only small, low-risk, unambiguous breakages, each with a regression test (or a documented replay/screenshot check when no automated test is meaningful) and its own commit
@@ -75,15 +75,15 @@ One pass:
 
 ### Flows before the matrix
 
-Each user-visible change becomes a flowchart: entry, actions, branches, side effects, true end state (including email click-through). The matrix is derived from those diagrams, not from a flat page list. A one-route change gets one small chart. Mapping is never skipped.
+Each user-visible change becomes a flowchart: entry, actions, branches, side effects, true end state (including email click-through). The matrix comes from those diagrams, not from a flat page list. A one-route change gets one small chart. Mapping is never skipped.
 
 ### Functional and experiential judgment
 
-Every scenario is scored twice: right data, right destination, no console errors; and whether it feels aligned with the product. Walking the flow as each primary persona produces **paper cuts**: small frictions that still `Pass` functionally. A sharp paper cut can enter the fix loop. The rest stay in the report.
+Every scenario is scored twice: right data, right destination, no console errors; and whether it feels aligned with the product. Walking the flow as each primary persona produces paper cuts, small frictions that still `Pass` functionally. A sharp paper cut can enter the fix loop. The rest stay in the report.
 
 ### Size-gated autonomous fixes
 
-Auto-fix when the change is small, understood, and low-risk. Do not auto-fix when it needs an architecture or schema decision, changes product behavior, spans many files, or has competing answers. Each autonomous fix gets a regression test and a `ce-commit`. Too-big items go under **Decisions for a human** and the scenario is `Blocked (human decision)`.
+Auto-fix when the change is small, understood, and low-risk. Not when it needs an architecture or schema decision, changes product behavior, spans many files, or has competing answers. Each autonomous fix gets a regression test and a `ce-commit`. Too-big items go under "Decisions for a human" and the scenario becomes `Blocked (human decision)`.
 
 ### Resumable report
 
@@ -138,29 +138,16 @@ On-demand. Nothing in the core loop calls this. After a green (or explicitly blo
 
 ---
 
-## Use Standalone
-
-- **Current branch:** `/ce-dogfood` (in place; refuses the trunk)
-- **PR:** `/ce-dogfood 847` (offers a worktree so this checkout stays put)
-- **Other branch:** `/ce-dogfood feature/new-dashboard` (same isolation offer)
-- **Port:** `/ce-dogfood --port 5000`
-
-A PR is always diffable against its base, so a PR whose head happens to be named `main` still runs. A bare `/ce-dogfood` on the trunk does not.
-
-If a server is already listening on the chosen port, it reuses it. Otherwise it starts `bin/dev`, `rails server`, or `npm run dev` without asking.
-
----
-
 ## Reference
 
 | Argument | Effect |
 |----------|--------|
 | _(empty)_ | Dogfood the current branch in place. Stops if that branch is the trunk |
-| `<PR number>` | Dogfood that PR. Offers a worktree. Never refused for a `main`-named head |
+| `<PR number>` | Dogfood that PR. Offers a worktree so this checkout stays put. Never refused for a `main`-named head, because a PR always has a base to diff against |
 | `<branch name>` | Dogfood that branch. Offers a worktree if you are not already on it |
 | `--port <number>` | Skip port detection |
 
-Required: `agent-browser` on PATH (not `npx agent-browser`), and a local dev server the skill can start or reuse. Port order matches the other browser skills: `--port`, a port already in active project instructions, `package.json`, `.env*`, then `3000`.
+Required: `agent-browser` on PATH (not `npx agent-browser`), and a local dev server the skill can start or reuse. If a server is already listening on the chosen port, it reuses it; otherwise it starts `bin/dev`, `rails server`, or `npm run dev` without asking. Port order matches the other browser skills: `--port`, a port already in active project instructions, `package.json`, `.env*`, then `3000`.
 
 Report path relocates with `docs_root` (see [configuration](./configuration.md)).
 

--- a/docs/guides/ce-explain.md
+++ b/docs/guides/ce-explain.md
@@ -2,11 +2,11 @@
 
 > Build a dense visual document about a concept, a diff, an idea, or a window of your own recent work. Keep it. Optionally drill yourself on it.
 
-`ce-explain` is an on-demand **teaching** skill. Point it at something worth understanding and you get a self-contained explainer, evidence-grounded when the material lives in this repo, written to disk before you are asked where to put it.
+`ce-explain` is the on-demand **teaching** skill. Point it at something worth understanding and it writes a self-contained explainer, grounded in repo evidence when the material lives here, saved to disk before you are asked where to put it.
 
-It is not a status update or a standup memo. A recap is a document you can study or speak from. If you want the terse update itself, say so and the skill declines that form. Ordinary Q&A stays in chat. Operational questions ("why is X doing Y", "is X configured right") get a direct answer first; an explainer is offered only when a real concept sits behind the question.
+It is not a status memo. A recap from this skill is a document you can study or speak from; if you ask for the terse update itself, it declines that form. Ordinary Q&A stays in chat. Operational questions ("why is X doing Y") get a direct answer first, and an explainer is offered only when a real concept sits behind the question.
 
-It also is not `ce-compound` (that teaches the repo) and not `ce-pov` (that returns a verdict). The check-in (predict a diff, or do corrected exercises) is opt-in. Most runs skip it.
+It also is not `ce-compound` (that teaches the repo) and not `ce-pov` (that returns a verdict). The check-in (predict a diff, or do corrected exercises) is opt-in, and most runs skip it.
 
 ---
 
@@ -16,7 +16,7 @@ It also is not `ce-compound` (that teaches the repo) and not `ce-pov` (that retu
 |----------|--------|
 | What does it do? | Classifies the request as concept, diff, idea, or recap, grounds it, writes one visual explainer, then asks where to put it |
 | When to use it | You want a document to keep about a change, a topic, an idea, or what you actually did in a window |
-| What it produces | One self-contained HTML file (markdown if you ask). Written to a temp run dir first, then copied or published if you pick a destination |
+| What it produces | One self-contained HTML file (markdown if you ask), written to a temp run dir first, then copied or published if you pick a destination |
 | What's next | Keep the file, optionally take the quiz, then optional offers into `/ce-ideate`, `/ce-simplify-code`, `/ce-polish`, or `/ce-compound-refresh` |
 
 ---
@@ -63,13 +63,13 @@ Plain language is the ordinary path. Tokens force a mode when inference could go
 
 ## The Problem
 
-Agent-driven work detaches you from what shipped, in two different ways.
+Agent-driven work detaches you from what shipped in two ways.
 
 You cannot account for it. A week of agent commits later, git has the record and you cannot read it in three minutes.
 
-You cannot explain it. Writing the code forced comprehension. Reviewing agent output does not. The debt accumulates on your own projects.
+You cannot explain it. Writing the code forced comprehension; reviewing agent output does not, and the debt accumulates on your own projects.
 
-The first wants a report. The second wants a report and, sometimes, a way to make it stick. Other skills do not cover this. `/ce-compound` stores knowledge for the repo. `/ce-pov` returns a verdict.
+The first wants a report. The second wants a report and, sometimes, a way to make it stick. `/ce-compound` stores knowledge for the repo and `/ce-pov` returns a verdict; neither covers this.
 
 ## The Solution
 
@@ -92,23 +92,23 @@ Idea mode never scopes (`ce-brainstorm`) and never ranks alternatives (`ce-ideat
 
 ### Evidence first, including an honest empty
 
-The scout gathers before anything is characterized. An early `git --all` glance would seed a false model of what happened. Unreachable PRs become one honest line, not a guess from branch names. An empty `diff:` range names what it resolved to and asks before substituting. An external topic with no web access is labeled in the header: *Unverified, from model knowledge, not checked against current sources*.
+The scout gathers before anything is characterized, because an early `git --all` glance would seed a false model of what happened. Unreachable PRs become one honest line, not a guess from branch names. An empty `diff:` range names what it resolved to and asks before substituting. An external topic with no web access is labeled in the header: *Unverified, from model knowledge, not checked against current sources*.
 
 ### Offline, one file, written before the ask
 
-Default output is one self-contained HTML file (markdown via `output:md`). CSS and SVG are inline. Images are data URIs. System fonts only. No scripts, forms, or embedded quiz. A reader who skips every visual still gets the full explanation in prose. The form follows the material: diagram for architecture, annotated snippets for code, numbered flow for a lifecycle, timeline for a recap, two-column contrast for a trade-off.
+Default output is one self-contained HTML file (markdown via `output:md`). CSS and SVG are inline, images are data URIs, fonts are system fonts. No scripts, forms, or embedded quiz. A reader who skips every visual still gets the full explanation in prose. The form follows the material: diagram for architecture, annotated snippets for code, numbered flow for a lifecycle, timeline for a recap, two-column contrast for a trade-off.
 
-The header is visible text: `Date`, `Input shape`, `Subject`. Those names are fixed so a later library can index them.
+The header is visible text with fixed field names (`Date`, `Input shape`, `Subject`) so a later library can index them.
 
-The file is written to `/tmp/compound-engineering-<effective-uid>/ce-explain/<run-id>/` before the destination ask. Declining every destination loses nothing. That path is temporary. Pick a destination if you want to keep it.
+The file lands in `/tmp/compound-engineering-<effective-uid>/ce-explain/<run-id>/` before the destination ask, so declining every destination loses nothing. That path is temporary; pick a destination if you want to keep the file.
 
 ### The destination menu comes from this session
 
-The menu offers only what this session actually has. Local file and Leave it are always there. HTML prefers a Claude Artifact in Claude Code when that tool is present, otherwise a public ht-ml.app URL. ht-ml.app is public and is never chosen headlessly; the option itself warns that the page may be indexed, crawled, copied, or archived. Proof is offered on markdown runs. Thinkroom appears only when that capability is detected.
+The menu offers only what this session actually has. Local file and Leave it are always there. HTML prefers a Claude Artifact in Claude Code when that tool is present, otherwise a public ht-ml.app URL. ht-ml.app is never chosen headlessly, and the option itself warns that the page may be indexed, crawled, copied, or archived. Proof is offered on markdown runs. Thinkroom appears only when that capability is detected.
 
 ### Written for you, or re-rendered for a reader
 
-Default voice is second person and assumes the context you already have. `audience:team` (or "write this up for the team") drops second person, names the subject in third person when the evidence supplies a name, and adds the minimum orientation an outside reader needs. Depth, real code, and honesty labels do not change. Wanting to *speak* from the material (standup prep, meeting prep) stays personal. You are still the reader.
+Default voice is second person and assumes the context you already have. `audience:team` (or "write this up for the team") drops second person, names the subject in third person when the evidence supplies a name, and adds the minimum orientation an outside reader needs. Depth, real code, and honesty labels do not change. Wanting to *speak* from the material (standup prep, meeting prep) stays personal; you are still the reader.
 
 If you compose the personal default and then pick a destination that puts it in front of other people, it offers once to re-render before sending.
 
@@ -116,9 +116,9 @@ If you compose the personal default and then pick a destination that puts it in 
 
 Before anything is revealed, the skill decides whether the material warrants active recall. A gnarly diff or a hard concept does. A routine recap or a document written for someone else does not. The offer is two choices, in this order: **Just the explainer (Recommended)**, then **Quiz me**. Declining is final for the run.
 
-Quiz me on a diff shows the raw change and nothing else, asks what you think it does and why, and ends the turn there. The explainer is composed after your prediction. The reveal names what you got right, missed, and wrong.
+Quiz me on a diff shows the raw change and nothing else, asks what you think it does and why, and ends the turn there. The explainer is composed after your prediction, and the reveal names what you got right, missed, and wrong.
 
-Quiz me on a concept, idea, or dense recap poses two to four exercises in chat after the document, one at a time. Each answer is checked once. The gap is named. No lecture past it.
+Quiz me on a concept, idea, or dense recap poses two to four exercises in chat after the document, one at a time. Each answer is checked once and the gap is named. No lecture past it.
 
 ---
 
@@ -126,9 +126,9 @@ Quiz me on a concept, idea, or dense recap poses two to four exercises in chat a
 
 You type `/ce-explain since last Monday`. That is a recap. A scout walks the window and writes evidence with shas. The week has real commits, so a document is composed: a timeline, each entry naming what changed and why it mattered.
 
-The material is a routine recap, so there is no quiz offer. The HTML lands in the run dir. You are asked where to put it. You pick a local file and open it.
+The material is routine, so there is no quiz offer. The HTML lands in the run dir, you are asked where to put it, and you pick a local file and open it.
 
-The recap evidence includes a plan that shipped work has since contradicted. After the destination is settled, the skill offers `/ce-compound-refresh` on that doc. You can take it or leave it.
+The evidence includes a plan that shipped work has since contradicted. After the destination is settled, the skill offers `/ce-compound-refresh` on that doc. Take it or leave it.
 
 ---
 
@@ -143,7 +143,7 @@ Use `ce-explain` when:
 
 Skip it when:
 
-- You want a standup blurb or status memo. This skill will not write one. Recap mode can still catch you up so you can write it
+- You want a standup blurb or status memo. This skill will not write one, though recap mode can catch you up so you can
 - Ordinary Q&A, a quick "why?", or a trade-off that belongs in chat
 - Operational diagnosis ("why is X doing Y") unless you then accept the explainer offer
 - You need a verdict on whether to adopt something → `/ce-pov`
@@ -162,7 +162,7 @@ Closing offers, only after the destination is settled:
 - UI/UX polish → you invoke `/ce-polish` yourself (`ce-polish` is user-invoked only)
 - A plan or solution doc the evidence has overtaken → `/ce-compound-refresh`
 
-Those are offers. They do not auto-fire. An unattended run reports the temp path and skips them.
+Those are offers, never auto-fired. An unattended run reports the temp path and skips them.
 
 ---
 
@@ -185,29 +185,29 @@ A bare `/ce-explain` asks what to explain. It does not invent a default artifact
 | `output:md` | Markdown artifact instead of HTML (`output:html` forces HTML) |
 | `audience:<who>` | Render for that reader instead of you personally |
 
-A token in flag position beats inference. A colon inside a sentence does not. `diff:` and `since:` together conflict, and the skill asks which you meant. An unrecognized `word:value` (including `feat:` inside a topic) stays as request text.
+A token in flag position beats inference; a colon inside a sentence does not. `diff:` and `since:` together conflict, and the skill asks which you meant. An unrecognized `word:value` (including `feat:` inside a topic) stays as request text.
 
 ---
 
 ## FAQ
 
 **Do I have to do the quiz?**
-No. "Just the explainer" is first and recommended. Routine material skips the offer entirely.
+No. "Just the explainer" is first and recommended, and routine material skips the offer entirely.
 
 **Can I use this for standup?**
-You can use recap mode to catch yourself up, then speak. Prepping you to speak stays personal. The skill will not write the status update. If the document itself is going to a team, say so (or pass `audience:`) and it renders for them at full depth.
+Recap mode can catch you up so you can speak; the skill will not write the status update itself. If the document is going to a team, say so (or pass `audience:`) and it renders for them at full depth.
 
 **Can I share the report?**
 Yes. Ask for that audience up front, or take the re-render offer when you pick a shared destination.
 
 **Where does the artifact go?**
-`$RUN_DIR` under `/tmp/compound-engineering-<effective-uid>/ce-explain/` first. A destination copies or publishes it. Leave it, and the path is temporary.
+`$RUN_DIR` under `/tmp/compound-engineering-<effective-uid>/ce-explain/` first. A destination copies or publishes it; leave it and the path is temporary.
 
 **Is this `ce-compound` for humans?**
-Roughly. A Learning teaches the repo's future work. An explainer documents something for you. They are complements.
+Roughly. A Learning teaches the repo's future work; an explainer documents something for you. They are complements.
 
 **Can it quiz me later, or track what I have learned?**
-Not in v1. No library, no spaced repetition, no progress state. The stable run-dir layout and fixed header fields are the hook a later library can use.
+Not in v1. No library, no spaced repetition, no progress state. The stable run-dir layout and fixed header fields are what a later library could build on.
 
 ---
 

--- a/docs/guides/ce-handoff.md
+++ b/docs/guides/ce-handoff.md
@@ -1,10 +1,10 @@
 # `ce-handoff`
 
-> Preserve the useful context from one agent session so a fresh agent can orient without the original transcript. Resume explains what it found and waits. It does not continue the work on its own.
+> Save the useful context from one agent session so a fresh agent can pick up without the original transcript.
 
-`ce-handoff` is a two-direction **session-continuity** utility. A bare invocation creates a handoff. Resume intent finds or reads a continuity source you select, then orients and recommends a next step. It does not start `ce-plan`, `ce-work`, or any other workflow until you say so.
+`ce-handoff` runs in two directions. A bare invocation creates a handoff file. Resume intent finds or reads a continuity source you select, summarizes what it found, recommends a next step, and waits. It never starts `ce-plan`, `ce-work`, or any other workflow until you say so.
 
-The skill is prose-first. It uses the active agent's available capabilities. It adds no transport script, mutable index, or lifecycle database.
+The skill is prose-first. It uses whatever capabilities the active agent already has and adds no transport script, index database, or lifecycle machinery.
 
 ---
 
@@ -12,12 +12,12 @@ The skill is prose-first. It uses the active agent's available capabilities. It 
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Creates an immutable session snapshot, or orients from a continuity source you select |
+| What does it do? | Writes an immutable session snapshot, or orients from a continuity source you select |
 | When to use it | Before ending a useful session, or when a new agent needs prior context |
 | What does bare `/ce-handoff` do? | Always creates a new handoff |
-| Where does it write? | Default: `/tmp/compound-engineering-<effective-uid>/ce-handoff/<repo-namespace>/<topic>.md` (under `$TMPDIR/compound-engineering-<effective-uid>/` instead when `/tmp` cannot host a writable private root, as in a sandbox that only allowlists `$TMPDIR`; the skill prints the path it used). An explicit path, format, or publish destination overrides that. |
+| Where does it write? | Default: `/tmp/compound-engineering-<effective-uid>/ce-handoff/<repo-namespace>/<topic>.md`. Sandboxes that only allow `$TMPDIR` get the same layout there; the skill prints the path it used. An explicit path, format, or publish destination overrides the default. |
 | What do I paste into the next session? | `/ce-handoff resume <path-or-URL>` |
-| What happens after resume? | A summary, a continuation matched to that handoff's reason, then a wait. Numbered choices appear only for real forks. |
+| What happens after resume? | A summary, one recommended continuation, then a wait. Numbered choices appear only for real forks. |
 
 ---
 
@@ -53,57 +53,45 @@ On Codex, the copyable resume line uses `$ce-handoff resume <source>` when that 
 
 ---
 
-## The Problem
+## The problem
 
-A productive agent session holds more than changed files: intent, decisions, rejected alternatives, constraints, failed attempts, verification, and fragile local state. A fresh agent in another model or harness cannot see that history.
+A productive session holds more than changed files: intent, decisions, rejected alternatives, constraints, failed attempts, verification, fragile local state. A fresh agent in another model or harness sees none of it.
 
-Copying a transcript is noisy. Rewriting durable plans just to keep temporary continuity duplicates the source of truth. `ce-handoff` is a small bridge between those.
+The two obvious fixes both fail. Pasting a transcript buries the next agent in noise. Rewriting durable plans just to carry temporary context duplicates the source of truth. A handoff sits between them: small, disposable, and pointing at the durable artifacts instead of copying them.
 
-## The Solution
+## What it writes
 
-By default the skill writes one pointer-first Markdown document with:
+One Markdown document containing:
 
-- A flat `ce-handoff/v1` frontmatter index for later discovery
+- A flat `ce-handoff/v1` frontmatter index (title, summary, keywords, creation time, cwd, optional Git metadata) so later discovery works without reading bodies
 - The objective and latest user intent
 - Progress, decisions, constraints, blockers, verification, and abandoned wrong turns
-- Current-state phrasing that distinguishes complete, in-progress, and not-started work when those differ
-- References to plans, issues, commits, diffs, docs, and repo files, each saying what is load-bearing there
-- Labels for machine-local paths and fragile worktree state
-- Plausible next steps as remaining status and dependencies. User-requested directives only when you asked for them. Context-loading pointers (what to read) stay welcome.
+- Current-state phrasing that separates complete, in-progress, and not-started work when those differ
+- References to plans, issues, commits, diffs, docs, and repo files, each saying what matters there
+- Labels on machine-local paths and fragile worktree state
+- Next steps stated as remaining status and dependencies, plus pointers to what the next agent should read. Directives appear only when you asked for them.
 
-Only managed-store frontmatter has a fixed contract, because default discovery depends on it. The body has no closed section schema. The agent may add, combine, rename, reorder, or omit example sections so the next agent can see *this* session clearly.
+Only the managed-store frontmatter has a fixed contract, because default discovery depends on it. The body has no fixed section list; the agent shapes it around what this session actually needs to convey.
 
-The managed store is a default, not a restriction. If you name another path, folder, format, or publication destination, the agent follows that with an installed capability. It does not also write a temporary copy unless you asked or the publish flow needs a working file.
+Repo files get relative paths. Absolute paths mark machine-local context. Secrets and unrelated personal information get redacted. The skill never commits, stashes, copies, or preserves a worktree on its own; if continuity depends on fragile state, it warns you instead.
 
-Repository files are referenced relatively when possible. Absolute paths are reserved for machine-local context. The skill redacts secrets and unrelated personal information. It never commits, stashes, copies, or preserves a worktree on its own.
+The managed `/tmp` store is a default, not a restriction. Name another path, folder, format, or publish destination and the agent uses that instead, without also writing a temporary copy unless you asked or the publish flow needs a working file. Filename collisions get a numeric suffix, reserved atomically.
 
-Default files live in OS-managed `/tmp`. The topic filename sits in a repository-level collection. Creation time and worktree identity stay in frontmatter. A real filename collision gets a numeric suffix. The skill says the file is reusable across sessions but not permanent project documentation.
+One limit to know: automatic discovery only works when the next session sees the same filesystem. For another machine or container, publish or transfer the file and resume from that explicit source. The skill does not add its own transport.
 
-Automatic discovery works when the receiving session can see the same host filesystem. If the next agent is on another machine, in another container, or cannot see that `/tmp`, transfer or publish the handoff and resume from that explicit source. The skill does not add its own transport layer.
+## How resume protects you
 
----
+Resume stops twice, and both stops are yours.
 
-## What Makes It Novel
+Discovery is metadata-only. `resume <keywords>` ranks candidates by frontmatter, filename, and file metadata, lists them with match reasons, and stops. No body is read until you pick one.
 
-### One skill, two explicit directions
+Orientation stops before action. After reading your selection, the agent checks that referenced state still exists, summarizes what it recovered, recommends one continuation matched to the handoff's reason, and waits. Selecting a file authorized reading that file, nothing else. An old instruction in a handoff does not become current authority.
 
-Bare `ce-handoff` creates. Resume is an explicit mode or natural language. The plugin does not need a second skill name.
-
-### Frontmatter as a search index
-
-Title, summary, keywords, creation time, cwd, and optional Git metadata let a fresh agent find likely CE-created handoffs without loading every prior session body. Sources without that index can still appear as unindexed candidates.
-
-### Pointer-first continuity
-
-The handoff carries only what a fresh agent cannot infer. Durable project artifacts remain the source of truth. That keeps the snapshot small even if a worktree is later torn down.
-
-### Two stops you control
-
-Discovery stops before any document body is read. You pick the candidate. Orientation then stops before action. A likely match or an old instruction does not become current authority.
+You can also resume things this skill never wrote. Any readable file, URL, page, or pasted document works; CE frontmatter is not required.
 
 ---
 
-## Quick Example
+## Quick example
 
 You are mid-migration and about to close the session. `/ce-handoff create finish the authentication migration` writes a snapshot under `/tmp/compound-engineering-<effective-uid>/ce-handoff/<repo>/authentication-migration.md`, summarizes what it captured, and prints:
 
@@ -111,13 +99,13 @@ You are mid-migration and about to close the session. `/ce-handoff create finish
 /ce-handoff resume /tmp/compound-engineering-<effective-uid>/ce-handoff/.../authentication-migration.md
 ```
 
-In a new session you paste that command. The agent reads the file, checks that the worktree still exists, summarizes the recovered state, and recommends one continuation (for example `ce-work` on the open plan). It then waits. Selecting the file authorized that read only.
+In a new session you paste that command. The agent reads the file, checks that the worktree still exists, summarizes the recovered state, recommends one continuation (say, `ce-work` on the open plan), and waits.
 
-If you remember the topic but not the path, `/ce-handoff resume authentication migration` lists likely files with match reasons and stops. Nothing is ingested until you choose.
+If you remember the topic but not the path, `/ce-handoff resume authentication migration` lists likely files with match reasons and stops until you choose.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Use `ce-handoff` when:
 
@@ -125,23 +113,23 @@ Use `ce-handoff` when:
 - A different agent, model, or harness will pick up the work
 - You want to tear down a session while keeping decisions and fragile-state warnings
 - You remember the topic of an earlier handoff but not its path
-- You have a file, page, pasted summary, or other continuity source and want orientation before deciding
+- You have a file, page, or pasted summary and want orientation before deciding anything
 
 Skip it when:
 
 - You are continuing in the current session
 - The information belongs in a durable plan, issue, learning, or project document
-- You need guaranteed long-term retention. `/tmp` is OS-managed and may be cleaned up. Write or publish somewhere durable instead.
+- You need guaranteed retention. `/tmp` is OS-managed and may be cleaned up; write or publish somewhere durable instead.
 
 ---
 
-## Chain Position
+## Chain position
 
 `ce-handoff` is a utility, not a pipeline stage. It can capture research, brainstorming, planning, implementation, debugging, review, or a conversation with no repository at all.
 
-`/lfg` may offer an opt-in handoff at closeout for the next separately planned area. That offer waits for you. Accepting it creates a handoff for a fresh session to brainstorm that area. It does not extend the plan that just shipped.
+`/lfg` may offer an opt-in handoff at closeout for the next separately planned area. That offer waits for you; accepting creates a handoff for a fresh session to brainstorm that area, not an extension of the plan that just shipped.
 
-On resume, the skill recommends a continuation matched to the selected source. It does not automatically invoke `ce-plan`, `ce-work`, `ce-debug`, or any other workflow.
+On resume, the skill recommends a continuation and stops. It does not invoke `ce-plan`, `ce-work`, `ce-debug`, or anything else on its own.
 
 ---
 
@@ -156,8 +144,6 @@ On resume, the skill recommends a continuation matched to the selected source. I
 | `resume <path-or-URL>` | Reads that source directly. Authorship and `ce-handoff/v1` are not required. |
 | Natural-language create or resume | Same routes. Ordinary "keep going" in the current session is not handoff intent. |
 
-A resume source may be a local file, URL or page, pasted document, or any other readable artifact, from any person or system.
-
 ---
 
 ## FAQ
@@ -169,14 +155,14 @@ No. It orients, recommends, and waits. Selection authorizes reading that source 
 Yes. An explicit source does not need CE frontmatter or to have been written as a formal handoff.
 
 **Why is the default under `/tmp`?**
-It is continuity, not project documentation. Say a durable path or a publish destination when the next session will not share this filesystem, or when you need the file to survive a reboot.
+It is continuity, not project documentation. Name a durable path or publish destination when the next session will not share this filesystem, or when the file must survive a reboot.
 
 **Will two handoffs overwrite each other?**
-No. A real filename collision gets a numeric suffix. The skill reserves the name atomically.
+No. A real filename collision gets a numeric suffix, and the skill reserves the name atomically.
 
 ---
 
-## See Also
+## See also
 
 - [`/ce-plan`](./ce-plan.md): a durable implementation plan when the work itself needs one
 - [`/ce-work`](./ce-work.md): execute a concrete plan after you choose to continue

--- a/docs/guides/ce-ideate.md
+++ b/docs/guides/ce-ideate.md
@@ -1,10 +1,10 @@
 # `ce-ideate`
 
-> When you don't yet have an idea, get a ranked set of grounded directions you can pick from, discuss, or discard.
+> When you don't have an idea yet, get a ranked set of grounded directions you can pick from, discuss, or discard.
 
-`ce-ideate` is the optional **discovery** step. Use it when the question is "which directions are worth exploring?" not "help me refine this one I already have." It grounds first (the repo, past learnings, prior art on the web, and optionally Slack or your issue tracker), generates candidates from six frames, and keeps only the ones that survive an adversarial cut. Every survivor carries a tagged **basis** you can check. Rejected ideas come with reasons.
+`ce-ideate` is the optional discovery step. Use it when the question is "which directions are worth exploring?" rather than "help me refine this one I already have." It grounds first (the repo, past learnings, prior art on the web, and optionally Slack or your issue tracker), generates candidates from six thinking frames, and keeps only the ones that survive an adversarial cut. Every survivor cites a basis you can check. Rejected ideas come with reasons.
 
-It works on software in this repo, on a product outside the repo, and on topics with no software surface (names, narrative, personal decisions, business strategy). The generate-then-critique engine and the basis rule stay the same.
+It works on software in this repo, on a product outside the repo, and on topics with no software at all: names, narrative, personal decisions, business strategy. The generate-then-critique engine and the basis rule stay the same.
 
 This is the first step in the compound-engineering ideation chain. Skip it when you already know what to explore:
 
@@ -15,7 +15,7 @@ This is the first step in the compound-engineering ideation chain. Skip it when 
                                         this?"
 ```
 
-Acting on a survivor goes to `ce-brainstorm`. In a repo, do not skip from ideation to `ce-plan`. Outside a software build, the saved idea set can be the end of the run.
+Acting on a survivor goes to `ce-brainstorm`. In a repo, don't skip from ideation to `ce-plan`. Outside a software build, the saved idea set can be the end of the run.
 
 If the options are already on the table and you need a verdict, use `ce-pov` instead.
 
@@ -25,9 +25,9 @@ If the options are already on the table and you need a verdict, use `ce-pov` ins
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Grounds in real material, splits the topic into axes, generates candidates across six frames, critiques them, and presents 5-7 survivors, each with a tagged basis |
+| What does it do? | Grounds in real material, splits the topic into axes, generates candidates across six frames, critiques them all, and presents 5-7 survivors, each with a cited basis |
 | When to use it | You don't have a specific idea yet: greenfield, a codebase audit, issue-tracker mining, surprise-me, naming, a decision, a strategy question |
-| What it produces | A ranked ideation file, HTML by default (openable in a browser). `output:md` writes markdown. Lands in `docs/ideation/` when that tree exists, otherwise a temp path under `/tmp/compound-engineering-<effective-uid>/` |
+| What it produces | A ranked ideation file, HTML by default. `output:md` writes markdown. Lands in `docs/ideation/` when that tree exists, otherwise a temp path under `/tmp/compound-engineering-<effective-uid>/` |
 | What's next | `ce-brainstorm` on one survivor, stay here and discuss or refine the set, or keep the file and stop |
 
 ---
@@ -60,26 +60,14 @@ If the options are already on the table and you need a verdict, use `ce-pov` ins
 /ce-ideate developer experience improvements output:md
 ```
 
-Use `ce-pov` when the candidates are already known and need judgment. Use `ce-brainstorm` when one candidate needs scope.
-
 ---
 
-## The Problem
+## Why not just ask the model for ideas?
 
-Asking an AI "what's worth exploring here?" usually returns:
-
-- Plausible bullets with no grounding in the actual subject
-- The first few obvious frames and nothing else
-- A flat list with no signal about which directions are strong
-- No record of what was considered and rejected
-- Claims that sound confident and cite nothing
-
-## The Solution
-
-`ce-ideate` separates grounding, generation, critique, and selection. Quality comes from explicit rejection with reasons, not optimistic ranking.
+Because one "give me ideas" prompt returns plausible bullets with no grounding in the actual subject, drawn from the model's most-trained directions, ranked by nothing, with no record of what was considered and cut. `ce-ideate` separates grounding, generation, critique, and selection, and gets its quality from explicit rejection with reasons.
 
 - Grounding agents go first: codebase scan (in a repo), past learnings, web prior art, optional Slack and issue intelligence
-- The topic is split into 3-5 axes from that grounding: *what* to cover, separate from *how* to think
+- The topic splits into 3-5 axes from that grounding: what to cover, separate from how to think
 - Six frames generate in parallel, each spreading ideas across those axes
 - Every idea carries a tagged basis: `direct:`, `external:`, or `reasoned:`
 - Ideas without a basis are dropped
@@ -88,15 +76,15 @@ Asking an AI "what's worth exploring here?" usually returns:
 
 ---
 
-## What Makes It Novel
+## How it works
 
-### 1. Grounding before any idea is generated
+### Grounding before any idea is generated
 
-Every run starts with parallel grounding: the codebase (in repo mode), `docs/solutions/`, web prior art, and optional Slack or issue intelligence. In a repo, cheap evidence scouts then pull verbatim quotes with `file:line` pointers so later ideas cite real code. Web prior art is the piece that stops the run from remixing only what's already in the repo or in your head.
+Every run starts with parallel grounding: the codebase (in repo mode), `docs/solutions/`, web prior art, and optional Slack or issue intelligence. In a repo, cheap evidence scouts then pull verbatim quotes with `file:line` pointers so later ideas cite real code. The web pass is what stops the run from remixing only what's already in the repo or in your head.
 
-You can also point the prompt at your own research (a survey export, an analytics dump, a social-listening report). A cheap agent distills that into a citable dossier. It adds source classes web research doesn't reach; it does not replace the web pass.
+You can also point the prompt at your own research (a survey export, an analytics dump, a social-listening report). A cheap agent distills it into a citable dossier. It adds sources web research can't reach; it doesn't replace the web pass.
 
-### 2. Every idea cites its evidence
+### Every idea cites its evidence
 
 Each survivor carries one tagged basis:
 
@@ -104,33 +92,33 @@ Each survivor carries one tagged basis:
 - `external:` named prior art
 - `reasoned:` a written-out first-principles argument, not a gesture
 
-Plausible speculation with no basis is rejected. Grounding without a basis is well-informed speculation. A basis without grounding is clever-sounding rationalization.
+Plausible speculation with no basis is rejected. Grounding without a basis is well-informed speculation; a basis without grounding is clever-sounding rationalization. The skill requires both.
 
-### 3. Six frames, then a cut
+### Six frames, then a cut
 
-The frames are pain and friction; inversion, removal, or automation; assumption-breaking; leverage and compounding; cross-domain analogy; and constraint-flipping. One prompt tends to collapse into the model's most-trained directions. Separate frames, especially analogy and constraint-flipping, produce a wider set.
+The frames are pain and friction; inversion, removal, or automation; assumption-breaking; leverage and compounding; cross-domain analogy; and constraint-flipping. Separate frames, especially analogy and constraint-flipping, produce a wider set than one prompt would.
 
-Default software and product runs use five agents to cover all six frames. `go deep` raises the whole fleet to the conversation's top-tier model, doubles verification, and adds a second critic. A tactical ask (`quick wins`, `polish`, `cleanup`) keeps every frame and shrinks volume: fewer ideas per frame, fewer verification reads, at most 3 axes. Issue-tracker runs replace the six frames with the tracker's highest-leverage themes (up to four) when the scan returns usable themes.
+Default software and product runs use five agents to cover all six frames. `go deep` puts the whole fleet on the conversation's top-tier model, doubles verification, and adds a second critic. A tactical ask (`quick wins`, `polish`, `cleanup`) keeps every frame and shrinks volume: fewer ideas per frame, fewer verification reads, at most 3 axes. Issue-tracker runs replace the six frames with the tracker's highest-leverage themes (up to four) when the scan returns usable themes.
 
-Critique is two layers. A verifier that never saw generation tries to refute each candidate: do the quotes exist, is the prior art real, does the argument hold? Then the orchestrator makes the final cut. Every rejection gets a one-line reason.
+Critique runs in two layers. A verifier that never saw generation tries to refute each candidate: do the quotes exist, is the prior art real, does the argument hold? Then the orchestrator makes the final cut. Every rejection gets a one-line reason.
 
-### 4. Axes so six frames don't all land on the same slice
+### Axes so six frames don't all land on the same slice
 
-Frames decide *how* to think. Axes decide *what part* of the topic to think on. Before dispatch, the orchestrator derives 3-5 orthogonal axes from grounding. For social sharing those might be send, discovery, arrival, compounding, and actor types. Each frame spreads ideas across them. If an axis has zero ideas, one bounded recovery dispatch fills it. Atomic topics (a name, a tagline) and surprise-me runs skip this.
+Frames decide how to think; axes decide what part of the topic to think on. Before dispatch, the orchestrator derives 3-5 orthogonal axes from grounding. For social sharing those might be send, discovery, arrival, compounding, and actor types. Each frame spreads ideas across them, and if an axis ends up with zero ideas, one bounded recovery dispatch fills it. Atomic topics (a name, a tagline) and surprise-me runs skip this.
 
-### 5. Three modes, plus surprise-me and the issue tracker
+### Three modes, plus surprise-me and the issue tracker
 
-The same engine runs on things in this codebase, a software product outside this repo, or a topic with no software surface.
+The same engine runs on things in this codebase, a software product outside this repo, or a topic with no software at all.
 
-Non-software mode uses a facilitator in the topic's own language. Same six frames, same basis rule, same critique. Depth is Quick (3-5 survivors, one inline round), Standard (5-7, still inline), or Full (5-7, frames dispatched as agents). `ce-brainstorm` on a non-software survivor develops that idea further (a name into a brand brief, a plot into an outline). It is not the first step of a build chain.
+Non-software mode uses a facilitator in the topic's own language. Same six frames, same basis rule, same critique. Depth is Quick (3-5 survivors, one inline round), Standard (5-7, still inline), or Full (5-7, frames dispatched as agents). `ce-brainstorm` on a non-software survivor develops that idea further (a name into a brand brief, a plot into an outline); it is not the first step of a build chain.
 
-`/ce-ideate surprise me` skips naming a subject. Each frame picks its own from the grounding. Combinations across those subjects are expected.
+`/ce-ideate surprise me` skips naming a subject. Each frame picks its own from the grounding, and combinations across those subjects are expected.
 
 Phrases like "what users are reporting" or "biggest issue patterns" start an issue-intelligence pass against GitHub, Linear, or Jira, whichever is reachable. Large trackers are scoped by the tracker's own structure. The skill asks at most one question, and only when the tracker is genuinely split. It says what it did and did not analyze.
 
 ---
 
-## Quick Example
+## Quick example
 
 You invoke `ce-ideate "DX improvements"` from inside a repo. The agent names the grounding and ideation agents it will dispatch and lists the skip phrases (`no external research`, `no slack`).
 
@@ -145,11 +133,11 @@ The full cards (basis, rationale, downsides, confidence, complexity) plus the re
 3. Discuss or refine the ideas first
 4. Done: keep the file and stop
 
-Say `discard` if you don't want a file created this run. Discard does not delete a resumed existing doc.
+Say `discard` if you don't want a file kept this run. Discard does not delete a resumed existing doc.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Reach for `ce-ideate` when:
 
@@ -169,7 +157,7 @@ Skip `ce-ideate` when:
 
 ---
 
-## Use as Part of the Chained Workflow
+## Use as part of the chained workflow
 
 ```text
 /ce-ideate            "What's worth exploring?"
@@ -187,7 +175,7 @@ Skip `ce-ideate` when:
 /ce-work              "Build it."
 ```
 
-Each artifact is input for the next. The survivor's basis becomes the brainstorm's evidence seed. The brainstorm's decisions become the plan's requirements and scope. The plan's U-IDs and test scenarios are the guardrails `ce-work` executes against. When you pick "Brainstorm one idea," `ce-brainstorm` loads with that idea's basis, rationale, and tradeoffs. The ideation file is already saved.
+Each artifact feeds the next. The survivor's basis seeds the brainstorm's evidence; the brainstorm's decisions become the plan's requirements and scope; the plan's U-IDs and test scenarios are what `ce-work` executes against. When you pick "Brainstorm one idea," `ce-brainstorm` loads with that idea's basis, rationale, and tradeoffs. The ideation file is already saved.
 
 In a repo, acting on an idea always goes to `ce-brainstorm`, not `ce-plan`. `ce-plan` wants a brainstorm-grounded Product Contract.
 
@@ -195,28 +183,26 @@ The chain works outside software too: weekend-trip directions feed a brainstorm 
 
 ---
 
-## Use Standalone
+## Use standalone
 
-`ce-ideate` is a complete ideation cycle on its own. It produces a ranked, reasoned idea set as a saved file you can open, share, brainstorm from, or discard.
+`ce-ideate` is a complete ideation cycle on its own: a ranked, reasoned idea set saved as a file you can open, share, brainstorm from, or discard.
 
 **Software:**
 
-- **Codebase audits:** `/ce-ideate "what to improve in this repo"` (pair with `STRATEGY.md` for strategy-aligned weighting)
-- **Issue triage:** `/ce-ideate "biggest issue themes in the last quarter"`
-- **Pricing or positioning ideation:** `/ce-ideate "pricing page A/B test ideas"`
-- **Surprise-me runs:** `/ce-ideate "surprise me"` from inside any repo
+- Codebase audits: `/ce-ideate "what to improve in this repo"` (pair with `STRATEGY.md` for strategy-aligned weighting)
+- Issue triage: `/ce-ideate "biggest issue themes in the last quarter"`
+- Pricing or positioning: `/ce-ideate "pricing page A/B test ideas"`
+- Surprise-me runs: `/ce-ideate "surprise me"` from inside any repo
 
 **Non-software:**
 
-- **Naming:** coffee shops, baby names, products, brands
-- **Personal decisions:** career options, sabbatical destinations
-- **Plot or narrative ideation:** short story directions, character beats
-- **Business strategy:** go-to-market, positioning against a competitor
-- **Travel and events:** trip themes, wedding-venue concepts
+- Naming: coffee shops, baby names, products, brands
+- Personal decisions: career options, sabbatical destinations
+- Plot or narrative ideation: short story directions, character beats
+- Business strategy: go-to-market, positioning against a competitor
+- Travel and events: trip themes, wedding-venue concepts
 
-The file is written every run. Say `discard` to delete a file created this run.
-
-If a related ideation file from the last 30 days exists, the skill offers to resume it instead of starting a duplicate.
+The file is written every run. Say `discard` to delete a file created this run. If a related ideation file from the last 30 days exists, the skill offers to resume it instead of starting a duplicate.
 
 ---
 
@@ -240,19 +226,13 @@ Skip phrases supported anywhere in the prompt: `no external research`, `no slack
 
 ## FAQ
 
-**Why six frames? Why not just one "give me ideas" prompt?**
-One prompt collapses into the model's most-trained directions. Separate frames, especially cross-domain analogy and constraint-flipping, surface ideas a single prompt usually misses.
-
 **Why a basis requirement?**
-Without a basis, plausible-sounding ideas pass through unfiltered. Every survivor cites real evidence, real prior art, or a written-out argument. You can audit it.
-
-**Does it work for non-software topics?**
-Yes. A facilitator runs the same generate-critique-survive engine in the topic's own language for naming, narrative, personal decisions, and business strategy. Codebase grounding is replaced by user-context synthesis and web research.
+Without one, plausible-sounding ideas pass through unfiltered. Every survivor cites real evidence, real prior art, or a written-out argument, so you can audit it.
 
 **Can I go straight to `ce-plan` from a survivor?**
-Not from inside a repo. Acting on an idea loads `ce-brainstorm` with a substance seed. `ce-plan` wants a brainstorm-grounded Product Contract. Outside a software build, the saved idea set can be the end of the run; brainstorming there is optional deeper development of one idea.
+Not from inside a repo. Acting on an idea loads `ce-brainstorm` with a substance seed; `ce-plan` wants a brainstorm-grounded Product Contract. Outside a software build, the saved idea set can be the end of the run, and brainstorming there is optional deeper development of one idea.
 
-**What if I want to tweak or talk through the ideas before committing to a brainstorm?**
+**What if I want to talk through the ideas before committing to a brainstorm?**
 Pick "Discuss or refine the ideas first." Stay in `ce-ideate` and work across the set: adjust or interrogate one idea, compare several, or combine them. Adjustments and merges update the saved file; pure Q&A and comparison do not. The file is written automatically, so if you didn't want a new one kept, say `discard`.
 
 **What if my prompt is ambiguous?**
@@ -260,7 +240,7 @@ A subject-identification gate asks one scope question when the prompt names only
 
 ---
 
-## See Also
+## See also
 
 - [`ce-brainstorm`](./ce-brainstorm.md): once you've picked a survivor, brainstorm the chosen direction into a requirements-only unified plan
 - [`ce-pov`](./ce-pov.md): when the options are already known and you need a verdict, not a new candidate set

--- a/docs/guides/ce-optimize.md
+++ b/docs/guides/ce-optimize.md
@@ -4,9 +4,9 @@
 
 `ce-optimize` is an on-demand **experimentation** skill. Use it when the right change is not obvious, you can try several variants, and "better" is a number or a judged score. If you already know the change, make it. If you need a root cause, that is `ce-debug`.
 
-It writes a spec (or loads yours), measures a baseline, then runs experiments in isolated worktrees (or via Codex when the spec says so). Wins stay on an `optimize/<spec-name>` branch. Losses revert. Every result is written to disk so a long run can survive a crash or a compacted context.
+It writes a spec (or loads yours), measures a baseline, then runs experiments in isolated worktrees (or via Codex when the spec says so). Wins stay on an `optimize/<spec-name>` branch. Losses revert. It writes every result to disk, so a long run survives a crash or a compacted context.
 
-Karpathy's autoresearch is the nearest ancestor. This version is for multi-file code changes and for non-ML work: clustering, search, prompts, build time, latency, anything you can score the same way twice.
+It handles multi-file code changes and non-ML work alike: clustering, search, prompts, build time, latency, anything you can score the same way twice.
 
 Skip it when you already know the change, when you are hunting a root cause, or when nothing can be measured.
 
@@ -91,13 +91,13 @@ Judge runs bucket the output (large, mid, small, singletons, or the equivalent f
 
 ### Disk is the run, not the chat
 
-Each result is appended to the experiment log as soon as it is measured, then read back. A `result.yaml` in the experiment worktree covers the gap if the orchestrator dies before the log update. On resume the log is the source of truth; leftover markers are recovered into it.
+The loop appends each result to the experiment log the moment it is measured, then reads it back. A `result.yaml` in the experiment worktree covers the gap if the orchestrator dies before the log update. On resume the log is the source of truth; leftover markers are recovered into it.
 
 The files under `.context/compound-engineering/ce-optimize/<spec-name>/` are local scratch. They are gitignored, so they survive a resume on this machine and do not travel with the branch.
 
 ### Parallel isolation, then file-disjoint combines
 
-Each experiment owns a worktree and a branch. Merges are serial. After the winner lands, runners-up that edited completely different files can be combined and scored again, up to a cap. A combo that is not eligible on the re-measurement is reverted and logged as promising alone but neutral or harmful together.
+Each experiment owns a worktree and a branch. Merges are serial. After the winner lands, the loop combines runners-up that edited completely different files and scores them again, up to a cap. A combo that is not eligible on the re-measurement is reverted and logged as promising alone but neutral or harmful together.
 
 After each batch a strategy digest (categories tried, what worked, what is still untried, current best) steers the next hypotheses. The digest is working state for the loop, not a kept deliverable.
 
@@ -201,7 +201,7 @@ The `optimize/<spec-name>` branch, with a commit per kept experiment. The spec a
 Yes. Put them in `metric.objectives` as `role: required`. An experiment that improves one required target without regressing the others is eligible. The loop is not done until every declared required target is met. A spec that omits `objectives` still uses the single primary metric.
 
 **What if each measurement takes minutes?**
-Use `stability.mode: ladder` and a relative or paired comparison. The five-run protocol is for baseline, a candidate you are about to keep, and final confirmation — not for every exploratory try. See `references/example-expensive-benchmark-spec.yaml`.
+Use `stability.mode: ladder` and a relative or paired comparison. The five-run protocol is for baseline, a candidate you are about to keep, and final confirmation, not for every exploratory try. See `references/example-expensive-benchmark-spec.yaml`.
 
 **Does it debug?**
 No. It searches a scored design space. A failing test, a stack trace, or "why is this wrong" is `/ce-debug`.

--- a/docs/guides/ce-plan.md
+++ b/docs/guides/ce-plan.md
@@ -1,14 +1,14 @@
 # `ce-plan`
 
-> Establish the guardrails an implementation needs (decisions, units, files, tests, scope, risks) without prescribing the actual code or step-by-step choreography. Plans capture the WHAT; the implementing agent figures out the HOW.
+> Establish the guardrails an implementation needs (decisions, units, files, tests, scope, risks) without prescribing the code or the step-by-step choreography. The plan captures WHAT; the implementing agent figures out HOW.
 
-`ce-plan` produces **decision documents with execution guardrails**, not implementation choreography. The plan captures what decisions have been made, what scope is in or out, what atomic units of work exist, what files each unit touches, what test scenarios must pass, and what risks need mitigation. It does not pre-write code, exact API signatures, or step-by-step shell sequences. Those belong to the implementing agent (`ce-work`, another AI agent, or a human) when code is in front of them.
+`ce-plan` produces decision documents, not implementation scripts. A plan records what was decided and why, what scope is in or out, what atomic units of work exist, which files each unit touches, what test scenarios must pass, and what risks need mitigation. It does not pre-write code, exact API signatures, or shell sequences. Those belong to whoever implements (`ce-work`, another agent, or a human) once code is in front of them.
 
-Plans that pre-write implementation tend to be wrong by the time you implement them: signatures do not compile, choreography is stale, micro-steps hide the real decisions. Plans that capture guardrails stay portable for weeks or months and leave judgment to the implementer.
+The reason is practical. Plans that pre-write implementation are usually wrong by the time anyone implements them. Signatures do not compile, choreography goes stale, and micro-steps bury the real decisions. Plans that capture guardrails stay usable for weeks and leave judgment to the implementer.
 
-It works for any multi-step task where structure helps: software features, refactors, bug fixes, study plans, research workflows, event planning, even annual hot-water-tank maintenance. Same engine, same U-ID stability, same right-sized template.
+The same engine handles non-software work: study plans, event planning, research workflows, even annual hot-water-tank maintenance. Same unit IDs, same right-sized template.
 
-This is the third step in the compound-engineering ideation chain:
+`ce-plan` is the third step in the compound-engineering ideation chain:
 
 ```text
 /ce-ideate         /ce-brainstorm      /ce-plan             /ce-work
@@ -17,7 +17,7 @@ This is the third step in the compound-engineering ideation chain:
                                         this?"
 ```
 
-A prior brainstorm is useful context but is never required. Many teams invoke `ce-plan` directly with a requirements-only unified plan, a legacy requirements doc, a GitHub issue, a PRD, a rough description, or a non-software multi-step task.
+A prior brainstorm helps but is never required. You can invoke `ce-plan` directly with a requirements-only unified plan, a legacy requirements doc, a GitHub issue, a PRD, a rough description, or a non-software task.
 
 ---
 
@@ -26,8 +26,8 @@ A prior brainstorm is useful context but is never required. Many teams invoke `c
 | Question | Answer |
 |----------|--------|
 | What does it do? | Researches context, captures decisions and scope, breaks work into atomic units with stable IDs, enumerates test scenarios per unit, then auto-strengthens weak sections via a confidence check |
-| When to use it | Requirements ready and execution guardrails needed; solo planning when the task is already clear; non-software multi-step tasks; investigative questions that need a structured answer |
-| What it produces | Software: a unified plan in `docs/plans/YYYY-MM-DD-HHMM-<type>-<name>-plan.md` (local wall-clock write time, atomically reserved with a numeric collision suffix when needed). Brainstorm-sourced plans move from `artifact_readiness: requirements-only` to `implementation-ready` in place. Non-software plan-seeking writes a domain plan (or publishes to Proof). Answer-seeking delivers the answer in chat and does not write a plan file. |
+| When to use it | Requirements are ready and execution guardrails are needed; solo planning when the task is already clear; non-software multi-step tasks; investigative questions that need a structured answer |
+| What it produces | Software: a unified plan in `docs/plans/YYYY-MM-DD-HHMM-<type>-<name>-plan.md` (local wall-clock write time, atomically reserved with a numeric collision suffix when needed). Brainstorm-sourced plans move from `artifact_readiness: requirements-only` to `implementation-ready` in place. Non-software plan-seeking writes a domain plan (or publishes to Proof). Answer-seeking delivers the answer in chat with no plan file. |
 | What's next | Software: start `ce-work` (recommended), run it as a `/goal` when the host supports that, decide on remaining review items or prototype a remaining feel-question, create a tracked issue, or open an HTML plan in the browser. Non-software: save, publish to Proof, or both. Answer-seeking: the answer is the end. |
 
 ---
@@ -63,9 +63,6 @@ An empty invoke uses the current conversation if one is already underway (includ
 /ce-plan plan for a plan: synthesize the three research PDFs into a decision memo
 
 # Write the plan as a self-contained HTML page
-/ce-plan turn the notification mute requirements into an implementation-ready plan and make it a self-contained HTML page
-
-# Equivalent shorthand when a repeatable automation needs it
 /ce-plan turn the notification mute requirements into an implementation-ready plan output:html
 
 # Skip the pre-plan scoping-confirmation pause for this run only
@@ -81,27 +78,16 @@ Start with `ce-brainstorm` when the product shape is still unsettled. Direct pla
 
 ## The Problem
 
-Plans written by humans (or AI without structure) tend to fail in predictable ways:
+Plans fail in predictable ways:
 
 - Renumbering chaos: refactor the unit list and every reference in the issue, PR, and conversation is now wrong
 - Vague test "scenarios": "test the new behavior" tells the implementer nothing
 - Forgotten origin context: the brainstorm decided this was for a specific actor, but the plan never mentions them
 - Half-resolved questions: "TBD: figure out caching strategy" sitting in the plan months later
-- Implementation choreography: exact method signatures, micro-steps, or shell sequences pre-written, then wrong when implementation starts
-- No depth check: the author has no signal whether the plan is grounded enough to execute
+- Implementation choreography: pre-written method signatures and shell sequences, wrong by the time implementation starts
+- No depth signal: the author cannot tell whether the plan is grounded enough to execute
 
-## The Solution
-
-`ce-plan` separates **what decisions need to be honored** from **how to satisfy them in code**:
-
-- The plan captures decisions, scope boundaries, atomic units, files, test scenarios, and risks
-- It does not pre-write code, exact API signatures, or step-by-step shell choreography
-- Stable U-IDs survive reordering, splitting, and deletion, so blocker references and PR mentions stay valid
-- Plan decisions are traceable back to origin (R-IDs from brainstorm; AE-IDs cited in test scenarios)
-- The output contract is decided at intake, before any research: a few sentences in chat (Direct), a chat brief with units and test expectations, or the Durable plan file — see below
-- On the Durable path, research runs in parallel before structuring (repo, learnings, framework docs, best practices, spec flow); a Lightweight Durable plan grounds from inline reads instead
-- A confidence check runs automatically after writing a Durable plan and dispatches targeted sub-agents to strengthen weak sections
-- Planning-time vs implementation-time questions are separated. No fake certainty.
+`ce-plan` addresses each of these with structure: stable U-IDs, per-unit test scenarios with named inputs and outcomes, origin tracing back to brainstorm identifiers, a hard separation between planning-time and implementation-time questions, and an automatic confidence check that strengthens the weakest sections before handoff.
 
 ---
 
@@ -109,19 +95,19 @@ Plans written by humans (or AI without structure) tend to fail in predictable wa
 
 ### Three output contracts, decided before research
 
-At intake, after resume and before depth classification, `ce-plan` grounds itself with a few bounded reads of the files the request names and picks one of three results. **Direct**: the work can be stated, done, and verified in one pass with no decision you would weigh — it says what changes in a few sentences and hands off to `ce-work` or to you. **Chat brief**: bounded work with at most one decision and no risk surface — a summary, implementation units with files and test expectations, and a one-line offer to save it or hand it to `ce-work`, all in chat. **Durable**: everything else — the unified plan file with its full floor, confidence check, document review, and handoff menu, exactly as before. When the tier is uncertain the heavier one wins; pipeline and headless runs, goal-driven runs, and risk surfaces (authentication, payments, migrations, external contracts) are always Durable. A saved chat brief is a plain markdown file without the unified-plan contract; re-invoke `ce-plan` on it when you want the full floor.
+Not every planning request deserves a plan file. At intake, `ce-plan` grounds itself with a few bounded reads of the files the request names and picks one of three results:
 
-### Guardrails over choreography
+- **Direct.** The work can be stated, done, and verified in one pass with no decision you would weigh. The skill says what changes in a few sentences and hands off to `ce-work` or to you.
+- **Chat brief.** Bounded work with at most one decision and no risk surface. You get a summary, implementation units with files and test expectations, and a one-line offer to save it or hand it to `ce-work`, all in chat.
+- **Durable.** Everything else: the full unified plan file with confidence check, document review, and handoff menu.
 
-Plans capture decisions and constraints, not code: decisions made (with rationale), scope boundaries, atomic units of work, files touched, test scenarios that must pass, and risks needing mitigation. They exclude exact method signatures, framework-specific syntax, step-by-step shell sequences, and pseudo-code dressed up as an implementation spec. The implementing agent reads the guardrails and figures out HOW with code in front of them.
-
-That is also why the same engine works for non-software tasks. A hot-water-tank-maintenance plan has decisions, units, files-equivalent (which valves, which manuals), test scenarios ("verify no leaks after refill"), and risks, but no code.
+When the tier is uncertain, the heavier one wins. Pipeline and headless runs, goal-driven runs, requests that ask for a plan file by name, and risk surfaces (authentication, payments, migrations, external contracts) are always Durable. A saved chat brief is plain markdown without the unified-plan contract; re-invoke `ce-plan` on it when you want the full treatment.
 
 ### U-IDs that never renumber
 
 Each unit heading is `### U1. Name`, `### U2. Name`, and so on. Existing IDs are never renumbered after reordering, splitting, or deleting. Splits keep the original U-ID on the original concept; new units take the next unused number; deletions leave gaps.
 
-`ce-work` references units by U-ID across plan edits. Renumbering during a deepening pass would silently break every blocker reference, every PR that cites a unit, and every downstream conversation.
+This matters because `ce-work` references units by U-ID across plan edits. Renumbering during a deepening pass would silently break every blocker reference, every PR that cites a unit, and every downstream conversation.
 
 ### Origin tracing and per-unit tests
 
@@ -131,24 +117,22 @@ Every feature-bearing unit enumerates test scenarios from each applicable catego
 
 ### Confidence check, then research that matches intent
 
-After the plan is written, `ce-plan` scores sections, picks the weakest ones, dispatches targeted sub-agents (correctness for units, data integrity for migrations, architecture for key technical decisions), and synthesizes findings back into the plan. Auto mode (default during generation) integrates findings directly. Interactive mode (when you ask to deepen an existing plan) presents findings for accept/reject.
+After writing a Durable plan, `ce-plan` scores sections, picks the weakest ones, dispatches targeted sub-agents (correctness for units, data integrity for migrations, architecture for key technical decisions), and folds findings back into the plan. During generation this runs in auto mode. When you ask to deepen an existing plan, findings are presented one by one for accept/reject.
 
-Phase 1 always runs local research in parallel (repo patterns and `docs/solutions/` learnings), plus spec-flow analysis for Standard/Deep plans, and optional Slack research. External research is decided by intent, not a single on/off switch. An explicit request ("research competitors", "best practices from the web", "which library") always runs. Implicit signals (thin local patterns, or an unsettled external option set the recommendations depend on) can trigger it too. Implementation-guidance routes to framework docs and best practices. Landscape or option-discovery routes to a web scan. Mixed requests run the landscape scan first, then docs on the shortlist.
+Research earlier in the run is decided by intent, not a single on/off switch. Local research (repo patterns, `docs/solutions/` learnings) always runs in parallel, plus spec-flow analysis for Standard and Deep plans. An explicit request ("research competitors", "which library") always triggers external research. Implicit signals can too, when local patterns are thin or the recommendations hinge on an unsettled external option set. Implementation-guidance questions route to framework docs; landscape questions route to a web scan; mixed requests run the scan first, then docs on the shortlist.
 
 ### Universal planning and approach altitude
 
-Non-software work skips the software confidence check, but U-IDs, dependency ordering, scope boundaries, verification scenarios, and the right-sized template carry over.
+Non-software work skips the software confidence check but keeps U-IDs, dependency ordering, scope boundaries, verification scenarios, and the right-sized template. Two dispositions:
 
-Two dispositions:
+- Plan-seeking (a trip, a study curriculum, an event): the saved plan is the deliverable. The wrap-up offers save to disk, publish to Proof, or both.
+- Answer-seeking ("how often does X happen, is it a big deal?"): the answer is the deliverable. The skill states a brief plan-of-attack in chat, executes it (research and synthesis, never code), and writes no plan file. Only a genuine single-fact lookup skips the plan-of-attack and gets answered outright.
 
-- Plan-seeking (a trip, a study curriculum, an event): the saved plan is the deliverable. After writing it, the wrap-up offers save to disk, publish to Proof, or both.
-- Answer-seeking (investigative or analytical: "how often does X happen, is it a big deal?"): the answer is the deliverable. The skill states a brief plan-of-attack in chat, executes it (research and synthesis, never code), and does not write a plan file. Only a genuine single-fact lookup skips planning and gets answered outright.
-
-For a hard problem, you can ask one level up: produce a grounded **approach-plan** (a plan for how the deliverable will be made) and hold at a checkpoint. Enter it explicitly (`plan for a plan`, `don't write it yet, plan how you'd approach it`). Rarely, the skill offers this when the method is genuinely unsettled and getting it wrong is costly. After light recon it lays out the approach in chat, file-optional and deepenable. You run it now or save it for later. Code still flows to `ce-work`. A non-code deliverable is marked `execution: knowledge-work` and runs through `ce-work`'s lightweight carve-out. `ce-plan` itself never executes.
+For a hard problem you can ask one level up: produce a grounded approach-plan (a plan for how the deliverable will be made) and hold at a checkpoint. Enter it explicitly (`plan for a plan`, `don't write it yet, plan how you'd approach it`). Rarely, the skill offers this itself when the method is genuinely unsettled and getting it wrong is costly. Code still flows to `ce-work`; a non-code deliverable is marked `execution: knowledge-work` and runs through `ce-work`'s lightweight carve-out. `ce-plan` itself never executes.
 
 ### Session-settled decisions are carried, not re-asked
 
-When a decision was examined and chosen in the invoking conversation, or arrives distilled in a caller brief, `ce-plan` records it on its Key Technical Decision as `session-settled: user-directed` or `user-approved`, names what it was chosen over, and never re-asks it. Research may contradict a settled decision only on evidence: nothing found proceeds silently; suboptimal-but-workable proceeds with a conflict call-out; invalidating evidence (infeasible, wrong-thing, destructive) stops the run. In pipeline mode that returns a `settled-decision-invalidated` blocked report. An unexamined assertion is not settled. It earns exactly one plan-time challenge.
+When a decision was examined and chosen in the invoking conversation, or arrives distilled in a caller brief, `ce-plan` records it on its Key Technical Decision as `session-settled: user-directed` or `user-approved`, names what it was chosen over, and never re-asks it. Research may contradict a settled decision only on evidence: nothing found proceeds silently, suboptimal-but-workable proceeds with a conflict call-out, and invalidating evidence (infeasible, wrong-thing, destructive) stops the run. In pipeline mode that returns a `settled-decision-invalidated` blocked report. An unexamined assertion is not settled; it earns exactly one plan-time challenge.
 
 ---
 
@@ -156,11 +140,11 @@ When a decision was examined and chosen in the invoking conversation, or arrives
 
 You invoke `ce-plan` with a requirements-only unified plan from `ce-brainstorm`. The skill detects `artifact_readiness: requirements-only`, uses the Product Contract as primary input, and verifies no resolve-before-planning blockers remain.
 
-It dispatches research in parallel (repo analyst, learnings researcher). Strong local patterns and no external comparison requested means it skips external research. An explicit "research competitors" or "best practices from the web" request would have overridden that. A spec-flow analyzer runs to surface edge cases. The brainstorm-sourced scoping synthesis surfaces a tier-shaped summary plus zero or more call-outs (the plan-time forks where another reasonable agent might choose differently). Confirm or redirect. Auto-proceed only fires for Lightweight plans with no forks worth flagging. Standard and Deep always get the explicit checkpoint.
+It dispatches research in parallel (repo analyst, learnings researcher). Local patterns are strong and no external comparison was requested, so it skips external research. A spec-flow analyzer runs to surface edge cases. The scoping synthesis surfaces a tier-shaped summary plus any call-outs, the plan-time forks where another reasonable agent might choose differently. You confirm or redirect. Auto-proceed only fires for Lightweight plans with no forks worth flagging; Standard and Deep always get the explicit checkpoint.
 
-The plan is written. The confidence check then runs automatically. It finds `Risks & Dependencies` thin on a mute-leak risk and one unit's tests missing permission edge cases, dispatches reviewers, and synthesizes findings back. The plan is stamped with a `deepened:` date.
+The plan is written. The confidence check finds `Risks & Dependencies` thin on a mute-leak risk and one unit's tests missing permission edge cases, dispatches reviewers, and folds the findings back. The plan gets stamped with a `deepened:` date.
 
-Document review then runs in non-interactive mode on markdown or HTML plans. Safe auto-fixes apply silently in the artifact's native format. Remaining findings surface as a one-line summary above the post-generation menu (`Doc review applied 2 fixes. 3 decisions, 1 FYI remain.`). The menu offers: start `ce-work` (recommended), run it as a `/goal` when the host supports that, decide on remaining review items or prototype a remaining feel-question, create a tracked issue, or open the file if it is HTML. There is no Proof option on the software menu, and no pause option. The file is already saved.
+Document review then runs non-interactively. Safe auto-fixes apply silently; remaining findings surface as one line above the menu (`Doc review applied 2 fixes. 3 decisions, 1 FYI remain.`). The menu offers: start `ce-work` (recommended), run it as a `/goal` when the host supports that, decide on remaining review items or prototype a remaining feel-question, create a tracked issue, or open the file if it is HTML. There is no Proof option on the software menu and no pause option. The file is already saved.
 
 ---
 
@@ -186,11 +170,11 @@ Skip `ce-plan` when:
 
 ## Make It Automatic
 
-If you want planning to run on its own before implementation, add a standing instruction to your agent's instruction file (the repo's `AGENTS.md`/`CLAUDE.md`, or your global one). The activation condition is the part that keeps small changes cheap:
+If you want planning to run on its own before implementation, add a standing instruction to your agent's instruction file (the repo's `AGENTS.md`/`CLAUDE.md`, or your global one). The activation condition is what keeps small changes cheap:
 
 > Before implementing work that spans several files or carries a design decision, invoke the `ce-plan` skill. Skip it for a change already specified down to the files it touches that touches no risk surface (authentication, payments, migrations, external contracts); do that directly or with the `ce-work` skill.
 
-Two phrases are load-bearing: "invoke the `ce-plan` skill", because the slash-command form is not agent-callable on every harness; and the skip clause, because `ce-plan` itself decides its output contract only after it fires — an instruction that invokes it on every change still pays the skill load for a typo.
+Two phrases carry the weight. "Invoke the `ce-plan` skill", because the slash-command form is not agent-callable on every harness. And the skip clause, because `ce-plan` decides its output contract only after it fires; an instruction that invokes it on every change still pays the skill load for a typo.
 
 ---
 
@@ -220,13 +204,13 @@ Two phrases are load-bearing: "invoke the `ce-plan` skill", because the slash-co
 /ce-compound        (capture the learning)
 ```
 
-The handoff from `ce-plan` to `ce-work` is concrete: `ce-work` reads U-IDs, file paths, scope boundaries, and test scenarios, then determines the actual implementation. The plan tells the implementer **what must be true** when the unit is done. The implementer figures out **how to make it true**.
+The handoff to `ce-work` is concrete: it reads U-IDs, file paths, scope boundaries, and test scenarios, then determines the implementation. The plan says what must be true when a unit is done; the implementer makes it true.
 
 ---
 
 ## Use Standalone
 
-Many people reach for `ce-plan` directly when they already know what to do, for software and equally often for non-software multi-step tasks.
+Plenty of work never goes through a brainstorm. Direct invocations that work well:
 
 **Software:**
 
@@ -243,10 +227,7 @@ Many people reach for `ce-plan` directly when they already know what to do, for 
 - Trip planning: bookings, packing, daily itinerary, contingency boundaries
 - Research workflows: gathering, synthesis, drafting, with explicit deliverables
 - Event planning: venue, vendors, agenda, day-of run-of-show
-- Personal projects: workshop build-outs, home renovations
 - Answer-seeking questions, delivered in chat with no plan file
-
-In universal-planning mode, U-IDs, dependency ordering, scope boundaries, and the right-sized template carry over. The software-specific confidence check is skipped.
 
 ---
 
@@ -273,22 +254,19 @@ In universal-planning mode, U-IDs, dependency ordering, scope boundaries, and th
 ## FAQ
 
 **Doesn't a plan tell you HOW to build something?**
-Not in `ce-plan`'s framing. The plan tells you what must be honored: decisions, scope, units, files, tests, risks. It does not pre-write code, exact API signatures, or step-by-step shell choreography. The implementing agent figures out HOW with code in front of them. That same frame is what lets the engine plan a software refactor, a tank-maintenance job, and a 6-week study plan.
+Not in `ce-plan`'s framing. The plan tells you what must be honored: decisions, scope, units, files, tests, risks. The implementing agent figures out HOW with code in front of them. That same frame is what lets one engine plan a software refactor, a tank-maintenance job, and a 6-week study plan.
 
 **Why U-IDs instead of just numbered units?**
-Numbering breaks when units are reordered, split, or deleted. U-IDs stay put. Splits keep the original on the original concept. Deletes leave gaps. `ce-work`'s blocker references work across plan edits because of this.
+Numbering breaks when units are reordered, split, or deleted. U-IDs stay put, so `ce-work`'s blocker references survive plan edits.
 
 **Why does the confidence check run automatically?**
 The expensive moment to discover a thin section is during execution, not during planning. Auto-deepening runs while research context is still warm.
 
 **What if I want to keep the existing plan and just review it?**
-Use the deepen-intent fast path: `/ce-plan deepen <plan>`. It runs in interactive mode. Agents present findings one by one for accept/reject.
+Use the deepen fast path: `/ce-plan deepen <plan>`. It runs interactively, presenting findings one by one for accept/reject.
 
 **What about implementation code in the plan?**
-Disallowed by default. Pseudo-code and DSL grammars are permitted in High-Level Technical Design when they communicate the shape of the solution, framed as directional guidance, not implementation specification. Exact method signatures, imports, framework-specific syntax, and step-by-step shell sequences do not belong in plans.
-
-**Is it really useful for non-software plans?**
-Yes. Universal-planning keeps U-IDs, dependency ordering, the right-sized template, and the guardrails-not-choreography frame. Real uses include tank maintenance, study plans, trip planning, research workflows, and event planning. Investigative questions use the same engine but deliver the answer in chat.
+Disallowed by default. Pseudo-code and DSL grammars are permitted in High-Level Technical Design when they communicate the shape of the solution as directional guidance. Exact method signatures, imports, framework-specific syntax, and step-by-step shell sequences do not belong in plans.
 
 **Can I publish a software plan to Proof from the post-plan menu?**
 No. Proof is on the non-software wrap-up menu (save, publish, or both). Software next steps are `ce-work`, `/goal` when supported, review or prototype, create an issue, or open an HTML file. Publish a markdown plan later with `/ce-proof` if you want a shareable link.
@@ -297,9 +275,9 @@ No. Proof is on the non-software wrap-up menu (save, publish, or both). Software
 
 ## Model elevation
 
-When you want a specific model for the heavy reasoning step, `ce-plan` can author the plan on that model instead of your session model. Only the interpret-findings-then-author step is dispatched, with read access so it can verify its brief. Dialogue and research stay on your session model. Name a model in the prompt (`use fable`, `have opus plan this`), or set `plan_model: <model>` in CE config (`config.local.yaml` then `config.yaml`). A prompt request overrides the config key.
+When you want a specific model for the heavy reasoning step, `ce-plan` can author the plan on that model instead of your session model. Only the interpret-findings-then-author step is dispatched, with read access so it can verify its brief. Dialogue and research stay on your session model. Name a model in the prompt (`use fable`, `have opus plan this`) or set `plan_model: <model>` in CE config; a prompt request overrides the config key.
 
-This works on any harness. The host serves the chosen model natively where it can, otherwise it invokes the Claude CLI (which must be installed and authenticated), otherwise it runs the step on your session model and says which precondition was unmet. Setting `plan_model` therefore takes effect in every harness you run `ce-plan` in, not just Claude Code.
+This works on any harness. The host serves the chosen model natively where it can, otherwise it invokes the Claude CLI (which must be installed and authenticated), otherwise it runs the step on your session model and says which precondition was unmet.
 
 ## See Also
 

--- a/docs/guides/ce-polish.md
+++ b/docs/guides/ce-polish.md
@@ -2,11 +2,11 @@
 
 > Start the dev server, open the feature in a browser, and iterate together. You say what feels off; fixes land on the running page.
 
-`ce-polish` is on-demand **live UX polish** for a feature that already works. It starts the project's dev server from a complete `.claude/launch.json` configuration or fills only the missing startup facts through framework detection, opens the URL through the active harness when it can, and then waits. You use the page and name what is off. The change lands, hot-reload updates the page, and you keep going until you are done.
+`ce-polish` is live UX polish for a feature that already works. It starts the project's dev server, opens the verified URL through the active harness when it can, and then waits. You use the page and name what is off. It edits, hot reload updates the page, and you keep going until you say you are done. Then it commits on the current branch and stops. No PR.
 
 It is not `ce-prototype` (decide how something should feel before it exists), not `ce-simplify-code` (trim recently changed code), and not `ce-dogfood` or `ce-test-browser` (autonomous QA or a test pass). Polish is a conversation with a running app.
 
-Manual invocation only. The model will not start this on its own, because it starts a server and runs the branch.
+Manual invocation only. It starts a server and runs the checked-out branch, so it waits for you to type it.
 
 ---
 
@@ -36,47 +36,31 @@ Arguments only pick which branch to sit on. The loop after that is always the sa
 /ce-polish feat/notification-settings
 ```
 
-If the project type is unknown, it asks how to start. A `.claude/launch.json` configuration with a usable command, working directory, environment, and numeric port skips detection next time.
+If it cannot work out how to start the project, it asks. A `.claude/launch.json` with a usable command, working directory, environment, and numeric port skips detection next time.
 
 ---
 
 ## The Problem
 
-Late-stage feel is a poor fit for the other skills:
-
-- The feature already works, so a build or plan skill is the wrong tool
-- Code review does not tell you the toggle looks off or the empty state is cold
-- Screenshots in chat miss hover, motion, and odd data
-- Writing a polish plan takes longer than fixing the first few issues
-- Starting the server, opening a browser, and pasting shots back into chat is a lot of handoffs for small visual work
+Late-stage feel fits none of the other skills. Code review does not tell you the toggle looks off or the empty state reads cold. Screenshots pasted into chat miss hover, motion, and odd data. Writing a polish plan takes longer than fixing the first three issues. And doing it by hand means starting the server, opening a browser, describing what you see, waiting for an edit, and reloading, over and over, for work that is individually tiny.
 
 ## The Solution
 
-`ce-polish` does the plumbing, then stays in a short loop:
+`ce-polish` does the plumbing once, then stays in a short loop:
 
-- Phase 0 resolves a safe feature-branch workspace. It stays in the current checkout for an empty invocation. For a requested PR or branch, it uses an existing worktree first, then the active harness's checkout capability only when no other worktree owns the target. It refuses the repository's default branch or a detached checkout.
-- Phase 1 selects the intended server, reusing an attributed instance or starting one in the background, then verifies and opens its actual URL
-- Phase 2 is conversation: you describe a fix, it edits, hot-reload shows the result
-
-When you ask it to check something, it uses a browser inspection capability exposed by the active harness. If none is available, it asks you to describe what you see. When you say you are done, it commits and stops.
+1. **Workspace.** With no argument it stays in the current checkout. For a PR or branch it prefers an existing worktree, and falls back to the harness's checkout capability only when no other worktree owns the target. It refuses the default branch and detached checkouts.
+2. **Server.** It reuses a running server only when it can confirm that process is this project's server; otherwise it starts one in the background and probes the default `http://localhost:<port>` candidate for up to 30 seconds; server output or your correction can identify a different actual URL. It continues only once the response is attributable to the server it selected. If the server it launched never answers, it shows diagnostics with the last 20 log lines and asks what to do.
+3. **Loop.** You describe a fix, it edits, hot reload shows the result. When you ask it to look at something, it uses whatever browser inspection the harness exposes; with none available, you describe what you see. When you say done, it commits and stops.
 
 ---
 
-## What Makes It Novel
+## How it finds the startup command
 
-### Dev-server start without a setup lecture
+It needs four facts to start a server: command, working directory, environment, and port. A `.claude/launch.json` configuration that supplies a usable tuple goes straight to startup. When a fact is missing, only the mechanism that can supply it runs: framework classification and the port resolver supply a missing port, and detection plus package-manager resolution fill in a missing command. A project it cannot classify gets one question, not a setup interview.
 
-It first resolves a startup tuple: command, working directory, environment, and port. A selected `.claude/launch.json` configuration that supplies a usable tuple goes straight to startup. When a fact is missing, only the mechanism that can supply it runs: a selected command, working directory, and environment remain unchanged while classification and the port resolver supply a missing port; when the command is missing, classification, a start recipe, and package-manager resolution supply it. Unknown projects get one question for the facts that cannot be derived.
+If the harness can open a browser, it opens the verified actual URL. If not, or the handoff fails, it prints the URL. The server is up either way.
 
-Polish selects exactly one intended server instance. It reuses a process already serving the chosen port only when evidence identifies it as the intended project server; otherwise it starts the resolved command in the background with output in a temp log. The resolved port provides a default `http://localhost:<port>` candidate, but server output or your correction can identify a different actual URL. It probes that URL for up to 30 seconds and continues only when the response is attributed to the selected server. If the server does not answer, it shows diagnostics and includes the last 20 log lines only when it launched that server, then asks what to do.
-
-### Browser handoff, then a printed URL if unavailable
-
-It uses the browser-opening capability exposed by the active harness with the verified actual URL. If the harness has none or opening fails, it prints that URL. The server is already up either way.
-
-### Conversation, not a checklist
-
-There is no scoring rubric. You name what is wrong; it changes that. A fixed checklist would turn this into an inspection.
+There is no scoring rubric and no checklist. You name what is wrong; it changes that. A fixed checklist would turn this into an inspection, and inspection is `ce-dogfood`'s job.
 
 ---
 
@@ -84,11 +68,11 @@ There is no scoring rubric. You name what is wrong; it changes that. A fixed che
 
 The notification settings page works. Spacing is tight, the off toggle is easy to miss, and the empty-state copy is dry. You run `/ce-polish` on the feature branch.
 
-No `.claude/launch.json`. It detects Next.js, resolves `pnpm`, starts `pnpm dev` on port 3000, verifies the server's actual URL, and opens that URL through the active harness or prints it.
+No `.claude/launch.json`. It detects Next.js, resolves `pnpm`, starts `pnpm dev` on port 3000, verifies the actual URL, and opens it.
 
-You go to `/settings/notifications`. "The toggle rows are too tight." It edits the component; hot-reload updates. "The off state needs to look more off." Another edit. "This empty-state copy is sterile." It rewrites the copy.
+You go to `/settings/notifications`. "The toggle rows are too tight." It edits the component; hot reload updates. "The off state needs to look more off." Another edit. "This empty-state copy is sterile." It rewrites the copy.
 
-You say you are done. It commits. You ship with `/ce-commit-push-pr` or leave the commits for a later session.
+You say you are done. It commits. Ship with `/ce-commit-push-pr` or leave the commits for a later session.
 
 ---
 
@@ -118,19 +102,7 @@ On-demand, after the feature works:
 /ce-work or /ce-debug  ->  feature works  ->  /ce-polish  ->  /ce-commit-push-pr
 ```
 
-Nothing in the core loop calls this. `ce-explain` may tell you to run it; you still type `/ce-polish` yourself. After the loop, shipping is a separate choice (`/ce-commit-push-pr`). Polish often spans more than one session, so it does not open a PR.
-
----
-
-## Use Standalone
-
-- **Current feature branch:** `/ce-polish`
-- **A PR:** `/ce-polish 1234`
-- **A branch:** `/ce-polish feat/notification-settings`
-
-For a requested PR or branch, the skill enters its existing worktree when the harness can. It uses the harness's checkout capability only when no other worktree owns the target. Every form stops on the repository's default branch, a detached checkout, or a requested branch that cannot be reached without moving user changes or creating another worktree behind the harness.
-
-Add `.claude/launch.json` when detection is wrong or you are tired of answering how to start.
+Nothing in the core loop calls this. `ce-explain` may suggest it; you still type `/ce-polish` yourself. Shipping afterward is a separate choice, because polish often spans more than one sitting and a PR every time would pile up.
 
 ---
 
@@ -142,26 +114,23 @@ Add `.claude/launch.json` when detection is wrong or you are tired of answering 
 | `<PR number>` | Uses the PR branch under the worktree and harness-checkout constraints above, then runs the same loop |
 | `<branch name>` | Uses the named branch under the same constraints, then runs the same loop |
 
-Required: a startable local dev server. Browser opening and inspection use capabilities exposed by the active harness; when opening is unavailable, the skill prints the URL, and when inspection is unavailable, you describe what you see.
+Required: a startable local dev server. Browser opening and inspection come from the active harness; with neither, it prints the URL and you describe what you see. Every form stops on a requested branch that cannot be reached without moving user changes or creating a worktree behind the harness.
 
 ---
 
 ## FAQ
 
-**Why is it manual only?**
-It starts a server and runs the checked-out branch. That should be a choice you type, not something the model starts because you mentioned a page.
-
 **What if my framework is not detected?**
-It asks how to start. Put a complete startup tuple in `.claude/launch.json` if you want the next run to skip detection.
+It asks how to start. Put the command, working directory, environment, and port in `.claude/launch.json` if you want the next run to skip detection.
 
 **Does it work without browser automation?**
-Yes. It prints the URL when the active harness cannot open the browser, and you can describe what you see when the harness cannot inspect the page. Hot reload still applies.
+Yes. It prints the URL when the harness cannot open a browser, and you describe what you see when it cannot inspect the page. Hot reload still applies.
 
 **What about Cursor, VS Code, or a plain terminal?**
-It uses whatever browser-opening capability the active harness exposes, then prints the URL if none is available or the handoff fails. Framework detection and server start do not depend on the browser handoff.
+Same answer. Framework detection and server start do not depend on the browser handoff.
 
 **Why no PR at the end?**
-Polish is often more than one sitting. A PR every time would pile up. Commit-and-PR is `/ce-commit-push-pr`.
+Polish is often more than one sitting. Commit-and-PR is `/ce-commit-push-pr`.
 
 ---
 

--- a/docs/guides/ce-pov.md
+++ b/docs/guides/ce-pov.md
@@ -1,14 +1,12 @@
 # `ce-pov`
 
-> Form a decisive, project-grounded point of view in the subject's own shape: an adoption verdict, a document take, or a position on supplied approaches.
+> Get a decisive, project-grounded point of view: an adoption verdict, a take on a document, or a position on approaches already on the table.
 
-`ce-pov` is the on-demand **judgment** skill. Give it an adoption question, a plan or spec to react to as a whole, or approaches already on the table. It returns a verdict in that subject's shape: **Adopt / Trial / Hold / Reject / Not-our-problem** for adoption, a bottom line with strengths and risks for a document, or a preferred approach (or an honest toss-up) for supplied options.
+`ce-pov` is the on-demand judgment skill. Give it an adoption question, a plan or spec to react to as a whole, or a set of approaches, and it answers in that subject's shape: **Adopt / Trial / Hold / Reject / Not-our-problem** for adoption, a bottom line with strengths and risks for a document, a preferred approach (or an honest toss-up) for supplied options.
 
-It is not generic research. Research explains a topic. This skill decides what that topic means here. Every POV cites a verified project fact. Adoption verdicts also need a verified external source. Document and approach POVs verify external claims only when those claims carry the bottom line.
+It is not research. Research explains a topic; this skill decides what the topic means for your project, and it refuses to decide without a verified project fact behind the answer. Adoption verdicts also need a verified external source. It is not a findings review either: `ce-doc-review` finds issues in a document, `ce-code-review` finds issues in a diff, `ce-debug` handles things that are actually broken.
 
-It is also not a findings review. Use `ce-doc-review` for issue-by-issue findings on a document, `ce-code-review` for findings on a diff, and `ce-debug` when something is actually broken.
-
-`ce-brainstorm` offers this skill when a request is really a whether-to-adopt verdict on a named external candidate. Otherwise invoke it directly. After a position lands, it proposes one next step from that POV (edit, plan, scope, or spike). A warm mid-session invoke returns the POV and hands control back.
+After a position lands, it proposes one next step (edit, plan, scope, or spike). Invoked bare mid-session, it infers the question from the conversation, returns the POV, and hands control back.
 
 ---
 
@@ -16,16 +14,14 @@ It is also not a findings review. Use `ce-doc-review` for issue-by-issue finding
 
 | Question | Answer |
 |----------|--------|
-| What does it do? | Grounds a question, document, or supplied approach set against this project and returns a decisive POV in the same shape |
+| What does it do? | Grounds a question, document, or approach set against this project and returns a decisive POV in the same shape |
 | When to use it | "Should we adopt X?", "what do you think of this plan?", "A or B here?", or a mid-session second opinion |
-| What it produces | A compact chat POV. Optionally a shareable write-up, a captured decision, or an attributed cross-model panel note |
-| What's next | One reasoned handoff from the POV: edits, `/ce-plan`, `/ce-brainstorm`, or a spike with `/ce-work`. Warm invokes skip the offer |
+| What it produces | A compact chat POV. A shareable write-up, a captured decision, or a cross-model panel note are all opt-in |
+| What's next | One handoff reasoned from the POV: edits, `/ce-plan`, `/ce-brainstorm`, or a spike with `/ce-work`. Warm invokes skip the offer |
 
 ---
 
 ## Example invocations
-
-Adoption, a document take, a choice among known options, a bare link, an exposure question, or a panel. Empty invoke is a warm second opinion on the current conversation.
 
 ```text
 # Decide whether an external tool fits this project
@@ -60,100 +56,85 @@ Use `ce-ideate` when the options still need inventing. Use `ce-doc-review` when 
 
 ---
 
-## The Problem
+## The problem
 
-A bare agent asked "what's your POV on X?" fails in predictable ways:
+Ask a bare agent "what's your POV on X?" and it fails in predictable ways. It answers in the abstract without checking your dependencies, conventions, or call-sites. It agrees with your framing and ratifies whatever you already wanted. It stops at the first source, or cites things it never verified. The answer scrolls away and the next person re-asks. Or it guesses the question: a bare link becomes "should we migrate" when you only wanted a comparison.
 
-- Answers in the abstract, without checking your dependencies, conventions, or call-sites
-- Agrees with your framing and ratifies whatever you already wanted
-- Stops at the first source, or cites things it did not verify
-- Evaporates: the answer scrolls away and the next person re-asks
-- Guesses the question. A bare link becomes "should we migrate" when you only wanted a comparison
-
-## The Solution
-
-`ce-pov` runs evaluation with explicit gates:
-
-- Frame before grounding. Orient on the input, settle the intent, never guess
-- Subject-aware grounding. Every POV needs a concrete project fact. External evidence is required wherever an external claim carries the conclusion
-- Skeptic stance. Seek disconfirming evidence and name the alternatives. "No" and "not our problem" are first-class
-- Reversibility-tiered effort. A one-way door gets the full workup. A reversible `npm i` gets one screen
-- Optional different-model panel. Named peers and `oracle` can cross-check. Material dissent gets a bounded debate, not a vote
-- Reasoned handoff. The next step is computed from the POV, not assumed
+`ce-pov` puts gates in front of each failure. It settles the intent before grounding and never guesses. Every POV needs a concrete project fact; external evidence is required wherever an external claim carries the conclusion. It hunts for disconfirming evidence, and "no" and "not our problem" are real answers, not fallbacks. Effort scales with reversibility, so a one-way door gets the full workup and a reversible `npm i` gets one screen. The next step is computed from the POV, not assumed.
 
 ---
 
-## What Makes It Novel
+## How it works
 
-### Subject-aware grounding floors
+### Grounding floors
 
-Every POV must clear a **project floor**: a verified project fact relevant to the decision or take. Adoption questions also require a verified external source. Document and approach subjects require one when an external claim materially supports the bottom line.
+Every POV must clear a project floor: a verified fact about this project relevant to the decision. Adoption questions also require a verified external source. Document and approach subjects need one only when an external claim carries the bottom line.
 
-Failed adoption floors return a `Hold` subtype (`Hold: insufficient project grounding` or `Hold: external evidence unavailable`). Failed document or approach floors return an explicit `Blocked` result rather than a confident guess.
+A failed adoption floor returns a `Hold` subtype (`Hold: insufficient project grounding` or `Hold: external evidence unavailable`). A failed document or approach floor returns an explicit `Blocked` result. Neither turns into a confident guess.
 
 ### Propose the frame, never guess it
 
-Before any grounding, the skill orients on what you gave it (it fetches a bare link to learn what it is) and settles the intent: adopt, migrate, compare, is-this-our-problem, document-take, approach-set, or just-an-explainer. Clear input gets a one-line inferred frame. Ambiguous input gets proposed framings to confirm. A pure explainer is answered as research, never forced into a verdict.
+Before grounding, the skill orients on what you gave it (fetching a bare link to learn what it is) and settles the intent: adopt, migrate, compare, is-this-our-problem, document-take, approach-set, or plain explainer. Clear input gets a one-line inferred frame. Ambiguous input gets proposed framings to confirm. A pure explainer is answered as research, never forced into a verdict.
 
-A selection question ("what should we use for auth?") belongs here only when the realistic field is bounded (roughly five or fewer real candidates) and the criteria are knowable. Otherwise it Holds and routes to `ce-ideate` or `ce-brainstorm`.
+A selection question ("what should we use for auth?") belongs here only when the field is bounded, roughly five or fewer real candidates with knowable criteria. Otherwise it Holds and routes to `ce-ideate` or `ce-brainstorm`.
 
-### Project grounding a generic tool can't do
+### Grounding a generic tool can't do
 
-What a generic tool cannot do is read this project: dependency manifests and lockfiles, license compatibility, the incumbent and its call-sites, conventions, git history, the issue tracker, and PRs (descriptions and comments, never diffs). It also surfaces prior decisions (`docs/solutions/`, ADRs, closed issues, abandoned PRs) so a verdict does not re-litigate something the team already settled. A non-code project folder (docs, decks, data) is in scope. Only the no-local-context case is out of scope.
+The skill reads this project: dependency manifests and lockfiles, license compatibility, the incumbent and its call-sites, conventions, git history, the issue tracker, and PR descriptions and comments (never diffs). It also checks prior decisions (`docs/solutions/`, ADRs, closed issues, abandoned PRs) so a verdict does not re-litigate something the team already settled. A non-code project folder works too; only the no-local-context case is out of scope.
 
-Grounding runs in scout sub-agents that return a compact dossier. The orchestrator reasons over the verdict on a clean context. A reversible Tier-1 call runs a single combined pass. The full fleet is reserved for one-way decisions. When the load-bearing facts are already located and verified, it may confirm them with bounded inline reads instead of dispatching scouts. The prior-decision scan still runs either way.
+Grounding runs in scout sub-agents that return a compact dossier, and the orchestrator reasons over the verdict on a clean context. A reversible Tier-1 call runs a single combined pass; the full fleet is reserved for one-way decisions. When the load-bearing facts are already located and verified, bounded inline reads can replace the scouts. The prior-decision scan runs either way.
 
 ### Cold and warm invocation
 
-Run it cold (you state the question) or warm (drop `/ce-pov` into a live session). In warm mode the conversation supplies only the question and the claims to verify, never grounding. Provenance buckets keep "things the chat assumed" out of the verified-facts column. Warm mode is a guest: a POV block, then control handed back. Peers run only when you ask. There is no next-step menu.
+Run it cold (you state the question) or warm (drop `/ce-pov` into a live session). In warm mode the conversation supplies the question and the claims to verify, never the grounding itself. Provenance buckets keep "things the chat assumed" out of the verified-facts column. Warm mode behaves like a guest: a POV block, then control handed back. No peers unless you ask, no next-step menu.
 
-### Reversibility-tiered effort
+### Reversibility tiers
 
-The skill classifies the decision and sizes the work:
+The skill classifies the decision and sizes the work to match:
 
 - **Tier 1** (two-way door): a dependency, lint rule, or config. One-screen verdict, no reversal trigger
 - **Tier 2** (one-way but bounded): a data store, internal contract, or in-repo migration. Full scout fleet plus alternatives
-- **Tier 3** (one-way and high-stakes): security, legal, privacy, a public contract, or an irreversible data migration. Deep external research, a precedent search, and a durable-record offer
+- **Tier 3** (one-way and high-stakes): security, legal, privacy, a public contract, an irreversible data migration. Deep external research, a precedent search, and a durable-record offer
 
-The classification is stated, so a shallow verdict is defensible.
+The classification is stated in the output, so a shallow verdict is defensible.
 
-### Shape-specific output
+### Output in the subject's shape
 
-Adoption verdicts use the same five grades and a fixed schema (incumbent, verified facts, conditions, handoff, and a reversal trigger on Tier 2/3). Document takes lead with a bottom line, then strengths, risks, and a recommendation. Approach-set positions choose one supplied option, or say "Either is viable" with the material tradeoffs rather than forcing a scoreboard winner.
+Adoption verdicts use the five grades and a fixed schema: incumbent, verified facts, conditions, handoff, and a reversal trigger on Tier 2/3. Document takes lead with a bottom line, then strengths, risks, and a recommendation. Approach-set positions pick one supplied option, or say "either is viable" with the material tradeoffs rather than forcing a scoreboard winner.
 
-### Independent, bounded cross-model panels
+### Cross-model panels
 
-A peer never replaces this skill's own judgment. Name one or more providers to cross-check, ask in ordinary language for independent opinions, use `oracle` as shorthand for up to two reachable different-model peers, or accept a proactive offer on a decision with meaningful correction cost. Named peers are honored exactly and are not capped. Warm invocations never offer a panel.
+A peer never replaces the skill's own judgment. Name one or more providers to cross-check, ask for independent opinions in ordinary language, use `oracle` as shorthand for up to two reachable different-model peers, or accept a proactive offer on a decision with meaningful correction cost. Named peers are honored exactly and not capped. Warm invocations never offer a panel.
 
-Peers inspect the shared working tree directly. The first round carries the framed question, subject, read scope, and evidence, but withholds this skill's conclusion. When the subject is itself an already-formed position, that position ships as the subject and peers return their own verdict on the underlying question.
+Peers inspect the shared working tree directly. The first round carries the framed question, subject, read scope, and evidence, but withholds this skill's own conclusion so peers stay independent. When the subject is itself an already-formed position, that position ships as the subject and peers give their own verdict on the underlying question.
 
-A default panel is one blind independent round plus at most two reconciliations. Before each exchange, disputed project claims are verified and every voice gets the same evidence delta. Convergence is this skill's reasoned confidence, not a vote. At the cap, automatic dispatch stops and a further round needs your approval unless you supplied a larger limit up front. A failed peer never blocks the solo POV. A POV delivered after any panel summons reports which peers ran, or that none did and why.
+A default panel is one blind round plus at most two reconciliations. Before each exchange, disputed project claims get verified and every voice sees the same evidence. Convergence is reasoned confidence, not a vote. At the cap, automatic dispatch stops and further rounds need your approval unless you supplied a larger limit up front. A failed peer never blocks the solo POV. Any POV that follows a panel request states which peers ran, or that none did and why.
 
-### Reasoned, tier-gated follow-up
+### Follow-up
 
-The chat verdict is the deliverable. Implementation is outside this read-only contract.
+The chat verdict is the deliverable; implementation is outside this read-only contract.
 
-- **Adopt** with clear scope proposes `/ce-plan`. Fuzzy scope proposes `/ce-brainstorm`
+- **Adopt** with clear scope proposes `/ce-plan`; fuzzy scope proposes `/ce-brainstorm`
 - **Trial** proposes a timeboxed spike with `/ce-work`
 - **Hold / Reject / Not-our-problem** ends
-- A document take with actionable revisions offers to apply those edits through the workflow that owns the document
-- A chosen, defined approach proceeds through planning or execution. An honest toss-up or a Blocked result does not
+- A document take with actionable revisions offers to apply them through the workflow that owns the document
+- A chosen, defined approach proceeds through planning or execution. A toss-up or a Blocked result does not
 
-Handoff happens without another question only when the original request named that downstream action. Otherwise it offers one logical continuation and waits. A full shareable write-up (HTML by default) and a `ce-compound` capture into `docs/solutions/` are both opt-in. Trivial verdicts get a one-line prose offer, not a menu. Warm invocations skip all of this unless you ask.
+Handoff happens without another question only when the original request named that downstream action. Otherwise it offers one continuation and waits. A shareable write-up (HTML by default) and a `ce-compound` capture into `docs/solutions/` are both opt-in. Warm invocations skip all of this unless you ask.
 
 ---
 
-## Quick Example
+## Quick example
 
 You paste a link to a new auth service. The intent is ambiguous, so the skill fetches the link, learns it is a passkeys provider, and proposes: adopt passkeys, migrate auth to them, or compare them to current sign-in? You pick "adopt."
 
 It classifies the decision as Tier 3 (auth is hard to reverse) and runs the full scout fleet. A project-grounding scout finds password + email today, with the auth code centralized in one module. A precedent scout finds no prior decision. An external researcher verifies passkey maturity and migration pitfalls.
 
-Both floors pass. The skill returns `Trial` ("yes, if we pilot it on the internal admin app first") with the conditions, a reversal trigger ("re-evaluate if enterprise SSO becomes a requirement"), and a proposed next step: a timeboxed spike with `/ce-work`. It offers to take the decision into `/ce-plan`, or to write up the full case. You take it to `/ce-plan`, seeded with the verdict.
+Both floors pass. The skill returns `Trial` ("yes, if we pilot it on the internal admin app first") with conditions, a reversal trigger ("re-evaluate if enterprise SSO becomes a requirement"), and a proposed spike with `/ce-work`. It offers to take the decision into `/ce-plan` or write up the full case. You take it to `/ce-plan`, seeded with the verdict.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Use `ce-pov` when:
 
@@ -164,21 +145,21 @@ Use `ce-pov` when:
 - You want to revisit a past decision
 - You want a holistic take on a plan, spec, or brainstorm rather than an issue list
 - You supplied competing approaches and want a project-grounded choice or honest tradeoff
-- You want this take cross-checked by named different-model peers or `oracle`
+- You want the take cross-checked by named different-model peers or `oracle`
 - You are mid-session and want a grounded second opinion on the current direction
 
 Skip `ce-pov` when:
 
 - You just want to understand a topic with no project angle → general research
 - You want options generated from a blank slate → `/ce-ideate`
-- You want findings or an issue-by-issue review of a document → `/ce-doc-review`
+- You want an issue-by-issue review of a document → `/ce-doc-review`
 - You want findings on a code diff → `/ce-code-review`
 - You have already decided and want to scope or build it → `/ce-brainstorm` or `/ce-plan`
 - You are diagnosing broken behavior → `/ce-debug`
 
 ---
 
-## Use as Part of the Workflow
+## Use as part of the workflow
 
 `ce-pov` is an on-demand insert, not a required pipeline stage.
 
@@ -188,12 +169,6 @@ Skip `ce-pov` when:
 - **Routes into `/ce-work`** for a Trial spike
 - **Captures into `/ce-compound`** on request, as a `tooling_decision` or `architecture_pattern` record so the next run's precedent check can find it
 - **Mid-session second opinion** in any skill's session. Returns a POV and hands control back
-
----
-
-## Use Standalone
-
-The examples near the top cover the main subject shapes and panel routes. Other useful prompts include migration decisions, bounded technology selection, CVE exposure, revisiting a past decision, and a Cursor-default cross-check.
 
 ---
 
@@ -211,7 +186,7 @@ The examples near the top cover the main subject shapes and panel routes. Other 
 
 ### Peer target names
 
-Target names distinguish models from harnesses, and are not aliases for each other:
+Target names distinguish models from harnesses and are not aliases for each other:
 
 | Name | Resolves to |
 |------|-------------|
@@ -226,29 +201,29 @@ Cursor Auto is labeled unverified unless a serving-model receipt exists. Without
 ## FAQ
 
 **How is this different from a general "deep research" tool?**
-A general research tool explains a topic in the abstract. `ce-pov` refuses to issue a verdict unless it cites a concrete fact about this project. It ends in a decision, not a report.
+A research tool explains a topic in the abstract. `ce-pov` refuses to issue a verdict unless it cites a concrete fact about this project. It ends in a decision, not a report.
 
 **Why are the floors subject-aware?**
-An adoption verdict built only on web evidence is abstract. A document take does not need ceremonial web research unless an external claim actually carries its conclusion. The project floor always applies. The external floor applies wherever it can change the answer.
+An adoption verdict built only on web evidence is abstract, so adoption always needs both floors. A document take does not need ceremonial web research unless an external claim actually carries its conclusion. The project floor always applies.
 
 **How is this different from `ce-doc-review`?**
-Use `ce-pov` for "what do you think of this doc?": a holistic bottom line with strengths and risks. Use `ce-doc-review` for "review this doc" or "find the issues": structured findings and remediation.
+Use `ce-pov` for "what do you think of this doc?": a bottom line with strengths and risks. Use `ce-doc-review` for "review this doc" or "find the issues": structured findings and remediation.
 
 **Why only two reconciliation rounds?**
-Two is the cap on automatic spend, not on the debate. A default run is up to three exchanges (one blind independent round plus two reconciliations). Most runs stop earlier, because the skill ends on reasoned confidence rather than a round count. When a decision needs more, it proposes a bounded extension with the specific unresolved question, and you can supply a larger limit up front.
+Two is the cap on automatic spend, not on the debate. A default run is up to three exchanges (one blind round plus two reconciliations), and most runs stop earlier because the skill ends on reasoned confidence rather than a round count. When a decision needs more, it proposes a bounded extension with the specific unresolved question, or you supply a larger limit up front.
 
 **Does it always write a document?**
-No. The default is a compact chat POV. A full shareable write-up and a durable `ce-compound` capture are both opt-in.
+No. The default is a compact chat POV. A full write-up and a durable `ce-compound` capture are both opt-in.
 
 **Will it nag me with clarifying questions?**
-Only when the intent is genuinely ambiguous (a bare link, no stated intent). A clear question gets a one-line inferred frame and proceeds.
+Only when the intent is genuinely ambiguous, like a bare link with no stated intent. A clear question gets a one-line inferred frame and proceeds.
 
 **Does it work without a code repo?**
-Yes, for any project folder with real material (docs, decks, data) to ground against. The only out-of-scope case is no local context at all. There it asks for context rather than dispensing generic advice.
+Yes, for any project folder with real material (docs, decks, data) to ground against. Only the no-local-context case is out of scope; there it asks for context rather than dispensing generic advice.
 
 ---
 
-## See Also
+## See also
 
 - [`ce-ideate`](./ce-ideate.md): generate options from a blank slate. `ce-pov` judges a given external thing
 - [`ce-brainstorm`](./ce-brainstorm.md): scope a decision once it is a yes. `ce-pov` decides whether

--- a/docs/guides/ce-product-pulse.md
+++ b/docs/guides/ce-product-pulse.md
@@ -2,9 +2,9 @@
 
 > A time-windowed pulse on what users experienced and how the product performed: usage, quality, errors, and signals worth investigating. One page, every time.
 
-`ce-product-pulse` is the **observation** skill. After work has shipped, it queries the product's data sources for a lookback window and writes a single-page report. It is not a step in `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work`. The loop decides and builds; this skill reports what users actually hit.
+`ce-product-pulse` is the **observation** skill. After work ships, it queries the product's data sources for a lookback window and writes a single-page report. It is not a step in `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work`. The loop decides and builds; this skill reports what users actually hit.
 
-You invoke it yourself (it is not model-invoked). Combined with `ce-strategy` as the upstream anchor, follow-ups from the pulse can feed `ce-ideate` ("what's worth exploring?") or `ce-brainstorm` ("what does this need to be?"). It does not replace Sentry, PostHog, or your dashboards. It consolidates one page so you are not re-deriving "what happened" from four tools.
+You invoke it yourself (it is not model-invoked). With `ce-strategy` as the upstream anchor, follow-ups from the pulse feed `/ce-ideate` ("what's worth exploring?") or `/ce-brainstorm` ("what does this need to be?"). It does not replace Sentry, PostHog, or your dashboards. It saves you from re-deriving "what happened" out of four tools every Monday.
 
 ```text
 /ce-strategy (metrics seed the pulse)
@@ -66,27 +66,21 @@ Pick the shortest window that answers the question. A launch check and a weekly 
 
 ## The Problem
 
-"How are we doing?" reports fail in familiar ways:
+"How are we doing?" reports fail in familiar ways. Forty metrics across six tools, and nobody reads any of them. Red / yellow / green from guessed thresholds that were never calibrated to this product. The last 15 minutes of analytics under-reported, so "what just happened?" is wrong. Emails and account IDs landing in saved files and Slack threads. A "report" tool that turns out to have write access to production.
 
-- Forty metrics across six tools, and nobody reads any of them
-- Red / yellow / green based on guessed thresholds that do not match how the product actually runs
-- The last 15 minutes of analytics are under-reported, so "what just happened?" is wrong
-- Emails, account IDs, and message content land in saved files and Slack threads
-- A "report" tool that can write to the database or mark events
-- Pulses live in chat, so you cannot compare last week to this week
-- The pulse measures whatever happens to be instrumented, not what the strategy says matters
+Two quieter failures matter as much: pulses that live only in chat, so last week can't be compared to this week, and pulses that measure whatever happens to be instrumented instead of what the strategy says matters.
 
 ## The Solution
 
 `ce-product-pulse` is a structured observation pass with a few hard rules:
 
 - One page, about 30-40 lines. Thin sections stay thin.
-- Numbers only. No "good" / "bad" labels and no hardcoded thresholds. You judge.
-- Every query's upper bound is `now - 15m`, so ingestion lag does not under-count the tail of the window
+- Numbers only. No "good" / "bad" labels, no hardcoded thresholds. You judge.
+- Every query's upper bound is `now - 15m`, so ingestion lag does not under-count the tail of the window.
 - Saved reports hold counts and anonymized notes. No emails, account IDs, or message text.
 - Every data source is queried read-only. The interview refuses read-write database credentials.
-- When a strategy doc exists (`STRATEGY.md`, or when absent the first of `VISION.md`, `PRODUCT.md`), setup seeds product name and key metrics from it, then wires sources to measure those metrics
-- Every run writes `docs/pulse-reports/` so past pulses are a browseable timeline
+- When a strategy doc exists (`STRATEGY.md`, or the first of `VISION.md`, `PRODUCT.md` when it is absent), setup seeds the product name and key metrics from it, then wires sources to measure those metrics.
+- Every run writes `docs/pulse-reports/`, so past pulses read as a timeline.
 
 ---
 
@@ -100,11 +94,11 @@ Deltas compare this window to the previous equal-length window. If a comparison 
 
 ### Strategy-seeded setup
 
-On first run (or `reconfigure`), the interview reads the strategy doc when present (`STRATEGY.md`, else the first of `VISION.md`, `PRODUCT.md` that exists; metrics are found by meaning, and a linked legacy doc is followed when `STRATEGY.md` defers them there), shows the seeded product name and key metrics, and lets you correct them before wiring sources. Metrics that are not instrumented yet are not silently dropped: each one is either marked pending (`no data` in every report) or explicitly excluded from the pulse while staying in `STRATEGY.md`.
+On first run (or `reconfigure`), the interview reads the strategy doc when present, shows the seeded product name and key metrics, and lets you correct them before wiring sources. Metrics are found by meaning, and a linked legacy doc is followed when `STRATEGY.md` defers them there. Metrics not instrumented yet are not silently dropped: each one is either marked pending (`no data` in every report) or explicitly excluded from the pulse while staying in `STRATEGY.md`.
 
-When none of those docs exists, setup says so and starts from scratch. It also notes that `ce-strategy` can seed a later reconfigure.
+When no strategy doc exists, setup says so and starts from scratch, noting that `ce-strategy` can seed a later reconfigure.
 
-Every metric, event, and signal you propose is checked for being specific, measurable, actionable, relevant, and timely. Vanity metrics get a sharper question. The interview never uses the word "SMART" with you.
+Every metric, event, and signal you propose gets checked for being specific, measurable, actionable, relevant, and timely. Vanity metrics get a sharper question. The interview never says the word "SMART" to you.
 
 ### Read-only, and a trailing buffer
 
@@ -114,11 +108,11 @@ Database access is optional. Many products finish the pulse on analytics and tra
 
 Analytics, tracing, and payments queries run in parallel. Database queries run one at a time, scoped, never as a full-table scan. An expensive DB query is skipped and noted.
 
-The 15-minute buffer is why a `24h` run queries `[now - 24h - 15m, now - 15m]`. Without it, every short window under-states recent activity.
+The 15-minute buffer is why a `24h` run queries `[now - 24h - 15m, now - 15m]`. Without it, every short window understates recent activity.
 
 ### Optional quality scoring
 
-For AI products, you can opt in to scoring up to 10 sampled sessions 1-5 on one dimension you define. Normal sessions default to 4 or 5. Scores 1-3 are for a clear failure (wrong answer, user stuck, error shown). The report carries the distribution and a short anonymized note on anything below 4, not the transcript.
+For AI products, you can opt in to scoring up to 10 sampled sessions 1-5 on one dimension you define. Normal sessions default to 4 or 5. Scores 1-3 mean a clear failure: wrong answer, user stuck, error shown. The report carries the distribution and a short anonymized note on anything below 4, not the transcript.
 
 ---
 
@@ -132,7 +126,7 @@ If quality scoring is on, it samples up to 10 sessions. A distribution like 7×5
 
 The report lands at `docs/pulse-reports/2026-05-04_08-45.md` with Headlines, Usage (engagement, value, completions, any strategy metrics, the quality sample), System performance (p50 / p95 / p99 and the top 5 errors), and Followups. Chat shows the Headlines, the top follow-up, and the path, not the whole file.
 
-A climbing error pattern is a `/ce-debug` follow-up. A product-shaped gap is `/ce-ideate` or `/ce-brainstorm`.
+A climbing error pattern becomes a `/ce-debug` follow-up. A product-shaped gap goes to `/ce-ideate` or `/ce-brainstorm`.
 
 ---
 
@@ -156,24 +150,7 @@ Skip `ce-product-pulse` when:
 
 ## Use as Part of the Workflow
 
-`ce-product-pulse` sits outside the build loop and feeds it.
-
-```text
-                    /ce-strategy
-                         |
-                         v  (key metrics seed pulse)
-   /ce-product-pulse ----+---- follow-ups ----> /ce-ideate --> /ce-brainstorm --> /ce-plan --> /ce-work
-         ^                                                                              |
-         +------------------------ shipped, observed in production ---------------------+
-```
-
-In a configured project:
-
-- `STRATEGY.md` (from `/ce-strategy`, or a legacy `VISION.md`/`PRODUCT.md` in its absence) names the metrics
-- `/ce-product-pulse` writes the report and surfaces follow-ups
-- Follow-ups go to `/ce-ideate`, `/ce-debug`, or `/ce-brainstorm`
-
-The pulse does not decide what to build. It reports what happened so you can choose the next loop step.
+`ce-product-pulse` sits outside the build loop and feeds it. In a configured project, `STRATEGY.md` (from `/ce-strategy`, or a legacy `VISION.md`/`PRODUCT.md` in its absence) names the metrics, the pulse measures them and surfaces follow-ups, and each follow-up picks its own loop entry: `/ce-ideate`, `/ce-brainstorm`, or `/ce-debug`. The pulse does not decide what to build. It reports what happened so you can choose the next step.
 
 First-run setup offers a recurring run via the harness scheduler (the in-plugin `schedule` skill when present, otherwise cron or GitHub Actions). It never schedules unless you confirm. After three or more manual runs with no schedule on file, it mentions the offer once.
 
@@ -207,22 +184,13 @@ Default report path: `docs/pulse-reports/YYYY-MM-DD_HH-MM.md`. If `docs_root` is
 ## FAQ
 
 **Why no thresholds in the report?**
-Thresholds are theater unless they are calibrated for this product, and calibrating every metric is more work than the pulse. You already know what is normal. If a number looks wrong, you notice.
-
-**Why a 15-minute trailing buffer?**
-Most analytics and tracing tools under-report the last few minutes. Without the buffer, every short window understates recent activity.
-
-**Why is database access read-only?**
-A report skill should not be able to mutate production. The interview refuses read-write credentials. Many products never enable the DB at all.
+Thresholds are theater unless they are calibrated for this product, and calibrating every metric is more work than the pulse. You already know what normal looks like. If a number is wrong, you notice.
 
 **Why is the report a single page?**
 A 40-metric dashboard spreads attention. Four sections on one page force a choice about what matters. Depth still lives in the native tools.
 
 **What's the relationship to `STRATEGY.md`?**
-The first-run interview seeds product name and key metrics from it (or, when it is absent, from the first of `VISION.md`, `PRODUCT.md` that exists — the same rule every report re-resolves). Each later pulse re-reads those metrics from that source. Pending ones render as `no data`. Excluded ones stay in the strategy file and do not appear.
-
-**Does it support scheduling?**
-Yes, as an offer during setup (and a one-time reminder after several manual runs). Confirmation is required. The skill does not schedule itself.
+The first-run interview seeds product name and key metrics from it (or from the first of `VISION.md`, `PRODUCT.md` when it is absent — the same rule every report re-resolves). Each later pulse re-reads those metrics from that source. Pending ones render as `no data`. Excluded ones stay in the strategy file and do not appear.
 
 **What about non-Claude-Code platforms?**
 It runs anywhere you have read-only data-source tools. Config is resolved from the repo at runtime. The interview hands scheduling off to whatever the harness exposes.

--- a/docs/guides/ce-promote.md
+++ b/docs/guides/ce-promote.md
@@ -2,31 +2,15 @@
 
 > Draft user-facing announcement copy for a feature that just shipped. It never posts.
 
-`ce-promote` is the **post-ship messaging** utility. After a merge, it figures out what a user can now do, picks channels, and drafts copy you can paste: an X post or thread, a one-line changelog blurb, a LinkedIn post, an email, a blog intro, a short demo script.
+`ce-promote` writes the announcement while the ship context is still in your session. After a merge, it works out what a user can now do, picks channels, and hands you copy-pasteable drafts: an X post or thread, a one-line changelog blurb, a LinkedIn post, an email, a blog intro, a short demo script.
 
-It drafts with nothing extra installed. When the [Spiral CLI](https://www.npmjs.com/package/@every-env/spiral-cli) is present and signed in, those drafts are voice-matched to your brand. Declining the one-time Spiral setup offer is remembered in checkout-local config. See the [configuration reference](./configuration.md).
+It needs nothing installed. If the [Spiral CLI](https://www.npmjs.com/package/@every-env/spiral-cli) is present and signed in, drafts come back voice-matched to your brand; if you decline the one-time Spiral setup offer, that decline is remembered in checkout-local config (see the [configuration reference](./configuration.md)).
 
-It is explicit-invocation only (`disable-model-invocation: true`). Shipping a feature does not start it on its own.
-
-It drafts only. It never posts, publishes, schedules, commits, or opens a PR.
-
----
-
-## TL;DR
-
-| Question | Answer |
-|----------|--------|
-| What does it do? | Summarizes the user-facing value, picks channels, drafts copy, and presents it for review |
-| When to use it | Right after a user-facing feature ships, while the context is still in the session |
-| What it produces | Copy-pasteable drafts, labeled by channel. Never an auto-post. |
-| What's next | You paste and publish. The skill offers a revision if the tone or channel is wrong. |
-| Spiral | Optional. Ready CLI: voice-matched drafts plus a web URL per draft. Otherwise a one-time setup offer, then direct drafts. |
+Two hard limits. It only runs when you invoke it (`disable-model-invocation: true`), so shipping a feature does not start it on its own. And it only drafts. It never posts, publishes, schedules, commits, or opens a PR. Posting stays a human action because it is outward-facing and hard to undo.
 
 ---
 
 ## Example invocations
-
-Empty invoke derives what shipped from the repo. Named channels change the set. The skill always drafts and never posts.
 
 ```text
 # Derive what shipped from the merged PR, diff, changelog, and recent commits
@@ -48,76 +32,47 @@ Empty invoke derives what shipped from the repo. Named channels change the set. 
 /ce-promote a short demo script for the CSV export
 ```
 
-Name channels when you need a particular shape. Otherwise the default is an X post (or short thread) plus a one-line changelog blurb.
+An empty invoke derives what shipped from the repo and drafts the default set: an X post (or short thread) plus a one-line changelog blurb. Name channels when you want a different shape.
 
 ---
 
-## The Problem
+## Why it exists
 
-Announcement copy usually waits for a later marketing pass, so it lags the ship. The engineer who knows the user value is often not the person who writes it. Ad hoc drafts tend toward "We're thrilled to announce…", hashtag spam, and implementation talk instead of what a user can now do.
+Announcement copy usually waits for a later marketing pass, so it lags the ship. The engineer who knows the user value is rarely the person who writes it. And ad hoc drafts drift toward "We're thrilled to announce...", hashtag spam, and implementation talk instead of what a user can now do.
 
-## The Solution
+`ce-promote` drafts at ship time, from ship context. A free-form description in the prompt is the source of truth; without one, it reads the merged or active PR, the diff, the changelog, and recent commits, then writes a short user-facing summary. Outcome, not the serializer or endpoint. If it cannot tell what shipped, it asks one short question rather than guessing.
 
-`ce-promote` drafts at ship time, from ship context:
-
-- A free-form description in the prompt is the source of truth. Otherwise it derives what shipped from the merged or active PR, the diff, the changelog, and recent commits, then writes a short **user-facing** summary. Outcome, not the serializer or endpoint.
-- Default channels are an X post plus a changelog blurb. Named channels replace or add to that. A small fix gets one or two short drafts. A flagship change can get a cross-channel set.
-- If Spiral is ready, drafts come back voice-matched and persist to the Spiral account. If not, the skill offers setup once, then drafts itself. A decline is recorded so the offer does not repeat in this repo.
-- Every draft is presented as a labeled, copy-pasteable block. Then it offers a revision. It does not post.
+It scales to the change: a small fix gets one or two short drafts, a flagship feature can get a cross-channel set. Every draft arrives as a labeled block, followed by an offer to revise. Then it stops.
 
 ---
 
-## What Makes It Novel
+## How Spiral fits in
 
-### Spiral is optional
+Detection is `which spiral` plus `spiral auth status --json`, which lands in one of three states: ready, installed but not signed in, or absent.
 
-Detection is `which spiral` plus `spiral auth status --json`: ready, installed but not signed in, or absent. Ready uses Spiral. Otherwise it offers setup once (sign in, or the one-step install). You approve in a browser. The API key never goes through the agent. Decline and it drafts directly, then writes `ce_promote_spiral_optout: true` in `.compound-engineering/config.local.yaml` so it does not ask again.
+Ready means Spiral writes the drafts, voice-matched, and each one comes back with a web URL so you can keep tweaking in the Spiral app. Not ready means a one-time setup offer: sign in, or the one-step install. You approve in a browser, and the API key never passes through the agent. Decline and the skill drafts directly, then writes `ce_promote_spiral_optout: true` to `.compound-engineering/config.local.yaml` so it does not ask again in this repo. Non-interactive runs skip the offer entirely.
 
-Non-interactive runs skip the offer and draft directly.
+A Spiral failure never blocks the skill. An error or unusable output falls back silently to direct drafting for the affected channels.
 
 ### Phrasing picks one channel or many
 
-Spiral treats "3 tweet options" as N variations of one channel. Words like `campaign`, `across`, `multi-channel`, `everywhere`, or `cross-post`, or naming two or more channels, switch it to a cross-channel set. The skill phrases the request so you get the shape you asked for. When you want several tweets, avoid those cue words. When you want a launch set, name the channels.
+Spiral treats "3 tweet options" as N variations of one channel. Words like `campaign`, `across`, `multi-channel`, `everywhere`, or `cross-post`, or naming two or more channels, switch it to a cross-channel set, and campaign mode ignores the variation count. So if you asked for three tweets and got one, a cue word or a second channel name is usually why. Want several tweets, avoid those words. Want a launch set, name the channels.
 
-Without Spiral, the same split still holds: one strong draft per named channel, or more only when you ask (`3 tweet options`), capped at about three.
+Without Spiral the same split holds: one strong draft per named channel, more only when you ask, capped at about three.
 
-### Drafts only
+### Direct drafts have standards too
 
-The summary is what a user can now do and why they would care. Direct drafts ban AI tells, throat-clearing, and hashtag spam, and match length to the channel. Posting stays a human action because it is outward-facing and hard to undo.
-
----
-
-## Quick Example
-
-A PR adding one-click CSV export just merged.
-
-`/ce-promote 3 tweet options for the new one-click CSV export` summarizes the value, then returns three distinct X drafts as labeled blocks. If Spiral is ready, each draft also has a web URL you can tweak.
-
-`/ce-promote a launch across X, LinkedIn, and email` returns a labeled set for those channels. Spiral decides how many drafts per channel. Without Spiral, you get one draft per named channel.
+The summary is what a user can now do and why they would care. Direct drafts ban AI tells, throat-clearing, and hashtag spam, lead with the outcome, and match each channel's native length and shape. Nothing gets reused verbatim across channels.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
-Use `ce-promote` when:
+Use it when a user-facing feature just shipped and you want the announcement drafted before the context fades, when you need several channels from one prompt, or when you want voice-matched copy and Spiral is installed.
 
-- A user-facing feature just shipped and you want the announcement drafted before the context fades
-- You need several channels from one prompt
-- You want voice-matched copy and Spiral is installed
+Skip it when nothing user-facing shipped (internal refactor, CI-only, test-only), when you only need internal release history (use GitHub Releases), or when you want the agent to actually post or open a PR. It will not.
 
-Skip it when:
-
-- Nothing user-facing shipped (internal refactor, CI-only, test-only)
-- You only need internal release history (use GitHub Releases for plugin history)
-- You want the agent to post or open a PR. This skill will not do that.
-
----
-
-## Use Standalone
-
-This is a post-ship utility, not a pipeline stage. Invoke it after merge, or after you already know what to announce.
-
-It does not run as a side effect of `/ce-work`, `/lfg`, or `/ce-commit-push-pr`. Call it when you want the copy.
+This is a post-ship utility, not a pipeline stage. It does not run as a side effect of `/ce-work`, `/lfg`, or `/ce-commit-push-pr`. Call it when you want the copy.
 
 ---
 
@@ -135,23 +90,7 @@ Spiral CLI details live in the skill's `references/spiral-cli.md`.
 
 ---
 
-## FAQ
-
-**Will it post the tweet or publish the email?**
-No. It prints labeled drafts and reminds you they are yours to ship.
-
-**What if I do not have Spiral?**
-It still drafts. You get a one-time setup offer. Decline it and the skill will not ask again in this repo.
-
-**Why did I get one tweet when I asked for three?**
-A cue word (`campaign`, `across`, `multi-channel`, and similar) or a second channel name switches Spiral into campaign mode, which ignores the variation count. Ask for `3 tweet options` and do not name other channels.
-
-**What if it cannot tell what shipped?**
-It asks one short question rather than guessing.
-
----
-
-## See Also
+## See also
 
 - [Compound Engineering configuration](./configuration.md): `ce_promote_spiral_optout` and how local config is resolved
 - Harness-native screenshots or recordings: useful visual context to pair with the copy when you have them

--- a/docs/guides/ce-proof.md
+++ b/docs/guides/ce-proof.md
@@ -2,13 +2,11 @@
 
 > Publish a local markdown file to a shareable [Proof](https://www.proofeditor.ai) URL, or read, comment on, and edit an existing Proof doc.
 
-`ce-proof` is a **publish and collaborate** utility, not a review skill and not a proofreader. Proof is a real-time markdown editor. Humans and agents can work in the same document.
+Proof is a real-time markdown editor where humans and agents work in the same document. `ce-proof` is the plugin's bridge to it. Despite the name, it does not proofread, check math, gather evidence, or build proofs of concept.
 
-The usual job is **one-way publish**: take a local markdown file (a brainstorm, a plan, a learning, a draft), create a shared Proof doc, and hand back a URL. The local file stays canonical. Publishing does not write anything back to disk.
+The usual job is a one-way publish: take a local markdown file (a brainstorm, a plan, a learning, a draft), create a shared Proof doc, and hand back a URL. The local file stays canonical. Publishing writes nothing back to disk.
 
-It also reads a Proof URL and can comment, suggest, or edit over Proof's hosted v3 web API. Pulling remote content down to a local file is a separate, explicit action.
-
-It does not review documents, check math, gather evidence, or stand in for a proof of concept. If the source is an HTML unified plan, it does not upload it. It returns the local browser path instead.
+Given a Proof URL instead of a file, it reads the doc and can comment, suggest, or edit through Proof's hosted v3 API. Pulling remote content down to a local file is a separate, explicit action.
 
 ---
 
@@ -48,29 +46,25 @@ Publishing creates a new shared doc. A URL argument reads or edits that doc. A p
 /ce-proof delete the Proof doc we just published
 ```
 
-Only markdown is published. An HTML plan stays local. Do not put secrets or private personal data in Proof unless you explicitly approve the upload.
+Only markdown is published. An HTML plan stays local; the skill returns the local browser path instead of uploading it. Don't put secrets or private personal data in Proof unless you explicitly approve the upload.
 
 ---
 
 ## The Problem
 
-Sharing a long markdown draft for review is awkward:
+Sharing a long markdown draft for review is awkward. Chat loses structure, and a 2,000-line plan pasted into a thread is hard to comment on. "See the bullet on line 47" does not stay attached to that bullet a week later. Suggested edits need accept/reject, not a second copy of the file.
 
-- Chat loses structure. A 2,000-line plan pasted into a thread is hard to comment on.
-- "See the bullet on line 47" does not stay attached to that bullet a week later.
-- Suggested edits need accept/reject, not a second copy of the file.
-- Agent edits need a stable identity, or the comment trail looks like several different authors.
-- Create returns an `ownerSecret` that is the only delete credential for an unclaimed doc. Drop it and the doc cannot be cleaned up.
-- Upload is a real third-party transfer. You should know what is leaving disk.
+The API side has its own traps. Agent edits need a stable identity, or the comment trail looks like several different authors. Create returns an `ownerSecret` that is the only delete credential for an unclaimed doc; drop it and the doc can never be cleaned up. And an upload is a real third-party transfer, so you should know what is leaving disk.
 
 ## The Solution
 
-`ce-proof` talks to Proof's hosted API at `proofeditor.ai`:
+`ce-proof` talks to Proof's hosted API at `proofeditor.ai`. Publish reads the local markdown, posts it to `POST /share/markdown`, binds the display name, and returns the `tokenUrl`. Nothing syncs back.
 
-- **Publish** reads the local markdown, posts it to `POST /share/markdown`, binds the display name, and returns the `tokenUrl`. Nothing syncs back.
-- **Collaborate** reads `v3/document` and writes through `v3/edit`: narrow replace/insert/delete first, then suggestions, then whole-doc replace only when you asked for it or a narrow edit cannot express the change.
-- **Pull** is explicit. It reads the current Proof markdown and writes it atomically to a local path. If the pull is a side effect of something else, the skill asks first.
-- **Cleanup** deletes an unclaimed doc with the session `ownerSecret` when you ask. Publish handoffs do not auto-delete.
+For collaboration it reads `v3/document` and writes through `v3/edit`, choosing the narrowest operation that expresses the change: a scoped replace, insert, or delete first, then suggestions, then whole-doc replace only when you asked for it or a narrow edit cannot express the change.
+
+A pull is explicit. It reads the current Proof markdown and writes it atomically to a local path. If the pull is a side effect of something else, the skill asks first.
+
+Cleanup deletes an unclaimed doc with the session `ownerSecret` when you ask. Publish handoffs never auto-delete; review docs need to linger.
 
 If typed `proof_*` MCP tools are already available, the skill prefers those. Otherwise it uses HTTP.
 
@@ -80,26 +74,23 @@ If typed `proof_*` MCP tools are already available, the skill prefers those. Oth
 
 ### One-way publish is the default
 
-The chain use is "give me a link." The local file remains the record. Two equivalent entries:
+The chain use is "give me a link." The local file remains the record. Two entries land here: a direct request ("share this to proof", "get me a proof link for this doc") and an upstream handoff from `ce-ideate` (markdown output) or a non-software `ce-brainstorm` or `ce-plan`.
 
-- A direct request: "share this to proof", "publish this to proof", "get me a proof link for this doc"
-- An upstream handoff from `ce-ideate` (markdown output), non-software `ce-brainstorm`, or non-software `ce-plan`
+Software brainstorm and software plan menus do not offer Proof. Invoke `/ce-proof` yourself on the markdown file. HTML artifacts are never uploaded.
 
-Software brainstorm and software plan menus do not offer Proof. Invoke `/ce-proof` yourself on the markdown file. HTML artifacts are not uploaded.
-
-When the source is a unified plan, the Proof title is labeled by readiness when that metadata is available, for example `Plan: <title> (requirements-only)` or `Plan: <title> (implementation-ready)`.
+When the source is a unified plan and its readiness metadata is known, the Proof title carries it: `Plan: <title> (requirements-only)` or `Plan: <title> (implementation-ready)`.
 
 ### Two credentials, different jobs
 
-Create returns `accessToken` (everyday read, edit, presence) and `ownerSecret` (delete while the doc is unclaimed). The skill keeps `ownerSecret` in session memory only. It never writes tokens into the repo. Always share the `tokenUrl`, not a bare `/d/<slug>`.
+Create returns `accessToken` (everyday read, edit, presence) and `ownerSecret` (delete, while the doc is unclaimed). The skill keeps `ownerSecret` in session memory only and never writes tokens into the repo. It always shares the `tokenUrl`, not a bare `/d/<slug>`, because the editor token doubles as the claim capability.
 
-If someone claims the doc in the Proof UI, `ownerSecret` is revoked for good. `accessToken` still works. Delete then belongs to the Every owner account.
+If someone claims the doc in the Proof UI, `ownerSecret` is revoked for good. `accessToken` still works, and delete then belongs to the owner's Every account.
 
-### Narrow edits, then suggestions, then whole-doc
+### Narrow edits before big ones
 
-Targets are visible text, not raw markdown syntax. Ambiguous matches fail closed. `set_document` is last and is applied as a minimal diff, so it is safe with live collaborators. Emptying the markdown does not remove comment marks. Delete the document if you need a privacy cleanup.
+Edit targets are visible text, not raw markdown syntax. Ambiguous matches fail closed rather than guessing at the first occurrence. `set_document` comes last and is applied as a minimal diff, so it is safe with live collaborators. Emptying the markdown does not remove comment marks; a privacy cleanup means deleting the document.
 
-Identity defaults are `by: "ai:compound-engineering"` and display name `Compound Engineering`. Do not use `ai:compound` unless a caller overrides the pair on purpose.
+Every write is attributed as `by: "ai:compound-engineering"` with display name `Compound Engineering`. Callers can override the pair on purpose; improvised variants like `ai:compound` are not allowed.
 
 ---
 
@@ -109,7 +100,7 @@ You ask to share a notification-mute plan. The skill reads the markdown, posts i
 
 You open the URL, leave inline comments, and send the link to a teammate. Nothing syncs back. If a wrap-up menu handed this off, that menu comes back so you can start work, create an issue, or stop.
 
-Later, `/ce-proof pull this Proof document to docs/reviews/notification-mute.md` writes the current Proof markdown to that path. If the pull is a side effect of another action, the skill asks first.
+Later, `/ce-proof pull this Proof document to docs/reviews/notification-mute.md` writes the current Proof markdown to that path.
 
 ---
 
@@ -124,20 +115,17 @@ Use `ce-proof` when:
 
 Skip it when:
 
-- You want a document reviewed for gaps or quality → `/ce-doc-review` (or `/ce-code-review` for code)
-- The artifact is HTML → open the local file; Proof does not ingest HTML
-- The doc is small enough that chat is enough
-- You are offline (`proofeditor.ai` is required)
-- The content is too sensitive to upload
+- You want a document reviewed for gaps or quality. That is `/ce-doc-review`, or `/ce-code-review` for code.
+- The artifact is HTML. Open the local file; Proof does not ingest HTML.
+- The doc is small enough that chat is enough.
+- You are offline. The skill needs `proofeditor.ai`.
+- The content is too sensitive to upload.
 
 ---
 
 ## Use as Part of the Workflow
 
-Wrap-up menus that offer Proof:
-
-- Non-software `/ce-brainstorm` and `/ce-plan`
-- `/ce-ideate` Phase 5, markdown output only
+Wrap-up menus that offer Proof: non-software `/ce-brainstorm`, non-software `/ce-plan`, and `/ce-ideate` Phase 5 on markdown output.
 
 The handoff is one-way. `ce-proof` publishes, prints the URL, and returns control. The originating skill's local file stays canonical, so that menu can re-render as it was.
 
@@ -147,11 +135,11 @@ Software brainstorm and software plan menus do not include Proof. Publish those 
 
 ## Use Standalone
 
-- **Publish a file:** `/ce-proof share docs/plans/foo.md to Proof`
-- **Publish the file just edited:** `share this to proof`
-- **Work from a URL:** `/ce-proof https://www.proofeditor.ai/d/abc123?token=xxx`
-- **Pull to disk:** an explicit path, atomic write, confirmed when it is a side effect
-- **Cleanup:** delete an unclaimed doc this session created, using the session `ownerSecret`
+- Publish a file: `/ce-proof share docs/plans/foo.md to Proof`
+- Publish the file just edited: `share this to proof`
+- Work from a URL: `/ce-proof https://www.proofeditor.ai/d/abc123?token=xxx`
+- Pull to disk: an explicit path, atomic write, confirmed when it is a side effect
+- Cleanup: delete an unclaimed doc this session created, using the session `ownerSecret`
 
 ---
 
@@ -202,8 +190,8 @@ The skill retries once. After that you get an error and can stay in the originat
 
 ## See Also
 
-- [`/ce-brainstorm`](./ce-brainstorm.md): non-software wrap-up still offers Proof
-- [`/ce-plan`](./ce-plan.md): non-software wrap-up still offers Proof
+- [`/ce-brainstorm`](./ce-brainstorm.md): non-software wrap-up offers Proof
+- [`/ce-plan`](./ce-plan.md): non-software wrap-up offers Proof
 - [`/ce-ideate`](./ce-ideate.md): Phase 5 "Publish to Proof" on markdown output
 - [Proof](https://www.proofeditor.ai): the editor
 - [Proof agent docs](https://www.proofeditor.ai/agent-docs): hosted agent contract

--- a/docs/guides/ce-prototype.md
+++ b/docs/guides/ce-prototype.md
@@ -2,15 +2,11 @@
 
 > Build a throwaway prototype so someone can experience how the product should work, feel, or read, then write those decisions into an existing plan or continue into brainstorm or plan.
 
-`ce-prototype` is an on-demand **experience** skill, not a step in the core loop. Use it when committing the wrong answer would be expensive to unravel and neither talk nor a cheap sketch can settle it.
+`ce-prototype` is an on-demand **experience** skill, not a step in the core loop. Use it when committing the wrong answer would be expensive to unravel and neither talk nor a cheap sketch can settle it. `ce-brainstorm` and `ce-plan` both offer this insert on that same test.
 
-It grounds in the current repo and whatever conversation or artifact you already have, names the questions only a real artifact can settle, and builds for the one that would be most expensive to get wrong. One rule: do not fake the dimension being tested. A flow or state model is settled by driving it. A layout or a mark is settled by seeing it at real finish. Your perception settles the question, not the agent's judgment of the artifact.
+One rule governs everything it builds: do not fake the dimension being tested. A flow or state model is settled by driving it. A layout or a mark is settled by seeing it at real finish. Your perception settles the question, never the agent's judgment of the artifact.
 
-It sits between a rough one-decision visual probe (those live in `ce-brainstorm`) and late-stage polish (`ce-polish`). More finished than a sketch, earlier than a working feature. It does not decide *what* to build; that is `ce-ideate` or `ce-brainstorm`.
-
-`ce-brainstorm` and `ce-plan` both offer this insert on the same test: committing the wrong answer would be expensive to unravel, and neither talk nor a cheap sketch can settle it.
-
-A person has to experience the prototype. On LFG, `mode:pipeline`, or any unattended run, the skill stops.
+It sits between a rough one-decision visual probe (those live in `ce-brainstorm`) and late-stage polish (`ce-polish`). It does not decide *what* to build; that is `ce-ideate` or `ce-brainstorm`. And because a person has to experience the prototype, the skill stops on LFG, `mode:pipeline`, or any unattended run.
 
 ---
 
@@ -48,11 +44,8 @@ Named questions can be a flow, a state model, a visual direction, or a close com
 # Narrow: one control vs another, still expensive to reverse once coded
 /ce-prototype vertical hamburger nav with animation instead of the current horizontal nav
 
-# Ground in this plan, pick the feel-question that would be most expensive to
-# get wrong, and build that. When you apply, decisions write into this file's
-# Product Contract. An implementation-ready plan is set back to
-# requirements-only and its HOW sections are removed, so ce-work cannot ship
-# the old HOW; run ce-plan again to re-enrich.
+# Ground in this plan and build for its costliest unsettled feel-question.
+# Applying writes the decisions into this file's Product Contract.
 /ce-prototype docs/plans/2026-08-12-1430-feat-reading-queue-plan.md
 
 # Same write-back against a brainstorm artifact
@@ -64,68 +57,56 @@ Named questions can be a flow, a state model, a visual direction, or a close com
 
 ---
 
-## The Problem
+## Why it exists
 
 Requirements and plans can name an outcome. They cannot say how something should work, feel, or read until someone experiences it. Settling that in conversation quietly commits a lot of behavior that later planning and code will treat as given.
 
-People already ask an agent to mock something up, then rewrite the requirements once they have decided. The rewrite is fine. What is missing is picking which question to build for, matching finish to that question, a natural place to offer the step, and a write-back the other skills can pick up.
+People already ask an agent to mock something up, then rewrite the requirements once they have decided. The rewrite is fine. What was missing is picking which question to build for, matching finish to that question, a natural place in the workflow to offer the step, and a write-back the other skills can pick up. That is the whole skill.
 
-## The Solution
+## How a run goes
 
-`ce-prototype` grounds first and asks only when the question or the constraints are too thin. It names the questions only a real artifact can settle and builds for the costliest one.
+The skill grounds in the current repo and whatever conversation or artifact you already have, and asks only when the question or the constraints are too thin. It names the questions only a real artifact can settle, builds for the one that would be most expensive to get wrong, and asks for a go-ahead before building: what it will try, why, and how the work is split.
 
-- Competing options sit on one surface so they can be judged together.
+While you try the prototype:
+
+- Competing options sit on one surface so you can judge them together.
 - After each action or option change, the relevant state is visible.
 - It never marks a question answered on its own judgment. It waits for you to experience the thing and choose.
-- After you decide, it re-lists what is still worth building and says what changed before the next one. A decision often answers a later question, kills one, or turns up one nobody had listed.
+- After you decide, it re-lists what is still worth building. A decision often answers a later question, kills one, or turns up one nobody had listed.
 - If what you decide changes *what you want to build* rather than answering the question, it stops and hands back what it learned.
-- With nobody there to try it, it stops rather than inventing how something should feel.
-- Before it builds, it asks for a go-ahead: what it will try, why, and how the work is split.
-- When a related plan exists, decisions land in that file's Product Contract (markdown or HTML). An implementation-ready plan is downgraded to `requirements-only` and its HOW sections are stripped, so `ce-work` cannot ship the old HOW.
-- When no related file exists, it does not mint a plan. It recaps the decisions and recommends `ce-brainstorm` or `ce-plan` from the session.
 
----
+### Finish matches the question
 
-## What Makes It Novel
-
-### Picking the question before building
-
-The skill names what still has to be decided against a real artifact, or takes the question you named, and builds only for that. A visual-probe question you already judged is not rebuilt. It re-works that list after every decision rather than marching the one it started with.
-
-### How finished it gets matches the question
-
-How finished the prototype gets follows this question, not a setting for the session. Throwaway constrains durability, not finish: unmaintained and unshipped, so nothing is tested, abstracted, or hardened past runnable, but finish goes as far as the dimension under test needs. Button placement stays cheap. A control you operate, motion, a transition, or a flow you move through gets rich enough to drive. A visual direction (a mark, a type system, a layout at real density) gets finished enough to judge, because rough would strip the thing being judged. Within one wide question, avenues can differ. Density or chrome on an existing page may need a throwaway overlay in the real app; that overlay is undone when the try ends and leaves no kept artifact.
-
-The default is a scratch prototype, not the full product and not a seed for production code, left in place when the run ends so later implementation can read it next to the decisions.
-
-The substrate defaults to the web, whatever the product is written in. A native app's navigation feel gets a web approximation, not SwiftUI. That yields in two cases only: you name a technology, or the dimension under test cannot be rendered in a browser without faking it. The skill says which it picked before building.
+Throwaway constrains durability, not finish. Nothing is tested, abstracted, or hardened past runnable, but finish goes as far as the dimension under test needs. Button placement stays cheap. A control you operate, motion, or a flow you move through gets rich enough to drive. A visual direction gets finished enough to judge, because rough would strip the thing being judged.
 
 A **narrow** question (this control vs that one) stays a close comparison of two or three variants. A **wide** question (make this more fun to use) names three to five genuinely different mechanisms first, then narrows by using them. The skill does not invent a wild alternative for a one-detail question, and it does not answer a wide question by building a single idea.
 
-### A floor under the thing you are judging
+Prototypes build for the web by default, whatever the product is written in. A native app's navigation feel gets a web approximation, not SwiftUI. That yields in two cases only: you name a technology, or the dimension under test cannot be rendered in a browser without faking it. The skill says which it picked before building. Density or chrome on an existing page instead gets a throwaway overlay in the real app, undone when the try ends.
 
-On a question settled by seeing (a layout, a type system, a mark, density) the render itself can produce the wrong answer. Text you cannot read, or a control with no visible focus, gets read as "that direction is worse" when the direction was never the problem. So a seeing question loads a craft floor: measurable thresholds for contrast, line measure, spacing rhythm, real states, and keyboard focus; one authored motion moment instead of scattered effects; and copy that names actions and recoveries. It applies only the items the question's dimensions actually reach. A placement question does not acquire an empty state because the floor lists one.
+### A floor under seeing questions
 
-Cleanliness is not enough. A surface can clear every threshold and still be a template: the arrangement any product would get for any subject. Avenues have to differ by organizing principle. A palette or typeface swap over one arrangement is one avenue shown twice.
+On a question settled by seeing (a layout, a type system, a mark, density) the render itself can produce the wrong answer. Text you cannot read gets judged as "that direction is worse" when the direction was never the problem. So a seeing question loads a craft floor: measurable thresholds for contrast, line measure, spacing rhythm, real states, and keyboard focus; one authored motion moment instead of scattered effects; and copy that names actions and recoveries. Only the items the question's dimensions actually reach apply. A placement question does not acquire an empty state because the floor lists one.
+
+Cleanliness is not enough. A surface can clear every threshold and still be a template, the arrangement any product would get for any subject. Avenues have to differ by organizing principle. A palette or typeface swap over one arrangement is one avenue shown twice.
 
 ### Where the prototype lives
 
-The prototype stays on disk. It lands in `.context/compound-engineering/ce-prototype/<date>-<slug>/`, gitignored, not committed, so it is still openable next week when implementation reads it. Each question in a run gets its own directory beneath that, and the capsule names them, so a second question cannot bury the first one's winner. If `.context/compound-engineering/` is not already ignored, the skill offers to append that one line. Decline it, or run outside a git repository, and it falls back to OS temp, where survival is best-effort. Nothing is deleted for you. The directory is yours to prune.
+The prototype lands in `.context/compound-engineering/ce-prototype/<date>-<slug>/`, gitignored and uncommitted, so it is still openable next week when implementation reads it. Each question in a run gets its own directory beneath that. If `.context/compound-engineering/` is not already ignored, the skill offers to append that one line; decline it, or run outside a git repository, and it falls back to OS temp, where survival is best-effort. Nothing is deleted for you.
 
-The run also writes `decisions.md` in that run directory: the question, what was built, which screen sits in which directory, what won and why, what was rejected, stated adjustments that were not in the prototype, and what is still open. That capsule is continuity for the next skill, not a plan.
+The run also writes `decisions.md` there: the question, what was built, what won and why, what was rejected, stated adjustments that were not in the prototype, and what is still open. That capsule is continuity for the next skill, not a plan.
 
-### Write-back into the existing artifact
+### Write-back
 
-Decisions update the Product Contract in the related brainstorm or plan you already have. They do not become a third kind of note. After write-back, `ce-plan` re-enriches HOW. If relatedness is unclear, the skill recaps in chat instead of guessing a file.
+When a related brainstorm or plan exists, decisions land in that file's Product Contract (markdown or HTML). An implementation-ready plan is downgraded to `requirements-only` and its HOW sections are stripped, so `ce-work` cannot ship the old HOW; run `ce-plan` again to re-enrich. When no related file exists, the skill does not mint a plan. It recaps the decisions and recommends `ce-brainstorm` or `ce-plan` from the session.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Use `ce-prototype` when:
 
 - Committing an approach now would be expensive to unravel. Later planning and code will treat it as given.
-- Neither talk nor a cheap sketch can settle it. A question turning on finish or motion is already past the sketch tier, because rough strips those dimensions.
+- Neither talk nor a cheap sketch can settle it. A question turning on finish or motion is already past the sketch tier.
 - You want to compare competing options on one surface, or explore an open space (look, flow, or state) before picking.
 - One prototype answered its question and the next related question still needs an artifact to be decided.
 
@@ -139,7 +120,7 @@ Skip it when:
 
 ---
 
-## Chain Position
+## Chain position
 
 `ce-prototype` is an on-demand insert, not a required pipeline stage.
 
@@ -148,7 +129,7 @@ Skip it when:
 /ce-plan        →  /ce-prototype (optional)  →  /ce-plan (re-enrich)  →  /ce-work
 ```
 
-Standalone prompt-only runs stay file-free and continue into `ce-brainstorm` or `ce-plan`. Stay in this skill for the next *related* question that still needs an artifact. Do not bounce out while that list is open, and do not start an unrelated campaign.
+Standalone prompt-only runs stay file-free and continue into `ce-brainstorm` or `ce-plan`. The skill stays put for the next *related* question that still needs an artifact rather than bouncing out, and it does not start an unrelated campaign.
 
 ---
 
@@ -169,10 +150,7 @@ Standalone prompt-only runs stay file-free and continue into `ce-brainstorm` or 
 A visual probe is a rough, display-only sketch for a one-decision question you can judge in chat. Use `ce-prototype` when the question turns on finish, motion, or behavior you have to drive, or when a sketch was built and failed to settle it.
 
 **Does it become the real feature?**
-No. The prototype is throwaway: unmaintained and unshipped. A scratch prototype is kept so implementation can read it. An overlay on the real app is undone when the try ends.
-
-**What happens to an existing plan when I apply?**
-Decisions land in that file's Product Contract. If the plan was `implementation-ready`, it is set back to `requirements-only` and its HOW sections are removed so `ce-work` cannot ship the old HOW. Then `ce-plan` re-enriches.
+No. The prototype is unmaintained and unshipped. A scratch prototype is kept so implementation can read it. An overlay on the real app is undone when the try ends.
 
 **Can it run unattended?**
 No. If there is no person to experience the prototype, the skill stops and does not invent how something should feel.

--- a/docs/guides/ce-resolve-pr-feedback.md
+++ b/docs/guides/ce-resolve-pr-feedback.md
@@ -2,11 +2,11 @@
 
 > Evaluate, fix, and reply to PR review feedback in one pass. Fix what is real. Do not churn on what is not.
 
-`ce-resolve-pr-feedback` is the **fix-the-comments-now** skill. It is a git-workflow tool, not a core-loop step. After reviewers comment, it fetches unresolved threads, judges every finding in one place, and dispatches fixers only for items it has already approved. Then it commits, pushes, replies, and resolves threads.
+`ce-resolve-pr-feedback` is the fix-the-comments-now skill. It is a git-workflow tool, not a core-loop step. After reviewers comment, it fetches unresolved threads, judges every finding in one place, and dispatches fixers only for items it has already approved. Then it commits, pushes, replies, and resolves threads.
 
-That is a single pass (at most two fix-verify cycles). It is not a watch loop. `/ce-babysit-pr` is the skill that sits on an open PR over time and *calls this one* whenever new comments arrive. Use this skill when you want the comments handled now. Use babysit when you want that repeated until the PR looks ready.
+That is a single pass, at most two fix-verify cycles. It is not a watch loop. `/ce-babysit-pr` is the skill that sits on an open PR over time and calls this one whenever new comments arrive. Use this skill when you want the comments handled now. Use babysit when you want that repeated until the PR looks ready.
 
-It judges on merit, not source or form. Human or bot, inline thread or top-level comment: the finding is either real or it is not. The default is to fix. It diverts only when reading the code trips a concrete signal.
+It judges on merit, not source or form. Human or bot, inline thread or top-level comment, the finding is either real or it is not. The default is to fix. It diverts only when reading the code trips a concrete signal.
 
 GitHub only, including GitHub Enterprise that `gh` is configured for.
 
@@ -25,7 +25,7 @@ GitHub only, including GitHub Enterprise that `gh` is configured for.
 
 ## Example invocations
 
-Empty, a PR number, or a bare `/pull/N` URL is **Full** mode. Only a `#discussion_r` fragment is **Targeted**. A `#issuecomment-` URL is Full: top-level comments have no review thread to pin.
+Empty, a PR number, or a bare `/pull/N` URL is Full mode. Only a `#discussion_r` fragment is Targeted. A `#issuecomment-` URL is Full, because top-level comments have no review thread to pin.
 
 ```text
 # All new unresolved feedback on this branch's PR
@@ -48,37 +48,24 @@ To keep handling later rounds as they arrive, use `/ce-babysit-pr` instead.
 
 ---
 
-## The Problem
+## How it works
 
-Resolving a pile of review comments by hand, or with a "fix everything" reflex, fails in familiar ways:
+Resolving a pile of review comments by hand, or with a fix-everything reflex, fails in familiar ways. Bots over-flag and blind application churns the PR. Findings get taken on authority without checking the code. Top-level comments have no resolve API, so they come back every run. Twelve threads handled one at a time waste wall-clock, and twelve in parallel collide on the same file.
 
-- Review bots over-flag. Blindly applying them churns the PR
-- A finding is taken on authority ("a reviewer said so") without checking the code
-- Top-level comments and review bodies have no resolve API, so they come back every run
-- Bot wrapper text ("Here are some automated review suggestions...") inflates the work count
-- Twelve threads handled one at a time waste wall-clock. Twelve in parallel collide on the same file
-- Each fixer tests only its own change. Cross-agent breakage slips through
-
-## The Solution
-
-The skill runs a fixed pipeline:
+The skill runs a fixed pipeline instead:
 
 1. Fetch unresolved review threads, PR comments, and review bodies
-2. Triage new vs already handled. A substantive deferral counts as handled. Bot wrappers are dropped silently
+2. Triage new vs already handled. A substantive deferral counts as handled. Bot wrapper text ("Here are some automated review suggestions...") is dropped silently
 3. Judge every new item in the orchestrator's own context (the legitimacy gate)
 4. Dispatch fixers only for approved fixes. Overlapping files serialize
 5. One full validation run on the combined diff
 6. Commit and push
 7. Reply with a quote of the original ask, then resolve review threads via GraphQL
-8. Re-fetch. If new threads remain, one more cycle. After two cycles, escalate the pattern as `needs-human`
+8. Re-fetch. If new threads remain, one more cycle. After two cycles, escalate the recurring pattern as `needs-human`
 
 If you have an unsubmitted (PENDING) review on the PR, the skill stops before it replies. Those replies would disappear into the draft. Submit or discard that review yourself; the skill will not.
 
----
-
-## What Makes It Novel
-
-### Default to fixing. Divert only on a tripwire
+### Default to fixing, divert only on a tripwire
 
 Most feedback, nitpicks included, is correct. Validation is not a separate analysis pass. The agent has to read the code to make the fix anyway, and it diverts only on a signal it notices during that read:
 
@@ -91,7 +78,7 @@ Most feedback, nitpicks included, is correct. Validation is not a separate analy
 
 "I'm uneasy" is not a tripwire. Source does not matter. A bot can be right; a human can be wrong.
 
-The one place the default inverts is agent instruction prose (a `SKILL.md`, a skill reference, a persona or rule file). A natural-language condition can always be made more specific, so a case the stated condition already decides is answered with the condition (`not-addressing`), not patched; only a wrong or missing condition, or a mechanism at the wrong owning layer, is a fix. A second round of findings against text the first round added is a signal to restate the block, not qualify it, and the loop cap counts rounds per PR (from the branch's review-fix commits) so it survives re-invocation by `ce-babysit-pr`. The project's own review guidance in context frames these verdicts.
+The one place the default inverts is agent instruction prose (a `SKILL.md`, a skill reference, a persona or rule file). A natural-language condition can always be made more specific, so a case the stated condition already decides is answered with the condition (`not-addressing`), not patched. Only a wrong or missing condition, or a mechanism at the wrong owning layer, is a fix. A second round of findings against text the first round added is a signal to restate the block, not qualify it, and the loop cap counts rounds per PR (from the branch's review-fix commits) so it survives re-invocation by `ce-babysit-pr`.
 
 ### Judge once, then fan out only the fixes
 
@@ -99,7 +86,7 @@ The orchestrator holds every thread from a single fetch. It can read a file once
 
 1-4 fixes run in parallel. 5+ go in batches of 4. Two fixers that touch the same file never run at the same time. Harnesses without parallel dispatch run them sequentially.
 
-When the same invariant applies to other sites **this PR introduced**, those sites become one class fix, not a drip of follow-up nits.
+When the same invariant applies to other sites this PR introduced, those sites become one class fix, not a drip of follow-up nits.
 
 ### Six verdicts
 
@@ -114,16 +101,9 @@ When the same invariant applies to other sites **this PR introduced**, those sit
 
 `needs-human` is rare. It includes what the reviewer said, what was investigated, why a decision is needed, and options with tradeoffs. Escalations never block the rest of the run. That is what lets `/ce-babysit-pr` call this skill unattended.
 
-### Full vs Targeted
-
-| Mode | When | Behavior |
-|------|------|----------|
-| **Full** (default) | Empty, PR number, `/pull/N` URL, or `#issuecomment-` | All unresolved feedback on that PR |
-| **Targeted** | `#discussion_r` fragment | That review thread only |
-
 ---
 
-## Quick Example
+## Quick example
 
 A reviewer and a review bot leave eight comments. You invoke `/ce-resolve-pr-feedback`.
 
@@ -141,7 +121,7 @@ Only three items need a fixer. The two `dispatcher.rb` edits serialize; the thir
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Use `ce-resolve-pr-feedback` when:
 
@@ -159,7 +139,7 @@ Skip it when:
 
 ---
 
-## Chain Position
+## Chain position
 
 One-shot closer after a PR has comments. Not a watch.
 
@@ -169,15 +149,7 @@ One-shot closer after a PR has comments. Not a watch.
 /ce-babysit-pr -----------------------------------------------/
 ```
 
-`/ce-code-review` reviews *before* the PR is open. This skill handles incoming feedback *after*. `/ce-debug` is for broken behavior, not review comments.
-
----
-
-## Use Standalone
-
-- Current branch: `/ce-resolve-pr-feedback`
-- Specific PR: `/ce-resolve-pr-feedback 1234` or a `/pull/N` URL
-- One thread: `/ce-resolve-pr-feedback https://github.com/.../pull/1234#discussion_r5678901`
+`/ce-code-review` reviews before the PR is open. This skill handles incoming feedback after. `/ce-debug` is for broken behavior, not review comments.
 
 ---
 
@@ -204,9 +176,6 @@ Yes, by default. A correct nit that improves the code gets fixed. A purely cosme
 **Does it treat bot feedback differently from human feedback?**
 No. Reading the code is the same work either way. An "it's a bot, so ignore it" rule would drop real bugs. Form only changes the reply mechanic: inline threads resolve via GraphQL; review bodies and top-level comments get a top-level reply.
 
-**Why drop bot wrappers silently?**
-Announcing them adds noise. The wrapper around CodeRabbit findings is not actionable. The findings inside it still go through the gate.
-
 **What if two parallel fixers conflict?**
 Overlapping files serialize before dispatch. If a fix expands to callers in another file, combined validation and the verify pass catch the breakage, and those agents re-run sequentially.
 
@@ -221,7 +190,7 @@ The skill stops. Replies posted during a PENDING review are swallowed by that dr
 
 ---
 
-## See Also
+## See also
 
 - [`/ce-babysit-pr`](./ce-babysit-pr.md): watch the PR over time; calls this skill for each comment round
 - [`/ce-code-review`](./ce-code-review.md): pre-PR review

--- a/docs/guides/ce-retune.md
+++ b/docs/guides/ce-retune.md
@@ -2,13 +2,13 @@
 
 > Retune a skill corpus for a new model, measurement-first.
 
-`ce-retune` is an on-demand **corpus** skill. Use it when a model upgrade made an agent workflow worse: it stalls, stops mid-run, or burns far more tokens than before, or someone wants to rewrite skill prose to "fix" the new model.
+`ce-retune` is an on-demand **corpus** skill. Use it when a model upgrade made an agent workflow worse. The pipeline stalls, stops mid-run, or burns far more tokens than before, and someone wants to rewrite skill prose to fix it.
 
 It is not a general skill editor. Reading the corpus and rewriting what looks wrong produces a plausible fix list and no way to tell whether any item mattered. This skill mines the run archive, measures a noise floor on two identical builds, audits with an adversary that defends the existing prose, then cuts in measured passes until a bar you registered in advance clears.
 
 Hard requirement: a benchmark harness that can A/B two builds of the corpus. Without one, the skill stops and names what to build. It will not pretend a static audit is a retune.
 
-The skill is user-invoked only. It spends many paid runs, so an agent is not allowed to route into it on its own.
+The skill is user-invoked only. It spends many paid runs, so an agent may not route into it on its own.
 
 ---
 
@@ -49,26 +49,18 @@ If any of the three measurement pieces is missing (archive or a harness that pro
 
 ---
 
-## The Problem
+## How it works
 
-A model upgrade can make a working corpus worse. The instinct is to read the skills and rewrite what looks off. That fails because the corpus is large enough that nobody can reason about its prose reliably, including the people who wrote it.
+The failure this skill targets is stochastic. Identical inputs produce a wide spread of outcomes, so one run tells you nothing and a before-and-after drawn from a handful of runs is indistinguishable from doing nothing. The fix is to measure in a fixed order, where each step buys the right to take the next.
 
-The failure is usually stochastic. Identical inputs produce a wide spread of outcomes. One run tells you nothing. A small sample tells you nothing. A before-and-after drawn from a handful of runs is indistinguishable from doing nothing. Fix lists assembled this way feel rigorous and are not.
-
-## The Solution
-
-Measure first, in a fixed order. Each step buys the right to take the next.
-
-1. **Gate on measurability.** No archive, no build selector, no repeatable task: stop and say what to build. An audit-only pass is a legitimate request and a different one.
+1. **Gate on measurability.** No archive, no build selector, no repeatable task: stop and say what to build.
 2. **Mine the archive.** Historical runs are a free baseline, usually larger than any experiment you can afford this week.
-3. **Find the noise floor.** Two identical builds, same commit. Whatever difference appears is the floor every later claim must clear, and it sets the sample size. Register the bar in writing before any change exists.
-4. **Audit adversarially.** One agent per unit proposes cuts. A second defends the existing prose from the project's learnings, tests, and git history. A defended keep leaves the list.
+3. **Find the noise floor.** Run the harness against two identical builds, same commit on both sides. Whatever difference appears is the floor every later claim must clear, and it sets the sample size. Register the bar in writing before any change exists. A bar chosen after seeing results is not a bar.
+4. **Audit adversarially.** One agent per skill proposes cuts. A second defends the existing prose from the project's learnings, tests, and git history. A defended keep leaves the list.
 5. **Cut in surgical passes.** One problem per agent, disjoint file ownership, reconcile after every edit.
-6. **Let the failure choose the next fix.** Where a run failed matters more than whether it did. Loop until the bar clears.
+6. **Measure, and let the failure choose the next fix.** Where a run failed matters more than whether it did. Loop until the bar clears.
 
-Done is a cleared bar, or a report of the claim the run could not support. A green test suite is not done. It proves nothing broke, not that behavior improved.
-
-Word count is not the result. Leanness and performance share a corpus and are separate programs.
+Done is a cleared bar, or a report of the claim the run could not support. A green test suite is not done. It proves nothing broke, not that behavior improved. And word count is not the result: leanness and performance share a corpus and are separate programs.
 
 ---
 
@@ -84,7 +76,7 @@ Empty transcripts and error exits look like model failures and silently inflate 
 
 ### The noise floor comes before the claim
 
-Two identical builds are compared before anything is credited. That is the step most retuning skips, and skipping it is why those results do not survive scrutiny. It also yields the cheap one-armed test: once the baseline rate is known, N consecutive clean runs has an exact probability under it, so a streak can clear a bar without a control arm.
+Two identical builds are compared before anything is credited. That is the step most retuning skips, and skipping it is why those results do not survive scrutiny. It also yields a cheap one-armed test: once the baseline rate is known, N consecutive clean runs has an exact probability under it, so a streak can clear a bar without a control arm.
 
 ### An adversary defends the prose
 
@@ -92,9 +84,13 @@ Every proposed cut faces an agent whose job is to find why that line exists. "A 
 
 Proposal and defense need separate contexts. If the host cannot run them as separate agents, the audit stops rather than arguing both sides in one conversation and calling that an audit.
 
+### Not every stop is the enemy
+
+Some workflows exist to stop and ask; that is the product. Every stop gets sorted by who is actually on the other side before anyone touches it. And a removed string that a test pins is a finding to report, never a test to weaken.
+
 ### It expects to be wrong
 
-The write-up has to report what contradicts the premise: where defenders won, which unit was leaner than its word count implied, and where the corpus already argued against its own ceremony. Confirming a thesis you already hold teaches nothing. Hypotheses that died are recorded on purpose, so the next attempt does not rerun a dead end.
+The write-up has to report what contradicts the premise: where defenders won, which unit was leaner than its word count implied, and where the corpus already argued against its own ceremony. Hypotheses that died are recorded on purpose, so the next attempt does not rerun a dead end.
 
 ### It audits what the instrument cannot reach
 
@@ -146,9 +142,7 @@ Adjacent: `/ce-optimize` is a generic metric-driven loop. It knows nothing about
 
 ## Use Standalone
 
-Most runs start from a symptom in chat. The default corpus is `./skills`. Name another tree when that is not the one that degraded.
-
-The skill will not be suggested by the model. You have to invoke it.
+Most runs start from a symptom in chat. The default corpus is `./skills`; name another tree when that is not the one that degraded. The model will never suggest this skill on its own. You have to invoke it.
 
 ---
 
@@ -182,7 +176,7 @@ The skill stops and names the missing piece. Build the harness (archive, build s
 Yes, if you ask for it as an audit. That pass can say what looks cuttable. It cannot say whether cutting helped.
 
 **What does `bar:8` mean?**
-Eight consecutive clean runs under the one-armed test, once the baseline rate is known. The bar is written down before any change exists. A bar chosen after seeing results is not a bar.
+Eight consecutive clean runs under the one-armed test, once the baseline rate is known. The bar is written down before any change exists.
 
 **Is a green test suite enough?**
 No. Tests prove the suite still passes. They do not prove the new model finishes the workflow.

--- a/docs/guides/ce-riffrec-feedback-analysis.md
+++ b/docs/guides/ce-riffrec-feedback-analysis.md
@@ -1,12 +1,12 @@
 # `ce-riffrec-feedback-analysis`
 
-> Turn a [Riffrec](https://github.com/kieranklaassen/riffrec) capture (or a video, audio clip, or meeting notes) into structured product feedback.
+> Turn a [Riffrec](https://github.com/kieranklaassen/riffrec) capture, or a video, audio clip, or meeting notes, into structured product feedback.
 
-`ce-riffrec-feedback-analysis` is the **consumption** skill for Riffrec recordings. Riffrec is a separate capture tool. It records synchronized screen, voice, and events and emits a `riffrec-*.zip`. This skill analyzes a Riffrec capture bundle, zipped or unpacked, or a standalone video, audio file, or notes file, and routes to setup, a quick bug report, or extensive analysis.
+Riffrec is a separate capture tool. It records synchronized screen, voice, and events and emits a `riffrec-*.zip`. This skill is the consumption side: it takes a Riffrec bundle (zipped or unpacked), or a standalone video, audio file, or notes file, and routes it to setup help, a quick bug report, or extensive analysis.
 
-Use it for those recordings. Short text feedback can go straight into `/ce-brainstorm`. A debug session is `/ce-debug`. Bare transcription, with no structure, is a transcription tool.
+Short text feedback can go straight into `/ce-brainstorm`. A debug session is `/ce-debug`. If all you want is a transcript, use a transcription tool.
 
-The skill also activates when an unpacked Riffrec capture appears (`session.json`, `events.json`, `recording.webm`, `voice.webm`). Pass the capture directory itself so the analyzer preserves its synchronized metadata and media.
+The skill also activates when an unpacked Riffrec capture appears (`session.json`, `events.json`, `recording.webm`, `voice.webm`). Pass the capture directory itself, not just `recording.webm`, so the analyzer keeps the event log and timestamps.
 
 ---
 
@@ -23,7 +23,7 @@ The skill also activates when an unpacked Riffrec capture appears (`session.json
 
 ## Example invocations
 
-Length and wording pick the path. You do not pass a flag.
+Length and wording pick the path. There is no flag.
 
 ```text
 # A complete Riffrec zip. Length and event count pick quick vs extensive
@@ -34,7 +34,7 @@ Length and wording pick the path. You do not pass a flag.
 /ce-riffrec-feedback-analysis voice-memo.m4a
 /ce-riffrec-feedback-analysis meeting-notes.md
 
-# Force the short path: one bug report in chat, no brainstorm, nothing written unless you ask
+# Force the short path: one bug report in chat, nothing written unless you ask
 /ce-riffrec-feedback-analysis just transcribe this clip.mp4
 
 # Longer walkthrough, extract only. Artifacts land, brainstorm does not start
@@ -44,7 +44,7 @@ Length and wording pick the path. You do not pass a flag.
 /ce-riffrec-feedback-analysis how do I install and use Riffrec?
 ```
 
-A Riffrec bundle with no extra wording is inspected first (duration, event count). If that is still unclear, the skill asks before doing the heavy work.
+A Riffrec bundle with no extra wording gets inspected first (duration, event count). If the route is still unclear, the skill asks before doing the heavy work. Better one question than the wrong path.
 
 ---
 
@@ -53,7 +53,7 @@ A Riffrec bundle with no extra wording is inspected first (duration, event count
 A raw walkthrough does not turn into something you can build from:
 
 - A 12-minute session is too dense to act on as a blob
-- Several issues collapse into whichever one is mentioned first
+- Several issues collapse into whichever one gets mentioned first
 - A transcript of what was said misses what the person was trying to do
 - Raw screen and audio sitting in the repo get committed by accident
 - Nothing in the chain consumes the recording as requirements
@@ -61,13 +61,13 @@ A raw walkthrough does not turn into something you can build from:
 
 ## The Solution
 
-Three paths, chosen from the input, not from a mode flag:
+Three paths, chosen from the input:
 
 - **Setup** when there is no recording yet and the question is how to install, capture, or share. The skill walks the Riffrec install guide. The analyzer does not run.
-- **Quick bug report** when the clip is under ~60 seconds, names a single issue, or asks for "quick", "small", or "just transcribe". One concise bug report, printed in chat. No full artifact set, no brainstorm. A file is written only if you ask for one.
+- **Quick bug report** when the clip is under ~60 seconds, names a single issue, or asks for "quick", "small", or "just transcribe". One concise bug report, printed in chat. No artifact set, no brainstorm. A file gets written only if you ask.
 - **Extensive analysis** when the recording is longer, covers several issues or a workflow, or you want requirements material. Structured analysis plus screenshots, then a handoff to `/ce-brainstorm`. Say "extract only" or "analyze, do not brainstorm" to stop after the artifacts.
 
-Raw recordings, audio, zip contents, and extracted frames stay local by default. Text artifacts can be committed when they are needed for traceability and contain no sensitive data.
+Raw recordings, audio, zip contents, and extracted frames stay local by default. Text artifacts can be committed when you need them for traceability and they contain no sensitive data.
 
 ---
 
@@ -75,21 +75,21 @@ Raw recordings, audio, zip contents, and extracted frames stay local by default.
 
 ### The path follows the recording
 
-A short single-issue clip should not pay for a requirements package. A multi-issue walkthrough should not collapse into one ticket. When a zip arrives without context, the skill looks at length and event count before choosing. If a quick-path transcript turns out to hold several issues, it says so and switches to extensive.
+A short single-issue clip should not pay for a requirements package, and a multi-issue walkthrough should not collapse into one ticket. When a zip arrives without context, the skill looks at length and event count before choosing. If a quick-path transcript turns out to hold several issues, it says so and switches to extensive.
 
 ### Privacy default on the raw bits
 
-`raw/` and `frames/` are not committed unless you ask and confirm privacy is acceptable. Committed docs use repo-relative screenshot paths so a later agent can open the evidence without an absolute local path.
+`raw/` and `frames/` never get committed unless you ask and confirm privacy is acceptable. Committed docs use repo-relative screenshot paths, so a later agent can open the evidence without an absolute local path.
 
 ### One intake, several file shapes
 
-Non-setup runs share one analyzer. Accepted inputs: a Riffrec `.zip` or unpacked capture directory; `.mp4` / `.mov` / `.webm` video; `.m4a` / `.mp3` / `.wav` audio; a meeting-notes `.md`. A Riffrec bundle is richer because events and timestamps come along. A video or voice memo still goes through the same router.
+Non-setup runs share one analyzer. It accepts a Riffrec `.zip` or unpacked capture directory; `.mp4` / `.mov` / `.webm` video; `.m4a` / `.mp3` / `.wav` audio; a meeting-notes `.md`. A Riffrec bundle is richer because events and timestamps come along, but a plain video or voice memo goes through the same router.
 
 In a repo that has `docs/brainstorms/`, extensive output defaults to `docs/brainstorms/riffrec-feedback/` as kickoff evidence. The durable plan still comes from `ce-brainstorm` under `docs/plans/`. The quick path writes to a temp directory so a one-issue report does not land in that tree.
 
 ### Extensive always continues, unless you said not to
 
-The recording is what the user experienced. That is evidence, not a decision. After the analysis lands, the skill loads `/ce-brainstorm` with `requirements-kickoff.md` and asks you to confirm, correct, or regroup the captured requirements. The quick path skips that handoff because the bug report is the deliverable.
+The recording is what the user experienced. That is evidence, not a decision. Without brainstorm, the analysis sits on disk and nobody decides what to build. So after the analysis lands, the skill loads `/ce-brainstorm` with `requirements-kickoff.md` and asks you to confirm, correct, or regroup the captured requirements. The quick path skips the handoff because the bug report is the deliverable.
 
 ---
 
@@ -120,7 +120,7 @@ Skip it when:
 
 - The feedback is short and already text. Paste it into `/ce-brainstorm`
 - The recording is a debug session, not product feedback → `/ce-debug`
-- You only want a transcript with no structure. Use a transcription tool
+- You only want a transcript. Use a transcription tool
 - You already have a single known bug and a stack trace. Skip the capture skill
 
 ---
@@ -143,7 +143,7 @@ Extensive analysis is supposed to become a plan. Quick is done when the report i
 
 Most invocations are a file path plus optional intent ("just transcribe", "do not brainstorm", "how do I install").
 
-If you already unzipped a capture, pass its directory to preserve the synchronized metadata. Passing `recording.webm` alone still works as standalone video, but drops the event log and other capture context.
+If you already unzipped a capture, pass its directory to keep the synchronized metadata. Passing `recording.webm` alone still works as standalone video, but drops the event log and other capture context.
 
 ---
 
@@ -167,22 +167,13 @@ The output format the extensive path writes for brainstorm is `references/compou
 ## FAQ
 
 **What is Riffrec?**
-A separate capture tool ([github.com/kieranklaassen/riffrec](https://github.com/kieranklaassen/riffrec)). Screen, microphone, console, network, and DOM events into one `riffrec-*.zip`. This skill does not record. It consumes recordings.
+A separate capture tool ([github.com/kieranklaassen/riffrec](https://github.com/kieranklaassen/riffrec)). Screen, microphone, console, network, and DOM events in one `riffrec-*.zip`. This skill does not record. It consumes recordings.
 
 **Do I have to use Riffrec?**
-No. Video, audio, and markdown notes take the same paths. A Riffrec bundle, zipped or unpacked, is richer because events and timestamps travel with it.
-
-**Why does extensive analysis continue into `/ce-brainstorm`?**
-The recording is evidence. Without brainstorm, the analysis sits on disk and nobody decides what to build. Ask for extract-only if you want the files and not the handoff.
-
-**Why is the quick path different?**
-A 30-second single-bug clip does not need a requirements package. The report is printed in chat so you can confirm it. Nothing is written unless you ask.
-
-**What stays local?**
-Raw recordings, audio, zip contents, and frames stay local by default. Text artifacts can be committed when they are safe and you need the trace.
+No. Video, audio, and markdown notes take the same paths. A Riffrec bundle is richer because events and timestamps travel with it.
 
 **What if the input is ambiguous?**
-The skill inspects length and event count. If that is still unclear, it asks. Better one question than the wrong path.
+The skill inspects length and event count. If that is still unclear, it asks.
 
 ---
 

--- a/docs/guides/ce-setup.md
+++ b/docs/guides/ce-setup.md
@@ -1,12 +1,10 @@
 # `ce-setup`
 
-> Check Compound Engineering health, optional tool capabilities, and repo-local config safety. It does not bulk-install the plugin's dependencies.
+> Check Compound Engineering health, optional tool availability, and repo-local config safety. It does not bulk-install the plugin's dependencies.
 
-`ce-setup` is a **diagnosis and config** utility. It reports which optional tools are on PATH, creates repo `config.yaml` when missing (after you approve), refreshes the committed config example, and offers to gitignore a local override or CE scratch space. It also reports where artifacts will land and can repair an invalid `docs_root` or a broken CE Work engine block.
+`ce-setup` is a diagnosis and config utility. It reports which optional tools are on PATH, refreshes the committed config example, creates the repo `config.yaml` if you approve, and offers to gitignore a local override or CE scratch space. It also reports where CE artifacts will land and can repair an invalid `docs_root` or a broken CE Work engine block.
 
-It is explicit-invocation only (`disable-model-invocation: true`). Talking about setup does not start it.
-
-Outside a git repository it reports capabilities and stops. It does not create repo files there.
+It runs only when you invoke it explicitly (`disable-model-invocation: true`). Talking about setup does not start it. Outside a git repository it reports capabilities and stops without writing files.
 
 See [Compound Engineering configuration](./configuration.md) for every option and how local defaults interact with session and project instructions.
 
@@ -19,28 +17,15 @@ See [Compound Engineering configuration](./configuration.md) for every option an
 | What does it do? | Runs a health check, reports optional tools, refreshes the example config, and applies only the repo-local fixes you approve |
 | When to use it | First install, after an upgrade, when a skill says a tool is missing, or when onboarding a repo |
 | What it produces | A setup report, plus any config or gitignore edits you accepted |
-| What it does not do | Bulk-install every optional CE dependency, update the plugin itself, or create `config.local.yaml` |
+| What it does not do | Bulk-install optional CE dependencies, update the plugin itself, or create `config.local.yaml` |
 
 ---
 
 ## Example invocations
 
-The skill takes no feature argument. The same command covers first install, a later re-check, and a repo that is not a git checkout.
+There is no argument. One command covers first install, a re-check after an upgrade, a missing-tool report, and a directory that is not a git repo.
 
 ```text
-# First install, or a later re-check of tools and repo config
-/ce-setup
-
-# Same command after a plugin upgrade, to refresh
-# .compound-engineering/config.example.yaml and notice new keys
-/ce-setup
-
-# Same command when a skill said gh, agent-browser, or another
-# optional tool is missing. The report prints the install command.
-/ce-setup
-
-# Same command in a directory that is not a git repo.
-# It reports optional tools and stops without writing files.
 /ce-setup
 ```
 
@@ -48,53 +33,40 @@ On oh-my-pi the invocation is `/skill:ce-setup`. On Codex it is `$ce-setup` when
 
 ---
 
-## The Problem
+## Why setup does not install everything
 
-Compound Engineering has two different setup surfaces:
+Compound Engineering has two separate setup surfaces:
 
-- **Repo-local state** that should stay consistent and safe: the committed config example, the repo `config.yaml`, gitignore coverage if a `config.local.yaml` override exists, and (optionally) gitignore coverage for `.context/compound-engineering/` scratch.
-- **Optional external tools** used by specific workflows: `agent-browser` for browser testing and dogfood QA, `gh` for GitHub, `jq` for shell JSON, `ast-grep` for structural search, `ffmpeg` for Riffrec media analysis.
+- **Repo-local state** that should stay consistent and safe: the committed config example, the repo `config.yaml`, and gitignore coverage for `config.local.yaml` and `.context/compound-engineering/` scratch.
+- **Optional external tools** used by specific workflows: `agent-browser`, `gh`, `jq`, `ast-grep`, `ffmpeg`.
 
-A missing optional tool is not a broken plugin. Treating those as one install step forces a dependency footprint most workflows never use.
+A missing optional tool is not a broken plugin. Most workflows never touch `ffmpeg` or `ast-grep`, so installing everything up front is wasted footprint. `ce-setup` reports what is missing, says which workflow each tool serves, and prints the install command. You install only what you use.
 
-## The Solution
+## What it fixes
 
-`ce-setup` diagnoses first, then remediates only repo-local project issues. The example config is refreshed on its own. Other writes wait for approval:
+The example config refresh happens on its own (it is the committed template copy). Everything else waits for your approval:
 
-- Deletes obsolete `compound-engineering.local.md` if you say yes.
-- Refreshes `.compound-engineering/config.example.yaml` from the bundled template. Always, inside a git repo.
-- Offers to create `.compound-engineering/config.yaml` if it is missing. Does not create `config.local.yaml`. Does not overwrite either file if it already exists.
-- Offers to add `.compound-engineering/*.local.yaml` to `.gitignore` only when `config.local.yaml` already exists and is not ignored.
+- Deletes the obsolete `compound-engineering.local.md` if you say yes.
+- Refreshes `.compound-engineering/config.example.yaml` from the bundled template, always, inside a git repo.
+- Offers to create `.compound-engineering/config.yaml` when missing. Never overwrites an existing `config.yaml` or `config.local.yaml`, and never creates the local override.
+- Offers to add `.compound-engineering/*.local.yaml` to `.gitignore`, but only when `config.local.yaml` already exists and is not ignored.
 - Offers to add `.context/compound-engineering/` to `.gitignore` whether or not that directory exists yet. An uncovered path is a note, not a project issue.
-- Reports the resolved artifact root and which config layer supplied it. An invalid `docs_root` is a project issue. CE artifacts will not be written until it is fixed. See [Artifact root](./configuration.md#artifact-root).
-- Explains and repairs an invalid CE Work implementation-engine block, or leftover retired routing keys, in the layer that supplied the bad value.
-- Prints install commands or URLs for missing optional tools. It does not bulk-install them.
+- Repairs an invalid CE Work implementation-engine block, or leftover retired routing keys, in the config layer that supplied the bad value.
+- Repairs an invalid `docs_root`. This one is a real project issue: CE artifacts will not be written until it is fixed. See [Artifact root](./configuration.md#artifact-root).
 
-Each question uses the host's blocking question tool when one exists. It does not silently auto-configure.
+Each question uses the host's blocking question tool when one exists. It never silently auto-configures.
 
----
+## Where artifacts land
 
-## What Makes It Novel
-
-### Capabilities are informational
-
-Missing `ffmpeg` or `ast-grep` does not fail setup. The report says which workflows those tools serve and how to install them. You install only what you use.
-
-### Repo files are opt-in writes
-
-The example config is the one file it refreshes on its own (it is the committed template copy). Creating `config.yaml`, appending gitignore lines, deleting the obsolete local-md file, and editing a broken `docs_root` or work-engine block all wait for approval. Existing `config.yaml` and `config.local.yaml` are never overwritten wholesale.
-
-### It tells you where artifacts will land
-
-The health report includes the resolved artifact root (`docs/` by default, or a valid `docs_root` from `config.yaml`). `docs_root` in `config.local.yaml` is ignored. If local still has one, setup says so and offers to move it into `config.yaml`.
+The health report includes the resolved artifact root (`docs/` by default, or a valid `docs_root` from `config.yaml`) and which config layer supplied it. `docs_root` in `config.local.yaml` is ignored; if your local file still has one, setup says so and offers to move it into `config.yaml`.
 
 ---
 
-## Optional Capabilities
+## Optional capabilities
 
 | Tool | Capability |
 |------|------------|
-| `agent-browser` | browser testing and dogfood QA |
+| `agent-browser` | Browser testing and dogfood QA |
 | `gh` | GitHub PR, issue, and review workflows |
 | `jq` | JSON inspection in shell-based workflows |
 | `ast-grep` | Syntax-aware structural code search |
@@ -102,7 +74,7 @@ The health report includes the resolved artifact root (`docs/` by default, or a 
 
 ---
 
-## Quick Example
+## Quick example
 
 You just installed compound-engineering and want to check a repo:
 
@@ -118,20 +90,15 @@ Optional capabilities  3/5
   🟢  gh -- GitHub PR, issue, and review workflows
   🟡  ast-grep -- unavailable: syntax-aware structural code search
        brew install -q ast-grep
-
-Project config
-  🟢  No obsolete compound-engineering.local.md
-  ➖  No repo config yet (.compound-engineering/config.yaml)
-  🟡  Example config missing (.compound-engineering/config.example.yaml)
 ```
 
-It refreshes the example config and asks whether to create `.compound-engineering/config.yaml`. It does not create `config.local.yaml`. Missing optional tools stay in the summary as install hints.
+It refreshes the example config, asks whether to create `.compound-engineering/config.yaml`, and leaves the missing tools in the summary as install hints.
 
-When the bundled health script is not runnable, the skill runs the same checks inline and still offers the repo-local fixes.
+When the bundled health script is not runnable (on a non-Claude-Code platform, say), the skill runs the same checks inline and still offers the repo-local fixes.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Use `ce-setup` when:
 
@@ -144,22 +111,14 @@ Use `ce-setup` when:
 Skip it when:
 
 - You already know the exact tool to install
-- You are trying to update the plugin itself (use the host plugin manager)
-- You want every possible CE binary installed in one shot. This skill will not do that.
+- You want to update the plugin itself (use the host plugin manager)
+- You want every possible CE binary installed in one shot. It will not do that.
 
----
-
-## Use Standalone
-
-`ce-setup` is not a pipeline stage. Run it when you need a diagnosis or a safe config write. Re-run anytime. The summary prints the same invocation so you can do that.
+`ce-setup` is not a pipeline stage. Run it whenever you need a diagnosis or a safe config write; the summary prints the invocation so you can re-run it later.
 
 ---
 
 ## Reference
-
-| Argument | Effect |
-|----------|--------|
-| _(empty)_ | Diagnose, then remediate repo-local issues you approve. Outside a git repo: report optional tools and stop. |
 
 | Phase | Step |
 |-------|------|
@@ -171,17 +130,11 @@ Skip it when:
 
 ## FAQ
 
-**Why does setup not install everything?**
-Most CE workflows do not need every optional tool, and modern harnesses already provide some capture and browser affordances. Setup reports capabilities instead of forcing a broad install.
-
 **What is `compound-engineering.local.md` and why is it obsolete?**
-It was the old machine-local config file. Team defaults now live in `.compound-engineering/config.yaml`. `config.local.yaml` is the optional per-checkout override. Review-agent selection is automatic.
+It was the old machine-local config file. Team defaults now live in `.compound-engineering/config.yaml`, and `config.local.yaml` is the optional per-checkout override. Review-agent selection is automatic.
 
-**Why might `.compound-engineering/config.local.yaml` be gitignored?**
-It is the optional override. The committed `config.example.yaml` shows available settings. Setup creates the repo file, not the override.
-
-**Does it run on non-Claude-Code platforms?**
-Yes. When the bundled health script is not directly runnable, the skill falls back to equivalent inline checks and still performs repo-local config remediation.
+**Why gitignore `.compound-engineering/config.local.yaml`?**
+It is a per-checkout override, so committing it defeats the point. The committed `config.example.yaml` shows the available settings. Setup creates the repo file, never the override.
 
 ---
 

--- a/docs/guides/ce-simplify-code.md
+++ b/docs/guides/ce-simplify-code.md
@@ -2,30 +2,23 @@
 
 > Refine recently changed code. Three reviews look for reuse, quality, and efficiency issues; the skill applies the worthwhile ones and checks that behavior did not change.
 
-`ce-simplify-code` is on-demand **refinement** of a settled diff. It searches for utilities the new code duplicates, flags hacky patterns and dead code, and points out missed efficiency. Three focused reviews see the same scope from those angles. The skill applies the findings, then runs typecheck, lint, and scoped tests.
+A finished change usually carries debt you could not see while writing it: a helper that already exists in the repo, copy-paste with a small variation, string compares where an enum exists, names that only make sense if you followed the chat, two API calls that could run together. One "review and improve" prompt finds the obvious items and misses the ones that need a search across the tree.
 
-It preserves exact functionality. It will not relax assertions, weaken type signatures, or skip tests to make checks pass. It will not remove a safety check (trust-boundary validation, data-loss protection, security, accessibility) just because a finding called it boilerplate.
+`ce-simplify-code` runs three focused reviews of the same scope instead:
 
-This is not `ce-polish` (live UX on a working page), not `ce-code-review` (deeper review you still have to act on), and not a rewrite of the original feature. Use it after implementation has settled and before review, commit, or handoff.
+- **Reuse** searches for existing utilities, stdlib/runtime primitives, and platform guarantees the new code reimplements
+- **Quality** flags hacky structure, dead code, context-only names, leftover pre-release compatibility, and comments that only restate the code
+- **Efficiency** looks for extra work, missed concurrency, hot-path bloat, and no-op updates
 
-Point it at a branch, a file, or a description. Empty invoke resolves the branch diff.
+It applies what is worth keeping, notes false positives as skipped without stopping to argue, then runs project-wide typecheck and lint plus tests sized to the change. The summary reports what was already sound, what changed, counts by category, and which checks ran.
 
----
-
-## TL;DR
-
-| Question | Answer |
-|----------|--------|
-| What does it do? | Three focused reviews of recently changed code, then applies findings and verifies behavior is unchanged |
-| When to use it | After a feature or an agent-written chunk works, before review or PR |
-| What it produces | In-place edits plus a summary: what changed, what was already sound, checks run, counts by reuse / quality / efficiency, skipped count |
-| What's next | Whatever the change still needs: deeper review, more tests, commit/PR, or handoff. This skill does not pick the next stage |
+This is not `ce-polish` (live UX on a working page), not `ce-code-review` (deeper review you still act on yourself), and not a rewrite of the feature. Use it after implementation has settled and before review, commit, or handoff.
 
 ---
 
-## Example invocations
+## Invoking it
 
-Scope is the main knob. A name you give is authoritative and is never widened.
+Scope is the main knob. A scope you name is authoritative and never widened.
 
 ```text
 # Empty: branch vs its base, then staged + unstaged, then files edited in this chat
@@ -44,77 +37,43 @@ Scope is the main knob. A name you give is authoritative and is never widened.
 /ce-simplify-code the function I just wrote
 ```
 
-Outside git, or with no diff, it uses files named or edited in the conversation. If that is still empty, it asks.
+| Argument | Effect |
+|----------|--------|
+| _(empty)_ | Branch vs base, then staged + unstaged, then recent conversation edits. Asks if still empty |
+| `<file path>` | That file only (seams inside it) |
+| `<description>` | User-named scope, e.g. `the function I just wrote`. Never widened |
+
+Outside git, or with no diff, it uses files named or edited in the conversation. If that is still empty, it asks rather than guessing.
+
+A docs-only, generated, vendored, lockfile, or purely mechanical scope stops with "nothing to simplify." Mixed diffs keep the code files. That is a kind gate, not a size gate: a small function you named still runs. Size floors and cost thresholds belong to callers and standing instructions, not to this skill.
+
+Callers may also pass a plan path as structure-pin context. Its `session-settled:` decisions that name structure (keep this duplication, keep this wrapper) are pins the skill preserves; the plan is not the simplification scope.
 
 ---
 
-## The Problem
+## How it stays behavior-preserving
 
-A finished change often still has refinement debt that is easy to miss while writing:
+Edits stay inside the resolved scope and the import/export seams it requires. A user-named file or directory cannot pull fixes that would edit outside it. The skill inspects beyond the scope when it needs to evaluate a finding, but it only edits inside.
 
-- A new helper that already exists in the repo
-- Copy-paste with a small variation, unused imports, dead paths
-- String comparisons where an enum or union already exists
-- Names that only make sense if you followed the chat
-- Compatibility aliases for an earlier form of this unshipped change
-- Sequential work that could be concurrent, or a loop that writes the same state every tick
-- Comments that restate what the identifiers already say
+After the edits: typecheck and lint over the project, and tests matched to blast radius, broadened when a shared utility moved. If a check fails, the skill names it, then fixes the break or reverts that simplification. It never relaxes assertions, weakens types, or skips tests to get to green. If the project has no test suite, lint, or typecheck, the summary says so instead of silently skipping verification.
 
-One "review and improve" prompt usually finds the obvious items and misses the ones that need a search across the tree.
-
-## The Solution
-
-Three reviewers, then apply, then verify:
-
-- **Reuse** searches for existing utilities, stdlib/runtime primitives, and platform guarantees the new code reimplements
-- **Quality** flags hacky structure, dead code, context-only names, leftover pre-release compatibility, and comments that only restate the code
-- **Efficiency** looks for extra work, missed concurrency, hot-path bloat, and no-op updates
-
-The skill applies what is worth keeping, notes false positives as skipped, and runs project-wide typecheck and lint plus tests sized to the blast radius.
+Safety checks stay. The skill will not remove trust-boundary validation, data-loss protection, security checks, or accessibility affordances just because a finding called them boilerplate. A compatibility path for an earlier form of the same unshipped change may go only after the skill verifies it has no deployed, persisted, public, external, dependent-branch, or in-repo caller outside the scope, and every required caller update still fits inside the edit boundary.
 
 ---
 
-## What Makes It Novel
+## Worked example
 
-### Three reviews of the same scope
+You have been writing a notification-mute feature. Before the PR you run `/ce-simplify-code`. It takes the branch diff vs `origin/main` and runs the three reviews.
 
-A single "review and improve" prompt tends to follow the model's usual cleanup habits. Separate reuse, quality, and efficiency reviews cover the cross-tree search a generalist often skips. Dispatch is parallel when the host can run subagents; otherwise the same prompts run inline.
+Reuse finds that `formatDuration` near-duplicates `lib/utils/formatTime.ts`, path handling should use `path.join`, and a custom env check should use `isProduction()`. Quality finds string compares against `"active"` / `"paused"` where `SubscriptionStatus` already exists, a nested ternary that early-returns cleanly, an unused export, and a comment restating the function name. Efficiency finds two API calls in one handler that can run together and a polling loop that writes the same state every tick.
 
-### Scope you name is the mutation boundary
-
-Priority: your named file or description, else the branch diff vs base (or `git diff HEAD` if there is no usable base), else recent conversation edits, else ask. Edits stay inside that scope and the import/export seams it requires. A user-named file or directory cannot pull fixes that would edit outside it.
-
-A docs-only, generated, vendored, lockfile, or purely mechanical scope stops with "nothing to simplify." Mixed diffs keep the code files. That is a kind gate, not a size gate. A small function you named still runs.
-
-### Behavior stays the same, including safety
-
-After edits: typecheck and lint over the project; tests scoped to the change, broadened when a shared utility moved. Failures name the check. The skill fixes the break or reverts that simplification. No assertion relaxing, no weaker types, no skipped tests.
-
-Safety checks stay. A compatibility path for an earlier form of this unshipped change may go away only after it has no deployed, persisted, public, external, dependent-branch, or in-repo caller outside the scope, and every required caller update still fits the mutation boundary.
-
-If a caller passes a plan path whose `session-settled:` decisions name structure (keep this duplication, keep this wrapper), those are pins, not scope.
+The skill applies the fixes, skips one Quality finding as a false positive, and typecheck, lint, and scoped tests pass. The summary lists what was good, what changed, and which checks ran.
 
 ---
 
-## Quick Example
+## When to reach for it
 
-You have been writing a notification-mute feature. Before the PR you run `/ce-simplify-code`.
-
-It takes the branch diff vs `origin/main` and runs the three reviews.
-
-Reuse: `formatDuration` is a near-duplicate of `lib/utils/formatTime.ts`; path handling should use `path.join`; a custom env check should use `isProduction()`.
-
-Quality: string compares against `"active"` / `"paused"` where `SubscriptionStatus` already exists; a nested ternary that early-returns cleanly; an unused export; a comment that only restates the function name.
-
-Efficiency: two API calls in one handler can run together; a polling loop updates state every tick with no change guard.
-
-The skill applies the fixes, skips one Quality finding as a false positive, then typecheck, lint, and scoped tests all pass. The summary lists what was good, what changed, and which checks ran.
-
----
-
-## When to Reach For It
-
-Use `ce-simplify-code` when:
+Use it when:
 
 - A feature (or an agent-written chunk) works and you want it thinner before review
 - A refactor added helpers and you want to know they are not duplicates
@@ -129,61 +88,17 @@ Skip it when:
 
 ---
 
-## Position in a Workflow
+## Position in a workflow
 
-Run it after implementation has settled and before review, commit, or handoff.
+Run it after implementation has settled and before review, commit, or handoff. `ce-work`, `lfg`, and `ce-debug` may invoke it at their own completion boundaries; they own size floors and exclusions.
 
-`ce-work`, `lfg`, and `ce-debug` may invoke it at their own completion boundaries. They own size floors and exclusions. This skill does not.
+The skill does not pick the next stage. After it finishes, continue with whatever the change still needs: `ce-code-review`, more tests, `ce-commit-push-pr`, or a handoff.
 
-After it finishes, continue with the action the change still needs. That may be `ce-code-review`, more tests, `ce-commit-push-pr`, or a handoff.
-
-If you want the same wrap-up offer in ordinary sessions, add a standing instruction to the project's agent instructions: run (or offer) this skill once when a coherent unit is done, not after every edit, and not on docs-only or mechanical diffs. The skill already bails on a scope with no code.
+If you want the same wrap-up in ordinary sessions, add a standing instruction to the project's agent instructions: run (or offer) this skill once when a coherent unit is done, not after every edit, and not on docs-only or mechanical diffs. The skill already bails on a scope with no code.
 
 ---
 
-## Use Standalone
-
-- **Pre-PR on the branch:** `/ce-simplify-code`
-- **One file:** `/ce-simplify-code app/services/notification_dispatcher.rb`
-- **A named slice:** `/ce-simplify-code the changes I made to NotificationDispatcher`
-
----
-
-## Reference
-
-| Argument | Effect |
-|----------|--------|
-| _(empty)_ | Branch vs base, then staged + unstaged, then recent conversation edits. Asks if still empty |
-| `<file path>` | That file only (seams inside it) |
-| `<description>` | User-named scope, e.g. `the function I just wrote`. Never widened |
-
-Callers may also pass a plan path as structure-pin context. That is not the simplification scope.
-
----
-
-## FAQ
-
-**Why three reviewers instead of one?**
-One reviewer follows the usual cleanup paths. Reuse in particular needs a search for existing helpers, which a generalist often skips.
-
-**What if a finding is wrong?**
-The skill applies findings directly. False positives are skipped and mentioned in the summary. It does not stop to argue.
-
-**What if a fix breaks tests?**
-It will not paper over the break. It fixes the regression or reverts that simplification.
-
-**Why isn't this part of the original write?**
-You find an existing utility when you search for it. A later pass with a dedicated search catches what the write did not.
-
-**Does it refuse tiny diffs?**
-No. Size gates belong to callers and standing instructions. An explicit small scope still runs.
-
-**What if I point it at docs or a lockfile?**
-It stops with a short "nothing to simplify" note. On a mixed diff it keeps the code files.
-
----
-
-## See Also
+## See also
 
 - [`ce-work`](./ce-work.md): may run this before its review gate
 - [`lfg`](./lfg.md): may run this on the branch diff before review

--- a/docs/guides/ce-strategy.md
+++ b/docs/guides/ce-strategy.md
@@ -2,7 +2,7 @@
 
 > Create or maintain `STRATEGY.md`: what the product is, who it is for, how it succeeds, and where the team is investing.
 
-`ce-strategy` is the **upstream anchor**. It writes its sections of `STRATEGY.md`, the shared project document at the repo root next to `README.md` — a file other tools and people also write their own sections into, so the skill owns only what its template names and preserves the rest. It is not a step in `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work`. Those skills read `STRATEGY.md` when it exists and weight their suggestions toward the active tracks and the stated approach. `ce-product-pulse` also reads it to seed the metrics it measures.
+`ce-strategy` writes the upstream anchor. `STRATEGY.md` lives at the repo root next to `README.md` and is a shared project document. Other tools and people write their own sections into it, so the skill owns only what its template names and leaves the rest alone. It is not a step in `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work`. Those skills read `STRATEGY.md` when it exists and weight their suggestions toward the active tracks and the stated approach. `ce-product-pulse` also reads it to seed the metrics it measures.
 
 The doc is short on purpose. The skill grounds itself in what the repo already says the product is, asks a handful of sharp questions, pushes back on slogans and feature lists, and writes what you actually said.
 
@@ -23,7 +23,7 @@ of the loop.                                                         this?"
 |----------|--------|
 | What does it do? | Reads what the repo already says the product is, interviews you with pushback rules, stress-tests the answers, then writes or updates `STRATEGY.md` at the repo root |
 | When to use it | New product; adding a strategy doc to an existing repo; direction changed; "what are we working on?" has no written answer; a downstream skill flagged missing strategy grounding |
-| What it produces | `STRATEGY.md` with purpose, positioning, users, 3-5 key metrics, 2-4 tracks, boundaries, and optional milestones / brand. Frontmatter carries `name` and `last_updated`. |
+| What it produces | `STRATEGY.md` with purpose, positioning, users, 3-5 key metrics, 2-4 tracks, boundaries, and optional milestones and brand. Frontmatter carries `name` and `last_updated`. |
 | What's next | `/ce-ideate` or `/ce-brainstorm` if nothing downstream has run yet. `/ce-product-pulse` if you want those metrics measured. |
 
 ---
@@ -51,7 +51,7 @@ An empty invoke follows the file. A section name or scope hint jumps to that par
 /ce-strategy purpose
 ```
 
-Prefer a section or scope hint for maintenance. A bare invoke on an existing file is the broader path: it asks which section to open.
+Prefer a section or scope hint for maintenance. A bare invoke on an existing file asks which section to open.
 
 ---
 
@@ -72,15 +72,14 @@ A useful strategy doc is short and opened often. A generic "write a strategy" pr
 
 `ce-strategy` runs a repo-grounded interview with named pushback rules.
 
-- It reads the README, `CONCEPTS.md`, and `docs/` first, so the interview opens from a working model of the product instead of a blank page. Recent commits and PRs are read separately, as a signal of where attention has gone lately - useful for tracks, not for what the product is.
-
+- It reads the README, `CONCEPTS.md`, and `docs/` first, so the interview opens from a working model of the product instead of a blank page. Recent commits and PRs are read separately, as a signal of where attention has gone lately. That signal informs tracks, not what the product is.
 - Strategy is what the product is and why. Features belong in `ce-brainstorm`. Schedules belong in the issue tracker.
 - Section headers are plain English. The interview is where the discipline lives.
 - The template is constrained. Extra sections get pushback.
 - Re-runs update in place. Accurate sections stay; weak ones get the same pushback as a first write.
 - Each section has anti-patterns and probe questions that catch slogans, goals-as-strategy, and feature lists.
 
-The "Purpose / Positioning / Tracks" shape follows Richard Rumelt's kernel in *Good Strategy Bad Strategy*: diagnosis, guiding policy, and coherent action.
+The Purpose / Positioning / Tracks shape follows Richard Rumelt's kernel in *Good Strategy Bad Strategy*: diagnosis, guiding policy, coherent action.
 
 ---
 
@@ -88,23 +87,23 @@ The "Purpose / Positioning / Tracks" shape follows Richard Rumelt's kernel in *G
 
 ### Grounded in the repo, decided by you
 
-Before the first question the skill shows a three-to-five-line repo model - what it takes the product to be, who it seems to serve, where recent attention has gone - with sources named, and asks you to correct it. Evidence seeds the questions and sharpens the pushback ("the README says X; you just said Y - which is it?"). It never fills in a section on its own, and a burst of recent work in one area is offered as a question about tracks, not treated as the product's focus. A new or empty repo runs the interview ungrounded; that is a normal path.
+Before the first question the skill shows a three-to-five-line repo model with sources named: what it takes the product to be, who it seems to serve, where recent attention has gone. You correct it. Evidence seeds the questions and sharpens the pushback ("the README says X; you just said Y. Which is it?"). It never fills in a section on its own, and a burst of recent work in one area becomes a question about tracks, not a conclusion about the product's focus. A new or empty repo runs the interview ungrounded. That is a normal path, not a failure.
 
 ### Pushback in the interview
 
-For each section the skill asks the opening question, then applies that section's pushback rules. Two rounds maximum. If the answer is still weak, it captures what you gave and notes the section is worth another pass next run. Without that step the interview is just transcription.
+For each section the skill asks the opening question, then applies that section's pushback rules. Two rounds maximum. If the answer is still weak, it writes what you gave and notes the section is worth another pass next run. Without that step the interview is just transcription.
 
-Required sections, in the document's order: Purpose, Positioning, Users, Boundaries (always written, even if only to say nothing is named yet), Key metrics, Tracks - the universal sections first, then direction. The interview asks Boundaries after the stress test, since that is where its content comes from. Optional: Milestones, Brand - skipped when nothing came up. Unused optional sections are omitted, not left as empty headers. Metrics stay at 3-5. Tracks stay at 2-4.
+Required sections, in the document's order: Purpose, Positioning, Users, Boundaries (always written, even if only to say nothing is named yet), Key metrics, Tracks. The interview asks Boundaries after the stress test, since that is where its content comes from. Milestones and Brand are optional and skipped when nothing came up; unused optional sections are omitted, not left as empty headers. Metrics stay at 3-5. Tracks stay at 2-4.
 
 On a first run, the filled draft is shown in chat and you get one edit pass before anything is written.
 
 ### Stress test before the draft
 
-After the five required sections, the skill poses three to five concrete proposals aimed at the draft's fault lines - a tempting feature just off the approach, a second persona pulling the other way, a track that would starve another - chosen so your answer is not predictable from the draft. If the strategy already decides a proposal, it is confirmed. If it cannot, the approach or a track gets sharpened. Proposals you resist become Boundaries entries and feed a one-line "Resist a change when ..." test, so that section carries real content a downstream agent can apply.
+After the five required sections, the skill poses three to five concrete proposals aimed at the draft's fault lines: a tempting feature just off the approach, a second persona pulling the other way, a track that would starve another. They are chosen so your answer is not predictable from the draft. If the strategy already decides a proposal, that confirms it. If it cannot, the approach or a track gets sharpened. Proposals you resist become Boundaries entries and feed a one-line "Resist a change when ..." test, so that section carries real content a downstream agent can apply.
 
 ### Updates in place
 
-A second run does not start over. It reads the existing doc, summarizes it in 3-5 lines, checks it for drift against the repo and what has landed since `last_updated`, names any section that looks stale as a candidate, and either jumps to the section you named or asks which to revisit. The menu is Purpose; Positioning; Users; or Metrics, tracks, boundaries, or other. Sections you confirm are still accurate are left alone. `last_updated` is set to today.
+A second run does not start over. It reads the existing doc, summarizes it in 3-5 lines, checks for drift against the repo and what has landed since `last_updated`, and names any stale-looking section as a candidate. Then it jumps to the section you named, or asks which to revisit: Purpose; Positioning; Users; or Metrics, tracks, boundaries, or other. Sections you confirm are still accurate are left alone. `last_updated` is set to today.
 
 ### Read by downstream skills
 
@@ -115,7 +114,9 @@ When `STRATEGY.md` is at the repo root:
 - `ce-plan` flags decisions that pull away from the tracks or the stated positioning, or land inside the stated boundaries
 - `ce-product-pulse` seeds product name and key metrics, then wires sources to measure them
 
-The skills work without the file. With it, they have a signal for what kind of work matters right now. `ce-ideate`, `ce-brainstorm`, and `ce-plan` read by section meaning rather than exact heading and fall back to a legacy `PRODUCT.md` or `VISION.md` only for meanings `STRATEGY.md` lacks; `ce-dogfood` reads the persona section (`Users`, or `Who it's for` in older files) and then a legacy sibling; `ce-strategy` itself reads those as stated intent when grounding. `ce-product-pulse` reads `STRATEGY.md` (or, when absent, the first of `VISION.md`, `PRODUCT.md` that exists); it takes metrics from `## Key metrics` when `ce-strategy` wrote it, otherwise from whichever section lists the success measures — following a linked legacy doc when `STRATEGY.md` defers them there — and says when none are on file yet.
+The skills work without the file. With it, they know what kind of work matters right now.
+
+Readers match sections by meaning, not exact heading. `ce-ideate`, `ce-brainstorm`, and `ce-plan` fall back to a legacy `PRODUCT.md` or `VISION.md` only for meanings `STRATEGY.md` lacks. `ce-dogfood` reads the persona section (`Users`, or `Who it's for` in older files), then a legacy sibling. `ce-strategy` itself reads those files as stated intent when grounding. `ce-product-pulse` reads `STRATEGY.md`, or the first of `VISION.md` and `PRODUCT.md` when it is absent; it takes metrics from `## Key metrics` when `ce-strategy` wrote it, otherwise from whichever section lists the success measures, following a linked legacy doc when `STRATEGY.md` defers them there, and says when none are on file yet.
 
 The skill does not compute metric values, update the issue tracker, prioritize a backlog, or write requirements or plans.
 
@@ -129,7 +130,7 @@ Purpose: you answer "we help teams ship faster." That is a slogan, so the pushba
 
 Positioning: you answer "use AI." That is a tool, not a bet. The pushback asks what you are betting AI does here that the obvious alternative does not. You name the actual choice.
 
-The interview continues through Users, Key metrics, and Tracks - where the skill asks whether the recent GitHub work is a track or a push, and you say push. Then three proposals test the draft; you resist one ("a Slack bot for review nudges"), and it lands under Boundaries. You see the full draft, get one edit pass, and the file is written to `STRATEGY.md`.
+The interview continues through Users, Key metrics, and Tracks, where the skill asks whether the recent GitHub work is a track or a push, and you say push. Then three proposals test the draft; you resist one ("a Slack bot for review nudges"), and it lands under Boundaries. You see the full draft, get one edit pass, and the file is written to `STRATEGY.md`.
 
 The skill notes that `ce-ideate`, `ce-brainstorm`, and `ce-plan` will pick the file up on their next run, and suggests `ce-ideate` or `ce-brainstorm` if nothing downstream has run yet.
 
@@ -179,7 +180,7 @@ This skill is always invoked on its own. Nothing in the loop produces `STRATEGY.
 - Targeted update: `/ce-strategy positioning` jumps to that section
 - Open update: `/ce-strategy` (file exists, no argument) asks which section to revisit
 
-The sections this skill writes are meant to be readable in under five minutes; other tools' sections in the shared file are their own.
+The sections this skill writes should be readable in under five minutes. Other tools' sections in the shared file are their own.
 
 ---
 

--- a/docs/guides/ce-sweep.md
+++ b/docs/guides/ce-sweep.md
@@ -2,9 +2,9 @@
 
 > Sweep configured feedback sources for new items, track each one to a verified merge, and keep one rolling `/lfg`-ready plan.
 
-`ce-sweep` sits **around the loop**. It turns incoming customer feedback into a requirements-only plan. It is not a step in `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work`. The loop invents or refines work; this skill ingests what customers already sent.
+`ce-sweep` sits around the loop, not inside it. The `/ce-ideate` → `/ce-brainstorm` → `/ce-plan` → `/ce-work` loop invents or refines work; this skill ingests what customers already sent and turns it into a requirements-only plan.
 
-You invoke it yourself (it is not model-invoked). First run is interactive setup. Later runs can be manual or scheduled with `mode:non-interactive`. The output is `docs/plans/feedback-sweep-plan.md`, which `/lfg` can execute. It is not a time-windowed metrics report (`ce-product-pulse`) and not a one-off recording analysis (`ce-riffrec-feedback-analysis`).
+You invoke it yourself (it is not model-invoked). The first run is an interactive setup interview. Later runs can be manual or scheduled with `mode:non-interactive`. The output is `docs/plans/feedback-sweep-plan.md`, which `/lfg` can execute. It is not a time-windowed metrics report (`ce-product-pulse`) and not a one-off recording analysis (`ce-riffrec-feedback-analysis`).
 
 ```text
 customer Slack / GitHub / email
@@ -51,35 +51,25 @@ Empty follows config. First run is setup, then a sweep. Later empty is a sweep o
 /lfg docs/plans/feedback-sweep-plan.md
 ```
 
-A scheduled job should register `mode:non-interactive` so the run defers instead of blocking. First-run setup cannot run unattended.
+A scheduled job should pass `mode:non-interactive` so the run defers instead of blocking. First-run setup cannot run unattended.
 
 ---
 
-## The Problem
+## The problem
 
-Feedback triage tends to become a private ritual: scan Slack since last time, react so the customer knows it was seen, download recordings, guess whether something already shipped, keep a list in someone's head. Every project rebuilds this. "Fixed" claims get trusted without a merge.
+Feedback triage becomes a private ritual. Someone scans Slack since last time, reacts so the customer knows it was seen, downloads recordings, guesses whether something already shipped, and keeps the list in their head. Every project rebuilds this, and "fixed" claims get trusted without a merge to back them.
 
-## The Solution
+## How it works
 
-`ce-sweep` makes the sweep repeatable.
+Sources are declared once in `feedback_sources`. Each run fetches items newer than that source's cursor, acknowledges them at the source (emoji on Slack, label on GitHub Issues; email is tracked in state only), analyzes attached recordings, and closes an item only when a claimed fix has merged to the default branch. Open actionable items land in one rolling plan that `/lfg` can run. The [configuration reference](./configuration.md) lists the keys first-run setup writes.
 
-Sources are declared once in `feedback_sources`. Each run fetches items newer than that source's cursor, acknowledges them at the source (emoji on Slack, label on GitHub Issues; email is tracked in state only), analyzes attached recordings, and closes an item only when a claimed fix has merged to the default branch. Open actionable items land in one rolling plan that `/lfg` can run.
-
-The [configuration reference](./configuration.md) lists the feedback-source and sweep keys that first-run setup writes.
-
-Item lifecycle lives in a durable YAML state file. Runs resume cleanly. A crash does not double-acknowledge a customer's message.
+Item lifecycle lives in a durable YAML state file, so runs resume cleanly and a crash does not double-acknowledge a customer's message.
 
 The skill never replies to customers. Its only source-side writes are the ack and close-out actions you approved at setup.
 
----
-
-## What Makes It Novel
-
 ### Durability before the cursor moves
 
-For each new item the order is fixed: acknowledge at the source, confirm the ack is visible, write state, then advance the cursor. A crash in the middle recovers without a second customer-visible action. The bundled state engine is the only writer of that file.
-
-If another sweep holds the lease, this run stops rather than interleaving writes.
+For each new item the order is fixed: acknowledge at the source, confirm the ack is visible, write state, then advance the cursor. A crash in the middle recovers without a second customer-visible action. The bundled state engine is the only writer of that file, and if another sweep holds the lease, this run stops rather than interleaving writes.
 
 ### Merge evidence, not thread claims
 
@@ -87,9 +77,9 @@ A message that says "this is fixed" does not close the item. Close-out needs a v
 
 ### One rolling plan, not a log
 
-Every run reconciles `docs/plans/feedback-sweep-plan.md`. New items append. Closed items drain. A human-owned notes region is left untouched. If that path exists and is not both `product_contract_source: ce-sweep` and `artifact_readiness: requirements-only` (for example after `/lfg` has enriched it), the sweep archives the file to a dated sibling and writes a fresh view. It does not overwrite someone else's execution state.
+Every run reconciles `docs/plans/feedback-sweep-plan.md`. New items append, closed items drain, and a human-owned notes region is left untouched. If the file at that path is no longer a `ce-sweep` requirements-only plan (for example after `/lfg` has enriched it), the sweep archives it to a dated sibling and writes a fresh view rather than overwriting someone else's execution state.
 
-Customer quotes in the plan are marked untrusted data. Sensitive sources withhold body and quote from state and from the plan.
+Customer quotes in the plan are marked untrusted data. Sensitive sources withhold body and quote from both state and the plan.
 
 ### Safe to schedule
 
@@ -97,17 +87,17 @@ Customer quotes in the plan are marked untrusted data. Sensitive sources withhol
 
 ---
 
-## Quick Example
+## Quick example
 
 You have a Slack alpha channel and a GitHub issues inbox. You run `/ce-sweep`. No `feedback_sources` key exists, so setup starts.
 
-You add sources one at a time: type, target (Slack channel ID, or `owner/repo`), ack and close-out actions, standing approval for those writes, and whether content is sensitive. Then you pick where state lives (committed under `docs/feedback-sweep/`, or machine-local under `/tmp`), set the ack cap (default 25), and optionally import a legacy tracker so already-seen items are not acked again. Setup offers a schedule. Then the first sweep runs.
+You add sources one at a time: type, target (Slack channel ID, or `owner/repo`), ack and close-out actions, standing approval for those writes, and whether content is sensitive. Then you pick where state lives (committed under `docs/feedback-sweep/`, or machine-local under `/tmp`), set the ack cap, and optionally import a legacy tracker so already-seen items are not acked again. Setup offers a schedule, then the first sweep runs.
 
 A later `/ce-sweep` fetches items newer than each cursor, applies the approved ack, analyzes any recordings in parallel, checks `fix_pending` items against `gh` / git, and rewrites the machine-owned region of the plan. Interactive mode may ask one product question per category. The summary lists new items, recordings, closes with evidence, anything stuck or deferred, and the `/lfg` line for `docs/plans/feedback-sweep-plan.md`.
 
 ---
 
-## When to Reach For It
+## When to reach for it
 
 Reach for `ce-sweep` when:
 
@@ -123,7 +113,7 @@ Skip `ce-sweep` when:
 
 ---
 
-## Use as Part of the Workflow
+## Use as part of the workflow
 
 `ce-sweep` feeds the loop. It does not walk it.
 
@@ -133,19 +123,9 @@ Skip `ce-sweep` when:
                          +--> stay in the plan and answer Outstanding Questions
 ```
 
-The plan is requirements-only with `product_contract_source: ce-sweep`. `/lfg` is the intended next skill. You can also open the plan and work the items by hand.
+The plan is requirements-only with `product_contract_source: ce-sweep`. `/lfg` is the intended next skill, but you can also open the plan and work the items by hand.
 
 `ce-strategy` and `ce-product-pulse` are separate anchors. Pulse reports numbers over a window. Sweep tracks individual feedback items.
-
----
-
-## Use Standalone
-
-- First run: `/ce-sweep` (no config yet)
-- Later run: `/ce-sweep`
-- Add or edit sources: `/ce-sweep reconfigure` or `/ce-sweep setup`
-- Unattended: `/ce-sweep mode:non-interactive` (setup must already exist)
-- Execute the plan: `/lfg docs/plans/feedback-sweep-plan.md`
 
 State location is a setup choice. Committed state is the right default when more than one agent or machine shares the branch. Machine-local state under `/tmp` stays off the repo and is invisible to other checkouts.
 
@@ -161,7 +141,7 @@ State location is a setup choice. Committed state is the right default when more
 
 Source types: `slack`, `github-issues`, `email` (experimental, read-only, no source-side ack). Slack acks default to the `eyes` reaction and close out with `white_check_mark`. GitHub acks default to the `feedback:ack` label and close out with `feedback:resolved`.
 
-Config keys (interview writes `config.local.yaml`): `feedback_sources`, `sweep_state_path`, `sweep_ack_cap`, `sweep_shared_branch`. `sweep_lease_ttl_minutes` is written at its default of 60 and is not asked. See the [configuration reference](./configuration.md).
+Config keys (the interview writes `config.local.yaml`): `feedback_sources`, `sweep_state_path`, `sweep_ack_cap`, `sweep_shared_branch`. `sweep_lease_ttl_minutes` is written at its default of 60 and is not asked. See the [configuration reference](./configuration.md).
 
 Default paths (`docs/` is the artifact root unless `docs_root` is set):
 
@@ -178,7 +158,7 @@ On Codex, the handoff is `$lfg` with the same plan path.
 Your choice at setup: committed to the repo (recommended when several agents or machines share branches) or machine-local under `/tmp`. The schema is a versioned contract in the skill's `references/state-schema.md`.
 
 **Can it reply to customers?**
-No. The only source-side writes are the configured acknowledgment and close-out actions, standing-approved at setup. A `no` on approval keeps that source read-only; items land as deferred for you to handle.
+No. The only source-side writes are the configured acknowledgment and close-out actions, standing-approved at setup. A `no` on approval keeps that source read-only; its items land as deferred for you to handle.
 
 **What about prompt injection from feedback content?**
 Bodies, titles, quotes, media filenames, and text read back from state are treated as data, never as instructions. The emitted plan marks customer text as untrusted so `/lfg` inherits the same posture.
@@ -194,7 +174,7 @@ Not past the ack cap, and not on a source you left unapproved. Over-cap batches 
 
 ---
 
-## See Also
+## See also
 
 - [`ce-product-pulse`](./ce-product-pulse.md): time-windowed metrics reports, not item-level triage
 - [`ce-riffrec-feedback-analysis`](./ce-riffrec-feedback-analysis.md): the recording analyzer this sweep can run per attachment

--- a/docs/guides/ce-test-browser.md
+++ b/docs/guides/ce-test-browser.md
@@ -2,7 +2,7 @@
 
 > Run end-to-end browser tests on the pages the current PR or branch actually changed, using the best approved browser driver available.
 
-`ce-test-browser` is on-demand **browser testing**. It maps changed files to routes, checks (or, in pipeline mode, starts) the dev server, drives each affected page, captures rendered state and screenshots, pauses for human checks on external flows, and prints a structured summary.
+`ce-test-browser` is on-demand browser testing. It maps changed files to routes, checks (or, in pipeline mode, starts) the dev server, drives each affected page, captures rendered state and screenshots, pauses for human checks on external flows, and prints a structured summary.
 
 It tests and reports. It is not `ce-dogfood` (autonomous QA that fixes small breakages and writes a durable report), not `ce-polish` (you sit with a working feature and talk about feel), and not `ce-test-xcode` (iOS simulator).
 
@@ -23,7 +23,7 @@ Default is manual: you own the server. `mode:pipeline` is for `lfg` and other un
 
 ## Example invocations
 
-PR and branch arguments choose the **diff used to pick routes**. They do not switch your checkout. Have the target code checked out and, in manual mode, its server running.
+PR and branch arguments choose the diff used to pick routes. They do not switch your checkout. Have the target code checked out and, in manual mode, its server running.
 
 ```text
 # Empty: routes from git diff main...HEAD. You own the server
@@ -78,7 +78,9 @@ A fixed flow:
 
 ### Host-native browser first, `agent-browser` as fallback
 
-Prefer a host-native integrated browser: a surface embedded in or directly owned by the active harness. Local URLs, rendered and interactive state, click/fill/press, screenshots, console errors. Separately configured browser extensions or MCPs do not count. If the host has no such surface, fall back to `agent-browser`. One driver owns the run. It will not install standalone Playwright, Puppeteer, or another automation stack. A Playwright API *inside* the selected host browser is still that browser.
+The skill prefers a host-native integrated browser: a surface embedded in or directly owned by the active harness that can open local URLs, inspect rendered and interactive state, click/fill/press, screenshot, and read console errors. A separately configured browser extension or MCP does not count. If the host has no such surface, the run has to fall back to `agent-browser`.
+
+One driver owns the run. The skill will not install standalone Playwright, Puppeteer, or another automation stack. A Playwright API inside the selected host browser is still that browser, not a substitute stack.
 
 If neither a native browser nor `agent-browser` is available, it stops and points at `/ce-setup`.
 
@@ -168,18 +170,6 @@ Bare and `mode:agent` `ce-code-review` runs are report-only and can share the ch
 
 ---
 
-## Use Standalone
-
-- **Current branch:** `/ce-test-browser` or `/ce-test-browser current`
-- **PR file list:** `/ce-test-browser 847`
-- **Named branch diff:** `/ce-test-browser feature/new-dashboard`
-- **Custom port:** `/ce-test-browser --port 5000`
-- **Pipeline:** `/ce-test-browser mode:pipeline`
-
-Pipeline starts via `bin/dev`, `bin/rails server`, or `npm run dev`, whichever the project has, and waits up to 30 seconds.
-
----
-
 ## Reference
 
 | Argument | Effect |
@@ -193,6 +183,8 @@ Pipeline starts via `bin/dev`, `bin/rails server`, or `npm run dev`, whichever t
 Required: a host-native integrated browser or `agent-browser`. Manual mode also needs a listening server (or you restart after starting one).
 
 The selected driver must navigate locally, inspect rendered and interactive state, click/fill/press, screenshot, and read console errors.
+
+Pipeline mode starts the server via `bin/dev`, `bin/rails server`, or `npm run dev`, whichever the project has, and waits up to 30 seconds.
 
 ---
 

--- a/docs/guides/ce-test-xcode.md
+++ b/docs/guides/ce-test-xcode.md
@@ -49,7 +49,6 @@ Manual simulator testing is slow and easy to do incompletely:
 - "I tested it, looks fine" does not say which screens or what was skipped
 - Sign in with Apple, sandbox purchases, and push need a person, and they get forgotten
 - Simulated taps on SwiftUI inline `Text` links report success and do nothing
-- Screenshots and logs stay on one machine
 
 ## The Solution
 
@@ -60,9 +59,11 @@ A gated flow on top of [XcodeBuildMCP](https://github.com/getsentry/xcodebuildmc
 - Build, install, launch, start log capture
 - Per screen: screenshot, log check, pass or fail
 - Pause for device-only flows (and for SwiftUI inline links)
-- On failure, ask investigate-now (`ce-debug`, then rebuild and retest any accepted fix) or continue the remaining checks
+- On failure, ask whether to investigate now with `ce-debug` or continue the remaining checks
 - Print a summary you can paste into a PR
 - Stop log capture; optionally shut down the simulator
+
+A failed build never proceeds to install or launch.
 
 ---
 
@@ -96,13 +97,13 @@ No shell-`xcodebuild` fallback.
 | Location | Allow location and verify the map updates |
 | SwiftUI `Text` links | Tap the link yourself. Automated taps cannot trigger inline `AttributedString` links |
 
-You do the action on the simulator, then yes (continue) or no (describe the issue). Those flows are not silently skipped.
+You do the action on the simulator, then answer yes (continue) or no (describe the issue). Those flows are not silently skipped.
 
 Simulated taps do not fire gesture recognizers on SwiftUI `Text` with inline links. The tap looks successful. If the target URL is known, `xcrun simctl openurl <device> <URL>` is the fallback.
 
 ### Investigate now or continue
 
-A failed screen gets a screenshot, logs, and repro steps. You choose whether to hand the evidence to `ce-debug` or continue the remaining checks without investigation. That choice does not change the observed Fail. After an applied fix, rebuild and retest, then update status from the completed retest evidence. Without completed retest evidence, preserve Fail.
+A failed screen gets a screenshot, logs, and repro steps. You choose: hand the evidence to `ce-debug` now, or keep going through the remaining checks. Either way the screen stays Fail: the choice does not change the observed Fail. Only a completed, passing retest after a fix changes its status.
 
 ### Summary shape
 
@@ -113,9 +114,7 @@ A failed screen gets a screenshot, logs, and repro steps. You choose whether to 
 - Human verifications
 - Overall PASS / FAIL / PARTIAL
 
-Statuses follow evidence. Pass requires a completed passing check. Fail records observed failing evidence until a completed retest replaces it. Skip is only for a check with no completed outcome. Any remaining Fail makes the overall result FAIL. With no Fail, an unanswered or otherwise incomplete scoped check makes it PARTIAL; otherwise it is PASS.
-
-A failed build never proceeds to install or launch.
+Statuses follow evidence, not intentions. Pass means a completed passing check. Fail sticks until a retest replaces it. Without completed retest evidence, preserve Fail. Skip is only for a check with no completed outcome. Any Fail makes the overall result FAIL; no Fail but an incomplete scoped check makes it PARTIAL; otherwise PASS.
 
 ---
 
@@ -157,16 +156,6 @@ On-demand. `ce-work` and `ce-code-review` do not call this today. Run it yoursel
 
 ---
 
-## Use Standalone
-
-- **Default scheme:** `/ce-test-xcode`
-- **Named scheme:** `/ce-test-xcode MyApp-Debug`
-- **Last-used:** `/ce-test-xcode current`
-
-It prefers iPhone 15 Pro when that simulator exists, otherwise another available device.
-
----
-
 ## Reference
 
 | Argument | Effect |
@@ -175,7 +164,7 @@ It prefers iPhone 15 Pro when that simulator exists, otherwise another available
 | `<scheme name>` | Build that scheme |
 | `current` | Default / last-used scheme |
 
-Required: Xcode with CLT, a connected XcodeBuildMCP server, an Xcode project or workspace, at least one iOS Simulator.
+Required: Xcode with CLT, a connected XcodeBuildMCP server, an Xcode project or workspace, at least one iOS Simulator. It prefers iPhone 15 Pro when that simulator exists, otherwise another available device.
 
 ---
 

--- a/docs/guides/ce-work.md
+++ b/docs/guides/ce-work.md
@@ -2,11 +2,11 @@
 
 > Execute against the plan's guardrails, figure out the HOW with code in front of you, ship complete features, and hand off to a clean PR.
 
-`ce-work` is the **execution** skill. It takes a plan (or, for smaller scope, a bare prompt), implements against the plan's guardrails, runs tests continuously, selects an implementation engine and a safe scheduling strategy, runs quality gates, and hands off to a commit + PR flow. Implementation can stay on the current host or route bounded units to another qualified model or harness. The host still owns verification, canonical commits, and shipping.
+`ce-work` is the execution skill. Give it a plan, or a bare prompt for smaller work, and it implements against the plan's guardrails, runs tests as it goes, picks an implementation engine and a safe scheduling strategy, runs quality gates, and hands off to a commit + PR flow. Implementation can stay on the current host or route bounded units to another model or harness, but the host always owns verification, canonical commits, and shipping.
 
-It treats the plan as a **decision artifact**: authoritative for scope, decisions, units, and tests. It figures out the actual implementation itself. **This is the HOW phase that `ce-plan` deliberately does not pre-write.**
+The plan is a decision artifact: authoritative for scope, decisions, units, and tests. `ce-work` figures out the actual implementation itself. This is the HOW phase that `ce-plan` deliberately does not pre-write.
 
-This is the fourth step in the compound-engineering ideation chain:
+It is the fourth step in the compound-engineering ideation chain:
 
 ```text
 /ce-ideate         /ce-brainstorm      /ce-plan             /ce-work
@@ -15,7 +15,7 @@ This is the fourth step in the compound-engineering ideation chain:
                                         this?"
 ```
 
-`ce-work` is primarily software-focused. It commits, runs tests, opens PRs, and integrates with code review skills. It also has a lightweight **non-code carve-out**: a plan marked `execution: knowledge-work` (produced by `ce-plan`'s approach-altitude flow) routes to a knowledge-work path that reads sources, synthesizes, and produces a deliverable, skipping the code lifecycle. Other non-software work without that marker still ends at `ce-plan`, and a human executes it.
+`ce-work` is mostly software-focused: it commits, runs tests, opens PRs, and integrates with code review. One carve-out exists. A plan marked `execution: knowledge-work` (produced by `ce-plan`'s approach-altitude flow) routes to a path that reads sources, synthesizes, and saves a deliverable, skipping the code lifecycle. Non-software work without that marker still ends at `ce-plan`, and a human executes it.
 
 ---
 
@@ -25,8 +25,8 @@ This is the fourth step in the compound-engineering ideation chain:
 |----------|--------|
 | What does it do? | Reads an implementation-ready plan (or scopes a bare prompt), executes against the guardrails, runs tests continuously, ships a reviewed PR |
 | When to use it | Implementing a `ce-plan` plan with `artifact_readiness: implementation-ready`; small or medium bare-prompt work; resuming partly-shipped work |
-| What it produces | Commits and a PR (or just commits on the no-PR path). Knowledge-work plans produce a saved deliverable instead, with no commit/PR lifecycle. |
-| Caller-owned mode | For outer orchestrators (for example `lfg`): `mode:return-to-caller <plan path>` implements and locally verifies, then returns a structured envelope and skips the standalone shipping tail (final simplify, review, PR, CI). Mid-implementation Simplify as You Go still runs. |
+| What it produces | Commits and a PR (or just commits on the no-PR path). Knowledge-work plans produce a saved deliverable instead. |
+| Caller-owned mode | For outer orchestrators (for example `lfg`): `mode:return-to-caller <plan path>` implements and locally verifies, then returns a structured envelope and skips the standalone shipping tail (final simplify, review, PR, CI). Mid-implementation "Simplify as You Go" still runs. |
 | What's next | Review the PR; run `/ce-compound` to capture learnings |
 | Distinguishing | Plan-aware idempotency, native or cross-model implementation engines, conservative parallel waves, host-owned verification and commits, operational validation in the PR |
 
@@ -34,7 +34,7 @@ This is the fourth step in the compound-engineering ideation chain:
 
 ## Example invocations
 
-An empty invoke picks the newest eligible implementation-ready code plan in `docs/plans/`. It stops instead of guessing if the newest match is still requirements-only, knowledge-work, or an approach-plan. A requirements-only path is refused until `ce-plan` enriches it. A path argument is the plan to execute. A named engine changes who authors the code, not who verifies or ships.
+An empty invoke picks the newest eligible implementation-ready code plan in `docs/plans/`, and stops instead of guessing if the newest match is still requirements-only, knowledge-work, or an approach-plan. A requirements-only path is refused until `ce-plan` enriches it. A path argument is the plan to execute. A named engine changes who authors the code, not who verifies or ships.
 
 ```text
 # Execute a specific implementation-ready plan and own the shipping tail
@@ -77,9 +77,9 @@ Asking an agent "implement this plan" goes wrong in predictable ways:
 
 - Reimplementing already-shipped work when picking up a partly-finished branch
 - Treating the plan as a script: editing the literal files listed even when a different shape would be cleaner
-- Tests with everything mocked: proves logic in isolation, says nothing about whether layers interact
+- Tests with everything mocked, which prove logic in isolation and say nothing about whether layers interact
 - Half-finished features: visible work done, callbacks unwired, edge cases untouched
-- Parallel work with silent data loss: multiple agents writing the same file; only the last write survives
+- Parallel work with silent data loss: multiple agents writing the same file, and only the last write survives
 - No quality gate: the diff goes straight to PR with no simplification pass, no review, no operational monitoring
 
 ## The Solution
@@ -90,7 +90,7 @@ Asking an agent "implement this plan" goes wrong in predictable ways:
 - An idempotency check before each task: if verification is already satisfied, skip it
 - Scope-appropriate implementation (native inline/subagents by default, or a sanctioned cross-model route) and scheduling (serial or bounded independent waves)
 - Test discovery and evidence selection before behavior changes, plus integration coverage before any task is marked done
-- Portable self-sizing code review with a residual-work gate: accept, file, fix, or stop, but never silently ship
+- Portable self-sizing code review with a residual-work gate: apply, file, accept, or stop, but never silently ship
 - Every PR carries an operational validation plan: what to monitor, what triggers rollback
 
 ---
@@ -99,37 +99,37 @@ Asking an agent "implement this plan" goes wrong in predictable ways:
 
 ### Plan-aware execution, then idempotent re-entry
 
-`ce-work` reads the plan as a decision artifact, not a script. For unified plans it checks metadata first and refuses `artifact_readiness: requirements-only` artifacts until `ce-plan` enriches them. Scope, decisions, U-IDs, files, test scenarios, and verification criteria are authoritative. The plan body stays read-only during execution. Progress lives in git commits and the task tracker.
+`ce-work` reads the plan as a decision artifact, not a script. For unified plans it checks metadata first and refuses `artifact_readiness: requirements-only` artifacts until `ce-plan` enriches them. Scope, decisions, U-IDs, files, test scenarios, and verification criteria are authoritative. The plan body stays read-only during execution; progress lives in git commits and the task tracker.
 
-Before each task, it checks whether the unit's work is already present and matches the plan's intent. If verification is already satisfied, it marks the task complete and moves on. No silent reimplementation. A unit whose deliverable is out-of-repo state (a console setting, a DNS record) has no git-derived completion signal — it's decided from the observed state of the deliverable, never re-applied off a clean tree. That matters most when resuming after context compaction, picking up someone else's branch, or returning to a partly-shipped plan weeks later.
+Before each task, it checks whether the unit's work already exists and matches the plan's intent. If verification is already satisfied, it marks the task complete and moves on. A unit whose deliverable is out-of-repo state (a console setting, a DNS record) has no git-derived completion signal, so its status is decided from the observed state of the deliverable, never re-applied off a clean tree. This matters most when resuming after context compaction, picking up someone else's branch, or returning to a partly-shipped plan weeks later.
 
 ### Engine, workspace, and scheduling are separate decisions
 
 Ordinary synchronous native work stays in the active checkout. Each implementation unit gets a fresh, single-use native worker context using whatever isolation the current harness provides. A detached external worker always gets a private linked worktree. The host alone applies, verifies, and commits that result in the canonical checkout.
 
-The scheduler may author a bounded wave concurrently only after checking dependencies, actual and expected paths, shared interfaces, generated or config surfaces, migrations, and shared runtime resources. Results then fold in one at a time against the advancing canonical tree. A clean patch is not proof of semantic compatibility. Overlap or uncertainty returns the affected work to host resolution, re-dispatch, or serial execution.
+The scheduler may author a bounded wave concurrently only after checking dependencies, actual and expected paths, shared interfaces, generated or config surfaces, migrations, and shared runtime resources. Results then fold in one at a time against the advancing canonical tree. A clean patch is not proof of semantic compatibility; overlap or uncertainty returns the affected work to host resolution, re-dispatch, or serial execution.
 
-When the plan defines U-IDs, they propagate as task prefixes, into commit messages, and into the final summary. That works across plan edits because U-IDs are stable. Brainstorm-origin IDs (R/A/F/AE) are preserved when present.
+When the plan defines U-IDs, they propagate as task prefixes, into commit messages, and into the final summary. U-IDs are stable, so this survives plan edits. Brainstorm-origin IDs (R/A/F/AE) are preserved when present.
 
 ### Test evidence, review, and operational validation
 
 A task is not done when the code compiles. Before changing behavior, `ce-work` discovers the existing test files and chooses the right proof: use an existing failing test, update or strengthen the existing test that owns the contract, add a focused failing test, capture characterization coverage, or record a deliberate exception with replacement verification. Before marking a feature-bearing task complete, it checks that test scenarios cover the categories that apply (happy path, edges, error paths, integration) and traces two levels out for callbacks, middleware, and observers.
 
-Standalone shipping is not done until a `ce-code-review` receipt exists or the shipping summary carries an exact skip phrase (`Code review: skipped (mechanical diff)` or `Code review: skipped (ce-code-review unavailable)`). Mechanical means formatting, dep bumps, lint-only, or generated artifacts only. Review is read-only. `ce-work` applies eligible fixes afterward, then sends any actionable remainder through a four-option residual gate (apply / file tickets / accept with durable sink / stop). "Accept" requires a real durable record. Return-to-caller mode leaves review to the caller (for example `lfg`).
+Standalone shipping is not done until a `ce-code-review` receipt exists or the shipping summary carries an exact skip phrase (`Code review: skipped (mechanical diff)` or `Code review: skipped (ce-code-review unavailable)`). Mechanical means formatting, dep bumps, lint-only, or generated artifacts only. Review is read-only; `ce-work` applies eligible fixes afterward, then sends any actionable remainder through a four-option residual gate (apply / file tickets / accept with durable sink / stop). "Accept" requires a real durable record. Return-to-caller mode leaves review to the caller.
 
 Every PR description includes a `Post-Deploy Monitoring & Validation` section. If there is truly no production impact, the section still exists with that as the recorded decision.
 
 ### Smart triage on bare prompts
 
-Not every invocation has a plan. `ce-work` accepts a bare prompt and triages by complexity before its first reference read: trivial work (a couple of files, no behavioral change) goes straight to implementation with no task list, and a purely mechanical diff (formatting, dependency bump, lint-only, generated) also ships without a post-PR watch (`babysit:off` is passed to the shipping skill); a prompt that `ce-plan` already sized in this session — a Direct statement or a chat brief — is executed, never routed back to planning; small or medium work builds a task list; large or sensitive work recommends `/ce-brainstorm` or `/ce-plan` first. The triage is what makes direct invocation reasonable for small work.
+Not every invocation has a plan. `ce-work` accepts a bare prompt and triages by complexity before its first reference read. Trivial work (a couple of files, no behavioral change) goes straight to implementation with no task list, and a purely mechanical diff (formatting, dependency bump, lint-only, generated) also ships without a post-PR watch (`babysit:off` is passed to the shipping skill). A prompt that `ce-plan` already sized in this session is executed, never routed back to planning. Small or medium work builds a task list. Large or sensitive work gets a recommendation to run `/ce-brainstorm` or `/ce-plan` first. The triage is what makes direct invocation reasonable for small work.
 
-Invocation origin does not change this. Agent harnesses do not reliably tell the skill whether the user named it or the model selected it. If the conversation carries one unambiguous active plan (for example, the agent just authored it and the user says "proceed"), that plan is used before bare-prompt triage. Otherwise a concrete implementation request is the bare prompt.
+Invocation origin does not change this. Harnesses do not reliably tell the skill whether the user named it or the model selected it. If the conversation carries one unambiguous active plan (say, the agent just authored it and the user says "proceed"), that plan wins over bare-prompt triage. Otherwise a concrete implementation request is the bare prompt.
 
-When a qualified external implementation route is selected for clear bare-prompt work, `ce-work` does not send the conversation to the worker. It distills the request into a private bounded implementation brief: goal, scope, discovered files and tests, acceptance and verification, constraints, and conservative units. If it cannot fill in the goal, bounded scope, and authoritative verification without guessing, it clarifies or routes to `ce-plan` before any external egress.
+When an external route is selected for clear bare-prompt work, `ce-work` does not send the conversation to the worker. It distills the request into a private bounded implementation brief: goal, scope, discovered files and tests, acceptance and verification, constraints, and conservative units. If it cannot fill in the goal, bounded scope, and authoritative verification without guessing, it clarifies or routes to `ce-plan` before anything leaves the host.
 
 ### Session-settled decisions are not yours to improve
 
-A KTD carrying a `session-settled:` label records a decision the user examined and chose for a reason. `ce-work` implements it as specified instead of "improving" it. The restraint is scoped to labeled KTDs. Judgment on everything the plan leaves open is unchanged, and real defects inside a settled approach still surface at full strength. A discovery that a settled decision genuinely cannot work is a blocker return, never a silently-accepted residual.
+A KTD carrying a `session-settled:` label records a decision the user examined and chose for a reason. `ce-work` implements it as specified instead of "improving" it. The restraint is scoped to labeled KTDs: judgment on everything the plan leaves open is unchanged, and real defects inside a settled approach still surface at full strength. A discovery that a settled decision genuinely cannot work is a blocker return, never a silently-accepted residual.
 
 ---
 
@@ -137,7 +137,7 @@ A KTD carrying a `session-settled:` label records a decision the user examined a
 
 A plan with four implementation units arrives. `ce-work` reads it, picks up an `Execution note` asking for a failing request-level proof on one unit, and notes a deferred-implementation question. It builds a task list with U-ID prefixes and moves off the default branch onto a feature branch named from the plan, without asking.
 
-Two units share a contract, so they run serially. The other two are independent and can author concurrently. With native execution they use the host's available worker isolation. With a selected external route, each gets a detached sibling worktree. The host inspects every actual change set, folds results into the active checkout one at a time, verifies, and creates separate canonical commits. The idempotency check catches that one unit's verification was already satisfied by a prior session and marks it complete without reimplementation.
+Two units share a contract, so they run serially. The other two are independent and can author concurrently. With native execution they use the host's available worker isolation; with a selected external route, each gets a detached sibling worktree. The host inspects every actual change set, folds results into the active checkout one at a time, verifies, and creates separate canonical commits. The idempotency check catches that one unit's verification was already satisfied by a prior session and marks it complete without reimplementation.
 
 `ce-code-review` self-selects a lite roster for the small, low-risk diff. The two suggested findings are addressed afterward. Final validation passes, the operational validation plan is drafted, and `ce-work` invokes `ce-commit-push-pr` with `branding:on` (or the project's own shipping process, when its instructions name one). The plan itself is left untouched. Whether it shipped is derived from git, not recorded in the doc.
 
@@ -151,14 +151,14 @@ Reach for `ce-work` when:
 - You have small or medium work without a plan (bare-prompt mode handles it)
 - You are resuming partly-shipped work
 - You want conservative parallel execution with isolated concurrent workers
-- You want a complete shipping flow: tests, simplify, review, residuals, operational validation, PR
+- You want the full shipping flow: tests, simplify, review, residuals, operational validation, PR
 
 Skip `ce-work` when:
 
 - Product behavior is not decided yet → `/ce-brainstorm`
 - Implementation guardrails are not established for non-trivial work → `/ce-plan`
 - The bug has a known root cause and an obvious fix → `/ce-debug`
-- The task is non-software and is not a marked `execution: knowledge-work` plan. Plain non-software work is a human activity. A marked knowledge-work plan does route to the carve-out.
+- The task is non-software and is not a marked `execution: knowledge-work` plan. Plain non-software work is a human activity; a marked knowledge-work plan does route to the carve-out.
 
 ---
 
@@ -168,7 +168,7 @@ If you want implementation to go through `ce-work` by default, add a standing in
 
 > When asked to build or change code, invoke the `ce-work` skill. For a change already specified down to the files it touches with no behavior change — a typo, a rename, a dependency bump — make the change directly instead.
 
-`ce-work` is cheap on that kind of work when it does fire — the Trivial route skips the task list, and a mechanical diff also skips the post-PR watch — but not invoking it at all is cheaper still, which is what the skip clause buys.
+`ce-work` is cheap on that kind of work when it does fire. The Trivial route skips the task list, and a mechanical diff also skips the post-PR watch. But not invoking it at all is cheaper still, which is what the skip clause buys.
 
 ---
 
@@ -235,7 +235,7 @@ Native execution is the default. You can assign implementation to a target in th
 /ce-work use Codex to add retry limits to the existing webhook sender
 ```
 
-The first three are preferences: `ce-work` attempts the route and continues natively, with a prominent requested-versus-actual disclosure, if it is unavailable. The fourth is a requirement: `ce-work` keeps that external identity fixed while the route is viable and never substitutes another external recipient, but an unavailable route still continues on the current harness and session model after one disclosure. Intent matters, not a particular keyword.
+The first three are preferences: `ce-work` attempts the route and, if it is unavailable, continues natively with a prominent requested-versus-actual disclosure. The fourth is a requirement: `ce-work` keeps that external identity fixed while the route is viable and never substitutes another external recipient, but an unavailable route still continues on the current harness and session model after one disclosure. Intent matters, not a particular keyword.
 
 An explicit current task wins. A still-active session preference remains applicable. An implementation-only caller binding keeps its recorded provenance. Active project or user instructions already in context can supply a default. Per-checkout config is the final preference before native execution. An incidental model mention in feature prose, quoted text, examples, or filenames does nothing.
 
@@ -309,7 +309,7 @@ Resuming after context compaction, picking up someone else's branch, or returnin
 When `ce-code-review` surfaces actionable findings the follow-up pass did not resolve, `ce-work` will not silently ship them. It asks: apply now / file tickets / accept (with durable sink) / stop. "Accept" requires a real durable record.
 
 **Does `ce-work` support non-software plans?**
-For a plan marked `execution: knowledge-work` (produced by `ce-plan`'s approach-altitude flow), yes. A lightweight carve-out reads the sources, synthesizes, and produces the deliverable, skipping the commit/test/PR lifecycle. Other non-software work without that marker still ends at `ce-plan`, and a human executes it.
+For a plan marked `execution: knowledge-work` (produced by `ce-plan`'s approach-altitude flow), yes. The carve-out reads the sources, synthesizes, and produces the deliverable, skipping the commit/test/PR lifecycle. Other non-software work without that marker still ends at `ce-plan`, and a human executes it.
 
 **What happens if I pass a requirements-only brainstorm file?**
 The run stops and tells you the Product Contract needs `ce-plan` enrichment first. It offers the exact `ce-plan <plan-path>` handoff. Blank invoke does the same if the newest matching artifact is still requirements-only.

--- a/docs/guides/ce-worktree.md
+++ b/docs/guides/ce-worktree.md
@@ -2,16 +2,9 @@
 
 > Put the work in an isolated git worktree without disturbing the current checkout.
 
-`ce-worktree` is the **isolation** skill. It is a git-workflow tool, not a core-loop step. Most coding harnesses already create a worktree at session start, so the common case is that you are already isolated. The skill checks that first, prefers the harness's own worktree tool, and only then falls back to plain `git worktree add`.
-
-Nesting a worktree inside another one, or creating one the harness cannot see, is worse than working where you already are.
+`ce-worktree` is the **isolation** skill, a git-workflow tool rather than a core-loop step. Most coding harnesses already create a worktree at session start, so the common case is that you are already isolated. The skill checks that first, then prefers the harness's own worktree tool, and only falls back to plain `git worktree add` when neither applies. Nesting a worktree inside another one, or creating one the harness cannot see, is worse than working where you already are.
 
 There is no bundled script. The agent runs inline git from the project directory, so the same instructions work on Claude Code, Codex, Gemini, OpenCode, and Pi.
-
-Two modes:
-
-- **New work** (default). No ref named. Create a fresh branch from trunk.
-- **Attach.** You name a branch, PR, or commit. Check that ref out in a worktree instead of creating a new branch.
 
 ---
 
@@ -28,7 +21,7 @@ Two modes:
 
 ## Example invocations
 
-Empty or a work description is **create**. `isolate` plus a ref is **attach**. If this checkout is already a linked worktree, every form works in place rather than nesting.
+Empty or a work description means **new work**. `isolate` plus a ref means **attach**. If this checkout is already a linked worktree, every form works in place rather than nesting.
 
 ```text
 # New work. Detect isolation first. If none, create .worktrees/<named-branch> from trunk.
@@ -37,7 +30,7 @@ Empty or a work description is **create**. `isolate` plus a ref is **attach**. I
 # Already isolated (common in Orca or Cursor): report path and branch, stay here
 /ce-worktree
 
-# Attach a worktree to an existing branch. Does not create a second checkout of that branch.
+# Attach a worktree to an existing branch
 /ce-worktree isolate feature/account-notifications
 
 # Attach a worktree to a PR head on a local pr-1234 branch (so later commits can push back)
@@ -47,7 +40,7 @@ Empty or a work description is **create**. `isolate` plus a ref is **attach**. I
 /ce-worktree isolate abcdef1
 ```
 
-A branch can be checked out in only one worktree at a time. If the named ref is already checked out somewhere, the skill reports that path and stops. It does not force a second worktree.
+Git allows a branch in only one worktree at a time. If the named ref is already checked out somewhere, the skill reports that path and stops instead of forcing a second worktree. Work there, or ask for a detached worktree at the same commit if you truly need a separate tree.
 
 ---
 
@@ -62,39 +55,17 @@ A branch can be checked out in only one worktree at a time. If the named ref is 
 
 ## The Solution
 
-Isolation is an ordered decision, not a create script:
+Isolation is an ordered decision, not a create script.
 
-1. **Detect existing isolation.** Compare the resolved absolute git dir with the resolved absolute common git dir, then rule out submodules. Already isolated -> report path and branch, work in place. In attach mode, check the named ref out here rather than nesting.
-2. **Prefer the harness tool** (`EnterWorktree`, `/worktree`, `--worktree`, or similar) so the harness still owns the tree.
-3. **Git fallback** only when neither applies: create `.worktrees/<branch>` from the repo root, after confirming `.worktrees/` is gitignored, with a meaningful branch name.
+**1. Detect existing isolation.** The skill compares the resolved absolute git dir against the resolved absolute common git dir. A raw string compare is not enough. From a subdirectory, one side can come back absolute and the other relative, which looks like "already isolated" when it is not. When the two differ, `git rev-parse --show-superproject-working-tree` splits the cases: non-empty means submodule (treat as a normal checkout), empty means linked worktree. Already isolated means report path and branch and work in place. In attach mode, check the named ref out here rather than nesting.
 
-If `git worktree add` fails on sandbox or permissions, the skill does **not** continue in the current checkout. It reports the failure and asks whether to work here anyway or stop.
+**2. Prefer the harness tool.** If the harness has a worktree primitive (`EnterWorktree`, `/worktree`, `--worktree`, or similar), the skill uses it and stops, so the harness still owns the tree.
 
----
+**3. Git fallback.** Only when neither applies. From the repo root, the skill runs `git check-ignore -q .worktrees/` (trailing slash required), adds the `.gitignore` line if needed, fetches the base (non-fatal if there is no `origin` or the branch is local-only), and creates the tree with a meaningful branch name.
 
-## What Makes It Novel
+The two modes share the fallback. **New work** creates `feat/...` or `fix/...` from origin's default branch. **Attach** checks out the named branch, tag, commit, or PR. A PR is fetched to a local `pr-<n>` branch, then that branch is added as the worktree. A detached `FETCH_HEAD` is not used, because later fix commits would not update the PR. When you need fork-safe push tracking, the fallback is a detached add followed by `gh pr checkout`.
 
-### Detection before creation
-
-`git rev-parse --absolute-git-dir` is compared to the resolved common git dir. A raw string compare is not enough: from a subdirectory, one side can be absolute and the other relative, which looks like "already isolated" when it is not.
-
-When the two differ, `git rev-parse --show-superproject-working-tree` splits the cases. Non-empty is a submodule (treat as a normal checkout). Empty is a linked worktree: stay there.
-
-### Native tool first
-
-If the harness has a worktree primitive, the skill uses it and stops. A hidden `git worktree add` creates state the harness cannot manage.
-
-### Two modes, one-branch-one-worktree
-
-**New work** creates `feat/...` or `fix/...` from origin's default branch (or local default if fetch fails; fetch is non-fatal). **Attach** checks out the named branch, tag, commit, or PR.
-
-A PR is fetched to a local `pr-<n>` branch, then that branch is added as the worktree. A detached `FETCH_HEAD` is not used, because later fix commits would not update the PR. When you need fork-safe push tracking, the fallback is a detached add followed by `gh pr checkout`.
-
-If git reports the ref is already checked out, that is the end of the create path.
-
-### Gitignore before the add
-
-The fallback runs `git check-ignore -q .worktrees/` (trailing slash required) from the repo root, and adds that line to `.gitignore` if needed. Then it creates the tree.
+If `git worktree add` fails on sandbox or permissions, the skill does **not** continue in the current checkout. You chose isolation for a reason. It reports the failure and asks whether to work here anyway or stop.
 
 ---
 
@@ -118,6 +89,8 @@ Skip it when:
 - The work fits on a branch in the current checkout
 - You are already isolated and do not need a second, parallel workspace (the skill detects this)
 
+Why a skill at all, when the agent already knows `git worktree add`? The skill is the order: detect first, defer to the harness, do not nest or create phantom state. `ce-work` and `ce-code-review` share that order by calling this skill.
+
 ---
 
 ## Chain Position
@@ -131,11 +104,14 @@ On-demand isolation. Callers pass a meaningful branch name (`feat/...`, `fix/...
 
 ---
 
-## Use Standalone
+## Reference
 
-- New work: `/ce-worktree for the account-notifications feature`
-- Attach a branch: `/ce-worktree isolate feature/account-notifications`
-- Attach a PR: `/ce-worktree isolate PR 1234`
+| Argument | Effect |
+|----------|--------|
+| _(empty)_ | Detect isolation. If none, new-work fallback needs a name from context. |
+| `<work description>` | New work: create a named branch worktree from trunk |
+| `isolate <branch\|tag\|commit>` | Attach a worktree to that ref |
+| `isolate PR <n>` | Attach a worktree to that PR head on local `pr-<n>` |
 
 List, remove, and switch are plain git. The skill does not wrap them:
 
@@ -146,32 +122,7 @@ cd .worktrees/<branch>
 cd "$(git rev-parse --show-toplevel)"
 ```
 
----
-
-## Reference
-
-| Argument | Effect |
-|----------|--------|
-| _(empty)_ | Detect isolation. If none, new-work fallback needs a name from context. |
-| `<work description>` | New work: create a named branch worktree from trunk |
-| `isolate <branch\|tag\|commit>` | Attach a worktree to that ref |
-| `isolate PR <n>` | Attach a worktree to that PR head on local `pr-<n>` |
-
----
-
-## FAQ
-
-**Why a skill instead of `git worktree add`?**
-The agent already knows that command. The skill is the order: detect first, defer to the harness, do not nest or create phantom state. `ce-work` and `ce-code-review` share that order by calling this skill.
-
-**I am already in a worktree. Will it make another?**
-No. Existing isolation is detected and used in place.
-
-**The branch I named is already checked out.**
-Git allows a branch in only one worktree. The skill reports that path. Work there, or (only if you truly need a separate tree) ask for a detached worktree at the same commit.
-
-**How do I clean up?**
-Leave with `cd "$(git rev-parse --show-toplevel)"`, then `git worktree remove .worktrees/<branch>`. If the remote tracking branch is gone, `git fetch --prune` and `git branch -d <branch>` after you confirm it is merged.
+To clean up when you are done, leave with `cd "$(git rev-parse --show-toplevel)"`, then `git worktree remove .worktrees/<branch>`. If the remote tracking branch is gone, `git fetch --prune` and `git branch -d <branch>` after you confirm it is merged.
 
 ---
 

--- a/docs/guides/lfg.md
+++ b/docs/guides/lfg.md
@@ -2,11 +2,11 @@
 
 > Run the full hands-off engineering pipeline from planning through an open PR. It pushes and opens the PR without stopping for approval. It does not merge.
 
-`lfg` is the **autonomous pipeline**. It chains the main Compound Engineering workflow into one long-running run: plan, implement, simplify, review, apply eligible review fixes, run browser tests, commit, push, open a PR, then watch CI and repair failures inside a bounded loop.
+`lfg` chains the main Compound Engineering workflow into one long-running run: plan, implement, simplify, review, apply eligible review fixes, run browser tests, commit, push, open a PR, then watch CI and repair failures inside a bounded loop.
 
-Use it when you want the agent to take a software task from a description (or a requirements-only plan) to an open PR, and you are comfortable not inspecting each stage. It is not for in-the-loop work. If you want to approve the plan, the diff, or the review findings yourself, run those skills one at a time.
+Use it when you want a software task carried from a description (or a requirements-only plan) to an open PR and you are fine not inspecting each stage. It never pauses for approval, which is why it is the wrong tool for in-the-loop work. If you want to approve the plan, the diff, or the review findings yourself, run those skills one at a time.
 
-It is best after `/ce-brainstorm`, because the pipeline can then plan against real requirements instead of a one-line prompt. Software brainstorm wrap-up offers "Ship it autonomously with `lfg`" when a unified plan artifact exists and nothing is still blocked on `Resolve Before Planning`.
+It works best after `/ce-brainstorm`, because the pipeline can then plan against real requirements instead of a one-line prompt. A software brainstorm's wrap-up offers "Ship it autonomously with `lfg`" when a unified plan artifact exists and nothing is still blocked on `Resolve Before Planning`.
 
 ---
 
@@ -17,14 +17,14 @@ It is best after `/ce-brainstorm`, because the pipeline can then plan against re
 | What does it do? | Plans, implements, simplifies, reviews, applies eligible fixes, runs browser tests, commits, pushes, opens a PR, and watches CI |
 | When to use it | A software task you want shipped hands-off, already shaped by `/ce-brainstorm` or clear enough for `/ce-plan` |
 | What it produces | Code changes, commits, usually a PR. Unresolved review or CI leftovers become durable notes. No remote: local commits only. |
-| What's next | Review the PR. Run `/ce-babysit-pr` to watch it through review toward merge. Optionally `/ce-explain` for a new concept, `/ce-compound` for a reusable learning. |
+| What's next | Review the PR. Run `/ce-babysit-pr` to watch it through review toward merge. |
 | What it does not do | Merge the PR, skip planning, run non-software work, or continue into the next area unless you accept a closeout handoff offer |
 
 ---
 
 ## Example invocations
 
-The usual path is brainstorm, then empty `/lfg`. A plan path enriches that artifact, then ships. Stage assignments change who authors planning or implementation. The rest of the pipeline stays on `lfg`.
+The usual path is a brainstorm followed by an empty `/lfg`. A plan path enriches that artifact, then ships. Stage assignments change who authors planning or implementation; the rest of the pipeline stays on `lfg`.
 
 ```text
 # Most common: settle requirements, then ship from that context
@@ -32,10 +32,6 @@ The usual path is brainstorm, then empty `/lfg`. A plan path enriches that artif
 /lfg
 
 # Same handoff, but author the plan on a named model (implementation stays native)
-/ce-brainstorm design account-level notification controls for enterprise teams
-/lfg plan with fable
-
-# After brainstorm already settled the requirements. No feature text needed.
 /lfg plan with fable
 
 # Clear, already-bounded software task. Weaker product context than a brainstorm.
@@ -51,10 +47,10 @@ The usual path is brainstorm, then empty `/lfg`. A plan path enriches that artif
 /lfg implement the settled plan, but only use Composer for implementation
 
 # Both stages, each to its own model or harness
-/lfg add account-level notification mute settings, plan with fable and use Codex for implementation
+/lfg add mute settings, plan with fable and use Codex for implementation
 ```
 
-An unscoped "use fable" or "with Codex" binds to **implementation only**, and `lfg` says so in its opening line. "Plan with Codex" (a harness assigned to planning) is not supported and blocks. Use individual skills when you want to inspect or approve stages yourself.
+An unscoped "use fable" or "with Codex" binds to implementation only, and `lfg` says so in its opening line. Assigning a harness to planning ("plan with Codex") is not supported and blocks.
 
 ---
 
@@ -62,20 +58,20 @@ An unscoped "use fable" or "with Codex" binds to **implementation only**, and `l
 
 The normal CE workflow is staged on purpose: plan, work, simplify, review, ship. That is useful when you want to inspect each step. It is too much handoff when the task is well bounded and you want the agent to carry the whole thing.
 
-Without an explicit pipeline, autonomous runs tend to skip planning, treat review as optional, forget to persist leftover findings, or stop at "PR opened" while CI is still red.
+Without an explicit pipeline, autonomous runs skip planning, treat review as optional, forget to persist leftover findings, or stop at "PR opened" while CI is still red.
 
 ## The Solution
 
 `lfg` makes the sequence explicit and gated:
 
-1. Compose a short settled-decisions brief from the conversation (each decision, its class, the rejected alternative, and a reason), scoped to this feature, and pass it to `/ce-plan` so those choices are not re-asked. Skip the brief when nothing is settled.
+1. Compose a short settled-decisions brief from the conversation (each decision, its class, the rejected alternative, and a reason) and pass it to `/ce-plan` so those choices are not re-asked. Skip the brief when nothing is settled.
 2. `/ce-plan` must produce an implementation-ready **code** plan before work starts. A requirements-only plan, a knowledge-work plan, or a non-software result stops the pipeline.
 3. `/ce-work` runs in return-to-caller mode so `lfg` keeps the shipping tail. Behavior-changing work must return verification evidence. Missing evidence is retried once, then the run stops rather than shipping blind.
 4. `/ce-simplify-code` runs on the branch diff before review, unless the change is docs-only or roughly under 10 lines.
 5. `/ce-code-review` (`mode:agent`) reports findings. `lfg` applies eligible mechanical fixes and commits them. Review itself does not edit the tree.
 6. Leftover actionable findings, plus any flagged settlement conflicts, become a `## Unapplied review findings` checklist in the PR body for the reviewer to decide on: fix in-branch, dismiss, or file a ticket. `lfg` files tickets itself only when no PR will exist.
 7. `/ce-test-browser` runs in pipeline mode.
-8. `/ce-commit-push-pr mode:pipeline branding:on` commits remaining changes, pushes, and opens a PR when a remote exists, and marks CE provenance. If the project's instructions name their own shipping process (e.g. a `/create-pr` skill), that process runs instead, so CE branding may not appear.
+8. `/ce-commit-push-pr mode:pipeline branding:on` commits remaining changes, pushes, opens a PR when a remote exists, and marks CE provenance. If the project's instructions name their own shipping process (say, a `/create-pr` skill), that process runs instead, so CE branding may not appear.
 9. `/ce-babysit-pr mode:pipeline` watches the open PR: CI repairs via `/ce-debug`, incoming review comments via `/ce-resolve-pr-feedback`, up to three fix rounds by default. Pipeline babysit stops at "CI decided," not "merged."
 10. Print `DONE`. If the plan named a larger body of separately planned work and an area is still unplanned, `lfg` may offer an opt-in `/ce-handoff` for a fresh session. It does not continue that area itself.
 
@@ -95,9 +91,9 @@ Planning has to land an implementation-ready code plan. Implementation has to re
 
 ### You can route two stages, not the whole run
 
-Planning can be authored on a named model (`plan with fable`) via `ce-plan`'s model elevation. Implementation can be sent to a harness (`use Codex for implementation`, `only use Composer for implementation`). Unscoped assignments bind to implementation only. Standing defaults live in CE config (`plan_model`, `work_engine_mode`, `work_engine_preferences`). See [Implementation routing](./configuration.md#implementation-routing).
+Planning can be authored on a named model (`plan with fable`) via `ce-plan`'s model elevation. Implementation can be sent to a harness (`use Codex for implementation` as a preference, `only use Composer for implementation` as a requirement). `cursor` means the Cursor harness with its default model; `composer` means a Composer-family model through Cursor. Unscoped assignments bind to implementation only; in an interactive run that is genuinely ambiguous, `lfg` asks one question, then runs hands-off, while a headless run applies the implementation default and discloses it. With no stage instruction, `ce-plan` uses its `plan_model` config and `ce-work` follows session and project instructions, then checkout-local `work_engine_mode` and `work_engine_preferences`. See [Implementation routing](./configuration.md#implementation-routing).
 
-Both a preference and a requirement fall back to the current harness/session model with one disclosure when the external route cannot run. A requirement keeps the requested external identity fixed while viable; it never authorizes another external recipient. `lfg` does not ask whether to weaken the route.
+Both a preference and a requirement fall back to the current harness/session model with one disclosure when the external route cannot run. A requirement keeps the requested external identity fixed while viable; it never authorizes another external recipient, and `lfg` does not ask whether to weaken the route. A plain mention of a model in feature text, a quote, a comparison, or a filename does not activate routing. See [`ce-work`](./ce-work.md#choose-the-implementation-author) for fallback, timeouts, and detached-worktree behavior.
 
 On string-only hosts the implementation seam is `mode:return-to-caller implementation_engine:<compact-json> <plan-path>`. The `plan_model:<alias>` carrier rides beside, never inside, `ce-plan`'s request. Neither carrier becomes plan content, a settled product decision, or review input.
 
@@ -107,17 +103,7 @@ Unapplied review findings sit in the PR body as a checklist, since `lfg` never m
 
 ### Next work is an offer, not a second pipeline
 
-If the completed plan explicitly describes separately planned future areas, `lfg` picks one from current evidence and offers a handoff. Accepting creates a `ce-handoff` for a fresh session to brainstorm that area into a **separate** requirements-only plan. It does not edit the plan that just shipped.
-
----
-
-## Quick Example
-
-You finish `/ce-brainstorm` on account-level notification mute. The wrap-up offers `lfg`. You invoke `/lfg` (or `/lfg plan with fable`).
-
-`lfg` builds a settled-decisions brief from the brainstorm, invokes `/ce-plan` on the requirements-only artifact, and waits until that file is `implementation-ready` with `execution: code`. Then `/ce-work` implements in return-to-caller mode. Simplify runs. Review reports findings. `lfg` applies the eligible mechanical ones, commits them, and lists the rest as an `## Unapplied review findings` checklist for the PR body. Browser tests run. `ce-commit-push-pr` opens a PR. `ce-babysit-pr` watches CI for up to three repair rounds.
-
-The run prints `DONE` and a line to run `/ce-babysit-pr <pr-url>` if you want it watched through review toward merge. It does not merge. If the plan named a later area, you may get a handoff offer. Decline it and the session is over.
+If the completed plan explicitly describes separately planned future areas, `lfg` picks one from current evidence and offers a handoff. Accepting creates a `ce-handoff` for a fresh session to brainstorm that area into a separate requirements-only plan. It does not edit the plan that just shipped.
 
 ---
 
@@ -173,17 +159,6 @@ After `DONE`:
 
 Direct invocation is fine for a clear software task. The planner has less product context than it would after a brainstorm.
 
-## Route planning and implementation
-
-You can ask `lfg` to have a specific model or harness author one stage while `lfg` keeps the rest of the run.
-
-- **Scoped to planning:** `plan with fable`, `plan with opus`. This is model elevation inside `ce-plan`. Planning has no cross-harness engine. Assigning a harness to planning (`plan with Codex`, `plan on Cursor`) blocks.
-- **Scoped to implementation:** `use Codex for implementation` (preference), `only use Composer for implementation` (requirement). `cursor` means the Cursor harness with its default model. `composer` means a Composer-family model through Cursor.
-- **Unscoped:** `use fable`, `with Codex`. Binds to implementation only. In an interactive run that is genuinely ambiguous, `lfg` asks one question, then runs hands-off. In a headless run (scheduler, loop, nested orchestrator) it applies the implementation default and discloses it.
-- **No stage instruction:** `ce-plan` uses its `plan_model` config (or none). `ce-work` uses session/project instructions already in context, then checkout-local `work_engine_mode` and `work_engine_preferences`.
-
-A plain mention of a model in feature text, a quote, a comparison, or a filename does not activate routing. See [`ce-work`](./ce-work.md#choose-the-implementation-author) for fallback, timeouts, and detached-worktree behavior.
-
 ---
 
 ## Reference
@@ -209,9 +184,6 @@ No. That is the point of the skill, and why it is the wrong tool for in-the-loop
 
 **What if planning cannot produce an implementation-ready code plan?**
 The pipeline stops. Non-software tasks, requirements-only leftovers, knowledge-work plans, and invalidating settlement conflicts all halt before implementation.
-
-**Where do leftover review findings go?**
-They are listed as an `## Unapplied review findings` checklist in the PR body for the reviewer to decide on: fix in-branch, dismiss, or file a ticket. `lfg` files tickets itself only when no PR will exist.
 
 **What happens if there is no `origin`?**
 Local commits only. No push, no PR, no CI watch.


### PR DESCRIPTION
## Summary

Every skill guide in `docs/guides/` gets a clear edit pass for clarity.

A few notes the diff cannot show:

- Each rewrite was grounded against the corresponding `skills/<name>/SKILL.md`, and two guides gained documented behavior they had been missing: `ce-commit` (the `exclude:<paths>` argument and `-F` message-file mechanism) and `ce-retune` (stop triage by who is on the other side, and the never-weaken-a-test rule).
- The mechanical suite pins doc phrases in five guides (`ce-test-browser`, `ce-test-xcode`, `ce-polish`, `ce-work`, `lfg`). The pinned facts are all preserved, restored in the new wording where the rewrites had dropped them; `bun run test` passes (3707/3707).
- `README.md` and `configuration.md` were intentionally left untouched — they are not skill guide pages.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** `Claude Code · claude-fable-5`

