### PR TITLE
fix(skill-eval): preserve evidence across collection and reassessment

### DIFF
--- a/tests/skill-eval-cell/README.md
+++ b/tests/skill-eval-cell/README.md
@@ -22,8 +22,9 @@ bun run test:skill-eval-cell -- \
 Prints a `summary.json` path. Each host gets its own workspace copy plus stdout/stderr, git status/log, and a file list. PATH shims live beside that workspace, never inside it, so the skill under test never sees harness files as its own dirty tree. Grade those; Grok narrates before the answer (grep `FILES_READ:`). Codex transcript is stderr, final message is stdout. `claude -p` is one-tick only.
 
 Each invocation requires a new or empty `--out` directory and records input and
-evidence fingerprints. Packs freeze their scenario criteria and grader hashes;
-historical regrading writes a separate report and preserves the original grades.
+evidence fingerprints. Packs freeze their scenario criteria and grader hashes.
+Regrading applies current criteria by default; `--mode original` reproduces the
+recorded assessment. Both write separate reports and preserve original grades.
 See [reproducible evaluation evidence](reproducibility.md) for regrading commands,
 partial collection outcomes, legacy-pack compatibility, and snapshot limits.
 

--- a/tests/skill-eval-cell/README.md
+++ b/tests/skill-eval-cell/README.md
@@ -21,6 +21,12 @@ bun run test:skill-eval-cell -- \
 
 Prints a `summary.json` path. Each host gets its own workspace copy plus stdout/stderr, git status/log, and a file list. PATH shims live beside that workspace, never inside it, so the skill under test never sees harness files as its own dirty tree. Grade those; Grok narrates before the answer (grep `FILES_READ:`). Codex transcript is stderr, final message is stdout. `claude -p` is one-tick only.
 
+Each invocation requires a new or empty `--out` directory and records input and
+evidence fingerprints. Packs freeze their scenario criteria and grader hashes;
+historical regrading writes a separate report and preserves the original grades.
+See [reproducible evaluation evidence](reproducibility.md) for regrading commands,
+partial collection outcomes, legacy-pack compatibility, and snapshot limits.
+
 Gotchas baked in (see `docs/solutions/skill-design/size-driven-skill-restructure.md`): Codex stdin `/dev/null`, `CLAUDECODE` unset, `NO_COLOR=1`.
 
 ## Sweep A/B pack

