### PR TITLE
fix(pi): drop redundant pi.skills declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
   "pi": {
     "extensions": [
       "./.pi/extensions/compound-engineering.ts"
-    ],
-    "skills": [
-      "./skills"
     ]
   },
   "homepage": "https://github.com/EveryInc/compound-engineering-plugin",


### PR DESCRIPTION
The bundled `.pi/extensions/compound-engineering.ts` already registers the `skills/` directory through `resources_discover`, so the `pi.skills: ["./skills"]` entry in `package.json` was registering the same path twice. On pi the duplicate surfaces as a `(skipped)` collision warning for every skill whose name overlaps with a project-local copy, because each registration is enumerated as a separate discovery candidate.

The extension is now the single source of skill registration, so the same path only appears once in the diagnostic output. CE itself is unaffected on platforms whose loaders consume only `package.json` or only the extension.
