### PR TITLE
docs(readme): give co-maintainers prominent credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Compound Engineering is a plugin of 33 skills for AI coding agents. It structure
 
 It runs on 14 agent hosts, including Claude Code, Cursor, and Codex.
 
+Maintained by [Kieran Klaassen](https://github.com/kieranklaassen) and [Trevin Chow](https://github.com/tmchow), with contributions from the open-source community.
+
 ## Install
 
 ### Claude Code


### PR DESCRIPTION
## Summary
Make Kieran Klaassen and Trevin Chow visible as co-maintainers near the top of the README, with links to both GitHub profiles and credit to the open-source community.

## Validation
Reviewed the README-only diff, checked whitespace, and verified both GitHub profile links. No runtime changes.

## Security Disclosure
No security-relevant changes.

## Agent Disclosure
- **Model:** Codex Desktop · GPT-6
