### PR TITLE
fix(ce-compound): gate capture on durable knowledge

### DIFF
--- a/docs/guides/ce-compound.md
+++ b/docs/guides/ce-compound.md
@@ -1,12 +1,12 @@
 # `ce-compound`
 
-> Document a recently solved problem so the next encounter takes minutes instead of hours.
+> Preserve the reasoning behind a solved problem when the implementation alone will not.
 
-`ce-compound` is the knowledge-capture skill. After you solve a non-trivial problem, it writes a structured doc to `docs/solutions/` covering symptoms, root cause, what did not work, the working solution, and prevention. `ce-plan` and `ce-ideate` read that folder as institutional memory, so the same investigation does not happen twice.
+`ce-compound` is the knowledge-capture skill. After a verified solution produces durable, non-obvious project knowledge, it writes a structured doc to `docs/solutions/` covering symptoms, root cause, what did not work, the working solution, and prevention. `ce-plan` and `ce-ideate` read that folder as institutional memory, so the same investigation does not happen twice.
 
 It closes the loop on the `/ce-ideate` -> `/ce-brainstorm` -> `/ce-plan` -> `/ce-work` chain. The first time you solve "N+1 query in brief generation" costs 30 minutes of research. The second time, someone finds the doc and the fix takes 2 minutes.
 
-It is optional. Skip it for typos, one-line fixes, and purely mechanical work.
+It is optional. A completed or non-trivial fix is not enough: skip it when the final code and tests already communicate the whole lesson.
 
 ---
 
@@ -15,15 +15,39 @@ It is optional. Skip it for typos, one-line fixes, and purely mechanical work.
 | Question | Answer |
 |----------|--------|
 | What does it do? | Documents a solved problem to `docs/solutions/[category]/[filename].md` with structured frontmatter, bug-track or knowledge-track sections, and cross-references |
-| When to use it | After solving a non-trivial problem; when you say "that worked", "it's fixed", "problem solved" |
+| When to use it | After a verified solution produces durable reasoning that the final implementation does not readily reveal and that would be costly or risky to lose |
 | What it produces | One doc in `docs/solutions/`, plus optional `CONCEPTS.md` vocabulary capture. Interactive Full may also edit `AGENTS.md`/`CLAUDE.md` for discoverability after consent. |
 | What's next | No menu. Optional `/ce-compound-refresh` if the new learning suggests an older doc may be stale. |
 
 ---
 
+## What is worth compounding
+
+Use `ce-compound` only when all three conditions hold:
+
+1. **Non-obvious:** the important reasoning is not readily recoverable from the final code, tests, types, comments, or existing documentation.
+2. **Durable:** it explains an invariant, constraint, root cause, rejected approach, or decision that should remain useful beyond the exact diff.
+3. **Material:** forgetting it would plausibly cause recurrence, meaningful risk, or substantial rediscovery.
+
+Apply this counterfactual: if the learning document disappeared, would a future engineer reading the final implementation still be likely to repeat the mistake or redo substantial investigation? If not, do not compound.
+
+Put knowledge in the narrowest durable home that communicates it completely:
+
+| Knowledge | Best home |
+|-----------|-----------|
+| Machine-enforceable behavior | Test, type, or assertion |
+| Local non-obvious rationale | Code comment |
+| Change-specific history | Commit or PR description |
+| Shared domain language | `CONCEPTS.md` |
+| Durable reasoning that crosses implementation boundaries | `docs/solutions/` through `ce-compound` |
+
+An existing learning that became materially inaccurate or incomplete is worth updating because leaving it would mislead. Let the overlap check update that canonical doc instead of creating a duplicate. Use `ce-compound-refresh` for a broader maintenance pass over stale or overlapping learnings.
+
+---
+
 ## Example invocations
 
-An empty invoke captures the most recent verified fix from this conversation. A context hint focuses the run when the session holds several solved problems. `mode:non-interactive` is for automations and standing instructions: no blocking questions, Full by default. `depth:` is valid only with non-interactive intent.
+An empty invoke evaluates the most recent verified fix from this conversation and captures it when it qualifies. A context hint focuses the run when the session holds several solved problems. `mode:non-interactive` is for automations and standing instructions: no blocking questions, Full by default. `depth:` is valid only with non-interactive intent.
 
 ```text
 # Capture the verified solution from the current conversation
@@ -42,7 +66,7 @@ An empty invoke captures the most recent verified fix from this conversation. A 
 /ce-compound mode:non-interactive depth:full the verified caching fix
 ```
 