--- a/tests/skill-eval-cell/integration-reproducibility.test.ts
+++ b/tests/skill-eval-cell/integration-reproducibility.test.ts
@@ -1,9 +1,9 @@
-import { test } from "bun:test"
-import assert from "node:assert/strict"
+import { expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
+import { fingerprint } from "./provenance"
 
 const integrationTest = (name: string, body: () => void) => test(name, body, 30_000)
 
@@ -58,60 +58,255 @@ if (process.platform !== "win32") {
   integrationTest("collector writes actual input hashes, host metadata and sealed evidence", () => fixture(({ root, collect }) => {
     const out = path.join(root, "cell")
     const result = collect(out)
-    assert.equal(result.status, 0, result.stderr)
+    expect(result.status, result.stderr).toBe(0)
     const input = JSON.parse(fs.readFileSync(path.join(out, "input-manifest.json"), "utf8"))
-    assert.equal(input.requested_ref, "WORKTREE")
-    assert.equal(input.source_commit_is_skill_identity, false)
-    assert.equal(input.skill.sha256.length, 64)
-    assert.equal(input.observed_model, null)
+    expect(input.requested_ref).toBe("WORKTREE")
+    expect(input.source_commit_is_skill_identity).toBe(false)
+    expect(input.skill.sha256.length).toBe(64)
+    expect(input.observed_model).toBe(null)
     const runtime = JSON.parse(fs.readFileSync(path.join(out, "hosts/codex/runtime.json"), "utf8"))
-    assert.equal(runtime.version, "codex fixture-cli")
-    assert.equal(runtime.observed_model, null)
-    assert.ok(fs.existsSync(path.join(out, "evidence-manifest.json")))
+    expect(runtime.version).toBe("codex fixture-cli")
+    expect(runtime.observed_model).toBe(null)
+    expect(fs.existsSync(path.join(out, "evidence-manifest.json"))).toBeTruthy()
   }))
 
   integrationTest("collector refuses output reuse and keeps previous stdout", () => fixture(({ root, collect }) => {
     const out = path.join(root, "cell")
-    assert.equal(collect(out).status, 0)
+    expect(collect(out).status).toBe(0)
     const evidence = path.join(out, "hosts/codex/stdout.txt")
     const before = fs.readFileSync(evidence)
     const rerun = collect(out)
-    assert.notEqual(rerun.status, 0)
-    assert.match(rerun.stderr, /empty/)
-    assert.deepEqual(fs.readFileSync(evidence), before)
+    expect(rerun.status).not.toBe(0)
+    expect(rerun.stderr).toMatch(/empty/)
+    expect(fs.readFileSync(evidence)).toEqual(before)
   }))
 
-  integrationTest("frozen criteria survive catalog changes across fresh regrade processes", () => fixture(({ root, catalog, call, pack }) => {
+  integrationTest("regrading uses current criteria by default and original criteria on request", () => fixture(({ root, catalog, call, pack }) => {
     const out = path.join(root, "pack")
     const result = pack(out, ["--id", "fixture/pass"])
-    assert.equal(result.status, 0, result.stderr)
+    expect(result.status, result.stderr).toBe(0)
     const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
     fs.writeFileSync(catalog, fs.readFileSync(catalog, "utf8").replaceAll('["proof"]', '["new criterion absent from output"]'))
+    const current = call("regrade.ts", [source])
+    expect(current.status, current.stderr).toBe(1)
+    const original = call("regrade.ts", [source, "--mode", "original"])
+    expect(original.status, original.stderr).toBe(0)
+    expect(fs.readFileSync(source)).toEqual(before)
+    expect(current.stdout.trim()).not.toBe(original.stdout.trim())
+    expect(JSON.parse(fs.readFileSync(current.stdout.trim(), "utf8")).mode).toBe("current")
+    expect(JSON.parse(fs.readFileSync(original.stdout.trim(), "utf8")).mode).toBe("original")
+  }))
+
+  integrationTest("a corrected rubric reassesses preserved observations without replacing the original failure", () => fixture(({ root, catalog, call, pack }) => {
+    const goodCatalog = fs.readFileSync(catalog, "utf8")
+    fs.writeFileSync(catalog, goodCatalog.replaceAll('["proof"]', '["incorrect requirement"]'))
+    const out = path.join(root, "pack")
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(1)
+    const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
+    fs.writeFileSync(catalog, goodCatalog)
+    const result = call("regrade.ts", [source])
+    expect(result.status, result.stderr).toBe(0)
+    const report = JSON.parse(fs.readFileSync(result.stdout.trim(), "utf8"))
+    expect(report.scenarios["fixture/pass"].used_grade.must_include).toEqual(["proof"])
+    expect(report.scenarios["fixture/pass"].used_grade_sha256).not.toBe(report.scenarios["fixture/pass"].original_grade_sha256)
+    expect(JSON.parse(before.toString()).scenarios["fixture/pass"].arms.post.ok).toBe(false)
+    expect(fs.readFileSync(source)).toEqual(before)
+    expect(call("regrade.ts", [source, "--mode", "original"]).status).toBe(1)
+  }))
+
+  integrationTest("current criteria cannot replace the recorded task, controls, or fixture contents", () => fixture(({ root, repo, catalog, call, pack }) => {
+    const fixtureDir = path.join(repo, "fixture")
+    fs.mkdirSync(fixtureDir)
+    fs.writeFileSync(path.join(fixtureDir, "context.txt"), "original context")
+    const initialCatalog = fs.readFileSync(catalog, "utf8").replaceAll('task:"task"', 'task:"task",fixture:"fixture"')
+    fs.writeFileSync(catalog, initialCatalog)
+    const out = path.join(root, "pack")
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
+    const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
+    for (const [from, to] of [['task:"task"', 'task:"different task"'], ["read_only:true", "read_only:false"]]) {
+      fs.writeFileSync(catalog, initialCatalog.replaceAll(from!, to!))
+      const result = call("regrade.ts", [source])
+      expect(result.status, result.stderr).toBe(1)
+      const arm = JSON.parse(fs.readFileSync(result.stdout.trim(), "utf8")).scenarios["fixture/pass"].arms.post
+      expect(arm.status).toBe("not-assessable")
+      expect(arm.reason).toMatch(/task or collection controls changed/)
+      expect(call("regrade.ts", [source, "--mode", "original"]).status).toBe(0)
+    }
+    fs.writeFileSync(catalog, initialCatalog)
+    fs.writeFileSync(path.join(fixtureDir, "context.txt"), "changed context")
+    const result = call("regrade.ts", [source])
+    expect(result.status, result.stderr).toBe(1)
+    const arm = JSON.parse(fs.readFileSync(result.stdout.trim(), "utf8")).scenarios["fixture/pass"].arms.post
+    expect(arm.status).toBe("not-assessable")
+    expect(arm.reason).toMatch(/fixture contents changed/)
+    expect(call("regrade.ts", [source, "--mode", "original"]).status).toBe(0)
+    expect(fs.readFileSync(path.join(out, "fixture__pass/post/workspace/context.txt"), "utf8")).toBe("original context")
+    expect(fs.readFileSync(source)).toEqual(before)
+  }))
+
+  integrationTest("current mode uses changed grader code and original mode rejects it", () => fixture(({ root, dir, call, pack }) => {
+    const out = path.join(root, "pack")
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
+    const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
+    const grader = path.join(dir, "grade.ts")
+    fs.writeFileSync(grader, fs.readFileSync(grader, "utf8").replace(
+      "const allReasons = [...reasons, ...pointer_reasons]",
+      'const allReasons = [...reasons, ...pointer_reasons, "changed grader criterion"]',
+    ))
+    const current = call("regrade.ts", [source])
+    expect(current.status, current.stderr).toBe(1)
+    const report = JSON.parse(fs.readFileSync(current.stdout.trim(), "utf8"))
+    expect(report.grader_changed).toBe(true)
+    expect(report.scenarios["fixture/pass"].arms.post.grades[0].reasons).toContain("changed grader criterion")
+    const original = call("regrade.ts", [source, "--mode", "original"])
+    expect(original.status).toBe(2)
+    expect(original.stderr).toMatch(/grader changed/)
+    expect(fs.readdirSync(out).filter((name) => name.includes(".regrade-"))).toHaveLength(1)
+    expect(fs.readFileSync(source)).toEqual(before)
+  }))
+
+  integrationTest("original mode remains available after the catalog scenario is removed", () => fixture(({ root, catalog, call, pack }) => {
+    const out = path.join(root, "pack")
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
+    const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
+    fs.writeFileSync(catalog, fs.readFileSync(catalog, "utf8").replace('id:"fixture/pass"', 'id:"fixture/replacement"'))
+    const current = call("regrade.ts", [source])
+    expect(current.status, current.stderr).toBe(1)
+    const arm = JSON.parse(fs.readFileSync(current.stdout.trim(), "utf8")).scenarios["fixture/pass"].arms.post
+    expect(arm.status).toBe("not-assessable")
+    expect(arm.reason).toMatch(/absent from the current catalog/)
+    expect(call("regrade.ts", [source, "--mode", "original"]).status).toBe(0)
+    expect(fs.readFileSync(source)).toEqual(before)
+  }))
+
+  integrationTest("invalid regrade modes fail without creating an assessment", () => fixture(({ root, call, pack }) => {
+    const out = path.join(root, "pack")
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
+    const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
+    for (const flags of [["--mode", "unknown"], ["--mode"], ["--mode", "current", "--mode", "original"]]) {
+      const result = call("regrade.ts", [source, ...flags])
+      expect(result.status).toBe(2)
+      expect(result.stderr).toMatch(/usage:/)
+    }
+    expect(fs.readdirSync(out).filter((name) => name.includes(".regrade-"))).toHaveLength(0)
+    expect(fs.readFileSync(source)).toEqual(before)
+  }))
+
+  for (const [observer, criterion] of [["Git", 'git:"clean"'], ["command shims", 'shim_log_must_not:["git push"]']]) {
+    integrationTest(`current mode requires ${observer} observations while original mode preserves the historical verdict`, () => fixture(({ root, catalog, call, pack }) => {
+      fs.writeFileSync(catalog, fs.readFileSync(catalog, "utf8").replaceAll("grade:{", `grade:{${criterion},`))
+      const out = path.join(root, "pack")
+      // The original grader treated a missing observation as an empty, passing value.
+      expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
+      const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
+      const current = call("regrade.ts", [source])
+      expect(current.status, current.stderr).toBe(1)
+      const arm = JSON.parse(fs.readFileSync(current.stdout.trim(), "utf8")).scenarios["fixture/pass"].arms.post
+      expect(arm.status).toBe("not-assessable")
+      expect(arm.reason).toMatch(/not collected|not installed/)
+      const original = call("regrade.ts", [source, "--mode", "original"])
+      expect(original.status, original.stderr).toBe(0)
+      expect(JSON.parse(fs.readFileSync(original.stdout.trim(), "utf8")).scenarios["fixture/pass"].arms.post.status).toBe("regraded")
+      expect(fs.readFileSync(source)).toEqual(before)
+    }))
+  }
+
+  integrationTest("installed shims with no calls provide a valid negative observation", () => fixture(({ root, catalog, call, pack }) => {
+    fs.writeFileSync(catalog, fs.readFileSync(catalog, "utf8").replaceAll(
+      "grade:{", 'shim_git_push:true,grade:{shim_log_must_not:["git push"],',
+    ))
+    const out = path.join(root, "pack")
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
+    const shimDir = path.join(out, "fixture__pass/post/hosts/codex/.bin")
+    expect(fs.existsSync(path.join(shimDir, "git"))).toBe(true)
+    expect(fs.existsSync(path.join(shimDir, "shim-invocations.log"))).toBe(false)
+    const result = call("regrade.ts", [path.join(out, "pack.json")])
+    expect(result.status, result.stderr).toBe(0)
+    expect(JSON.parse(fs.readFileSync(result.stdout.trim(), "utf8")).scenarios["fixture/pass"].arms.post.status).toBe("regraded")
+  }))
+
+  integrationTest("Python imports use independent host copies while preserving and sealing every skill artifact", () => fixture(({ root, repo, bin, catalog, call }) => {
+    const python = ["python3", "python", "py"].map((name) => Bun.which(name)).find((executable) =>
+      executable && spawnSync(executable, ["-c", "import sys; assert sys.version_info.major == 3"], { timeout: 5000 }).status === 0,
+    )
+    expect(python, "a working Python 3 interpreter is required").toBeTruthy()
+    fs.writeFileSync(catalog, fs.readFileSync(catalog, "utf8").replaceAll("read_only:true", "read_only:false"))
+    const scripts = path.join(repo, "skills/fixture/scripts")
+    fs.mkdirSync(scripts)
+    fs.writeFileSync(path.join(scripts, "helper.py"), 'VALUE = "proof"\n')
+    fs.writeFileSync(path.join(scripts, "main.py"), `import helper
+from pathlib import Path
+marker = Path(__file__).with_name("ran.txt")
+assert not marker.exists(), "another host already used this skill copy"
+marker.write_text("executed")
+print(helper.VALUE)
+print("ACTIONS: none")
+`)
+    const hostScript = path.join(root, "fake-host.py")
+    fs.writeFileSync(hostScript, `import subprocess, sys
+from pathlib import Path
+if sys.argv[1:] == ["--version"]:
+    print("fake Python host")
+else:
+    host = Path.cwd().parent
+    first_line = (host / "prompt.md").read_text().splitlines()[0]
+    skill = Path(first_line.removeprefix("Read the skill at ").removesuffix(" first.")).parent
+    assert skill == host / "skill", "prompt must point to the host execution copy"
+    subprocess.run([sys.executable, str(skill / "scripts/main.py")], check=True)
+`)
+    for (const host of ["codex", "claude"]) {
+      fs.writeFileSync(path.join(bin, host), '#!/bin/sh\nexec "$CE_FAKE_PYTHON" "$CE_FAKE_HOST_SCRIPT" "$@"\n', { mode: 0o755 })
+    }
+    const out = path.join(root, "pack")
+    const result = call("pack.ts", ["--hosts", "codex,claude", "--arm", "post", "--id", "fixture/pass", "--out", out], {
+      CE_FAKE_PYTHON: python ?? undefined, CE_FAKE_HOST_SCRIPT: hostScript,
+      PYTHONDONTWRITEBYTECODE: undefined, PYTHONPYCACHEPREFIX: undefined,
+    })
+    expect(result.status, result.stderr).toBe(0)
+    const cell = path.join(out, "fixture__pass/post")
+    const input = JSON.parse(fs.readFileSync(path.join(cell, "input-manifest.json"), "utf8"))
+    const originalSkill = path.join(cell, "extract/skills/fixture")
+    expect(fingerprint(originalSkill)).toEqual(input.skill)
+    expect(fs.existsSync(path.join(originalSkill, "scripts/__pycache__"))).toBe(false)
+    expect(fs.existsSync(path.join(originalSkill, "scripts/ran.txt"))).toBe(false)
+    const caches: string[] = []
+    for (const host of ["codex", "claude"]) {
+      const executionScripts = path.join(cell, "hosts", host, "skill/scripts")
+      expect(fs.readFileSync(path.join(executionScripts, "ran.txt"), "utf8")).toBe("executed")
+      const cache = path.join(executionScripts, "__pycache__")
+      const bytecode = fs.readdirSync(cache).find((name) => name.endsWith(".pyc"))
+      expect(bytecode).toBeDefined()
+      caches.push(path.join(cache, bytecode!))
+    }
+    const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
     const regraded = call("regrade.ts", [source])
-    assert.equal(regraded.status, 0, regraded.stderr)
-    assert.deepEqual(fs.readFileSync(source), before)
-    assert.notEqual(regraded.stdout.trim(), source)
+    expect(regraded.status, regraded.stderr).toBe(0)
+    fs.appendFileSync(caches[0]!, "tampered")
+    const tampered = call("regrade.ts", [source])
+    expect(tampered.status).toBe(2)
+    expect(tampered.stderr).toMatch(/evidence/)
+    expect(fs.readFileSync(source)).toEqual(before)
   }))
 
   integrationTest("failed collection preserves partial pack and does not stop later bookkeeping", () => fixture(({ root, pack }) => {
     const out = path.join(root, "pack")
     const result = pack(out)
-    assert.equal(result.status, 1, result.stderr)
+    expect(result.status, result.stderr).toBe(1)
     const recorded = JSON.parse(fs.readFileSync(path.join(out, "pack.json"), "utf8"))
-    assert.equal(recorded.scenarios["fixture/pass"].arms.post.status, "graded")
-    assert.equal(recorded.scenarios["fixture/pass"].arms.post.ok, true)
-    assert.equal(recorded.scenarios["fixture/missing"].arms.post.status, "collection-error")
-    assert.equal(recorded.scenarios["fixture/after-failure"].arms.post.status, "graded")
-    assert.equal(recorded.scenarios["fixture/after-failure"].arms.post.ok, true)
-    assert.ok(recorded.finished_at)
+    expect(recorded.scenarios["fixture/pass"].arms.post.status).toBe("graded")
+    expect(recorded.scenarios["fixture/pass"].arms.post.ok).toBe(true)
+    expect(recorded.scenarios["fixture/missing"].arms.post.status).toBe("collection-error")
+    expect(recorded.scenarios["fixture/after-failure"].arms.post.status).toBe("graded")
+    expect(recorded.scenarios["fixture/after-failure"].arms.post.ok).toBe(true)
+    expect(recorded.finished_at).toBeTruthy()
   }))
 
   integrationTest("pack refuses nonempty output before changing an original result", () => fixture(({ root, pack }) => {
     const out = path.join(root, "pack")
-    assert.equal(pack(out, ["--id", "fixture/pass"]).status, 0)
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
     const before = fs.readFileSync(path.join(out, "pack.json"))
-    assert.notEqual(pack(out, ["--id", "fixture/pass"]).status, 0)
-    assert.deepEqual(fs.readFileSync(path.join(out, "pack.json")), before)
+    expect(pack(out, ["--id", "fixture/pass"]).status).not.toBe(0)
+    expect(fs.readFileSync(path.join(out, "pack.json"))).toEqual(before)
   }))
 
   integrationTest("pack refuses unsealed workspace criteria before launching a host", () => fixture(({ root, catalog, pack }) => {
@@ -120,55 +315,55 @@ if (process.platform !== "win32") {
       'grade:{workspace_contains:[{path:".git/config",needle:"proof"}],must_include:["proof"]',
     ))
     const out = path.join(root, "unsealed")
-    assert.equal(pack(out, ["--id", "fixture/pass"]).status, 1)
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(1)
     const recorded = JSON.parse(fs.readFileSync(path.join(out, "pack.json"), "utf8"))
     const arm = recorded.scenarios["fixture/pass"].arms.post
-    assert.equal(arm.status, "collection-error")
-    assert.match(arm.error, /unsealed workspace grade path/)
-    assert.equal(fs.existsSync(path.join(out, "fixture__pass/post")), false)
+    expect(arm.status).toBe("collection-error")
+    expect(arm.error).toMatch(/unsealed workspace grade path/)
+    expect(fs.existsSync(path.join(out, "fixture__pass/post"))).toBe(false)
   }))
 
   integrationTest("CLI regrading detects changed evidence and produces no success report", () => fixture(({ root, pack, call }) => {
     const out = path.join(root, "pack")
-    assert.equal(pack(out, ["--id", "fixture/pass"]).status, 0)
+    expect(pack(out, ["--id", "fixture/pass"]).status).toBe(0)
     fs.writeFileSync(path.join(out, "fixture__pass/post/hosts/codex/stdout.txt"), "tampered")
     const result = call("regrade.ts", [path.join(out, "pack.json")])
-    assert.equal(result.status, 2)
-    assert.match(result.stderr, /evidence/)
-    assert.equal(fs.readdirSync(out).filter(f => f.includes(".regrade-")).length, 0)
+    expect(result.status).toBe(2)
+    expect(result.stderr).toMatch(/evidence/)
+    expect(fs.readdirSync(out).filter(f => f.includes(".regrade-")).length).toBe(0)
   }))
 
   integrationTest("collector records timeouts separately from completed host processes", () => fixture(({ root, collect }) => {
     const out = path.join(root, "timeout")
     const result = collect(out, ["--timeout-secs", "0.1"], { CE_FAKE_MODE: "timeout" })
-    assert.equal(result.status, 0, result.stderr)
+    expect(result.status, result.stderr).toBe(0)
     const exit = JSON.parse(fs.readFileSync(path.join(out, "hosts/codex/exit.json"), "utf8"))
-    assert.equal(exit.timedOut, true)
-    assert.equal(exit.exitCode, null)
+    expect(exit.timedOut).toBe(true)
+    expect(exit.exitCode).toBe(null)
     const summary = JSON.parse(fs.readFileSync(path.join(out, "summary.json"), "utf8"))
-    assert.equal(summary.cells.codex.process_outcome, "timeout")
+    expect(summary.cells.codex.process_outcome).toBe("timeout")
   }))
 
   integrationTest("CLI absence never produces a pass", () => fixture(({ root, bin, fake, collect }) => {
     fs.unlinkSync(fake)
     // Do not fall through to a contributor's installed, authenticated host CLI.
     const result = collect(path.join(root, "missing"), [], { PATH: bin })
-    assert.equal(result.status, 2, result.stderr)
-    assert.match(result.stderr, /no harness/)
+    expect(result.status, result.stderr).toBe(2)
+    expect(result.stderr).toMatch(/no harness/)
   }))
 
   integrationTest("nonzero host exits retain diagnostic evidence", () => fixture(({ root, collect }) => {
     const out = path.join(root, "nonzero")
-    assert.equal(collect(out, [], { CE_FAKE_MODE: "nonzero" }).status, 0)
+    expect(collect(out, [], { CE_FAKE_MODE: "nonzero" }).status).toBe(0)
     const exit = JSON.parse(fs.readFileSync(path.join(out, "hosts/codex/exit.json"), "utf8"))
-    assert.equal(exit.exitCode, 7)
-    assert.match(fs.readFileSync(path.join(out, "hosts/codex/stderr.txt"), "utf8"), /failure/)
+    expect(exit.exitCode).toBe(7)
+    expect(fs.readFileSync(path.join(out, "hosts/codex/stderr.txt"), "utf8")).toMatch(/failure/)
   }))
 
   integrationTest("mutable refs resolve to a recorded commit and exclude uncommitted skill edits", () => fixture(({ root, repo, collect }) => {
     const git = (args: string[]) => {
       const result = spawnSync("git", args, { cwd: repo, encoding: "utf8" })
-      assert.equal(result.status, 0, result.stderr)
+      expect(result.status, result.stderr).toBe(0)
       return result.stdout.trim()
     }
     git(["init", "-b", "main"])
@@ -180,31 +375,31 @@ if (process.platform !== "win32") {
     fs.writeFileSync(path.join(repo, "skills/fixture/SKILL.md"), "uncommitted change")
     const out = path.join(root, "committed")
     const result = collect(out, ["--ref", "HEAD"])
-    assert.equal(result.status, 0, result.stderr)
+    expect(result.status, result.stderr).toBe(0)
     const input = JSON.parse(fs.readFileSync(path.join(out, "input-manifest.json"), "utf8"))
-    assert.equal(input.source_commit, commit)
-    assert.equal(input.requested_ref, "HEAD")
-    assert.equal(input.source_commit_is_skill_identity, true)
-    assert.equal(fs.readFileSync(path.join(out, "extract/skills/fixture/SKILL.md"), "utf8"), "fixture skill")
+    expect(input.source_commit).toBe(commit)
+    expect(input.requested_ref).toBe("HEAD")
+    expect(input.source_commit_is_skill_identity).toBe(true)
+    expect(fs.readFileSync(path.join(out, "extract/skills/fixture/SKILL.md"), "utf8")).toBe("fixture skill")
   }))
 
   integrationTest("WORKTREE identity includes modified and untracked skill bytes", () => fixture(({ root, repo, collect }) => {
     const first = path.join(root, "first")
-    assert.equal(collect(first).status, 0)
+    expect(collect(first).status).toBe(0)
     const before = JSON.parse(fs.readFileSync(path.join(first, "input-manifest.json"), "utf8"))
     fs.writeFileSync(path.join(repo, "skills/fixture/SKILL.md"), "modified skill")
     fs.writeFileSync(path.join(repo, "skills/fixture/new-reference.md"), "untracked reference")
     const second = path.join(root, "second")
-    assert.equal(collect(second).status, 0)
+    expect(collect(second).status).toBe(0)
     const after = JSON.parse(fs.readFileSync(path.join(second, "input-manifest.json"), "utf8"))
-    assert.notEqual(after.skill.sha256, before.skill.sha256)
-    assert.equal(fs.readFileSync(path.join(second, "extract/skills/fixture/SKILL.md"), "utf8"), "modified skill")
-    assert.equal(fs.readFileSync(path.join(second, "extract/skills/fixture/new-reference.md"), "utf8"), "untracked reference")
+    expect(after.skill.sha256).not.toBe(before.skill.sha256)
+    expect(fs.readFileSync(path.join(second, "extract/skills/fixture/SKILL.md"), "utf8")).toBe("modified skill")
+    expect(fs.readFileSync(path.join(second, "extract/skills/fixture/new-reference.md"), "utf8")).toBe("untracked reference")
   }))
 
   integrationTest("invalid timeout is rejected before collecting", () => fixture(({ root, collect }) => {
     for (const value of ["0", "-1", "NaN", "Infinity"]) {
-      assert.notEqual(collect(path.join(root, `invalid-${value}`), ["--timeout-secs", value]).status, 0)
+      expect(collect(path.join(root, `invalid-${value}`), ["--timeout-secs", value]).status).not.toBe(0)
     }
   }))
 }

--- a/tests/skill-eval-cell/integration-reproducibility.test.ts
+++ b/tests/skill-eval-cell/integration-reproducibility.test.ts
@@ -1,0 +1,210 @@
+import { test } from "bun:test"
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const integrationTest = (name: string, body: () => void) => test(name, body, 30_000)
+
+// Unix shell/process support matches the existing runner. No live model, network,
+// personal configuration or real credentials are used by these subprocess tests.
+function fixture(work: (ctx: ReturnType<typeof make>) => void) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ce-collector-test-"))
+  try { work(make(root)) } finally { fs.rmSync(root, { recursive: true, force: true }) }
+}
+
+function make(root: string) {
+  const repo = path.join(root, "repo")
+  const dir = path.join(repo, "tests", "skill-eval-cell")
+  const bin = path.join(root, "bin")
+  fs.mkdirSync(dir, { recursive: true }); fs.mkdirSync(bin)
+  for (const name of ["run.ts", "pack.ts", "regrade.ts", "provenance.ts", "grade.ts", "hosts.ts", "extract.ts", "cli.ts", "path-shim.ts"]) {
+    fs.copyFileSync(path.join(import.meta.dir, name), path.join(dir, name))
+  }
+  fs.mkdirSync(path.join(repo, "skills", "fixture"), { recursive: true })
+  fs.writeFileSync(path.join(repo, "skills", "fixture", "SKILL.md"), "fixture skill")
+  const catalog = path.join(dir, "catalog.ts")
+  fs.writeFileSync(catalog, `export const POST_SWEEP_REF = "WORKTREE";
+export const PRE_SWEEP_REF = "HEAD";
+export const rows = [
+{id:"fixture/pass",skill:"fixture",cohort:"untouched",key_behavior:"judgment",read_only:true,task:"task",grade:{must_include:["proof"],actions:"none"}},
+{id:"fixture/missing",skill:"does-not-exist",cohort:"untouched",key_behavior:"judgment",read_only:true,task:"task",grade:{must_include:["proof"]}},
+{id:"fixture/after-failure",skill:"fixture",cohort:"untouched",key_behavior:"judgment",read_only:true,task:"task",grade:{must_include:["proof"]}},
+];
+export const scenariosMatching = ({id}) => rows.filter(r => !id || r.id === id);
+export const scenarioById = id => rows.find(r => r.id === id);
+`)
+  const fake = path.join(bin, "codex")
+  fs.writeFileSync(fake, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo 'codex fixture-cli'; exit 0; fi
+if [ "$CE_FAKE_MODE" = "timeout" ]; then sleep 5; fi
+if [ "$CE_FAKE_MODE" = "nonzero" ]; then echo 'failure' >&2; exit 7; fi
+printf 'proof\\nFILES_READ: SKILL.md\\nACTIONS: none\\nDELEGATES_DISPATCHED: none\\n'
+`, { mode: 0o755 })
+  const executable = process.execPath
+  const env = { ...process.env, PATH: `${bin}${path.delimiter}${path.dirname(executable)}${path.delimiter}${process.env.PATH ?? ""}` }
+  const call = (script: string, args: string[], moreEnv: NodeJS.ProcessEnv = {}) => spawnSync(executable, [path.join(dir, script), ...args], {
+    cwd: repo, env: { ...env, ...moreEnv }, encoding: "utf8", timeout: 20000,
+  })
+  const collect = (out: string, more: string[] = [], moreEnv: NodeJS.ProcessEnv = {}) => call("run.ts", [
+    "--skill", "fixture", "--hosts", "codex", "--task", "task", "--read-only", "--out", out, ...more,
+  ], moreEnv)
+  const pack = (out: string, more: string[] = []) => call("pack.ts", ["--hosts", "codex", "--arm", "post", "--out", out, ...more])
+  return { root, repo, dir, bin, fake, catalog, call, collect, pack }
+}
+
+if (process.platform !== "win32") {
+  integrationTest("collector writes actual input hashes, host metadata and sealed evidence", () => fixture(({ root, collect }) => {
+    const out = path.join(root, "cell")
+    const result = collect(out)
+    assert.equal(result.status, 0, result.stderr)
+    const input = JSON.parse(fs.readFileSync(path.join(out, "input-manifest.json"), "utf8"))
+    assert.equal(input.requested_ref, "WORKTREE")
+    assert.equal(input.source_commit_is_skill_identity, false)
+    assert.equal(input.skill.sha256.length, 64)
+    assert.equal(input.observed_model, null)
+    const runtime = JSON.parse(fs.readFileSync(path.join(out, "hosts/codex/runtime.json"), "utf8"))
+    assert.equal(runtime.version, "codex fixture-cli")
+    assert.equal(runtime.observed_model, null)
+    assert.ok(fs.existsSync(path.join(out, "evidence-manifest.json")))
+  }))
+
+  integrationTest("collector refuses output reuse and keeps previous stdout", () => fixture(({ root, collect }) => {
+    const out = path.join(root, "cell")
+    assert.equal(collect(out).status, 0)
+    const evidence = path.join(out, "hosts/codex/stdout.txt")
+    const before = fs.readFileSync(evidence)
+    const rerun = collect(out)
+    assert.notEqual(rerun.status, 0)
+    assert.match(rerun.stderr, /empty/)
+    assert.deepEqual(fs.readFileSync(evidence), before)
+  }))
+
+  integrationTest("frozen criteria survive catalog changes across fresh regrade processes", () => fixture(({ root, catalog, call, pack }) => {
+    const out = path.join(root, "pack")
+    const result = pack(out, ["--id", "fixture/pass"])
+    assert.equal(result.status, 0, result.stderr)
+    const source = path.join(out, "pack.json"), before = fs.readFileSync(source)
+    fs.writeFileSync(catalog, fs.readFileSync(catalog, "utf8").replaceAll('["proof"]', '["new criterion absent from output"]'))
+    const regraded = call("regrade.ts", [source])
+    assert.equal(regraded.status, 0, regraded.stderr)
+    assert.deepEqual(fs.readFileSync(source), before)
+    assert.notEqual(regraded.stdout.trim(), source)
+  }))
+
+  integrationTest("failed collection preserves partial pack and does not stop later bookkeeping", () => fixture(({ root, pack }) => {
+    const out = path.join(root, "pack")
+    const result = pack(out)
+    assert.equal(result.status, 1, result.stderr)
+    const recorded = JSON.parse(fs.readFileSync(path.join(out, "pack.json"), "utf8"))
+    assert.equal(recorded.scenarios["fixture/pass"].arms.post.status, "graded")
+    assert.equal(recorded.scenarios["fixture/pass"].arms.post.ok, true)
+    assert.equal(recorded.scenarios["fixture/missing"].arms.post.status, "collection-error")
+    assert.equal(recorded.scenarios["fixture/after-failure"].arms.post.status, "graded")
+    assert.equal(recorded.scenarios["fixture/after-failure"].arms.post.ok, true)
+    assert.ok(recorded.finished_at)
+  }))
+
+  integrationTest("pack refuses nonempty output before changing an original result", () => fixture(({ root, pack }) => {
+    const out = path.join(root, "pack")
+    assert.equal(pack(out, ["--id", "fixture/pass"]).status, 0)
+    const before = fs.readFileSync(path.join(out, "pack.json"))
+    assert.notEqual(pack(out, ["--id", "fixture/pass"]).status, 0)
+    assert.deepEqual(fs.readFileSync(path.join(out, "pack.json")), before)
+  }))
+
+  integrationTest("pack refuses unsealed workspace criteria before launching a host", () => fixture(({ root, catalog, pack }) => {
+    fs.writeFileSync(catalog, fs.readFileSync(catalog, "utf8").replaceAll(
+      'grade:{must_include:["proof"]',
+      'grade:{workspace_contains:[{path:".git/config",needle:"proof"}],must_include:["proof"]',
+    ))
+    const out = path.join(root, "unsealed")
+    assert.equal(pack(out, ["--id", "fixture/pass"]).status, 1)
+    const recorded = JSON.parse(fs.readFileSync(path.join(out, "pack.json"), "utf8"))
+    const arm = recorded.scenarios["fixture/pass"].arms.post
+    assert.equal(arm.status, "collection-error")
+    assert.match(arm.error, /unsealed workspace grade path/)
+    assert.equal(fs.existsSync(path.join(out, "fixture__pass/post")), false)
+  }))
+
+  integrationTest("CLI regrading detects changed evidence and produces no success report", () => fixture(({ root, pack, call }) => {
+    const out = path.join(root, "pack")
+    assert.equal(pack(out, ["--id", "fixture/pass"]).status, 0)
+    fs.writeFileSync(path.join(out, "fixture__pass/post/hosts/codex/stdout.txt"), "tampered")
+    const result = call("regrade.ts", [path.join(out, "pack.json")])
+    assert.equal(result.status, 2)
+    assert.match(result.stderr, /evidence/)
+    assert.equal(fs.readdirSync(out).filter(f => f.includes(".regrade-")).length, 0)
+  }))
+
+  integrationTest("collector records timeouts separately from completed host processes", () => fixture(({ root, collect }) => {
+    const out = path.join(root, "timeout")
+    const result = collect(out, ["--timeout-secs", "0.1"], { CE_FAKE_MODE: "timeout" })
+    assert.equal(result.status, 0, result.stderr)
+    const exit = JSON.parse(fs.readFileSync(path.join(out, "hosts/codex/exit.json"), "utf8"))
+    assert.equal(exit.timedOut, true)
+    assert.equal(exit.exitCode, null)
+    const summary = JSON.parse(fs.readFileSync(path.join(out, "summary.json"), "utf8"))
+    assert.equal(summary.cells.codex.process_outcome, "timeout")
+  }))
+
+  integrationTest("CLI absence never produces a pass", () => fixture(({ root, bin, fake, collect }) => {
+    fs.unlinkSync(fake)
+    // Do not fall through to a contributor's installed, authenticated host CLI.
+    const result = collect(path.join(root, "missing"), [], { PATH: bin })
+    assert.equal(result.status, 2, result.stderr)
+    assert.match(result.stderr, /no harness/)
+  }))
+
+  integrationTest("nonzero host exits retain diagnostic evidence", () => fixture(({ root, collect }) => {
+    const out = path.join(root, "nonzero")
+    assert.equal(collect(out, [], { CE_FAKE_MODE: "nonzero" }).status, 0)
+    const exit = JSON.parse(fs.readFileSync(path.join(out, "hosts/codex/exit.json"), "utf8"))
+    assert.equal(exit.exitCode, 7)
+    assert.match(fs.readFileSync(path.join(out, "hosts/codex/stderr.txt"), "utf8"), /failure/)
+  }))
+
+  integrationTest("mutable refs resolve to a recorded commit and exclude uncommitted skill edits", () => fixture(({ root, repo, collect }) => {
+    const git = (args: string[]) => {
+      const result = spawnSync("git", args, { cwd: repo, encoding: "utf8" })
+      assert.equal(result.status, 0, result.stderr)
+      return result.stdout.trim()
+    }
+    git(["init", "-b", "main"])
+    git(["config", "user.name", "Eval fixture"])
+    git(["config", "user.email", "eval@example.invalid"])
+    git(["add", "."])
+    git(["commit", "-m", "fixture"])
+    const commit = git(["rev-parse", "HEAD"])
+    fs.writeFileSync(path.join(repo, "skills/fixture/SKILL.md"), "uncommitted change")
+    const out = path.join(root, "committed")
+    const result = collect(out, ["--ref", "HEAD"])
+    assert.equal(result.status, 0, result.stderr)
+    const input = JSON.parse(fs.readFileSync(path.join(out, "input-manifest.json"), "utf8"))
+    assert.equal(input.source_commit, commit)
+    assert.equal(input.requested_ref, "HEAD")
+    assert.equal(input.source_commit_is_skill_identity, true)
+    assert.equal(fs.readFileSync(path.join(out, "extract/skills/fixture/SKILL.md"), "utf8"), "fixture skill")
+  }))
+
+  integrationTest("WORKTREE identity includes modified and untracked skill bytes", () => fixture(({ root, repo, collect }) => {
+    const first = path.join(root, "first")
+    assert.equal(collect(first).status, 0)
+    const before = JSON.parse(fs.readFileSync(path.join(first, "input-manifest.json"), "utf8"))
+    fs.writeFileSync(path.join(repo, "skills/fixture/SKILL.md"), "modified skill")
+    fs.writeFileSync(path.join(repo, "skills/fixture/new-reference.md"), "untracked reference")
+    const second = path.join(root, "second")
+    assert.equal(collect(second).status, 0)
+    const after = JSON.parse(fs.readFileSync(path.join(second, "input-manifest.json"), "utf8"))
+    assert.notEqual(after.skill.sha256, before.skill.sha256)
+    assert.equal(fs.readFileSync(path.join(second, "extract/skills/fixture/SKILL.md"), "utf8"), "modified skill")
+    assert.equal(fs.readFileSync(path.join(second, "extract/skills/fixture/new-reference.md"), "utf8"), "untracked reference")
+  }))
+
+  integrationTest("invalid timeout is rejected before collecting", () => fixture(({ root, collect }) => {
+    for (const value of ["0", "-1", "NaN", "Infinity"]) {
+      assert.notEqual(collect(path.join(root, `invalid-${value}`), ["--timeout-secs", value]).status, 0)
+    }
+  }))
+}

--- a/tests/skill-eval-cell/integration-reproducibility.test.ts
+++ b/tests/skill-eval-cell/integration-reproducibility.test.ts
@@ -234,7 +234,10 @@ if (process.platform !== "win32") {
     const scripts = path.join(repo, "skills/fixture/scripts")
     fs.mkdirSync(scripts)
     fs.writeFileSync(path.join(scripts, "helper.py"), 'VALUE = "proof"\n')
-    fs.writeFileSync(path.join(scripts, "main.py"), `import helper
+    fs.writeFileSync(path.join(scripts, "main.py"), `import sys
+sys.dont_write_bytecode = False
+sys.pycache_prefix = None
+import helper
 from pathlib import Path
 marker = Path(__file__).with_name("ran.txt")
 assert not marker.exists(), "another host already used this skill copy"
@@ -251,7 +254,7 @@ else:
     host = Path.cwd().parent
     first_line = (host / "prompt.md").read_text().splitlines()[0]
     skill = Path(first_line.removeprefix("Read the skill at ").removesuffix(" first.")).parent
-    assert skill == host / "skill", "prompt must point to the host execution copy"
+    assert skill.resolve() == (host / "skill").resolve(), "prompt must point to the host execution copy"
     subprocess.run([sys.executable, str(skill / "scripts/main.py")], check=True)
 `)
     for (const host of ["codex", "claude"]) {
@@ -260,7 +263,7 @@ else:
     const out = path.join(root, "pack")
     const result = call("pack.ts", ["--hosts", "codex,claude", "--arm", "post", "--id", "fixture/pass", "--out", out], {
       CE_FAKE_PYTHON: python ?? undefined, CE_FAKE_HOST_SCRIPT: hostScript,
-      PYTHONDONTWRITEBYTECODE: undefined, PYTHONPYCACHEPREFIX: undefined,
+      PYTHONDONTWRITEBYTECODE: "1", PYTHONPYCACHEPREFIX: path.join(root, "external-cache"),
     })
     expect(result.status, result.stderr).toBe(0)
     const cell = path.join(out, "fixture__pass/post")

--- a/tests/skill-eval-cell/pack.ts
+++ b/tests/skill-eval-cell/pack.ts
@@ -175,7 +175,7 @@ function main() {
         }
         const graded = gradeArm({ out, scenario: snapshot, arm })
         if (graded.grades.length === 0) throw new Error("no host results were collected")
-        Object.assign(info, graded, { status: "graded" })
+        Object.assign(info, graded, { status: "graded", grade_result_sha256: valueHash(graded) })
       } catch (error) {
         Object.assign(info, { status: "collection-error", error: String(error), ok: false })
       }

--- a/tests/skill-eval-cell/pack.ts
+++ b/tests/skill-eval-cell/pack.ts
@@ -181,7 +181,6 @@ function main() {
       }
       writeJSON(packPath, pack)
     }
-    ;(pack.scenarios as Record<string, unknown>)[scenario.id] = row
   }
 
   pack.finished_at = new Date().toISOString()

--- a/tests/skill-eval-cell/pack.ts
+++ b/tests/skill-eval-cell/pack.ts
@@ -19,6 +19,7 @@ import {
 import { arg, flag } from "./cli"
 import { REPO_ROOT } from "./extract"
 import { gradeArm, type EvalArm } from "./grade"
+import { PACK_SCHEMA_VERSION, graderFingerprint, prepareOutput, valueHash, verifyEvidence, verifyWorkspaceGradePaths, writeJSON } from "./provenance"
 
 type Arm = EvalArm | "ab"
 
@@ -49,9 +50,9 @@ function hasBaseline(scenario: Scenario): boolean {
 function runCell(scenario: Scenario, arm: EvalArm, out: string, hosts?: string) {
   const ref = resolveArmRef(scenario, arm)
   if (!ref) throw new Error(`${scenario.id}: no ref for arm ${arm}`)
-  const taskFile = path.join(out, "task.md")
-  fs.mkdirSync(out, { recursive: true })
-  fs.writeFileSync(taskFile, scenario.task)
+  const taskFile = path.join(path.dirname(out), `${arm}-task.md`)
+  fs.mkdirSync(path.dirname(out), { recursive: true })
+  fs.writeFileSync(taskFile, scenario.task, { flag: "wx" })
   const argv = [
     "bun",
     path.join(import.meta.dir, "run.ts"),
@@ -88,8 +89,8 @@ function runCell(scenario: Scenario, arm: EvalArm, out: string, hosts?: string) 
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
   })
-  fs.writeFileSync(path.join(out, "pack-stdout.txt"), r.stdout)
-  fs.writeFileSync(path.join(out, "pack-stderr.txt"), r.stderr)
+  fs.writeFileSync(path.join(path.dirname(out), `${arm}-collector-stdout.txt`), r.stdout ?? "")
+  fs.writeFileSync(path.join(path.dirname(out), `${arm}-collector-stderr.txt`), r.stderr ?? "")
   if (r.status !== 0) {
     throw new Error(
       `${scenario.id} ${arm} cell failed (exit ${r.status})\n${r.stderr}\n${r.stdout}`,
@@ -135,9 +136,13 @@ function main() {
 
   const stamp = new Date().toISOString().replace(/[:.]/g, "-")
   const explicitOut = arg("--out")
-  const root = explicitOut ?? fs.mkdtempSync(path.join(os.tmpdir(), `ce-skill-eval-pack-${stamp}-`))
-  if (explicitOut) fs.mkdirSync(root, { recursive: true })
-  const pack: Record<string, unknown> = { root, arm: requested, scenarios: {} }
+  const root = prepareOutput(explicitOut ?? fs.mkdtempSync(path.join(os.tmpdir(), `ce-skill-eval-pack-${stamp}-`)))
+  const pack: Record<string, unknown> = {
+    schema_version: PACK_SCHEMA_VERSION, root, arm: requested,
+    started_at: new Date().toISOString(), grader: graderFingerprint(), scenarios: {},
+  }
+  const packPath = path.join(root, "pack.json")
+  writeJSON(packPath, pack)
 
   for (const scenario of selected) {
     const arms = armsFor(scenario, requested)
@@ -145,25 +150,42 @@ function main() {
       console.error(`warning: ${scenario.id} has no ${requested} arm; skip`)
       continue
     }
-    const row: Record<string, unknown> = { id: scenario.id, skill: scenario.skill, arms: {} }
+    const snapshot = JSON.parse(JSON.stringify(scenario)) as Scenario
+    const row: Record<string, unknown> = {
+      id: scenario.id, skill: scenario.skill,
+      scenario_snapshot: snapshot, scenario_sha256: valueHash(snapshot), arms: {},
+    }
+    ;(pack.scenarios as Record<string, unknown>)[scenario.id] = row
     for (const arm of arms) {
       const out = path.join(root, scenario.id.replaceAll("/", "__"), arm)
       console.error(`running ${scenario.id} ${arm} → ${out}`)
-      const summaryPath = runCell(scenario, arm, out, hosts)
-      const graded = gradeArm({ out, scenario, arm })
-      ;(row.arms as Record<string, unknown>)[arm] = {
-        out,
-        summary: summaryPath,
-        grades: graded.grades,
-        ok: graded.ok,
-        pointer_ok: graded.pointer_ok,
+      const info: Record<string, unknown> = {
+        out, out_relative: path.relative(root, out).split(path.sep).join("/"),
+        status: "collecting", ok: false,
       }
+      ;(row.arms as Record<string, unknown>)[arm] = info
+      writeJSON(packPath, pack)
+      try {
+        verifyWorkspaceGradePaths((snapshot.grade.workspace_contains ?? []).map((check) => check.path))
+        info.summary = runCell(snapshot, arm, out, hosts)
+        verifyEvidence(out)
+        info.evidence_sha256 = valueHash(JSON.parse(fs.readFileSync(path.join(out, "evidence-manifest.json"), "utf8")))
+        if (graderFingerprint().sha256 !== (pack.grader as { sha256: string }).sha256) {
+          throw new Error("grader changed during collection")
+        }
+        const graded = gradeArm({ out, scenario: snapshot, arm })
+        if (graded.grades.length === 0) throw new Error("no host results were collected")
+        Object.assign(info, graded, { status: "graded" })
+      } catch (error) {
+        Object.assign(info, { status: "collection-error", error: String(error), ok: false })
+      }
+      writeJSON(packPath, pack)
     }
     ;(pack.scenarios as Record<string, unknown>)[scenario.id] = row
   }
 
-  const packPath = path.join(root, "pack.json")
-  fs.writeFileSync(packPath, `${JSON.stringify(pack, null, 2)}\n`)
+  pack.finished_at = new Date().toISOString()
+  writeJSON(packPath, pack)
   console.log(packPath)
   // Exit status is the verdict: a caller running this as a check must not read a
   // failed arm as a pass. The artifact is written first so failures stay diagnosable.
@@ -185,4 +207,7 @@ function main() {
   }
 }
 
-main()
+try { main() } catch (error) {
+  console.error(error)
+  process.exitCode = 2
+}

--- a/tests/skill-eval-cell/provenance.test.ts
+++ b/tests/skill-eval-cell/provenance.test.ts
@@ -1,5 +1,4 @@
-import { test } from "bun:test"
-import assert from "node:assert/strict"
+import { expect, test } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -11,8 +10,8 @@ function inTemp(work: (dir: string) => void) {
 }
 
 test("JSON object order is stable; array order is significant", () => {
-  assert.equal(valueHash({ b: 2, a: [1, 2] }), valueHash({ a: [1, 2], b: 2 }))
-  assert.notEqual(valueHash([1, 2]), valueHash([2, 1]))
+  expect(valueHash({ b: 2, a: [1, 2] })).toBe(valueHash({ a: [1, 2], b: 2 }))
+  expect(valueHash([1, 2])).not.toBe(valueHash([2, 1]))
 })
 
 test("fingerprint does not depend on absolute root or creation order", () => inTemp((dir) => {
@@ -20,7 +19,7 @@ test("fingerprint does not depend on absolute root or creation order", () => inT
   fs.mkdirSync(a); fs.mkdirSync(b)
   fs.writeFileSync(path.join(a, "two"), "2"); fs.writeFileSync(path.join(a, "one"), "1")
   fs.writeFileSync(path.join(b, "one"), "1"); fs.writeFileSync(path.join(b, "two"), "2")
-  assert.equal(fingerprint(a).sha256, fingerprint(b).sha256)
+  expect(fingerprint(a).sha256).toBe(fingerprint(b).sha256)
 }))
 
 test("byte edits, renames and empty directory changes change the fingerprint", () => inTemp((dir) => {
@@ -29,65 +28,65 @@ test("byte edits, renames and empty directory changes change the fingerprint", (
   fs.writeFileSync(f, "b"); const b = fingerprint(dir).sha256
   fs.renameSync(f, path.join(dir, "other")); const c = fingerprint(dir).sha256
   fs.mkdirSync(path.join(dir, "empty")); const d = fingerprint(dir).sha256
-  assert.equal(new Set([a, b, c, d]).size, 4)
+  expect(new Set([a, b, c, d]).size).toBe(4)
 }))
 
 test("mtime changes do not change fingerprints", () => inTemp((dir) => {
   const f = path.join(dir, "data")
   fs.writeFileSync(f, "same"); const before = fingerprint(dir).sha256
   fs.utimesSync(f, 1000, 1000)
-  assert.equal(fingerprint(dir).sha256, before)
+  expect(fingerprint(dir).sha256).toBe(before)
 }))
 
 test("git internals are explicitly excluded", () => inTemp((dir) => {
   fs.mkdirSync(path.join(dir, ".git")); const before = fingerprint(dir).sha256
   fs.writeFileSync(path.join(dir, ".git", "config"), "private remote")
-  assert.equal(fingerprint(dir).sha256, before)
+  expect(fingerprint(dir).sha256).toBe(before)
 }))
 
 test("missing selected fingerprint roots fail closed", () => inTemp((dir) => {
-  assert.throws(() => fingerprint(dir, ["missing"]))
+  expect(() => fingerprint(dir, ["missing"])).toThrow()
 }))
 
 test("reserved output cannot be reused", () => inTemp((dir) => {
   const out = path.join(dir, "out")
-  assert.equal(prepareOutput(out), out)
-  assert.throws(() => prepareOutput(out), /empty/)
+  expect(prepareOutput(out)).toBe(out)
+  expect(() => prepareOutput(out)).toThrow(/empty/)
 }))
 
 test("nonempty outputs keep their original bytes", () => inTemp((dir) => {
   fs.writeFileSync(path.join(dir, "result"), "keep")
-  assert.throws(() => prepareOutput(dir), /empty/)
-  assert.equal(fs.readFileSync(path.join(dir, "result"), "utf8"), "keep")
+  expect(() => prepareOutput(dir)).toThrow(/empty/)
+  expect(fs.readFileSync(path.join(dir, "result"), "utf8")).toBe("keep")
 }))
 
 test("exclusive reports refuse overwrites", () => inTemp((dir) => {
   const file = path.join(dir, "report.json")
   writeJSON(file, { original: true }, true)
-  assert.throws(() => writeJSON(file, { original: false }, true))
-  assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf8")), { original: true })
+  expect(() => writeJSON(file, { original: false }, true)).toThrow()
+  expect(JSON.parse(fs.readFileSync(file, "utf8"))).toEqual({ original: true })
 }))
 
 test("collector snapshots replace only their owned destination with valid JSON", () => inTemp((dir) => {
   const file = path.join(dir, "pack.json")
   writeJSON(file, { stage: 1 }); writeJSON(file, { stage: 2 })
-  assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf8")), { stage: 2 })
-  assert.deepEqual(fs.readdirSync(dir), ["pack.json"])
+  expect(JSON.parse(fs.readFileSync(file, "utf8"))).toEqual({ stage: 2 })
+  expect(fs.readdirSync(dir)).toEqual(["pack.json"])
 }))
 
 test("relative paths cannot escape the pack", () => inTemp((dir) => {
   for (const rel of ["", "..", "../x", "/etc/passwd", "C:\\temp", "a/../../b", "a//b"]) {
-    assert.throws(() => containedPath(dir, rel))
+    expect(() => containedPath(dir, rel)).toThrow()
   }
   fs.mkdirSync(path.join(dir, "inside"))
-  assert.equal(containedPath(dir, "inside"), path.join(fs.realpathSync(dir), "inside"))
+  expect(containedPath(dir, "inside")).toBe(path.join(fs.realpathSync(dir), "inside"))
 }))
 
 test("grader fingerprint changes when a dependency changes", () => inTemp((dir) => {
   for (const name of ["grade.ts", "hosts.ts", "path-shim.ts"]) fs.writeFileSync(path.join(dir, name), "old")
   const before = graderFingerprint(dir).sha256
   fs.writeFileSync(path.join(dir, "hosts.ts"), "new")
-  assert.notEqual(graderFingerprint(dir).sha256, before)
+  expect(graderFingerprint(dir).sha256).not.toBe(before)
 }))
 
 if (process.platform !== "win32") {
@@ -98,16 +97,16 @@ if (process.platform !== "win32") {
     fs.symlinkSync(outside, path.join(root, "link"))
     const before = fingerprint(root)
     fs.writeFileSync(path.join(outside, "secret"), "second")
-    assert.equal(fingerprint(root).sha256, before.sha256)
-    assert.equal(before.entries.length, 1)
-    assert.throws(() => containedPath(root, "link/secret"), /symlink/)
-    assert.throws(() => prepareOutput(path.join(root, "link")))
+    expect(fingerprint(root).sha256).toBe(before.sha256)
+    expect(before.entries.length).toBe(1)
+    expect(() => containedPath(root, "link/secret")).toThrow(/symlink/)
+    expect(() => prepareOutput(path.join(root, "link"))).toThrow()
   }))
   test("executable-bit changes affect fingerprints", () => inTemp((dir) => {
     const file = path.join(dir, "script")
     fs.writeFileSync(file, "echo hello", { mode: 0o644 })
     const before = fingerprint(dir).sha256
     fs.chmodSync(file, 0o755)
-    assert.notEqual(fingerprint(dir).sha256, before)
+    expect(fingerprint(dir).sha256).not.toBe(before)
   }))
 }

--- a/tests/skill-eval-cell/provenance.test.ts
+++ b/tests/skill-eval-cell/provenance.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { fingerprint, valueHash, prepareOutput, containedPath, writeJSON, graderFingerprint } from "./provenance"
+import { fingerprint, valueHash, prepareOutput, containedPath, writeJSON, graderFingerprint, GRADER_FILES } from "./provenance"
 
 function inTemp(work: (dir: string) => void) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ce-provenance-test-"))
@@ -83,7 +83,7 @@ test("relative paths cannot escape the pack", () => inTemp((dir) => {
 }))
 
 test("grader fingerprint changes when a dependency changes", () => inTemp((dir) => {
-  for (const name of ["grade.ts", "hosts.ts", "path-shim.ts"]) fs.writeFileSync(path.join(dir, name), "old")
+  for (const name of GRADER_FILES) fs.writeFileSync(path.join(dir, name), "old")
   const before = graderFingerprint(dir).sha256
   fs.writeFileSync(path.join(dir, "hosts.ts"), "new")
   expect(graderFingerprint(dir).sha256).not.toBe(before)

--- a/tests/skill-eval-cell/provenance.test.ts
+++ b/tests/skill-eval-cell/provenance.test.ts
@@ -1,0 +1,113 @@
+import { test } from "bun:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { fingerprint, valueHash, prepareOutput, containedPath, writeJSON, graderFingerprint } from "./provenance"
+
+function inTemp(work: (dir: string) => void) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ce-provenance-test-"))
+  try { work(dir) } finally { fs.rmSync(dir, { recursive: true, force: true }) }
+}
+
+test("JSON object order is stable; array order is significant", () => {
+  assert.equal(valueHash({ b: 2, a: [1, 2] }), valueHash({ a: [1, 2], b: 2 }))
+  assert.notEqual(valueHash([1, 2]), valueHash([2, 1]))
+})
+
+test("fingerprint does not depend on absolute root or creation order", () => inTemp((dir) => {
+  const a = path.join(dir, "a"), b = path.join(dir, "b")
+  fs.mkdirSync(a); fs.mkdirSync(b)
+  fs.writeFileSync(path.join(a, "two"), "2"); fs.writeFileSync(path.join(a, "one"), "1")
+  fs.writeFileSync(path.join(b, "one"), "1"); fs.writeFileSync(path.join(b, "two"), "2")
+  assert.equal(fingerprint(a).sha256, fingerprint(b).sha256)
+}))
+
+test("byte edits, renames and empty directory changes change the fingerprint", () => inTemp((dir) => {
+  const f = path.join(dir, "data")
+  fs.writeFileSync(f, "a"); const a = fingerprint(dir).sha256
+  fs.writeFileSync(f, "b"); const b = fingerprint(dir).sha256
+  fs.renameSync(f, path.join(dir, "other")); const c = fingerprint(dir).sha256
+  fs.mkdirSync(path.join(dir, "empty")); const d = fingerprint(dir).sha256
+  assert.equal(new Set([a, b, c, d]).size, 4)
+}))
+
+test("mtime changes do not change fingerprints", () => inTemp((dir) => {
+  const f = path.join(dir, "data")
+  fs.writeFileSync(f, "same"); const before = fingerprint(dir).sha256
+  fs.utimesSync(f, 1000, 1000)
+  assert.equal(fingerprint(dir).sha256, before)
+}))
+
+test("git internals are explicitly excluded", () => inTemp((dir) => {
+  fs.mkdirSync(path.join(dir, ".git")); const before = fingerprint(dir).sha256
+  fs.writeFileSync(path.join(dir, ".git", "config"), "private remote")
+  assert.equal(fingerprint(dir).sha256, before)
+}))
+
+test("missing selected fingerprint roots fail closed", () => inTemp((dir) => {
+  assert.throws(() => fingerprint(dir, ["missing"]))
+}))
+
+test("reserved output cannot be reused", () => inTemp((dir) => {
+  const out = path.join(dir, "out")
+  assert.equal(prepareOutput(out), out)
+  assert.throws(() => prepareOutput(out), /empty/)
+}))
+
+test("nonempty outputs keep their original bytes", () => inTemp((dir) => {
+  fs.writeFileSync(path.join(dir, "result"), "keep")
+  assert.throws(() => prepareOutput(dir), /empty/)
+  assert.equal(fs.readFileSync(path.join(dir, "result"), "utf8"), "keep")
+}))
+
+test("exclusive reports refuse overwrites", () => inTemp((dir) => {
+  const file = path.join(dir, "report.json")
+  writeJSON(file, { original: true }, true)
+  assert.throws(() => writeJSON(file, { original: false }, true))
+  assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf8")), { original: true })
+}))
+
+test("collector snapshots replace only their owned destination with valid JSON", () => inTemp((dir) => {
+  const file = path.join(dir, "pack.json")
+  writeJSON(file, { stage: 1 }); writeJSON(file, { stage: 2 })
+  assert.deepEqual(JSON.parse(fs.readFileSync(file, "utf8")), { stage: 2 })
+  assert.deepEqual(fs.readdirSync(dir), ["pack.json"])
+}))
+
+test("relative paths cannot escape the pack", () => inTemp((dir) => {
+  for (const rel of ["", "..", "../x", "/etc/passwd", "C:\\temp", "a/../../b", "a//b"]) {
+    assert.throws(() => containedPath(dir, rel))
+  }
+  fs.mkdirSync(path.join(dir, "inside"))
+  assert.equal(containedPath(dir, "inside"), path.join(fs.realpathSync(dir), "inside"))
+}))
+
+test("grader fingerprint changes when a dependency changes", () => inTemp((dir) => {
+  for (const name of ["grade.ts", "hosts.ts", "path-shim.ts"]) fs.writeFileSync(path.join(dir, name), "old")
+  const before = graderFingerprint(dir).sha256
+  fs.writeFileSync(path.join(dir, "hosts.ts"), "new")
+  assert.notEqual(graderFingerprint(dir).sha256, before)
+}))
+
+if (process.platform !== "win32") {
+  test("symlink targets are not followed and symlink paths are refused", () => inTemp((dir) => {
+    const outside = path.join(dir, "outside"), root = path.join(dir, "root")
+    fs.mkdirSync(outside); fs.mkdirSync(root)
+    fs.writeFileSync(path.join(outside, "secret"), "first")
+    fs.symlinkSync(outside, path.join(root, "link"))
+    const before = fingerprint(root)
+    fs.writeFileSync(path.join(outside, "secret"), "second")
+    assert.equal(fingerprint(root).sha256, before.sha256)
+    assert.equal(before.entries.length, 1)
+    assert.throws(() => containedPath(root, "link/secret"), /symlink/)
+    assert.throws(() => prepareOutput(path.join(root, "link")))
+  }))
+  test("executable-bit changes affect fingerprints", () => inTemp((dir) => {
+    const file = path.join(dir, "script")
+    fs.writeFileSync(file, "echo hello", { mode: 0o644 })
+    const before = fingerprint(dir).sha256
+    fs.chmodSync(file, 0o755)
+    assert.notEqual(fingerprint(dir).sha256, before)
+  }))
+}

--- a/tests/skill-eval-cell/provenance.ts
+++ b/tests/skill-eval-cell/provenance.ts
@@ -1,0 +1,171 @@
+import { createHash, randomUUID } from "node:crypto"
+import fs from "node:fs"
+import path from "node:path"
+
+export const PACK_SCHEMA_VERSION = 2
+export const GRADER_FILES = ["grade.ts", "hosts.ts", "path-shim.ts"]
+const EVIDENCE_ROOTS = ["extract", "workspace", "hosts", "summary.json", "input-manifest.json", "task.md"]
+
+type Entry = { path: string; kind: "file" | "directory" | "symlink"; sha256?: string; executable?: boolean }
+export type Fingerprint = { sha256: string; entries: Entry[] }
+
+export function sha256(bytes: string | Buffer): string {
+  return createHash("sha256").update(bytes).digest("hex")
+}
+
+/** Object key order is irrelevant; array order and exact file bytes are not. */
+export function canonicalJSON(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    const json = JSON.stringify(value)
+    if (json === undefined) throw new Error("value is not JSON-serializable")
+    return json
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJSON).join(",")}]`
+  return `{${Object.entries(value as Record<string, unknown>)
+    .filter(([, item]) => item !== undefined)
+    .sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0)
+    .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJSON(item)}`).join(",")}}`
+}
+
+export function valueHash(value: unknown): string {
+  return sha256(canonicalJSON(value))
+}
+
+/** Do not dereference symlinks or read .git internals, sockets, devices or FIFOs. */
+export function fingerprint(root: string, roots?: string[]): Fingerprint {
+  const entries: Entry[] = []
+  function visit(rel: string) {
+    if (rel.split("/").includes(".git")) return
+    const file = path.join(root, rel)
+    const stat = fs.lstatSync(file)
+    if (stat.isSymbolicLink()) {
+      entries.push({ path: rel, kind: "symlink", sha256: sha256(fs.readlinkSync(file)) })
+    } else if (stat.isDirectory()) {
+      entries.push({ path: rel, kind: "directory" })
+      for (const name of fs.readdirSync(file).sort()) visit(rel ? `${rel}/${name}` : name)
+    } else if (stat.isFile()) {
+      entries.push({ path: rel, kind: "file", sha256: sha256(fs.readFileSync(file)), executable: Boolean(stat.mode & 0o111) })
+    } else {
+      throw new Error(`unsupported evidence file type: ${rel}`)
+    }
+  }
+  for (const rel of (roots ?? fs.readdirSync(root)).slice().sort()) visit(rel)
+  return { sha256: valueHash(entries), entries }
+}
+
+export function graderFingerprint(dir = import.meta.dir): Fingerprint {
+  for (const file of GRADER_FILES) {
+    if (!fs.lstatSync(path.join(dir, file)).isFile()) throw new Error(`grader is not a regular file: ${file}`)
+  }
+  return fingerprint(dir, GRADER_FILES)
+}
+
+/** Workspace criteria may read only paths covered by the evidence fingerprint. */
+export function verifyWorkspaceGradePaths(paths: string[]): void {
+  for (const relative of paths) {
+    if (typeof relative !== "string" || !relative || path.isAbsolute(relative) ||
+        relative.includes("\\") || relative.includes(":") ||
+        relative.split("/").some((part) => !part || part === "." || part === ".." || part === ".git")) {
+      throw new Error(`unsafe or unsealed workspace grade path: ${relative}`)
+    }
+  }
+}
+
+/** Refuse existing evidence rather than deleting it to obtain a clean workspace. */
+export function prepareOutput(dir: string): string {
+  const absolute = path.resolve(dir)
+  fs.mkdirSync(absolute, { recursive: true })
+  if (fs.lstatSync(absolute).isSymbolicLink() || fs.readdirSync(absolute).length !== 0) {
+    throw new Error(`output must be an empty, non-symlink directory: ${absolute}`)
+  }
+  // Atomic reservation prevents two collectors claiming the same empty directory.
+  fs.writeFileSync(path.join(absolute, ".eval-owner"), `${randomUUID()}\n`, { flag: "wx", mode: 0o600 })
+  return absolute
+}
+
+export function writeJSON(file: string, value: unknown, exclusive = false): void {
+  const body = `${JSON.stringify(value, null, 2)}\n`
+  if (exclusive) {
+    fs.writeFileSync(file, body, { flag: "wx", mode: 0o600 })
+    return
+  }
+  // Only collectors replace their own in-progress summaries. Regrades use wx.
+  const temp = `${file}.${randomUUID()}.tmp`
+  try {
+    fs.writeFileSync(temp, body, { flag: "wx", mode: 0o600 })
+    fs.renameSync(temp, file)
+  } finally {
+    try { fs.unlinkSync(temp) } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    }
+  }
+}
+
+export function sealEvidence(out: string): string {
+  const manifest = {
+    schema_version: 1,
+    roots: EVIDENCE_ROOTS,
+    fingerprint: fingerprint(out, EVIDENCE_ROOTS),
+    exclusions: [".git internals", "symlink target contents", "provider state", "user configuration and credentials"],
+  }
+  writeJSON(path.join(out, "evidence-manifest.json"), manifest, true)
+  return valueHash(manifest)
+}
+
+export function verifyEvidence(out: string, expectedManifestHash?: string): void {
+  const file = path.join(out, "evidence-manifest.json")
+  if (!fs.lstatSync(file).isFile()) throw new Error("evidence manifest must be a regular file")
+  const manifest = JSON.parse(fs.readFileSync(file, "utf8"))
+  if (manifest.schema_version !== 1 || canonicalJSON(manifest.roots) !== canonicalJSON(EVIDENCE_ROOTS)) {
+    throw new Error("unsupported evidence manifest")
+  }
+  if ((expectedManifestHash && valueHash(manifest) !== expectedManifestHash) ||
+      !Array.isArray(manifest.fingerprint?.entries) ||
+      valueHash(manifest.fingerprint.entries) !== manifest.fingerprint.sha256 ||
+      fingerprint(out, EVIDENCE_ROOTS).sha256 !== manifest.fingerprint.sha256) {
+    throw new Error(`evidence changed or is incomplete: ${out}`)
+  }
+  // grade.ts can read paths. Links would let it read target bytes we did not seal.
+  if (manifest.fingerprint.entries.some((entry: Entry) => entry.kind === "symlink")) {
+    throw new Error("historical regrading does not support symlink evidence")
+  }
+  const summary = JSON.parse(fs.readFileSync(path.join(out, "summary.json"), "utf8"))
+  const input = JSON.parse(fs.readFileSync(path.join(out, "input-manifest.json"), "utf8"))
+  const skillDir = containedPath(out, `extract/skills/${summary.skill}`)
+  if (input.schema_version !== 1 || input.task_sha256 !== sha256(fs.readFileSync(path.join(out, "task.md"))) ||
+      input.skill?.sha256 !== fingerprint(skillDir).sha256 ||
+      input.initial_workspace?.sha256 !== fingerprint(path.join(out, "workspace")).sha256) {
+    throw new Error("recorded inputs differ from collected bytes")
+  }
+  if (!Array.isArray(summary.hosts_run) || summary.hosts_run.length === 0 ||
+      new Set(summary.hosts_run).size !== summary.hosts_run.length) {
+    throw new Error("no unique host results were collected")
+  }
+  for (const host of summary.hosts_run) {
+    if (!["claude", "codex", "grok", "opencode"].includes(host)) throw new Error("unknown recorded host")
+    const dir = containedPath(out, `hosts/${host}`)
+    for (const name of ["stdout.txt", "stderr.txt", "exit.json", "prompt.md", "argv.json", "git-status.txt", "git-head-files.txt"]) {
+      if (!fs.lstatSync(path.join(dir, name)).isFile()) throw new Error(`missing regular host evidence: ${name}`)
+    }
+    const exit = JSON.parse(fs.readFileSync(path.join(dir, "exit.json"), "utf8"))
+    if (!(exit.exitCode === null || Number.isInteger(exit.exitCode)) || typeof exit.timedOut !== "boolean") {
+      throw new Error("invalid exit evidence")
+    }
+  }
+}
+
+/** Packs are relocatable. Never trust an archived absolute out path. */
+export function containedPath(root: string, relative: string): string {
+  if (typeof relative !== "string" || !relative || path.isAbsolute(relative) ||
+      relative.includes("\\") || relative.includes(":") ||
+      relative.split("/").some((part) => !part || part === "." || part === "..")) {
+    throw new Error(`invalid relative evidence path: ${relative}`)
+  }
+  const base = fs.realpathSync(root)
+  let current = base
+  for (const part of relative.split("/")) {
+    current = path.join(current, part)
+    if (fs.lstatSync(current).isSymbolicLink()) throw new Error(`symlink in evidence path: ${relative}`)
+  }
+  return current
+}

--- a/tests/skill-eval-cell/provenance.ts
+++ b/tests/skill-eval-cell/provenance.ts
@@ -3,7 +3,10 @@ import fs from "node:fs"
 import path from "node:path"
 
 export const PACK_SCHEMA_VERSION = 2
-export const GRADER_FILES = ["grade.ts", "hosts.ts", "path-shim.ts"]
+// The trusted assessment path, not only gradeArm's immediate dependencies.
+// Original mode does not query catalog.ts: its mutable criteria are separately
+// snapshotted. Include the entry point and evidence/root helpers, not just scoring.
+export const GRADER_FILES = ["extract.ts", "grade.ts", "hosts.ts", "path-shim.ts", "provenance.ts", "regrade.ts"]
 const EVIDENCE_ROOTS = ["extract", "workspace", "hosts", "summary.json", "input-manifest.json", "task.md"]
 
 type Entry = { path: string; kind: "file" | "directory" | "symlink"; sha256?: string; executable?: boolean }

--- a/tests/skill-eval-cell/regrade.ts
+++ b/tests/skill-eval-cell/regrade.ts
@@ -1,24 +1,60 @@
 import { randomUUID } from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
-import type { Scenario } from "./catalog"
+import { scenarioById, type Grade, type Scenario } from "./catalog"
+import { REPO_ROOT } from "./extract"
 import { gradeArm, type EvalArm, type ArmGrade } from "./grade"
-import { PACK_SCHEMA_VERSION, containedPath, graderFingerprint, sha256, valueHash, verifyEvidence, verifyWorkspaceGradePaths, writeJSON } from "./provenance"
+import { PACK_SCHEMA_VERSION, containedPath, fingerprint, graderFingerprint, sha256, valueHash, verifyEvidence, verifyWorkspaceGradePaths, writeJSON } from "./provenance"
 
-/** No catalog lookup, archived source execution, saved-command replay, or source-pack mutation. */
-export function regradePack(packPath: string, useCurrentGrader = false): { reportPath: string; ok: boolean } {
+export type RegradeMode = "current" | "original"
+
+/** Criteria can change; a recorded run still answers its original task under its original controls. */
+function collectionContext(scenario: Scenario) {
+  return {
+    skill: scenario.skill, task: scenario.task, fixture: scenario.fixture ?? null,
+    read_only: scenario.read_only, timeout_secs: scenario.timeout_secs ?? 600,
+    git_init: scenario.git_init ?? false, git_remote: scenario.git_remote ?? false,
+    git_untracked: scenario.git_untracked ?? [], git_staged: scenario.git_staged ?? [],
+    shim_git_push: scenario.shim_git_push ?? false, shim_gh_pr: scenario.shim_gh_pr ?? false,
+  }
+}
+
+/** An absent observation mechanism cannot prove the absence of an action. */
+function missingObservations(out: string, scenario: Scenario, grade: Grade): string | undefined {
+  const summary = JSON.parse(fs.readFileSync(path.join(out, "summary.json"), "utf8"))
+  for (const host of summary.hosts_run) {
+    const dir = path.join(out, "hosts", host)
+    if ((grade.git || grade.committed_must?.length || grade.committed_must_not?.length) &&
+        fs.readFileSync(path.join(dir, "git-status.txt"), "utf8").startsWith("(not a git repo)")) {
+      return `${host}: Git observations required by the criteria were not collected`
+    }
+    if (grade.shim_log_must_not?.length) {
+      const bins = [scenario.shim_git_push ? "git" : null, scenario.shim_gh_pr ? "gh" : null].filter(Boolean) as string[]
+      if (bins.length === 0 || bins.some((bin) => !fs.existsSync(path.join(dir, ".bin", bin)))) {
+        return `${host}: command shims required by the criteria were not installed`
+      }
+    }
+    if (grade.workspace_contains?.length && !fs.existsSync(path.join(dir, "workspace"))) {
+      return `${host}: workspace observations required by the criteria were not collected`
+    }
+  }
+}
+
+/** Assess sealed observations with trusted local code; never execute archives or replace the source pack. */
+export function regradePack(packPath: string, mode: RegradeMode = "current"): { reportPath: string; ok: boolean } {
+  if (mode !== "current" && mode !== "original") throw new Error("mode must be current or original")
   if (!fs.lstatSync(packPath).isFile()) throw new Error("pack must be a regular file")
   const originalBytes = fs.readFileSync(packPath)
   const pack = JSON.parse(originalBytes.toString("utf8"))
   if (pack.schema_version !== PACK_SCHEMA_VERSION || !pack.scenarios ||
       !pack.grader || !Array.isArray(pack.grader.entries) ||
       valueHash(pack.grader.entries) !== pack.grader.sha256) {
-    throw new Error("pack lacks frozen provenance; legacy packs cannot be reproduced safely")
+    throw new Error("pack lacks frozen provenance; legacy packs are not supported")
   }
   const currentGrader = graderFingerprint()
   const changedGrader = currentGrader.sha256 !== pack.grader.sha256
-  if (changedGrader && !useCurrentGrader) {
-    throw new Error("grader changed; use the original checkout or explicitly pass --use-current-grader")
+  if (mode === "original" && changedGrader) {
+    throw new Error("grader changed; original mode requires a trusted checkout matching the recorded grader")
   }
   const root = path.dirname(path.resolve(packPath))
   const rows: Record<string, unknown> = {}
@@ -29,10 +65,14 @@ export function regradePack(packPath: string, useCurrentGrader = false): { repor
       scenario_snapshot: Scenario; scenario_sha256: string;
       arms: Record<string, { status: string; out_relative: string; evidence_sha256: string } & Partial<ArmGrade>>;
     }
-    const scenario = row.scenario_snapshot
-    if (!scenario || scenario.id !== id || valueHash(scenario) !== row.scenario_sha256 || !row.arms) {
+    const original = row.scenario_snapshot
+    if (!original || original.id !== id || valueHash(original) !== row.scenario_sha256 || !row.arms) {
       throw new Error(`frozen scenario missing or changed: ${id}`)
     }
+    const current = mode === "current" ? scenarioById(id) : original
+    // Copy the selected criteria once; later catalog edits cannot change this assessment.
+    const usedGrade: Grade | null = current ? JSON.parse(JSON.stringify(current.grade)) : null
+    const contextChanged = current && valueHash(collectionContext(current)) !== valueHash(collectionContext(original))
     const results: Record<string, unknown> = {}
     for (const [arm, info] of Object.entries(row.arms)) {
       if (!["pre", "post", "preview"].includes(arm)) throw new Error(`invalid arm: ${arm}`)
@@ -45,13 +85,28 @@ export function regradePack(packPath: string, useCurrentGrader = false): { repor
       if (!/^[a-f0-9]{64}$/.test(info.evidence_sha256 ?? "")) throw new Error("missing evidence hash")
       const out = containedPath(root, info.out_relative)
       verifyEvidence(out, info.evidence_sha256)
-      if (fs.readFileSync(path.join(out, "task.md"), "utf8") !== scenario.task) {
+      if (fs.readFileSync(path.join(out, "task.md"), "utf8") !== original.task) {
         throw new Error("frozen task differs from the collected task")
       }
-      // Evidence verification already refuses symlinks. Missing workspace files
-      // remain grade failures; traversal and fingerprint exclusions are invalid inputs.
-      verifyWorkspaceGradePaths((scenario.grade.workspace_contains ?? []).map((check) => check.path))
-      const grade = gradeArm({ out, scenario, arm: arm as EvalArm })
+      let unavailable = !current ? "scenario is absent from the current catalog" :
+        contextChanged ? "task or collection controls changed; collect a new run" : undefined
+      if (!unavailable && mode === "current" && current?.fixture) {
+        const fixture = path.join(REPO_ROOT, current.fixture)
+        const input = JSON.parse(fs.readFileSync(path.join(out, "input-manifest.json"), "utf8"))
+        if (!fs.existsSync(fixture) || fingerprint(fixture).sha256 !== input.initial_workspace.sha256) {
+          unavailable = "fixture contents changed; collect a new run"
+        }
+      }
+      if (usedGrade) {
+        verifyWorkspaceGradePaths((usedGrade.workspace_contains ?? []).map((check) => check.path))
+        if (mode === "current") unavailable ??= missingObservations(out, original, usedGrade)
+      }
+      if (unavailable || !usedGrade) {
+        ok = false
+        results[arm] = { status: "not-assessable", reason: unavailable, ok: false }
+        continue
+      }
+      const grade = gradeArm({ out, scenario: { ...original, grade: usedGrade }, arm: arm as EvalArm })
       verifyEvidence(out, info.evidence_sha256)
       results[arm] = {
         status: "regraded", ...grade,
@@ -59,15 +114,19 @@ export function regradePack(packPath: string, useCurrentGrader = false): { repor
       }
       ok = ok && grade.ok && grade.grades.length > 0
     }
-    rows[id] = { scenario_sha256: row.scenario_sha256, arms: results }
+    rows[id] = {
+      scenario_sha256: row.scenario_sha256,
+      original_grade_sha256: valueHash(original.grade),
+      used_grade: usedGrade, used_grade_sha256: usedGrade ? valueHash(usedGrade) : null,
+      arms: results,
+    }
   }
   if (count === 0) throw new Error("pack contains no arms")
   if (graderFingerprint().sha256 !== currentGrader.sha256) throw new Error("grader changed while regrading")
   if (sha256(fs.readFileSync(packPath)) !== sha256(originalBytes)) throw new Error("source pack changed while regrading")
   const reportPath = path.join(root, `${path.basename(packPath, ".json")}.regrade-${randomUUID()}.json`)
   writeJSON(reportPath, {
-    schema_version: 1, created_at: new Date().toISOString(),
-    assessment: changedGrader ? "changed-grader" : "original-grader",
+    schema_version: 1, created_at: new Date().toISOString(), mode, grader_changed: changedGrader,
     source_pack: path.basename(packPath), source_pack_sha256: sha256(originalBytes),
     original_grader: pack.grader, used_grader: currentGrader,
     scenarios: rows, ok,
@@ -78,10 +137,12 @@ export function regradePack(packPath: string, useCurrentGrader = false): { repor
 if (import.meta.main) {
   try {
     const [packPath, ...flags] = process.argv.slice(2)
-    if (!packPath || flags.some((flag) => flag !== "--use-current-grader")) {
-      throw new Error("usage: bun tests/skill-eval-cell/regrade.ts <pack.json> [--use-current-grader]")
+    const mode = flags.length === 0 ? "current" : flags[1]
+    if (!packPath || (flags.length !== 0 && (flags.length !== 2 || flags[0] !== "--mode")) ||
+        (mode !== "current" && mode !== "original")) {
+      throw new Error("usage: bun tests/skill-eval-cell/regrade.ts <pack.json> [--mode current|original]")
     }
-    const result = regradePack(packPath, flags.includes("--use-current-grader"))
+    const result = regradePack(packPath, mode)
     console.log(result.reportPath)
     process.exitCode = result.ok ? 0 : 1
   } catch (error) {

--- a/tests/skill-eval-cell/regrade.ts
+++ b/tests/skill-eval-cell/regrade.ts
@@ -63,7 +63,7 @@ export function regradePack(packPath: string, mode: RegradeMode = "current"): { 
   for (const [id, raw] of Object.entries(pack.scenarios)) {
     const row = raw as {
       scenario_snapshot: Scenario; scenario_sha256: string;
-      arms: Record<string, { status: string; out_relative: string; evidence_sha256: string } & Partial<ArmGrade>>;
+      arms: Record<string, { status: string; out_relative: string; evidence_sha256: string; grade_result_sha256: string } & Partial<ArmGrade>>;
     }
     const original = row.scenario_snapshot
     if (!original || original.id !== id || valueHash(original) !== row.scenario_sha256 || !row.arms) {
@@ -81,6 +81,13 @@ export function regradePack(packPath: string, mode: RegradeMode = "current"): { 
         ok = false
         results[arm] = { status: "not-regraded", original_status: info.status, ok: false }
         continue
+      }
+      const originalGrade = { grades: info.grades, ok: info.ok, pointer_ok: info.pointer_ok }
+      if (!Array.isArray(originalGrade.grades) || typeof originalGrade.ok !== "boolean" ||
+          typeof originalGrade.pointer_ok !== "boolean" ||
+          !/^[a-f0-9]{64}$/.test(info.grade_result_sha256 ?? "") ||
+          valueHash(originalGrade) !== info.grade_result_sha256) {
+        throw new Error(`original grade missing or changed: ${id} ${arm}`)
       }
       if (!/^[a-f0-9]{64}$/.test(info.evidence_sha256 ?? "")) throw new Error("missing evidence hash")
       const out = containedPath(root, info.out_relative)
@@ -103,14 +110,17 @@ export function regradePack(packPath: string, mode: RegradeMode = "current"): { 
       }
       if (unavailable || !usedGrade) {
         ok = false
-        results[arm] = { status: "not-assessable", reason: unavailable, ok: false }
+        results[arm] = {
+          status: "not-assessable", reason: unavailable, ok: false,
+          original_grade: originalGrade, original_grade_sha256: info.grade_result_sha256,
+        }
         continue
       }
       const grade = gradeArm({ out, scenario: { ...original, grade: usedGrade }, arm: arm as EvalArm })
       verifyEvidence(out, info.evidence_sha256)
       results[arm] = {
         status: "regraded", ...grade,
-        original_grade: { grades: info.grades, ok: info.ok, pointer_ok: info.pointer_ok },
+        original_grade: originalGrade, original_grade_sha256: info.grade_result_sha256,
       }
       ok = ok && grade.ok && grade.grades.length > 0
     }

--- a/tests/skill-eval-cell/regrade.ts
+++ b/tests/skill-eval-cell/regrade.ts
@@ -1,22 +1,91 @@
+import { randomUUID } from "node:crypto"
 import fs from "node:fs"
-import { scenarioById } from "./catalog"
-import { gradeArm, type EvalArm } from "./grade"
+import path from "node:path"
+import type { Scenario } from "./catalog"
+import { gradeArm, type EvalArm, type ArmGrade } from "./grade"
+import { PACK_SCHEMA_VERSION, containedPath, graderFingerprint, sha256, valueHash, verifyEvidence, verifyWorkspaceGradePaths, writeJSON } from "./provenance"
 
-const packPath = process.argv[2]
-if (!packPath) {
-  console.error("usage: bun tests/skill-eval-cell/regrade.ts <pack.json>")
-  process.exit(2)
+/** No catalog lookup, archived source execution, saved-command replay, or source-pack mutation. */
+export function regradePack(packPath: string, useCurrentGrader = false): { reportPath: string; ok: boolean } {
+  if (!fs.lstatSync(packPath).isFile()) throw new Error("pack must be a regular file")
+  const originalBytes = fs.readFileSync(packPath)
+  const pack = JSON.parse(originalBytes.toString("utf8"))
+  if (pack.schema_version !== PACK_SCHEMA_VERSION || !pack.scenarios ||
+      !pack.grader || !Array.isArray(pack.grader.entries) ||
+      valueHash(pack.grader.entries) !== pack.grader.sha256) {
+    throw new Error("pack lacks frozen provenance; legacy packs cannot be reproduced safely")
+  }
+  const currentGrader = graderFingerprint()
+  const changedGrader = currentGrader.sha256 !== pack.grader.sha256
+  if (changedGrader && !useCurrentGrader) {
+    throw new Error("grader changed; use the original checkout or explicitly pass --use-current-grader")
+  }
+  const root = path.dirname(path.resolve(packPath))
+  const rows: Record<string, unknown> = {}
+  let ok = true
+  let count = 0
+  for (const [id, raw] of Object.entries(pack.scenarios)) {
+    const row = raw as {
+      scenario_snapshot: Scenario; scenario_sha256: string;
+      arms: Record<string, { status: string; out_relative: string; evidence_sha256: string } & Partial<ArmGrade>>;
+    }
+    const scenario = row.scenario_snapshot
+    if (!scenario || scenario.id !== id || valueHash(scenario) !== row.scenario_sha256 || !row.arms) {
+      throw new Error(`frozen scenario missing or changed: ${id}`)
+    }
+    const results: Record<string, unknown> = {}
+    for (const [arm, info] of Object.entries(row.arms)) {
+      if (!["pre", "post", "preview"].includes(arm)) throw new Error(`invalid arm: ${arm}`)
+      count++
+      if (info.status !== "graded") {
+        ok = false
+        results[arm] = { status: "not-regraded", original_status: info.status, ok: false }
+        continue
+      }
+      if (!/^[a-f0-9]{64}$/.test(info.evidence_sha256 ?? "")) throw new Error("missing evidence hash")
+      const out = containedPath(root, info.out_relative)
+      verifyEvidence(out, info.evidence_sha256)
+      if (fs.readFileSync(path.join(out, "task.md"), "utf8") !== scenario.task) {
+        throw new Error("frozen task differs from the collected task")
+      }
+      // Evidence verification already refuses symlinks. Missing workspace files
+      // remain grade failures; traversal and fingerprint exclusions are invalid inputs.
+      verifyWorkspaceGradePaths((scenario.grade.workspace_contains ?? []).map((check) => check.path))
+      const grade = gradeArm({ out, scenario, arm: arm as EvalArm })
+      verifyEvidence(out, info.evidence_sha256)
+      results[arm] = {
+        status: "regraded", ...grade,
+        original_grade: { grades: info.grades, ok: info.ok, pointer_ok: info.pointer_ok },
+      }
+      ok = ok && grade.ok && grade.grades.length > 0
+    }
+    rows[id] = { scenario_sha256: row.scenario_sha256, arms: results }
+  }
+  if (count === 0) throw new Error("pack contains no arms")
+  if (graderFingerprint().sha256 !== currentGrader.sha256) throw new Error("grader changed while regrading")
+  if (sha256(fs.readFileSync(packPath)) !== sha256(originalBytes)) throw new Error("source pack changed while regrading")
+  const reportPath = path.join(root, `${path.basename(packPath, ".json")}.regrade-${randomUUID()}.json`)
+  writeJSON(reportPath, {
+    schema_version: 1, created_at: new Date().toISOString(),
+    assessment: changedGrader ? "changed-grader" : "original-grader",
+    source_pack: path.basename(packPath), source_pack_sha256: sha256(originalBytes),
+    original_grader: pack.grader, used_grader: currentGrader,
+    scenarios: rows, ok,
+  }, true)
+  return { reportPath, ok }
 }
-const pack = JSON.parse(fs.readFileSync(packPath, "utf8"))
-for (const [id, row] of Object.entries(pack.scenarios as Record<string, any>)) {
-  const scenario = scenarioById(id)
-  if (!scenario) continue
-  for (const [arm, info] of Object.entries(row.arms as Record<string, any>)) {
-    const graded = gradeArm({ out: info.out, scenario, arm: arm as EvalArm })
-    info.grades = graded.grades
-    info.ok = graded.ok
-    info.pointer_ok = graded.pointer_ok
+
+if (import.meta.main) {
+  try {
+    const [packPath, ...flags] = process.argv.slice(2)
+    if (!packPath || flags.some((flag) => flag !== "--use-current-grader")) {
+      throw new Error("usage: bun tests/skill-eval-cell/regrade.ts <pack.json> [--use-current-grader]")
+    }
+    const result = regradePack(packPath, flags.includes("--use-current-grader"))
+    console.log(result.reportPath)
+    process.exitCode = result.ok ? 0 : 1
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 2
   }
 }
-fs.writeFileSync(packPath, `${JSON.stringify(pack, null, 2)}\n`)
-console.log(packPath)

--- a/tests/skill-eval-cell/reproducibility.md
+++ b/tests/skill-eval-cell/reproducibility.md
@@ -1,0 +1,120 @@
+# Reproducible evaluation evidence
+
+This change preserves the inputs and evidence behind a grade. It does **not**
+make provider/model output deterministic or turn the runner into a sandbox.
+Existing host execution/permission policies are unchanged. Start with read-only
+cells; write-enabled cells retain their pre-existing permission policies.
+
+## Collection
+
+Use a new output directory for each `run.ts` or `pack.ts` invocation. A nonempty
+`--out` is now an error, before extraction or workspace replacement. A private
+`.eval-owner` marker reserves an empty directory against another collector.
+Do not delete that marker to resume an old run; choose a new directory instead.
+The collector updates only its own in-progress summaries, using same-directory
+rename so a normal interruption does not expose a half-written JSON summary.
+This is not a power-loss durability or hostile-local-process guarantee.
+
+Each cell writes:
+
+- `task.md`: exact task text.
+- `input-manifest.json`: actual extracted skill/initial workspace fingerprints,
+  task SHA-256, harness source fingerprints, requested ref and resolved commit,
+  timeout/Git options, runtime and explicitly unknown model state.
+- `hosts/<host>/runtime.json`: CLI path, bounded version probe, unknown model state.
+- The existing prompt, argv, output, exit and workspace evidence.
+- `evidence-manifest.json`: fingerprints of the evidence roots after collection.
+
+Fingerprints sort relative paths and hash exact bytes, entry types and executable
+bits. They include empty directories and do not depend on the absolute root or
+mtime. `.git` internals and symlink target contents are excluded. The Git status,
+commit/file summaries remain evidence, not a replacement for a complete Git clone.
+Symlinks are recorded without dereferencing; historical grading refuses such
+bundles because the grader could otherwise follow an unsealed target.
+Workspace criteria must address paths covered by the fingerprint. Traversal and
+`.git` path components are rejected before collection and historical grading,
+including when the requested file does not yet exist.
+
+For a committed ref, resolve once to a commit and extract that commit. For
+`WORKTREE`, HEAD is context only; the actual extracted content fingerprint is the
+identity. The initial skill/workspace and task fingerprints are checked against
+the collected bytes before grading.
+
+Do not edit the skill/harness/evidence while a collection or regrade is running.
+The checks detect ordinary drift, not an adversary replacing files and hashes
+consistently or changing them between a check and a read.
+
+## Packs and partial failure
+
+Schema-v2 packs retain each complete scenario snapshot, its hash, the initial
+result, and hashes of the grader's runtime dependencies. `grade.ts`, `hosts.ts`
+and `path-shim.ts` currently form that dependency set; update `GRADER_FILES` if
+that runtime import graph changes. Type-only catalog imports are not dependencies.
+
+`pack.json` is written before collection and after each arm. An arm records
+`collecting`, `graded`, or `collection-error`. Failed collection does not erase
+completed arms. It never becomes a passing grade. Nonzero host exits and timeouts
+remain their original grading failures, with their raw exit evidence preserved;
+an exit code alone is not enough to diagnose an infrastructure versus model error.
+
+A cell may still skip unavailable hosts under the original selection rules.
+`summary.json` records wanted/run/skipped hosts: a successful subset is not a
+claim that every requested host was tested. No-host collections fail.
+
+## Historical regrading
+
+```bash
+bun tests/skill-eval-cell/regrade.ts /absolute/path/to/pack.json
+```
+
+The command uses the **recorded scenario**, never the current catalog. It requires
+matching grader bytes and checks the evidence before and after grading. A new
+`pack.regrade-<uuid>.json` report is written alongside the input pack. The input
+pack and its original grades are never replaced. Reports identify the original
+pack hash and both original/used grader fingerprints. Exit 0 means passing,
+1 means failed/uncollected arms, and 2 means invalid input/integrity/usage.
+
+When intentionally applying a changed grader to old observations:
+
+```bash
+bun tests/skill-eval-cell/regrade.ts /absolute/path/to/pack.json --use-current-grader
+```
+
+This still uses the frozen criteria and checks evidence. The report says
+`changed-grader`; it is a new assessment, not proof of an agent improvement.
+Archived TypeScript and saved commands are **never executed**. To reproduce the
+original grader, use a trusted checkout matching the recorded dependency hashes.
+
+Move or copy the **whole pack directory**, not only pack.json. Relative cell paths
+are resolved beneath its current parent; obsolete absolute paths are not used.
+Legacy packs without frozen provenance are refused rather than silently using
+today's catalog. Preserve those originals; they cannot acquire missing historical
+provenance retrospectively.
+
+## Boundaries
+
+Host CLI versions are probed with a timeout and output cap. A failed probe records
+unknown, not a guessed version. No credentials, raw environment, or user config
+are copied by the new metadata code. Existing prompts/workspace/stdout/stderr may
+still contain sensitive material: review the **whole bundle** before sharing.
+
+No explicit model selector was added. Requested/observed model remain null because
+host defaults are inherited. User configuration/hooks, provider/model revisions,
+external tools and services, and host wall-clock effects are not frozen. Source
+hashes are recorded, not executable archives. This supports audit and historical
+regrading, not hermetic replay or cryptographic authenticity.
+
+## Mechanical tests
+
+```bash
+bun test --timeout 30000 \
+  tests/skill-eval-cell/provenance.test.ts \
+  tests/skill-eval-cell/reproducibility.test.ts \
+  tests/skill-eval-cell/integration-reproducibility.test.ts
+```
+
+These tests use temp files and a fake CLI, never a provider or real credentials.
+The integration tests copy the real driver modules into a temporary repo with a
+small synthetic catalog. Unix subprocess cases are not Windows-native coverage.
+Run `bun run test` in the complete checkout before merging. Mechanical success is
+not live-model behavioral validation.

--- a/tests/skill-eval-cell/reproducibility.md
+++ b/tests/skill-eval-cell/reproducibility.md
@@ -25,7 +25,10 @@ outputs are sealed too; they do not change the preserved input snapshot.
 context. Committed refs resolve once to a commit before extraction.
 
 Schema-v2 packs freeze each scenario, its original grades, and the grader's
-runtime dependency hashes. Atomic summary writes before collection and after
+runtime dependency hashes. Each completed arm seals the canonical
+`{ grades, ok, pointer_ok }` object as `grade_result_sha256`. Missing or changed
+result hashes are rejected before either reassessment mode reports an original
+grade; do not manufacture hashes for older unsealed results. Atomic summary writes before collection and after
 each arm retain completed progress when later collection fails. Arm status is
 `collecting`, `graded`, or `collection-error`. Host nonzero exits and timeouts
 remain failed grades with diagnostic evidence. Wanted, skipped, and actual hosts
@@ -59,7 +62,9 @@ be specified explicitly.
 
 Both modes verify evidence and write a new `pack.regrade-<uuid>.json` beside the
 pack. Reports retain the selected criteria and their hash, grader fingerprints,
-mode, source-pack hash, and results. A score change under a corrected criterion
+mode, source-pack hash, and results. A `not-assessable` arm retains its verified
+`original_grade` and result hash too; an uncollected arm has no grade to invent.
+A score change under a corrected criterion
 is a reassessment, not proof of model improvement. Compare old and new runs under
 the same criteria and grader when measuring improvement.
 
@@ -74,8 +79,11 @@ Fingerprints cover relative paths, bytes, entry kinds, executable bits, and empt
 directories, independent of root location and mtime. Git internals and symlink
 target contents are excluded. Both initial pack grading and regrading reject
 symlink evidence, traversal, and workspace criteria reading `.git` components.
-The runtime grader dependencies are `grade.ts`, `hosts.ts`, and `path-shim.ts`;
-update `GRADER_FILES` if their runtime import graph changes.
+The trusted assessment fingerprint includes `regrade.ts`, `provenance.ts`,
+`extract.ts`, `grade.ts`, `hosts.ts`, and `path-shim.ts`. Maintain `GRADER_FILES`
+when that assessment path changes, including orchestration and verification,
+not only immediate scoring imports. Mutable catalog criteria are snapshotted
+separately: editing or removing today's scenario must not block original mode.
 
 This is local consistency verification, not hermetic replay or authenticity
 against an actor replacing evidence and hashes together. User configuration,

--- a/tests/skill-eval-cell/reproducibility.md
+++ b/tests/skill-eval-cell/reproducibility.md
@@ -1,120 +1,91 @@
-# Reproducible evaluation evidence
+# Evaluation evidence and regrading
 
-This change preserves the inputs and evidence behind a grade. It does **not**
-make provider/model output deterministic or turn the runner into a sandbox.
-Existing host execution/permission policies are unchanged. Start with read-only
-cells; write-enabled cells retain their pre-existing permission policies.
+Collection preserves what ran and how it was first graded. Regrading creates a
+new assessment of those observations; it never replaces the original pack.
 
 ## Collection
 
-Use a new output directory for each `run.ts` or `pack.ts` invocation. A nonempty
-`--out` is now an error, before extraction or workspace replacement. A private
-`.eval-owner` marker reserves an empty directory against another collector.
-Do not delete that marker to resume an old run; choose a new directory instead.
-The collector updates only its own in-progress summaries, using same-directory
-rename so a normal interruption does not expose a half-written JSON summary.
-This is not a power-loss durability or hostile-local-process guarantee.
+Each `run.ts` or `pack.ts` invocation requires a new or empty `--out` directory.
+An exclusive `.eval-owner` marker reserves it against concurrent collectors.
+Choose a new directory for another run; removing the marker does not resume one.
 
-Each cell writes:
+Each cell records:
 
-- `task.md`: exact task text.
-- `input-manifest.json`: actual extracted skill/initial workspace fingerprints,
-  task SHA-256, harness source fingerprints, requested ref and resolved commit,
-  timeout/Git options, runtime and explicitly unknown model state.
-- `hosts/<host>/runtime.json`: CLI path, bounded version probe, unknown model state.
-- The existing prompt, argv, output, exit and workspace evidence.
-- `evidence-manifest.json`: fingerprints of the evidence roots after collection.
+| Artifact | Purpose |
+| --- | --- |
+| `extract/skills/<skill>/` | Preserved initial skill bytes |
+| `workspace/`, `task.md` | Initial workspace and exact task |
+| `input-manifest.json` | Skill/workspace/task/harness fingerprints, requested ref, resolved commit, execution controls, runtime |
+| `hosts/<host>/` | Independent skill and workspace copies, prompts, argv, CLI metadata, stdout/stderr, exits, Git observations |
+| `evidence-manifest.json` | Content fingerprints sealing the collected artifacts |
 
-Fingerprints sort relative paths and hash exact bytes, entry types and executable
-bits. They include empty directories and do not depend on the absolute root or
-mtime. `.git` internals and symlink target contents are excluded. The Git status,
-commit/file summaries remain evidence, not a replacement for a complete Git clone.
-Symlinks are recorded without dereferencing; historical grading refuses such
-bundles because the grader could otherwise follow an unsealed target.
-Workspace criteria must address paths covered by the fingerprint. Traversal and
-`.git` path components are rejected before collection and historical grading,
-including when the requested file does not yet exist.
+A host may create Python caches or other files in its own skill copy. Those
+outputs are sealed too; they do not change the preserved input snapshot.
+`WORKTREE` identifies the actual copied content, with HEAD recorded only as
+context. Committed refs resolve once to a commit before extraction.
 
-For a committed ref, resolve once to a commit and extract that commit. For
-`WORKTREE`, HEAD is context only; the actual extracted content fingerprint is the
-identity. The initial skill/workspace and task fingerprints are checked against
-the collected bytes before grading.
+Schema-v2 packs freeze each scenario, its original grades, and the grader's
+runtime dependency hashes. Atomic summary writes before collection and after
+each arm retain completed progress when later collection fails. Arm status is
+`collecting`, `graded`, or `collection-error`. Host nonzero exits and timeouts
+remain failed grades with diagnostic evidence. Wanted, skipped, and actual hosts
+are recorded; a passing subset does not establish coverage of unavailable hosts.
 
-Do not edit the skill/harness/evidence while a collection or regrade is running.
-The checks detect ordinary drift, not an adversary replacing files and hashes
-consistently or changing them between a check and a read.
-
-## Packs and partial failure
-
-Schema-v2 packs retain each complete scenario snapshot, its hash, the initial
-result, and hashes of the grader's runtime dependencies. `grade.ts`, `hosts.ts`
-and `path-shim.ts` currently form that dependency set; update `GRADER_FILES` if
-that runtime import graph changes. Type-only catalog imports are not dependencies.
-
-`pack.json` is written before collection and after each arm. An arm records
-`collecting`, `graded`, or `collection-error`. Failed collection does not erase
-completed arms. It never becomes a passing grade. Nonzero host exits and timeouts
-remain their original grading failures, with their raw exit evidence preserved;
-an exit code alone is not enough to diagnose an infrastructure versus model error.
-
-A cell may still skip unavailable hosts under the original selection rules.
-`summary.json` records wanted/run/skipped hosts: a successful subset is not a
-claim that every requested host was tested. No-host collections fail.
-
-## Historical regrading
+## Regrade
 
 ```bash
-bun tests/skill-eval-cell/regrade.ts /absolute/path/to/pack.json
+bun tests/skill-eval-cell/regrade.ts /path/to/pack.json
 ```
 
-The command uses the **recorded scenario**, never the current catalog. It requires
-matching grader bytes and checks the evidence before and after grading. A new
-`pack.regrade-<uuid>.json` report is written alongside the input pack. The input
-pack and its original grades are never replaced. Reports identify the original
-pack hash and both original/used grader fingerprints. Exit 0 means passing,
-1 means failed/uncollected arms, and 2 means invalid input/integrity/usage.
+The default `current` mode applies the current catalog's **grade criteria** and
+current trusted grader to the original observations. It preserves the original
+skill, task, fixture, and arm context. A missing catalog scenario, changed task or
+collection controls, changed fixture contents, or missing observation mechanism
+produces `not-assessable`, not a passing or failed behavioral grade. Missing a
+required output in a complete observation remains an ordinary grade failure.
 
-When intentionally applying a changed grader to old observations:
+To reproduce the original assessment:
 
 ```bash
-bun tests/skill-eval-cell/regrade.ts /absolute/path/to/pack.json --use-current-grader
+bun tests/skill-eval-cell/regrade.ts /path/to/pack.json --mode original
 ```
 
-This still uses the frozen criteria and checks evidence. The report says
-`changed-grader`; it is a new assessment, not proof of an agent improvement.
-Archived TypeScript and saved commands are **never executed**. To reproduce the
-original grader, use a trusted checkout matching the recorded dependency hashes.
+Original mode uses the frozen criteria and requires a trusted checkout matching
+the recorded grader hashes. It does not need the scenario in today's catalog.
+It reproduces that grader's original decisions, including rubric mistakes;
+observation-applicability checks belong to current reassessment.
+Archived source and saved commands are never executed. `--mode current` can also
+be specified explicitly.
 
-Move or copy the **whole pack directory**, not only pack.json. Relative cell paths
-are resolved beneath its current parent; obsolete absolute paths are not used.
-Legacy packs without frozen provenance are refused rather than silently using
-today's catalog. Preserve those originals; they cannot acquire missing historical
-provenance retrospectively.
+Both modes verify evidence and write a new `pack.regrade-<uuid>.json` beside the
+pack. Reports retain the selected criteria and their hash, grader fingerprints,
+mode, source-pack hash, and results. A score change under a corrected criterion
+is a reassessment, not proof of model improvement. Compare old and new runs under
+the same criteria and grader when measuring improvement.
 
-## Boundaries
+Exit 0 means passing; 1 means a failed grade, uncollected arm, or unassessable
+observation; 2 means invalid input, integrity, or usage. Move the whole pack to
+relocate it: relative cell paths are resolved beneath its current parent. Legacy
+packs without provenance are unsupported; do not fabricate historical metadata.
 
-Host CLI versions are probed with a timeout and output cap. A failed probe records
-unknown, not a guessed version. No credentials, raw environment, or user config
-are copied by the new metadata code. Existing prompts/workspace/stdout/stderr may
-still contain sensitive material: review the **whole bundle** before sharing.
+## Evidence limits and maintenance
 
-No explicit model selector was added. Requested/observed model remain null because
-host defaults are inherited. User configuration/hooks, provider/model revisions,
-external tools and services, and host wall-clock effects are not frozen. Source
-hashes are recorded, not executable archives. This supports audit and historical
-regrading, not hermetic replay or cryptographic authenticity.
+Fingerprints cover relative paths, bytes, entry kinds, executable bits, and empty
+directories, independent of root location and mtime. Git internals and symlink
+target contents are excluded. Both initial pack grading and regrading reject
+symlink evidence, traversal, and workspace criteria reading `.git` components.
+The runtime grader dependencies are `grade.ts`, `hosts.ts`, and `path-shim.ts`;
+update `GRADER_FILES` if their runtime import graph changes.
 
-## Mechanical tests
+This is local consistency verification, not hermetic replay or authenticity
+against an actor replacing evidence and hashes together. User configuration,
+hooks, provider state, and external resources are not frozen. CLI version probes
+are bounded; requested/observed models remain unknown when inherited from host
+configuration. No new metadata dumps credentials, but existing transcripts and
+workspace files may contain sensitive material. Host permission policies are
+unchanged. Do not edit source or evidence during collection or assessment.
 
-```bash
-bun test --timeout 30000 \
-  tests/skill-eval-cell/provenance.test.ts \
-  tests/skill-eval-cell/reproducibility.test.ts \
-  tests/skill-eval-cell/integration-reproducibility.test.ts
-```
-
-These tests use temp files and a fake CLI, never a provider or real credentials.
-The integration tests copy the real driver modules into a temporary repo with a
-small synthetic catalog. Unix subprocess cases are not Windows-native coverage.
-Run `bun run test` in the complete checkout before merging. Mechanical success is
-not live-model behavioral validation.
+The provenance, regrading, and fake-CLI integration tests run in `bun run test`.
+They exercise actual driver modules in temporary repositories, including Python
+import side effects, without provider calls. They do not establish live-model
+behavior or Windows-native driver support.

--- a/tests/skill-eval-cell/reproducibility.test.ts
+++ b/tests/skill-eval-cell/reproducibility.test.ts
@@ -1,0 +1,198 @@
+import { test } from "bun:test"
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { gradeArm } from "./grade"
+import type { Scenario } from "./catalog"
+import { PACK_SCHEMA_VERSION, fingerprint, graderFingerprint, sealEvidence, sha256, valueHash, verifyEvidence, writeJSON } from "./provenance"
+import { regradePack } from "./regrade"
+
+function fixture(work: (ctx: ReturnType<typeof make>) => void) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ce-regrade-test-"))
+  try { work(make(root)) } finally { fs.rmSync(root, { recursive: true, force: true }) }
+}
+
+function make(root: string) {
+  const out = path.join(root, "case", "post")
+  const hostDir = path.join(out, "hosts", "codex")
+  const skillDir = path.join(out, "extract", "skills", "fixture")
+  for (const dir of [skillDir, path.join(out, "workspace"), path.join(hostDir, "workspace")]) fs.mkdirSync(dir, { recursive: true })
+  fs.writeFileSync(path.join(skillDir, "SKILL.md"), "fixture skill")
+  fs.writeFileSync(path.join(out, "task.md"), "task")
+  writeJSON(path.join(out, "summary.json"), { skill: "fixture", hosts_run: ["codex"] })
+  writeJSON(path.join(out, "input-manifest.json"), {
+    schema_version: 1, task_sha256: sha256("task"),
+    skill: fingerprint(skillDir), initial_workspace: fingerprint(path.join(out, "workspace")),
+  })
+  fs.writeFileSync(path.join(hostDir, "stdout.txt"), "proof\nFILES_READ: SKILL.md\nACTIONS: none\nDELEGATES_DISPATCHED: none\n")
+  for (const name of ["stderr.txt", "prompt.md", "git-status.txt", "git-head-files.txt"]) fs.writeFileSync(path.join(hostDir, name), "")
+  writeJSON(path.join(hostDir, "argv.json"), ["fake-codex"])
+  writeJSON(path.join(hostDir, "exit.json"), { exitCode: 0, timedOut: false })
+  const evidence_sha256 = sealEvidence(out)
+  const scenario: Scenario = {
+    id: "not-in-live-catalog", skill: "fixture", cohort: "untouched", key_behavior: "judgment",
+    read_only: true, why: "regression", pre_contract: "proof", task: "task",
+    grade: { must_include: ["proof"], actions: "none", delegates: "none" },
+  }
+  const pack = {
+    schema_version: PACK_SCHEMA_VERSION, grader: graderFingerprint(),
+    scenarios: { [scenario.id]: {
+      scenario_snapshot: scenario, scenario_sha256: valueHash(scenario),
+      arms: { post: {
+        ...gradeArm({ out, scenario, arm: "post" }), status: "graded",
+        out: "/obsolete/location", out_relative: "case/post", evidence_sha256,
+      } },
+    } },
+  }
+  const packPath = path.join(root, "pack.json")
+  const save = () => writeJSON(packPath, pack)
+  const reseal = () => {
+    fs.unlinkSync(path.join(out, "evidence-manifest.json"))
+    pack.scenarios[scenario.id].arms.post.evidence_sha256 = sealEvidence(out)
+    save()
+  }
+  save()
+  return { root, out, hostDir, pack, scenario, packPath, save, reseal }
+}
+
+test("regrade uses archived criteria without a live catalog entry and preserves the source", () => fixture(({ packPath }) => {
+  const before = fs.readFileSync(packPath)
+  const result = regradePack(packPath)
+  assert.equal(result.ok, true)
+  assert.notEqual(result.reportPath, packPath)
+  assert.deepEqual(fs.readFileSync(packPath), before)
+  const report = JSON.parse(fs.readFileSync(result.reportPath, "utf8"))
+  assert.equal(report.assessment, "original-grader")
+  assert.equal(report.source_pack_sha256, sha256(before))
+}))
+
+test("successive regrades produce distinct files", () => fixture(({ packPath }) => {
+  assert.notEqual(regradePack(packPath).reportPath, regradePack(packPath).reportPath)
+}))
+
+test("changed frozen criteria are rejected", () => fixture(({ pack, scenario, save, packPath }) => {
+  pack.scenarios[scenario.id].scenario_snapshot.grade.must_include = ["not present"]
+  save()
+  assert.throws(() => regradePack(packPath), /scenario/)
+}))
+
+test("changed grader needs explicit consent and gets a distinct assessment", () => fixture(({ pack, save, packPath }) => {
+  pack.grader.entries[0].sha256 = "a".repeat(64)
+  pack.grader.sha256 = valueHash(pack.grader.entries)
+  save()
+  assert.throws(() => regradePack(packPath), /grader changed/)
+  const result = regradePack(packPath, true)
+  assert.equal(JSON.parse(fs.readFileSync(result.reportPath, "utf8")).assessment, "changed-grader")
+}))
+
+test("changed stdout is detected before grading", () => fixture(({ hostDir, packPath }) => {
+  fs.writeFileSync(path.join(hostDir, "stdout.txt"), "changed")
+  assert.throws(() => regradePack(packPath), /evidence/)
+}))
+
+test("deleted exit evidence is not a vacuous pass", () => fixture(({ hostDir, packPath }) => {
+  fs.unlinkSync(path.join(hostDir, "exit.json"))
+  assert.throws(() => regradePack(packPath))
+}))
+
+test("added workspace files invalidate the evidence", () => fixture(({ hostDir, packPath }) => {
+  fs.writeFileSync(path.join(hostDir, "workspace", "unexpected.txt"), "extra")
+  assert.throws(() => regradePack(packPath), /evidence/)
+}))
+
+test("a relocated whole pack regrades without archived absolute paths", () => fixture(({ root }) => {
+  const relocated = fs.mkdtempSync(path.join(os.tmpdir(), "ce-regrade-moved-"))
+  try {
+    fs.cpSync(root, relocated, { recursive: true })
+    assert.equal(regradePack(path.join(relocated, "pack.json")).ok, true)
+  } finally { fs.rmSync(relocated, { recursive: true, force: true }) }
+}))
+
+test("a collection error remains ungraded rather than a pass", () => fixture(({ pack, scenario, save, packPath }) => {
+  pack.scenarios[scenario.id].arms.post.status = "collection-error"
+  save()
+  const result = regradePack(packPath)
+  assert.equal(result.ok, false)
+  assert.equal(JSON.parse(fs.readFileSync(result.reportPath, "utf8")).scenarios[scenario.id].arms.post.status, "not-regraded")
+}))
+
+test("a timeout is reproduced as a failed grade", () => fixture(({ hostDir, reseal, packPath }) => {
+  writeJSON(path.join(hostDir, "exit.json"), { exitCode: null, timedOut: true })
+  reseal()
+  assert.equal(regradePack(packPath).ok, false)
+}))
+
+test("a nonzero host exit is reproduced as a failed grade", () => fixture(({ hostDir, reseal, packPath }) => {
+  writeJSON(path.join(hostDir, "exit.json"), { exitCode: 7, timedOut: false })
+  reseal()
+  assert.equal(regradePack(packPath).ok, false)
+}))
+
+test("an empty recorded host set is rejected even if resealed", () => fixture(({ out, reseal, packPath }) => {
+  writeJSON(path.join(out, "summary.json"), { skill: "fixture", hosts_run: [] })
+  reseal()
+  assert.throws(() => regradePack(packPath), /host/)
+}))
+
+test("recorded absolute paths cannot redirect the regrader", () => fixture(({ pack, scenario, save, packPath }) => {
+  pack.scenarios[scenario.id].arms.post.out_relative = "../outside"
+  save()
+  assert.throws(() => regradePack(packPath), /relative/)
+}))
+
+test("unsealed changes to the initial skill cannot be laundered by resealing outputs", () => fixture(({ out, reseal, packPath }) => {
+  fs.writeFileSync(path.join(out, "extract/skills/fixture/SKILL.md"), "changed")
+  reseal()
+  assert.throws(() => regradePack(packPath), /inputs/)
+}))
+
+test("frozen task and collected task must agree", () => fixture(({ pack, scenario, save, packPath }) => {
+  scenario.task = "another task"
+  pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
+  save()
+  assert.throws(() => regradePack(packPath), /task/)
+}))
+
+test("unsafe grading paths cannot read outside the evidence", () => fixture(({ pack, scenario, save, packPath }) => {
+  scenario.grade.workspace_contains = [{ path: "../../../private", needle: "secret" }]
+  pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
+  save()
+  assert.throws(() => regradePack(packPath), /unsafe/)
+}))
+
+test("excluded git contents cannot become historical grading evidence", () => fixture(({ hostDir, out, pack, scenario, save, packPath }) => {
+  for (const relative of [".git/config", "nested/.git/config"]) {
+    const file = path.join(hostDir, "workspace", relative)
+    scenario.grade.workspace_contains = [{ path: relative, needle: "proof" }]
+    pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
+    save()
+    // Excluded paths are invalid even if currently absent.
+    assert.throws(() => regradePack(packPath), /unsealed workspace grade path/)
+    if (relative === ".git/config") {
+      fs.mkdirSync(path.dirname(file), { recursive: true })
+      fs.writeFileSync(file, "proof")
+      verifyEvidence(out)
+      assert.throws(() => regradePack(packPath), /unsealed workspace grade path/)
+      fs.writeFileSync(file, "changed without changing the evidence hash")
+      verifyEvidence(out)
+      assert.throws(() => regradePack(packPath), /unsealed workspace grade path/)
+    }
+  }
+}))
+
+test("legacy packs are refused without modifying them", () => fixture(({ packPath }) => {
+  writeJSON(packPath, { scenarios: {} })
+  const before = fs.readFileSync(packPath)
+  assert.throws(() => regradePack(packPath), /legacy/)
+  assert.deepEqual(fs.readFileSync(packPath), before)
+}))
+
+if (process.platform !== "win32") {
+  test("symlink evidence cannot escape fingerprint verification", () => fixture(({ hostDir, out, reseal, packPath }) => {
+    fs.symlinkSync("/etc/passwd", path.join(hostDir, "workspace", "link"))
+    reseal()
+    assert.throws(() => verifyEvidence(out), /symlink/)
+    assert.throws(() => regradePack(packPath), /symlink/)
+  }))
+}

--- a/tests/skill-eval-cell/reproducibility.test.ts
+++ b/tests/skill-eval-cell/reproducibility.test.ts
@@ -34,12 +34,13 @@ function make(root: string) {
     read_only: true, why: "regression", pre_contract: "proof", task: "task",
     grade: { must_include: ["proof"], actions: "none", delegates: "none" },
   }
+  const initialGrade = gradeArm({ out, scenario, arm: "post" })
   const pack = {
     schema_version: PACK_SCHEMA_VERSION, grader: graderFingerprint(),
     scenarios: { [scenario.id]: {
       scenario_snapshot: scenario, scenario_sha256: valueHash(scenario),
       arms: { post: {
-        ...gradeArm({ out, scenario, arm: "post" }), status: "graded",
+        ...initialGrade, status: "graded", grade_result_sha256: valueHash(initialGrade),
         out: "/obsolete/location", out_relative: "case/post", evidence_sha256,
       } },
     } },

--- a/tests/skill-eval-cell/reproducibility.test.ts
+++ b/tests/skill-eval-cell/reproducibility.test.ts
@@ -1,5 +1,4 @@
-import { test } from "bun:test"
-import assert from "node:assert/strict"
+import { expect, test } from "bun:test"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -58,107 +57,208 @@ function make(root: string) {
 
 test("regrade uses archived criteria without a live catalog entry and preserves the source", () => fixture(({ packPath }) => {
   const before = fs.readFileSync(packPath)
-  const result = regradePack(packPath)
-  assert.equal(result.ok, true)
-  assert.notEqual(result.reportPath, packPath)
-  assert.deepEqual(fs.readFileSync(packPath), before)
+  const result = regradePack(packPath, "original")
+  expect(result.ok).toBe(true)
+  expect(result.reportPath).not.toBe(packPath)
+  expect(fs.readFileSync(packPath)).toEqual(before)
   const report = JSON.parse(fs.readFileSync(result.reportPath, "utf8"))
-  assert.equal(report.assessment, "original-grader")
-  assert.equal(report.source_pack_sha256, sha256(before))
+  expect(report.mode).toBe("original")
+  expect(report.grader_changed).toBe(false)
+  expect(report.source_pack_sha256).toBe(sha256(before))
+}))
+
+test("default current mode does not fall back to archived criteria for an absent scenario", () => fixture(({ scenario, packPath }) => {
+  const before = fs.readFileSync(packPath)
+  const result = regradePack(packPath)
+  const report = JSON.parse(fs.readFileSync(result.reportPath, "utf8"))
+  expect(result.ok).toBe(false)
+  expect(report.mode).toBe("current")
+  expect(report.scenarios[scenario.id].used_grade).toBeNull()
+  expect(report.scenarios[scenario.id].used_grade_sha256).toBeNull()
+  expect(report.scenarios[scenario.id].arms.post).toMatchObject({
+    status: "not-assessable", reason: "scenario is absent from the current catalog", ok: false,
+  })
+  expect(fs.readFileSync(packPath)).toEqual(before)
+}))
+
+test("invalid modes are refused without writing an assessment", () => fixture(({ root, packPath }) => {
+  const before = fs.readFileSync(packPath)
+  // Exercise the runtime boundary used by untyped callers.
+  // @ts-expect-error invalid modes must also be rejected at runtime
+  expect(() => regradePack(packPath, "unknown")).toThrow(/mode must be current or original/)
+  expect(fs.readFileSync(packPath)).toEqual(before)
+  expect(fs.readdirSync(root).filter((name) => name.includes(".regrade-"))).toEqual([])
 }))
 
 test("successive regrades produce distinct files", () => fixture(({ packPath }) => {
-  assert.notEqual(regradePack(packPath).reportPath, regradePack(packPath).reportPath)
+  expect(regradePack(packPath, "original").reportPath).not.toBe(regradePack(packPath, "original").reportPath)
 }))
 
 test("changed frozen criteria are rejected", () => fixture(({ pack, scenario, save, packPath }) => {
   pack.scenarios[scenario.id].scenario_snapshot.grade.must_include = ["not present"]
   save()
-  assert.throws(() => regradePack(packPath), /scenario/)
+  expect(() => regradePack(packPath, "original")).toThrow(/scenario/)
 }))
 
-test("changed grader needs explicit consent and gets a distinct assessment", () => fixture(({ pack, save, packPath }) => {
+test("original grading refuses changed grader bytes", () => fixture(({ root, pack, save, packPath }) => {
   pack.grader.entries[0].sha256 = "a".repeat(64)
   pack.grader.sha256 = valueHash(pack.grader.entries)
   save()
-  assert.throws(() => regradePack(packPath), /grader changed/)
-  const result = regradePack(packPath, true)
-  assert.equal(JSON.parse(fs.readFileSync(result.reportPath, "utf8")).assessment, "changed-grader")
+  const before = fs.readFileSync(packPath)
+  expect(() => regradePack(packPath, "original")).toThrow(/grader changed/)
+  expect(fs.readFileSync(packPath)).toEqual(before)
+  expect(fs.readdirSync(root).filter((name) => name.includes(".regrade-"))).toEqual([])
 }))
 
 test("changed stdout is detected before grading", () => fixture(({ hostDir, packPath }) => {
   fs.writeFileSync(path.join(hostDir, "stdout.txt"), "changed")
-  assert.throws(() => regradePack(packPath), /evidence/)
+  expect(() => regradePack(packPath, "original")).toThrow(/evidence/)
 }))
 
 test("deleted exit evidence is not a vacuous pass", () => fixture(({ hostDir, packPath }) => {
   fs.unlinkSync(path.join(hostDir, "exit.json"))
-  assert.throws(() => regradePack(packPath))
+  expect(() => regradePack(packPath, "original")).toThrow()
 }))
 
 test("added workspace files invalidate the evidence", () => fixture(({ hostDir, packPath }) => {
   fs.writeFileSync(path.join(hostDir, "workspace", "unexpected.txt"), "extra")
-  assert.throws(() => regradePack(packPath), /evidence/)
+  expect(() => regradePack(packPath, "original")).toThrow(/evidence/)
 }))
 
 test("a relocated whole pack regrades without archived absolute paths", () => fixture(({ root }) => {
   const relocated = fs.mkdtempSync(path.join(os.tmpdir(), "ce-regrade-moved-"))
   try {
     fs.cpSync(root, relocated, { recursive: true })
-    assert.equal(regradePack(path.join(relocated, "pack.json")).ok, true)
+    expect(regradePack(path.join(relocated, "pack.json"), "original").ok).toBe(true)
   } finally { fs.rmSync(relocated, { recursive: true, force: true }) }
 }))
 
 test("a collection error remains ungraded rather than a pass", () => fixture(({ pack, scenario, save, packPath }) => {
   pack.scenarios[scenario.id].arms.post.status = "collection-error"
   save()
-  const result = regradePack(packPath)
-  assert.equal(result.ok, false)
-  assert.equal(JSON.parse(fs.readFileSync(result.reportPath, "utf8")).scenarios[scenario.id].arms.post.status, "not-regraded")
+  const result = regradePack(packPath, "original")
+  expect(result.ok).toBe(false)
+  expect(JSON.parse(fs.readFileSync(result.reportPath, "utf8")).scenarios[scenario.id].arms.post.status).toBe("not-regraded")
+}))
+
+test("an interrupted arm remains incomplete even without a cell directory", () => fixture(({ out, pack, scenario, save, packPath }) => {
+  pack.scenarios[scenario.id].arms.post.status = "collecting"
+  save()
+  const before = fs.readFileSync(packPath)
+  fs.rmSync(out, { recursive: true })
+  const result = regradePack(packPath, "original")
+  const report = JSON.parse(fs.readFileSync(result.reportPath, "utf8"))
+  expect(result.ok).toBe(false)
+  expect(report.scenarios[scenario.id].arms.post).toMatchObject({
+    status: "not-regraded", original_status: "collecting", ok: false,
+  })
+  expect(fs.readFileSync(packPath)).toEqual(before)
+}))
+
+test("an absent required workspace file fails grading and preserves the original verdict", () => fixture(({ pack, scenario, save, packPath }) => {
+  scenario.grade.workspace_contains = [{ path: "missing.txt", needle: "proof" }]
+  pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
+  save()
+  const before = fs.readFileSync(packPath)
+  const result = regradePack(packPath, "original")
+  const report = JSON.parse(fs.readFileSync(result.reportPath, "utf8"))
+  const arm = report.scenarios[scenario.id].arms.post
+  expect(result.ok).toBe(false)
+  expect(arm.status).toBe("regraded")
+  expect(arm.grades[0].reasons).toContain('missing.txt does not contain "proof"')
+  expect(arm.original_grade.ok).toBe(true)
+  expect(fs.readFileSync(packPath)).toEqual(before)
+}))
+
+test("original mode preserves the historical grader's pass on empty Git observations", () => fixture(({ pack, scenario, save, packPath }) => {
+  scenario.grade.git = "clean"
+  pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
+  save()
+  const before = fs.readFileSync(packPath)
+  const result = regradePack(packPath, "original")
+  const arm = JSON.parse(fs.readFileSync(result.reportPath, "utf8")).scenarios[scenario.id].arms.post
+  // Reproducing the original grade must preserve its observation gap.
+  expect(result.ok).toBe(true)
+  expect(arm.status).toBe("regraded")
+  expect(arm.grades).toEqual(pack.scenarios[scenario.id].arms.post.grades)
+  expect(fs.readFileSync(packPath)).toEqual(before)
+}))
+
+for (const configured of [false, true]) {
+  test(`original mode preserves the historical pass with no command shim (configured: ${configured})`, () => fixture(({ pack, scenario, save, packPath }) => {
+    scenario.shim_git_push = configured ? true : undefined
+    scenario.grade.shim_log_must_not = ["git push"]
+    pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
+    save()
+    const before = fs.readFileSync(packPath)
+    const result = regradePack(packPath, "original")
+    const arm = JSON.parse(fs.readFileSync(result.reportPath, "utf8")).scenarios[scenario.id].arms.post
+    // Availability checks belong to current assessment, not historical reproduction.
+    expect(result.ok).toBe(true)
+    expect(arm.status).toBe("regraded")
+    expect(arm.grades).toEqual(pack.scenarios[scenario.id].arms.post.grades)
+    expect(fs.readFileSync(packPath)).toEqual(before)
+  }))
+}
+
+test("an installed command shim without an invocation log proves no recorded push", () => fixture(({ hostDir, pack, scenario, reseal, packPath }) => {
+  scenario.shim_git_push = true
+  scenario.grade.shim_log_must_not = ["git push"]
+  pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
+  fs.mkdirSync(path.join(hostDir, ".bin"))
+  fs.writeFileSync(path.join(hostDir, ".bin", "git"), "#!/bin/sh\nexit 1\n", { mode: 0o755 })
+  reseal()
+  const before = fs.readFileSync(packPath)
+  const result = regradePack(packPath, "original")
+  const arm = JSON.parse(fs.readFileSync(result.reportPath, "utf8")).scenarios[scenario.id].arms.post
+  expect(result.ok).toBe(true)
+  expect(arm.status).toBe("regraded")
+  expect(arm.grades[0].reasons).toEqual([])
+  expect(fs.readFileSync(packPath)).toEqual(before)
 }))
 
 test("a timeout is reproduced as a failed grade", () => fixture(({ hostDir, reseal, packPath }) => {
   writeJSON(path.join(hostDir, "exit.json"), { exitCode: null, timedOut: true })
   reseal()
-  assert.equal(regradePack(packPath).ok, false)
+  expect(regradePack(packPath, "original").ok).toBe(false)
 }))
 
 test("a nonzero host exit is reproduced as a failed grade", () => fixture(({ hostDir, reseal, packPath }) => {
   writeJSON(path.join(hostDir, "exit.json"), { exitCode: 7, timedOut: false })
   reseal()
-  assert.equal(regradePack(packPath).ok, false)
+  expect(regradePack(packPath, "original").ok).toBe(false)
 }))
 
 test("an empty recorded host set is rejected even if resealed", () => fixture(({ out, reseal, packPath }) => {
   writeJSON(path.join(out, "summary.json"), { skill: "fixture", hosts_run: [] })
   reseal()
-  assert.throws(() => regradePack(packPath), /host/)
+  expect(() => regradePack(packPath, "original")).toThrow(/host/)
 }))
 
 test("recorded absolute paths cannot redirect the regrader", () => fixture(({ pack, scenario, save, packPath }) => {
   pack.scenarios[scenario.id].arms.post.out_relative = "../outside"
   save()
-  assert.throws(() => regradePack(packPath), /relative/)
+  expect(() => regradePack(packPath, "original")).toThrow(/relative/)
 }))
 
 test("unsealed changes to the initial skill cannot be laundered by resealing outputs", () => fixture(({ out, reseal, packPath }) => {
   fs.writeFileSync(path.join(out, "extract/skills/fixture/SKILL.md"), "changed")
   reseal()
-  assert.throws(() => regradePack(packPath), /inputs/)
+  expect(() => regradePack(packPath, "original")).toThrow(/inputs/)
 }))
 
 test("frozen task and collected task must agree", () => fixture(({ pack, scenario, save, packPath }) => {
   scenario.task = "another task"
   pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
   save()
-  assert.throws(() => regradePack(packPath), /task/)
+  expect(() => regradePack(packPath, "original")).toThrow(/task/)
 }))
 
 test("unsafe grading paths cannot read outside the evidence", () => fixture(({ pack, scenario, save, packPath }) => {
   scenario.grade.workspace_contains = [{ path: "../../../private", needle: "secret" }]
   pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
   save()
-  assert.throws(() => regradePack(packPath), /unsafe/)
+  expect(() => regradePack(packPath, "original")).toThrow(/unsafe/)
 }))
 
 test("excluded git contents cannot become historical grading evidence", () => fixture(({ hostDir, out, pack, scenario, save, packPath }) => {
@@ -168,15 +268,15 @@ test("excluded git contents cannot become historical grading evidence", () => fi
     pack.scenarios[scenario.id].scenario_sha256 = valueHash(scenario)
     save()
     // Excluded paths are invalid even if currently absent.
-    assert.throws(() => regradePack(packPath), /unsealed workspace grade path/)
+    expect(() => regradePack(packPath, "original")).toThrow(/unsealed workspace grade path/)
     if (relative === ".git/config") {
       fs.mkdirSync(path.dirname(file), { recursive: true })
       fs.writeFileSync(file, "proof")
       verifyEvidence(out)
-      assert.throws(() => regradePack(packPath), /unsealed workspace grade path/)
+      expect(() => regradePack(packPath, "original")).toThrow(/unsealed workspace grade path/)
       fs.writeFileSync(file, "changed without changing the evidence hash")
       verifyEvidence(out)
-      assert.throws(() => regradePack(packPath), /unsealed workspace grade path/)
+      expect(() => regradePack(packPath, "original")).toThrow(/unsealed workspace grade path/)
     }
   }
 }))
@@ -184,15 +284,15 @@ test("excluded git contents cannot become historical grading evidence", () => fi
 test("legacy packs are refused without modifying them", () => fixture(({ packPath }) => {
   writeJSON(packPath, { scenarios: {} })
   const before = fs.readFileSync(packPath)
-  assert.throws(() => regradePack(packPath), /legacy/)
-  assert.deepEqual(fs.readFileSync(packPath), before)
+  expect(() => regradePack(packPath, "original")).toThrow(/legacy/)
+  expect(fs.readFileSync(packPath)).toEqual(before)
 }))
 
 if (process.platform !== "win32") {
   test("symlink evidence cannot escape fingerprint verification", () => fixture(({ hostDir, out, reseal, packPath }) => {
     fs.symlinkSync("/etc/passwd", path.join(hostDir, "workspace", "link"))
     reseal()
-    assert.throws(() => verifyEvidence(out), /symlink/)
-    assert.throws(() => regradePack(packPath), /symlink/)
+    expect(() => verifyEvidence(out)).toThrow(/symlink/)
+    expect(() => regradePack(packPath, "original")).toThrow(/symlink/)
   }))
 }

--- a/tests/skill-eval-cell/review-integrity.test.ts
+++ b/tests/skill-eval-cell/review-integrity.test.ts
@@ -1,0 +1,150 @@
+import { test } from "bun:test"
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { valueHash } from "./provenance"
+
+// Exercise collection and fresh-process reassessment, not a second hash allowlist.
+// The fake executable is first on PATH; no real provider or credentials are used.
+function fixture(work: (ctx: ReturnType<typeof setup>) => void) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "ce-review-integrity-"))
+  try { work(setup(root)) } finally { fs.rmSync(root, { recursive: true, force: true }) }
+}
+function setup(root: string) {
+  const repo = path.join(root, "repo"), dir = path.join(repo, "tests/skill-eval-cell")
+  const bin = path.join(root, "bin"), out = path.join(root, "pack")
+  fs.mkdirSync(dir, { recursive: true }); fs.mkdirSync(bin)
+  for (const file of ["run.ts", "pack.ts", "regrade.ts", "provenance.ts", "grade.ts", "hosts.ts", "extract.ts", "cli.ts", "path-shim.ts"]) {
+    fs.copyFileSync(path.join(import.meta.dir, file), path.join(dir, file))
+  }
+  fs.mkdirSync(path.join(repo, "skills/fixture"), { recursive: true })
+  fs.writeFileSync(path.join(repo, "skills/fixture/SKILL.md"), "fixture skill")
+  fs.mkdirSync(path.join(repo, "fixture"))
+  fs.writeFileSync(path.join(repo, "fixture/context.txt"), "original")
+  const scenario = {
+    id: "fixture/pass", skill: "fixture", cohort: "untouched", key_behavior: "judgment",
+    read_only: true, task: "task", fixture: "fixture", grade: { must_include: ["proof"], actions: "none" },
+  }
+  const catalog = path.join(dir, "catalog.ts")
+  const setCatalog = (rows: unknown[]) => fs.writeFileSync(catalog, `
+export const POST_SWEEP_REF = "WORKTREE";
+export const PRE_SWEEP_REF = "HEAD";
+export const rows = ${JSON.stringify(rows)};
+export const scenariosMatching = () => rows;
+export const scenarioById = id => rows.find(row => row.id === id);
+`)
+  setCatalog([scenario])
+  fs.writeFileSync(path.join(bin, "codex"), `#!/bin/sh
+if [ "$1" = "--version" ]; then echo fixture-codex; exit 0; fi
+printf 'proof\\nFILES_READ: SKILL.md\\nACTIONS: none\\nDELEGATES_DISPATCHED: none\\n'
+`, { mode: 0o755 })
+  const call = (script: string, args: string[]) => spawnSync(process.execPath, [path.join(dir, script), ...args], {
+    cwd: repo, encoding: "utf8", timeout: 20_000,
+    env: { ...process.env, PATH: `${bin}${path.delimiter}${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH ?? ""}` },
+  })
+  const collect = () => call("pack.ts", ["--hosts", "codex", "--arm", "post", "--out", out])
+  const source = path.join(out, "pack.json")
+  const readPack = () => JSON.parse(fs.readFileSync(source, "utf8"))
+  const savePack = (pack: unknown) => fs.writeFileSync(source, JSON.stringify(pack))
+  const regrade = (mode: "current" | "original" = "current") => call("regrade.ts", [source, "--mode", mode])
+  const reports = () => fs.readdirSync(out).filter(name => name.includes(".regrade-"))
+  return { repo, dir, out, scenario, setCatalog, collect, source, readPack, savePack, regrade, reports }
+}
+function originalGrade(info: any) { return { grades: info.grades, ok: info.ok, pointer_ok: info.pointer_ok } }
+function collected(ctx: ReturnType<typeof setup>) {
+  const result = ctx.collect()
+  assert.equal(result.status, 0, result.stderr)
+  return ctx.readPack().scenarios["fixture/pass"].arms.post
+}
+
+if (process.platform !== "win32") {
+  test("collection seals exactly the original grade object", () => fixture(ctx => {
+    const info = collected(ctx)
+    assert.equal(info.grade_result_sha256, valueHash(originalGrade(info)))
+  }), 30_000)
+
+  for (const file of ["regrade.ts", "provenance.ts", "extract.ts"]) {
+    test(`original mode rejects drift in ${file}; current assessment labels it`, () => fixture(ctx => {
+      collected(ctx)
+      const before = fs.readFileSync(ctx.source)
+      fs.appendFileSync(path.join(ctx.dir, file), "\n// independent runtime drift probe\n")
+      const original = ctx.regrade("original")
+      assert.equal(original.status, 2, original.stderr)
+      assert.match(original.stderr, /grader changed/)
+      assert.deepEqual(ctx.reports(), [])
+      const current = ctx.regrade()
+      assert.equal(current.status, 0, current.stderr)
+      assert.equal(JSON.parse(fs.readFileSync(current.stdout.trim(), "utf8")).grader_changed, true)
+      assert.deepEqual(fs.readFileSync(ctx.source), before)
+    }), 30_000)
+  }
+
+  for (const field of ["grades", "ok", "pointer_ok", "grade_result_sha256"]) {
+    test(`both modes reject corrupted or missing original ${field}`, () => fixture(ctx => {
+      collected(ctx)
+      const pack = ctx.readPack(), info = pack.scenarios["fixture/pass"].arms.post
+      if (field === "grades") info.grades[0].reasons.push("edited historical reason")
+      else if (field === "grade_result_sha256") delete info.grade_result_sha256
+      else info[field] = !info[field]
+      ctx.savePack(pack)
+      const before = fs.readFileSync(ctx.source)
+      for (const mode of ["current", "original"] as const) {
+        const result = ctx.regrade(mode)
+        assert.equal(result.status, 2, result.stderr)
+        assert.match(result.stderr, /original grade missing or changed/)
+      }
+      assert.deepEqual(ctx.reports(), [])
+      assert.deepEqual(fs.readFileSync(ctx.source), before)
+    }), 30_000)
+  }
+
+  for (const reason of ["removed", "task", "controls", "fixture", "observations"]) {
+    for (const passing of [true, false]) {
+      test(`unassessable ${reason} retains original ${passing ? "pass" : "failure"}`, () => fixture(ctx => {
+        const scenario = { ...ctx.scenario, grade: { ...ctx.scenario.grade, must_include: [passing ? "proof" : "absent"] } }
+        ctx.setCatalog([scenario])
+        const result = ctx.collect()
+        assert.equal(result.status, passing ? 0 : 1, result.stderr)
+        const info = ctx.readPack().scenarios[scenario.id].arms.post
+        const before = fs.readFileSync(ctx.source)
+        if (reason === "removed") ctx.setCatalog([])
+        if (reason === "task") ctx.setCatalog([{ ...scenario, task: "different" }])
+        if (reason === "controls") ctx.setCatalog([{ ...scenario, read_only: false }])
+        if (reason === "fixture") fs.writeFileSync(path.join(ctx.repo, "fixture/context.txt"), "changed")
+        if (reason === "observations") ctx.setCatalog([{ ...scenario, grade: { ...scenario.grade, git: "clean" } }])
+        const current = ctx.regrade()
+        assert.equal(current.status, 1, current.stderr)
+        const arm = JSON.parse(fs.readFileSync(current.stdout.trim(), "utf8")).scenarios[scenario.id].arms.post
+        assert.equal(arm.status, "not-assessable")
+        assert.deepEqual(arm.original_grade, originalGrade(info))
+        assert.equal(arm.original_grade_sha256, info.grade_result_sha256)
+        assert.equal(ctx.regrade("original").status, passing ? 0 : 1)
+        assert.deepEqual(fs.readFileSync(ctx.source), before)
+      }), 30_000)
+    }
+  }
+
+  test("a rubric-only edit remains assessable and never replaces the historical grade", () => fixture(ctx => {
+    const info = collected(ctx), before = fs.readFileSync(ctx.source)
+    ctx.setCatalog([{ ...ctx.scenario, grade: { must_include: ["not in output"] } }])
+    const current = ctx.regrade()
+    assert.equal(current.status, 1, current.stderr)
+    const report = JSON.parse(fs.readFileSync(current.stdout.trim(), "utf8"))
+    assert.equal(report.grader_changed, false)
+    assert.deepEqual(report.scenarios[ctx.scenario.id].arms.post.original_grade, originalGrade(info))
+    assert.equal(ctx.regrade("original").status, 0)
+    assert.deepEqual(fs.readFileSync(ctx.source), before)
+  }), 30_000)
+
+  test("a collection failure does not fabricate an original grade", () => fixture(ctx => {
+    ctx.setCatalog([{ ...ctx.scenario, skill: "missing" }])
+    assert.equal(ctx.collect().status, 1)
+    const result = ctx.regrade()
+    assert.equal(result.status, 1, result.stderr)
+    const arm = JSON.parse(fs.readFileSync(result.stdout.trim(), "utf8")).scenarios[ctx.scenario.id].arms.post
+    assert.equal(arm.status, "not-regraded")
+    assert.equal(Object.hasOwn(arm, "original_grade"), false)
+  }), 30_000)
+}

--- a/tests/skill-eval-cell/run.ts
+++ b/tests/skill-eval-cell/run.ts
@@ -269,9 +269,13 @@ async function main() {
   for (const host of hosts) {
     const hostDir = path.join(out, "hosts", host)
     const hostWorkspace = path.join(hostDir, "workspace")
+    const hostSkillDir = path.join(hostDir, "skill")
     fs.mkdirSync(hostDir, { recursive: true })
     copyFixture(workspace, hostWorkspace)
-    const hostPrompt = wrapPrompt({ skillDir, workspace: hostWorkspace, task: taskText })
+    // Script imports can create caches. Keep the input snapshot unchanged and
+    // give every host its own execution copy, included in the sealed evidence.
+    fs.cpSync(skillDir, hostSkillDir, { recursive: true })
+    const hostPrompt = wrapPrompt({ skillDir: hostSkillDir, workspace: hostWorkspace, task: taskText })
     const promptFile = path.join(hostDir, "prompt.md")
     fs.writeFileSync(promptFile, hostPrompt)
     const plan = planHost(host, {
@@ -341,7 +345,6 @@ async function main() {
   }
 
   const summaryPath = path.join(out, "summary.json")
-  writeJSON(summaryPath, summary)
   sealEvidence(out)
   console.log(summaryPath)
 }

--- a/tests/skill-eval-cell/run.ts
+++ b/tests/skill-eval-cell/run.ts
@@ -10,9 +10,10 @@ import { spawn, spawnSync } from "node:child_process"
 import fs from "node:fs"
 import path from "node:path"
 import { arg, flag } from "./cli"
-import { WORKTREE_REF, extractSkill, mintCellDir } from "./extract"
+import { REPO_ROOT, WORKTREE_REF, extractSkill, mintCellDir } from "./extract"
 import { HOSTS, planHost, resolveRunHosts, wrapPrompt, type Host, type HostPlan } from "./hosts"
 import { installPathShims, type PathShim } from "./path-shim"
+import { fingerprint, prepareOutput, sealEvidence, sha256, writeJSON } from "./provenance"
 
 function parseHosts(): Host[] | undefined {
   const raw = arg("--hosts")
@@ -113,10 +114,11 @@ async function runPlan(
     }
     let stdout = ""
     let stderr = ""
-    child.stdout.on("data", (c) => {
+    // Both output streams are explicitly piped above; numeric stdin prevents overload narrowing.
+    child.stdout!.on("data", (c) => {
       stdout += c.toString()
     })
-    child.stderr.on("data", (c) => {
+    child.stderr!.on("data", (c) => {
       stderr += c.toString()
     })
     let backstop: ReturnType<typeof setTimeout> | undefined
@@ -169,6 +171,7 @@ async function main() {
 
   const ref = arg("--ref", WORKTREE_REF) ?? WORKTREE_REF
   const timeoutMs = Number(arg("--timeout-secs", "600")) * 1000
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) throw new Error("--timeout-secs must be positive and finite")
   const readOnly = flag("--read-only")
   const resolution = resolveRunHosts({ explicit: parseHosts() })
   for (const line of resolution.warnings) console.error(line)
@@ -178,14 +181,15 @@ async function main() {
     process.exit(2)
   }
 
-  const out = arg("--out") ?? mintCellDir()
-  fs.mkdirSync(out, { recursive: true })
-  const { skillDir } = extractSkill({ skill, ref, dest: path.join(out, "extract") })
+  const out = prepareOutput(arg("--out") ?? mintCellDir())
+  fs.writeFileSync(path.join(out, "task.md"), taskText, { flag: "wx" })
+  const sourceRev = spawnSync("git", ["rev-parse", "--verify", `${ref === WORKTREE_REF ? "HEAD" : ref}^{commit}`], {
+    cwd: REPO_ROOT, encoding: "utf8",
+  })
+  if (ref !== WORKTREE_REF && sourceRev.status !== 0) throw new Error(`cannot resolve ref: ${ref}`)
+  const resolvedRef = ref === WORKTREE_REF ? ref : sourceRev.stdout.trim()
+  const { skillDir } = extractSkill({ skill, ref: resolvedRef, dest: path.join(out, "extract") })
   const workspace = path.join(out, "workspace")
-  // A reused --out otherwise keeps the previous run's files, commits, and mutations,
-  // and --git-init skips reseeding because the old .git is still there.
-  fs.rmSync(workspace, { recursive: true, force: true })
-  fs.rmSync(path.join(out, "hosts"), { recursive: true, force: true })
   const fixture = arg("--fixture")
   if (fixture) copyFixture(fixture, workspace)
   else fs.mkdirSync(workspace, { recursive: true })
@@ -224,6 +228,26 @@ async function main() {
     spawnSync("git", ["symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main"], { cwd: workspace })
   }
 
+  writeJSON(path.join(out, "input-manifest.json"), {
+    schema_version: 1,
+    started_at: new Date().toISOString(),
+    requested_ref: ref,
+    source_commit: sourceRev.status === 0 ? sourceRev.stdout.trim() : null,
+    source_commit_is_skill_identity: ref !== WORKTREE_REF,
+    skill: fingerprint(skillDir),
+    initial_workspace: fingerprint(workspace),
+    task_sha256: sha256(taskText),
+    harness: fingerprint(import.meta.dir, fs.readdirSync(import.meta.dir).filter((name) => name.endsWith(".ts") && !name.endsWith(".test.ts"))),
+    runtime: { bun: Bun.version, node: process.version, platform: process.platform, arch: process.arch },
+    timeout_ms: timeoutMs,
+    read_only: readOnly,
+    git_init: flag("--git-init"), git_remote: flag("--git-remote"),
+    git_untracked: arg("--git-untracked") ?? null, git_staged: arg("--git-staged") ?? null,
+    requested_model: null,
+    observed_model: null,
+    limits: ["model/configuration inherited from host; not captured", "provider state and external resources are not frozen", ".git internals and symlink target contents are not hashed"],
+  }, true)
+
   const summary: Record<string, unknown> = {
     skill,
     ref,
@@ -241,6 +265,7 @@ async function main() {
     cells: {},
   }
 
+  writeJSON(path.join(out, "summary.json"), summary)
   for (const host of hosts) {
     const hostDir = path.join(out, "hosts", host)
     const hostWorkspace = path.join(hostDir, "workspace")
@@ -286,6 +311,17 @@ async function main() {
     if (shims.length > 0) Object.assign(plan.env, installPathShims(hostDir, shims))
     fs.writeFileSync(path.join(hostDir, "argv.json"), `${JSON.stringify(plan.argv, null, 2)}\n`)
     fs.writeFileSync(path.join(hostDir, "notes.txt"), `${plan.notes.join("\n")}\n`)
+    const cli = Bun.which(plan.argv[0])
+    const version = cli ? spawnSync(cli, ["--version"], {
+      env: plan.env, cwd: hostWorkspace, encoding: "utf8", timeout: 5000, maxBuffer: 8192,
+    }) : null
+    writeJSON(path.join(hostDir, "runtime.json"), {
+      executable: cli,
+      version: version?.status === 0 ? version.stdout.trim().slice(0, 1024) : null,
+      version_probe_ok: version?.status === 0,
+      requested_model: null,
+      observed_model: null,
+    }, true)
     const result = await runPlan(plan, hostWorkspace, timeoutMs)
     fs.writeFileSync(path.join(hostDir, "stdout.txt"), result.stdout)
     fs.writeFileSync(path.join(hostDir, "stderr.txt"), result.stderr)
@@ -299,11 +335,14 @@ async function main() {
       timedOut: result.timedOut,
       stdout_bytes: Buffer.byteLength(result.stdout),
       stderr_bytes: Buffer.byteLength(result.stderr),
+      process_outcome: result.timedOut ? "timeout" : result.exitCode === 0 ? "completed" : "nonzero-or-spawn-error",
     }
+    writeJSON(path.join(out, "summary.json"), summary)
   }
 
   const summaryPath = path.join(out, "summary.json")
-  fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`)
+  writeJSON(summaryPath, summary)
+  sealEvidence(out)
   console.log(summaryPath)
 }
 


### PR DESCRIPTION
Regrading currently replaces the original pack with scores from today's catalog, and reusing a cell output directory deletes earlier evidence. This change preserves the original observations and grades while allowing corrected criteria to produce separate, traceable assessments.

Fixes #1636.

## Changes

- Reserve empty output directories and checkpoint pack progress so later collection failures retain completed arms.
- Freeze original scenarios, grader hashes, and actual input/evidence fingerprints. Keep the initial extracted skill separate from per-host execution copies: Python imports may create caches without invalidating the original input, and all execution artifacts remain sealed.
- Preserve the existing useful default of regrading with **current criteria and current trusted grader code**. Apply only the new grade criteria to the original collection context. Changed task/fixture/controls or missing observation mechanisms produce `not-assessable` rather than a misleading behavioral verdict.
- Add `--mode original` to reproduce frozen criteria with matching grader bytes. It preserves historical grader decisions, including rubric mistakes. Both modes verify evidence and write a new report containing the selected criteria, hashes, mode, grader identity, and original/new grades.

The distinction between current reassessment and original reproduction preserves the rubric-correction workflow already documented in `docs/plans/2026-08-21-phase-loaded-skill-kernels-eval-report.md`. Original snapshots remain fixed; corrected criteria are not prevented from reassessing existing observations.

## Compatibility and limits

Nonempty output directories and legacy packs without frozen provenance are rejected. Regrade reports are separate files; relocate the whole pack directory. Existing grading rules, host selection, and host permission policies are retained. No new dependencies, workflow files, or skills are added.

Fingerprints verify local consistency, not deterministic provider output, hermetic replay, or authenticity against replacement of both evidence and hashes. User configuration/hooks, provider state, external resources, symlink target contents, and Git internals are not frozen. Archived source and saved commands are never executed.

## Validation

- [GitHub CI](https://github.com/22nsuk/compound-engineering-plugin/actions/runs/33979284091) passes for `3973a838`: PR title, Linux tests, and Windows checks. The first Windows attempt stalled; a fresh run and the PR job retry both passed on the unchanged commit, without changing tests or timeouts.
- Reproduced original overwrite/catalog-drift defects with native Bun and an isolated fake host.
- Reproduced and fixed the cache regression using the actual `ce-work` workspace controller: six Python bytecode files are created, the host exits 0, and the pack now grades successfully.
- 63 focused provenance, original/current regrading, and fake-CLI tests pass, including independent execution copies, evidence tampering, rubric correction, unavailable observations, and changed task/fixture/controls.
- Final local `bun run test`: **3,783 passed, one skipped, zero failures**, across 146 files. The existing `omp` smoke test was skipped because its CLI was unavailable.
- Strict TypeScript validation against the real catalog and installed Bun types, `bun run release:validate`, `bun run plugin:validate`, and `git diff --check` pass. Plugin validation used CI's Claude Code 2.1.220 pin.

Local validation used Linux and native Bun 1.4.2, with no live model calls. Windows-native driver execution and abrupt interruption recovery were not exercised locally; partial progress was tested across collection failures.

## Security Disclosure

Evidence validation rejects traversal, symlink evidence, and workspace criteria reading excluded `.git` contents. Fake-CLI tests isolate missing-host checks from installed authenticated providers. No host sandbox or permission-policy changes. Existing transcripts and workspace files can contain sensitive material even though the new metadata does not dump credentials or user configuration.

## Agent Disclosure

- **Model:** ChatGPT · GPT-6 Pro prepared the initial implementation, as disclosed in upstream issue #1636. Codex · GPT-6 reviewed, corrected, and validated it, with `gpt-6-astra` review, implementation, and reproduction subagents.