-One learning per run. If the session produced several distinct learnings, invoke the skill once per learning. A standalone "bootstrap CONCEPTS.md" request gets redirected to `ce-compound-refresh`. Use non-interactive mode only when the caller should own any follow-up decisions. Ordinary interactive capture can still ask before changing project guidance.
+One learning per run. If the session produced several distinct qualifying learnings, invoke the skill once per learning. A standalone "bootstrap CONCEPTS.md" request gets redirected to `ce-compound-refresh`. Use non-interactive mode only when the caller should own any follow-up decisions. Ordinary interactive capture can still ask before changing project guidance.
 
 ---
 
@@ -68,7 +92,7 @@ Full mode runs three research subagents in parallel (Context Analyzer, Solution 
 
 Lightweight mode writes the same doc type in a single pass. No subagents, no overlap detection, no session-history research, no semantic grounding validation.
 
-The skill picks the mode itself and does not ask. Full is the default. Lightweight only fires under real context pressure: the session is near its limit, or the fix is trivial enough that cross-referencing adds nothing. Those are conditions the agent can observe and you cannot. The first line of its output says which mode ran and why. If it guessed wrong, re-run it.
+The skill picks the mode itself and does not ask. Full is the default. Lightweight only fires when the session is near its context limit. That is a condition the agent can observe and you cannot. The first line of its output says which mode ran and why. If it guessed wrong, re-run it.
 
 Automations select the same tradeoff without a prompt. `mode:non-interactive depth:lightweight` runs the single-pass workflow; `mode:non-interactive depth:full` runs the complete workflow including the session-history probe. Bare `mode:non-interactive` (and the deprecated alias `mode:headless`) is Full by default. Depth is non-interactive-only. A depth flag without non-interactive intent, an unknown value, or conflicting depth flags fails explicitly.
 
@@ -95,21 +119,21 @@ Every run also checks whether the project's instruction file (`AGENTS.md` or `CL
 
 Before the doc compounds, its claims get checked against the tree. A deterministic script checks cited repo paths, commit SHAs, relative links, and dangling scaffold (flags are adjudicated, not auto-failed). Then a read-only validator subagent (Full mode, including non-interactive Full) verifies code-behavior claims by quoting the defining source line, and merge-state claims against remote truth. Lightweight keeps the deterministic check and skips the validator subagent.
 
-### Session history, refresh, and auto-invoke
+### Session history, refresh, and the capture checkpoint
 
 Full mode always runs a cheap two-stage session-history probe. A discovery-and-metadata pass runs in parallel with the research subagents. It lists Claude sessions from `~/.claude/projects/` (or `CLAUDE_CONFIG_DIR/projects` when that env var is set) and keeps the ones whose recorded `cwd` is the repo root, a parent of it, or a path inside it, so sessions started from a parent directory count. Codex sessions come from `~/.codex/sessions/` (or `CODEX_HOME/sessions` when set) plus `~/.agents/sessions/`. It escalates to extraction and synthesis only when a candidate session clears a relevance bar: current-branch match or at least two topic-keyword hits. On a hit, findings fold into "What Didn't Work" (bug track) or "Context" (knowledge track). Lightweight skips all of this.
 
 After capturing the new learning, `ce-compound` checks whether the learning suggests a specific older doc may now be stale. Only then does it recommend or invoke `/ce-compound-refresh`, with a narrow scope hint. It does not run refresh by default.
 
-Phrases like "that worked", "it's fixed", "working now", "problem solved" auto-invoke the skill so capture happens while context is fresh. `/ce-compound [context]` overrides.
+Phrases like "that worked", "it's fixed", "working now", and "problem solved" identify the completion checkpoint. They do not establish that a learning qualifies. Automatic capture still applies the non-obvious, durable, and material gate above. `/ce-compound [context]` requests immediate evaluation without waiting for a completion phrase; it does not lower the bar.
 
 ---
 
 ## Quick example
 
-You've just spent 45 minutes debugging an N+1 query in the brief-generation flow. You confirm the fix works and say "that worked, ship it."
+You've just spent 45 minutes debugging an N+1 query in the brief-generation flow. The root cause spans query assembly and a surprising ORM default that neither the final call site nor its regression test explains. You confirm the fix works and say "that worked, ship it."
 
-`ce-compound` auto-invokes. With plenty of context left, it picks Full mode and notes "Ran Full mode." at the top of its output. No prompt.
+The completion phrase marks the checkpoint. The agent applies the counterfactual, determines that a future engineer could plausibly repeat the investigation from the final implementation alone, and auto-invokes `ce-compound`. With plenty of context left, it picks Full mode and notes "Ran Full mode." at the top of its output. No prompt.
 
 Three subagents dispatch in parallel. Context Analyzer classifies the work as `performance_issue` (bug track) and proposes the filename and category. Solution Extractor structures the fix with before/after code. Related Docs Finder reports moderate overlap with an older doc on a different N+1 case. Alongside them, the session-history probe scans recent sessions; none clear the relevance bar, so it records "no relevant prior sessions."
 
@@ -121,29 +145,28 @@ Phase 3 dispatches the local `performance-oracle` prompt and, because the doc in
 
 ## When to reach for it
 
-Reach for `ce-compound` when:
+Reach for `ce-compound` when a solved and verified problem produced reasoning that is:
 
-- You just solved a non-trivial problem and the context is fresh
-- You say "that worked", "it's fixed", "working now", "problem solved"
-- You are at a natural pause and want to capture the learning before context fades
-- The problem took meaningful investigation, not a typo or one-line fix
+- not readily recoverable from the final implementation or existing docs
+- useful beyond the exact diff
+- costly or risky to lose
 
 Skip it when:
 
 - The problem is in-progress or the solution is unverified
-- The fix is a trivial typo or obvious error with no generalizable insight
-- The work is purely mechanical (formatting, dependency bumps)
+- The final code, tests, types, comments, or existing docs already communicate the reasoning
+- The proposed doc would mainly narrate the diff or preserve change-specific history
 - You want a repo-wide concept map rather than a learning from one solved problem → `/ce-compound-refresh`
 
 ---
 
 ## Use as part of the workflow
 
-`ce-compound` closes out multiple workflows. Invoke it after any verified, non-trivial fix:
+`ce-compound` closes out multiple workflows when the work clears the durable-learning gate:
 
-- After a successful debug and PR, when the bug is generalizable
-- After shipping, when the work yielded a reusable pattern, convention, or tooling decision
-- Stand-alone, after any non-trivial problem-solving session
+- After a successful debug when the root cause or prevention depends on reasoning the regression test cannot express
+- After shipping when the work yielded a durable cross-boundary invariant, convention, or tooling decision
+- Stand-alone after an investigation whose important reasoning would otherwise be lost
 
 The output feeds back upstream: `/ce-plan` reads `docs/solutions/` during Phase 1 research, and `/ce-ideate` reads it as grounding. When the new learning suggests an older doc may now be stale, `ce-compound` recommends `/ce-compound-refresh` with a narrow scope hint.
 
@@ -151,17 +174,17 @@ The output feeds back upstream: `/ce-plan` reads `docs/solutions/` during Phase 
 
 ## Make capture automatic
 
-The auto-invoke trigger phrases ("that worked", "it's fixed") only fire when you happen to say one of them. If you keep forgetting to capture, add a standing instruction to your agent's instruction file so the agent proposes capture on its own once a fix is verified.
+Completion phrases such as "that worked" and "it's fixed" mark a useful checkpoint, but they are not sufficient triggers. Add a standing instruction when you want the agent to evaluate the durable-learning gate at that checkpoint without waiting for you to ask.
 
-Put it in the repo's `AGENTS.md`/`CLAUDE.md`, or in your global instruction file (`~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`) to make it apply in every repo. Pick the variant that matches how much of a checkpoint you want.
+Put it in the repo's `AGENTS.md`/`CLAUDE.md`, or in your harness's global instruction file (for example `~/.claude/CLAUDE.md`, `~/.agents/AGENTS.md`, or `~/.codex/AGENTS.md`) to make it apply in every repo. Pick the variant that matches how much of a checkpoint you want.
 
 Offer first (the agent asks before capturing):
 
-> After a solved, verified problem produces a non-trivial, reusable learning, offer once to invoke the `ce-compound` skill, at the completion checkpoint — when the unit of work is complete — so the learning can ship in the PR that produced it. The deadline is while the learning can still be committed to that PR, whether it is not open yet, already open as a draft, or open and under review. Offer at the checkpoint rather than deferring to that deadline. Only where the repository treats captured learnings as tracked, committed knowledge.
+> After a solved, verified problem, offer once to invoke the `ce-compound` skill at the completion checkpoint only when the work produced durable project reasoning that is not readily recoverable from the final code, tests, types, comments, or existing documentation, and losing it would plausibly cause recurrence, material risk, or substantial rediscovery. Apply this counterfactual: if the learning document disappeared, would a future engineer reading the final implementation still be likely to repeat the mistake or redo substantial investigation? If not, do not offer. Completion, effort, and diff size alone are not enough. Offer at the checkpoint so a qualifying learning can ship in the PR that produced it, and only where the repository treats captured learnings as tracked, committed knowledge.
 
 Run it automatically (no prompt):
 
-> After a solved, verified problem produces a non-trivial, reusable learning, automatically invoke the `ce-compound` skill, passing `mode:non-interactive` as the skill argument. Fire at the completion checkpoint — when the unit of work is complete — so the learning ships in the PR that produced it rather than as a later orphan. The deadline is while the learning can still be committed to that PR, whether it is not open yet, already open as a draft, or open and under review. Capture at the checkpoint rather than deferring to that deadline. Only where the repository treats captured learnings as tracked, committed knowledge.
+> After a solved, verified problem, automatically invoke the `ce-compound` skill with `mode:non-interactive` at the completion checkpoint only when the work produced durable project reasoning that is not readily recoverable from the final code, tests, types, comments, or existing documentation, and losing it would plausibly cause recurrence, material risk, or substantial rediscovery. Apply this counterfactual: if the learning document disappeared, would a future engineer reading the final implementation still be likely to repeat the mistake or redo substantial investigation? If not, do not invoke it. Completion, effort, and diff size alone are not enough. Capture at the checkpoint so a qualifying learning can ship in the PR that produced it, and only where the repository treats captured learnings as tracked, committed knowledge.
 
 Use `mode:non-interactive depth:lightweight` instead when the standing workflow accepts reduced research and validation in exchange for a single-pass, no-subagent closure.
 
@@ -171,7 +194,7 @@ A few phrases in those standing lines are load-bearing:
 
 - "invoke the `ce-compound` skill", not "run `/ce-compound`": instruction files are read by whatever agent you are using, and the slash-command form is not reliably agent-callable across all of them.
 - "at the completion checkpoint", with the deadline as commit-reachability rather than a PR event: a PR can open early, so any deadline pegged to PR creation is already past by the time the work finishes. Whether the learning can still be committed to the producing PR holds in every case.
-- "non-trivial, reusable learning": the bar is reuse, not effort. An expensive one-off with nothing generalizable does not qualify.
+- "not readily recoverable" and the counterfactual: the bar is preserving reasoning that the primary artifacts do not already carry, not the effort or size of the fix.
 - "treats captured learnings as tracked, committed knowledge", not a named folder: the real question is whether the repo welcomes generated docs. Forks and OSS projects you contribute to often do not, and a named path goes stale since `docs_root` can move the store.
 
 ---
@@ -194,13 +217,13 @@ In interactive Full mode, the skill may also make a small edit to `AGENTS.md`/`C
 
 | Argument | Effect |
 |----------|--------|
-| _(empty)_ | Document the most recent verified fix using conversation context |
+| _(empty)_ | Evaluate the most recent verified fix using conversation context and document it when it qualifies |
 | `<brief context>` | Focuses the capture (for example, "the email digest race condition we fixed") |
 | `mode:non-interactive` | Unattended run: no blocking questions. Defaults to Full. Deprecated alias: `mode:headless`. |
 | `depth:lightweight` | Non-interactive only. Single-pass workflow: no subagents, no overlap research, no session-history probe. |
 | `depth:full` | Non-interactive only. Complete workflow, including the automatic session-history probe. |
 
-Auto-invoke triggers: phrases like "that worked", "it's fixed", "working now", "problem solved" anywhere in conversation.
+Auto-invoke checkpoint phrases include "that worked", "it's fixed", "working now", and "problem solved". They trigger the eligibility judgment, not automatic documentation by themselves.
 
 A standalone request to create or bootstrap `CONCEPTS.md` gets redirected to `ce-compound-refresh`. Vocabulary capture here is a side effect of documenting a real learning, scoped to that learning's area.
 
@@ -209,7 +232,7 @@ A standalone request to create or bootstrap `CONCEPTS.md` gets redirected to `ce
 ## FAQ
 
 **Why two modes, and why doesn't it ask me which one?**
-Full mode is for most cases: the parallel subagents catch duplicates, find related docs, and run specialized reviews. Lightweight exists for simple fixes or sessions running tight on context. The skill picks between them itself because the deciding factor, how much context budget is left, is something the agent can see and you cannot. It reports the choice in its output. Re-run it if it guessed wrong.
+Full mode is for most qualifying learnings: the parallel subagents catch duplicates, find related docs, and run specialized reviews. Lightweight exists for sessions running tight on context. The skill picks between them itself because the deciding factor, how much context budget is left, is something the agent can see and you cannot. It reports the choice in its output. Re-run it if it guessed wrong.
 
 **What's the difference between bug track and knowledge track?**
 Bug track captures incident-level fixes: "X broke, here's why and how we fixed it." Knowledge track captures durable guidance: "this is how we do X here, and why." Bug track has Symptoms / What Didn't Work / Solution. Knowledge track has Context / Guidance / When to Apply.

--- a/docs/guides/ce-debug.md
+++ b/docs/guides/ce-debug.md
@@ -175,7 +175,7 @@ Skip `ce-debug` when:
 - Runs post-fix quality checks through `/ce-simplify-code` and `/ce-code-review` on non-trivial interactive fixes
 - Hands off to `/ce-commit-push-pr` with `branding:on` after a successful fix, without asking permission, when the branch holds only that fix. It previews what it is about to commit so you can interrupt. If the branch also carries unrelated work, or there is no remote, it commits just the fix-owned files locally and pushes nothing. Project instructions that say otherwise (for example "don't open PRs from skills") outrank the default
 
-After a PR opens, the skill may offer `/ce-compound` when the lesson is generalizable: a one-sentence insight, a pattern in 3+ locations, or a wrong assumption about a shared dependency. Localized mechanical fixes are skipped so `docs/solutions/` does not fill with one-off entries.
+After a PR opens, the skill offers `/ce-compound` only when the verified fix produced non-obvious, durable project reasoning that is not readily recoverable from the final code, tests, types, comments, or existing documentation, and losing it would plausibly cause recurrence, material risk, or substantial rediscovery. If removing the learning document would not make a future engineer likely to repeat the mistake or redo substantial investigation, the skill skips the offer.
 
 ---
 

--- a/docs/solutions/skill-design/authoring-auto-invoke-standing-instructions.md
+++ b/docs/solutions/skill-design/authoring-auto-invoke-standing-instructions.md
@@ -1,6 +1,7 @@
 ---
 title: Authoring "Make It Automatic" auto-invoke guidance for CE skills
 date: 2026-07-12
+last_updated: 2026-09-02
 category: skill-design
 module: compound-engineering
 problem_type: convention
@@ -26,7 +27,7 @@ related_components:
 
 ## Context
 
-Several CE skills deliver their value at a moment that's easy to forget — `ce-simplify-code` right after a feature settles, `ce-compound` right after a fix verifies. Users bridge that gap by adding a standing instruction to their agent-instructions file (`AGENTS.md`/`CLAUDE.md`, or a global `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md`) so the agent invokes the skill on its own. A naive instruction does more harm than good in two concrete ways: it wastes cycles (a homegrown "always simplify after changes" rule ran `ce-simplify-code`'s three reviewer subagents on documentation-only diffs, which yield nothing), and it fires at the wrong moment (mid-build, where a simplification pass rewrites code still being shaped).
+Several CE skills deliver their value at a moment that's easy to forget — `ce-simplify-code` right after a feature settles, `ce-compound` after a verified solution produces durable reasoning worth preserving. Users bridge that gap by adding a standing instruction to their agent-instructions file (`AGENTS.md`/`CLAUDE.md`, or a global `~/.claude/CLAUDE.md` / `~/.codex/AGENTS.md`) so the agent invokes the skill on its own. A naive instruction does more harm than good in two concrete ways: it wastes cycles (a homegrown "always simplify after changes" rule ran `ce-simplify-code`'s three reviewer subagents on documentation-only diffs, which yield nothing), and it fires at the wrong moment (mid-build, where a simplification pass rewrites code still being shaped).
 
 `ce-compound` established the pattern with its "Make Capture Automatic" section (PR #1110). This learning generalizes how to author these sections for any CE skill, based on adding one to `ce-simplify-code` (PR #1113), and pairs it with the skill-side self-guard that makes the whole thing robust.
 
@@ -40,6 +41,8 @@ Put the skip logic in **both** the standing instruction and the skill, but split
 - **The skill self-guards on the no-yield boundary only** — if the resolved scope has no substantive change of the kind the skill acts on, it short-circuits before spending subagents. Crucially, the skill gates on the **kind** of change, **never on size**: an explicit user-named scope on a small function is authoritative and must still run. The numeric size floor is a *cost policy* that belongs only in the caller/standing instruction, not baked into the skill where it would override a legitimate explicit invocation.
 
 `ce-simplify-code` had no self-guard before this: `SKILL.md` Step 1 resolved any non-empty scope and Step 2 unconditionally dispatched three reviewers, so a markdown-only diff burned three dispatches. The added preflight (`skills/ce-simplify-code/SKILL.md` Step 1) short-circuits on a no-code scope and narrows to code files on a mixed diff.
+
+For `ce-compound`, the no-yield boundary is not "no verified fix". A completion phrase only identifies the checkpoint. The learning must preserve durable reasoning that is not readily recoverable from the final code, tests, types, comments, or existing documentation, and losing it must plausibly cause recurrence, material risk, or substantial rediscovery. The standing instruction carries that full value gate, while the skill repeats the same no-yield boundary before launching its capture workflow. This prevents every substantive fix from being rationalized into a second artifact that merely narrates the diff.
 
 ### 2. Anchor timing to a completion boundary, not per-edit
 

--- a/docs/solutions/skill-design/portable-agent-skill-authoring.md
+++ b/docs/solutions/skill-design/portable-agent-skill-authoring.md
@@ -18,7 +18,7 @@ tags:
   - protocol
   - judgment
   - skill-eval
-last_updated: 2026-08-21
+last_updated: 2026-09-02
 ---
 
 # Portable Agent Skill Authoring
@@ -159,6 +159,8 @@ The name and description are an activation contract. A correct body is useless i
 - Preserve deliberate invocation as a fallback when automatic routing is unavailable.
 - Use capability language instead of relying on one harness's command syntax.
 - Do not open with identity boilerplate, catalog synonyms or examples of one branch, dump workflow, flags, or procedure, or spend description words on content the body already carries.
+
+For an automatically routed follow-up that writes a durable artifact, a completion signal identifies the checkpoint, not eligibility. Pair it with a value condition that distinguishes knowledge missing from the primary artifacts from facts a reader can readily recover there. Put the cheap full gate in the caller and repeat the no-yield boundary in the skill, so routine completion does not launch an expensive workflow and direct routing still self-skips when it has nothing durable to add. A useful counterfactual is whether removing the secondary artifact would make a future maintainer likely to repeat the mistake or redo substantial investigation.
 
 Evaluate activation separately from execution with a few positive triggers, adjacent negatives, explicit invocations, and description-restraint fixtures for new model-invoked skills. A routing failure is not an execution failure.
 

--- a/skills/ce-compound/SKILL.md
+++ b/skills/ce-compound/SKILL.md
@@ -1,21 +1,25 @@
 ---
 name: ce-compound
-description: Document a recently solved problem as a durable repo learning. Use when capturing a learning after work.
+description: Document a solved problem as a durable repo learning. Use when verified work produced non-obvious reasoning absent from its final code, tests, or existing docs; avoid routine fixes whose artifacts already explain the lesson.
 argument-hint: "[optional: brief context] [mode:non-interactive] [depth:lightweight|full]"
 ---
 
 # /ce-compound
 
-**Outcome:** one solved problem is written as a durable learning under `<root>/solutions/`, grounded against the current tree, discoverable by the next agent.
+**Outcome:** one qualifying solved problem is written as a durable learning under `<root>/solutions/`, grounded against the current tree, discoverable by the next agent.
 
-**Done:** the doc is written or updated, its frontmatter and claims validated, vocabulary capture recorded even when nothing qualified, and the mode's completion report emitted.
+**Done:** a qualifying doc is written or updated, its frontmatter and claims validated, vocabulary capture recorded, and the mode's completion report emitted; when no learning qualifies, nothing is written and the report says why.
 
 **One learning per run.** A session that produced several gets several sequential runs, never one batched run — `references/research.md` carries what batching breaks.
 
 
 ## Preconditions
 
-Document a problem that is solved, verified working, and non-trivial. These are advisory: judge them from the session rather than asking about them. When the session plainly holds no such problem, write nothing and report why.
+Document only a problem that is solved and verified. The work must have produced durable project reasoning that is not readily recoverable from the final code, tests, types, comments, or existing documentation. Losing that reasoning must plausibly cause recurrence, material risk, or substantial rediscovery.
+
+Apply this counterfactual: if the learning document disappeared, would a future engineer reading the final implementation still be likely to repeat the mistake or redo substantial investigation? If not, write nothing and report why. Completion, effort, and diff size do not establish eligibility. Judge this from the session rather than asking. An explicit invocation requests the judgment now but does not lower the bar.
+
+An existing learning that became materially inaccurate or incomplete qualifies because leaving it would mislead. Update that learning instead of creating a duplicate.
 
 `ce-compound` is not a `CONCEPTS.md` bootstrap tool — it seeds the learning's own area as a side effect, never the whole repo. Send a standalone request to create or bootstrap that file to `ce-compound-refresh`, then exit.
 
@@ -53,7 +57,7 @@ The orchestrator writes the one learning under `<root>/solutions/`, plus two mai
 
 ## Choosing the path
 
-**Read `references/modes.md` before step 1.** An interactive run picks its own depth rather than asking the user, and that reference says why neither the depth choice nor session history is a question. Default to **Full**. Choose **Lightweight** only under real context pressure: the session is near its context limit, or the fix is trivial enough that cross-referencing would add nothing. In non-interactive mode, skip the choice and run the depth from Mode Detection.
+**Read `references/modes.md` before step 1.** An interactive run picks its own depth rather than asking the user, and that reference says why neither the depth choice nor session history is a question. Default to **Full**. Choose **Lightweight** only when the session is near its context limit. In non-interactive mode, skip the choice and run the depth from Mode Detection.
 
 Lightweight mode skips session history entirely; non-interactive Full runs the same automatic probe, which asks nothing and so preserves the non-interactive contract.
 

--- a/skills/ce-compound/references/modes.md
+++ b/skills/ce-compound/references/modes.md
@@ -8,6 +8,6 @@ Both are decisions the agent is better positioned to make than the user. Depth d
 
 ## Auto-Invoke
 
-<auto_invoke> <trigger_phrases> - "that worked" - "it's fixed" - "working now" - "problem solved" </trigger_phrases>
+Completion phrases such as "that worked", "it's fixed", "working now", and "problem solved" identify the completion checkpoint; they do not establish that a learning is worth documenting. Auto-invoke only when the Preconditions in `SKILL.md` qualify the learning.
 
-<manual_override> Invoke `ce-compound` with optional context to document immediately without waiting for auto-detection. </manual_override> </auto_invoke>
+An explicit invocation with optional context requests immediate evaluation without waiting for auto-detection. It does not waive the solved, verified, and durable-learning preconditions.

--- a/skills/ce-debug/SKILL.md
+++ b/skills/ce-debug/SKILL.md
@@ -117,4 +117,4 @@ If the user chose "Diagnosis only," skip to Phase 4's summary. If they chose "Re
 
 **Contextual override** ("don't open PRs from skills", "commit only", "stop after the fix") — follow what the user said, and **Stop here** without committing when that is what they asked for. A vague tonal cue is not an override.
 
-**After a PR is open** — apply the reference's learning-capture criteria; if the user accepts, invoke the `ce-compound` skill, then commit the learning doc to the same branch and push so the open PR picks it up.
+**After a PR is open** — apply the reference's learning-capture criteria. Only when that gate qualifies the fix, offer capture; if the user accepts, invoke the `ce-compound` skill, then commit and push only the artifacts it actually wrote or updated so the open PR picks them up. If it writes nothing, end without a documentation commit.

--- a/skills/ce-debug/references/post-fix-handoff.md
+++ b/skills/ce-debug/references/post-fix-handoff.md
@@ -53,10 +53,8 @@ SKILL.md's Phase 4 **Routing** block owns the bare per-case actions — which sk
 
 ## Learning-capture criteria (after a PR is open)
 
-Most bugs are localized mechanical fixes where the only "lesson" is the bug itself, and compounding those clutters `<root>/solutions/` without adding value.
+Offer once only when the verified fix produced non-obvious, durable project reasoning that is not readily recoverable from the final code, tests, types, comments, or existing documentation, and losing it would plausibly cause recurrence, material risk, or substantial rediscovery.
 
-- **Skip silently** when the fix is mechanical with no generalizable insight. Default to this when in doubt.
-- **Offer neutrally** when the lesson fits in one sentence — "X.foo() returns T | undefined when Y, not just T", or "the diagnostic path was non-obvious and worth recording." If you cannot articulate the lesson, skip rather than offer.
-- **Lean into the offer** when the pattern appears in 3+ locations, or the root cause reveals a wrong assumption about a shared dependency, framework, or convention that other code is likely to repeat.
+Apply this counterfactual: if the learning document disappeared, would a future engineer reading the final implementation still be likely to repeat the mistake or redo substantial investigation? If not, skip silently. Completion, effort, and diff size do not establish eligibility.
 
 These are the criteria only; SKILL.md's Routing block owns what fires when the user accepts.

--- a/tests/pipeline-review-contract.test.ts
+++ b/tests/pipeline-review-contract.test.ts
@@ -609,6 +609,35 @@ describe("ce-debug regression test selection", () => {
     // Linking an existing ticket stays allowed; only creating one is forbidden.
     expect(handoff).toMatch(/never open a new record/i)
   })
+
+  // ce-compound's durable-learning gate must be applied by ce-debug before it
+  // offers the handoff. The old sentence-length and location-count heuristics
+  // admitted routine fixes that the callee then had to reject.
+  test("applies ce-compound eligibility before offering learning capture", async () => {
+    const compound = await readRepoFile("skills/ce-compound/SKILL.md")
+    const debug = await readRepoFile("skills/ce-debug/SKILL.md")
+    const handoff = await readRepoFile("skills/ce-debug/references/post-fix-handoff.md")
+    const guide = await readRepoFile("docs/guides/ce-debug.md")
+
+    for (const condition of [
+      "durable project reasoning",
+      "not readily recoverable from the final code, tests, types, comments, or existing documentation",
+      "recurrence, material risk, or substantial rediscovery",
+      "if the learning document disappeared",
+      "Completion, effort, and diff size do not establish eligibility",
+    ]) {
+      expect(compound).toContain(condition)
+      expect(handoff).toContain(condition)
+    }
+
+    expect(debug).toMatch(/Only when that gate qualifies the fix, offer capture/i)
+    expect(debug).toMatch(/commit and push only the artifacts it actually wrote or updated/i)
+    expect(debug).toMatch(/If it writes nothing, end without a documentation commit/i)
+
+    const debugContract = [debug, handoff, guide].join("\n")
+    expect(debugContract).not.toMatch(/one-sentence insight|fits in one sentence/i)
+    expect(debugContract).not.toMatch(/pattern (?:appears )?in 3\+ locations/i)
+  })
 })
 
 describe("ce-plan review contract", () => {


### PR DESCRIPTION
## Summary

- Gate automatic `ce-compound` capture on knowledge that is non-obvious, durable, and material instead of treating every verified fix as documentation-worthy.
- Separate the completion checkpoint from eligibility, including for explicit invocations, and add a counterfactual that asks whether removing the learning would cause repeated mistakes or substantial rediscovery.
- Apply the same gate to `ce-debug`'s post-fix handoff so callers skip `ce-compound` when primary artifacts already preserve the lesson.
- Align the public guides, runtime contracts, and skill-authoring guidance on choosing the narrowest durable home for a learning.

## Why

The previous wording made "non-trivial, reusable learning" easy to satisfy after almost any fix. In practice, that could turn a completion checkpoint into an expensive documentation workflow even when the final code and regression tests already preserved everything a future maintainer needed.

The revised contract keeps `ce-compound` for reasoning that primary artifacts cannot readily communicate, while still allowing an existing materially misleading learning to be corrected in place. `ce-compound-refresh` remains unchanged because its corpus-maintenance activation is already explicitly evidence-gated.

## Validation

- `bun run release:validate`
- `bun run plugin:validate`
- `bun run test` (3,717 passed)
- Fresh `ce-compound` Claude and Codex evaluations: 8/8 correct across obvious fixes, expensive-but-fully-expressed changes, cross-boundary invariants, and misleading existing learnings
- Fresh `ce-debug` handoff evaluations: 6/6 correct across Claude and Codex
- Fresh host activation checks: 4/4 correct for skip versus capture routing

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Codex CLI · GPT-5
