### PR TITLE
chore(cli): add Cloud Agent environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "compound-engineering",
+  "install": "if [ ! -x \"$HOME/.bun/bin/bun\" ] && ! command -v bun >/dev/null 2>&1; then curl -fsSL https://bun.sh/install | bash; fi && export PATH=\"$HOME/.bun/bin:$PATH\" && bun install"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.cursor/environment.json` so Cursor Cloud Agents boot ready to work on this repo. The default Cloud Agent base image ships Node and Python but not Bun, which this repo requires (`bun install`, `bun run test`, `bun run release:validate`, the `bun run src/index.ts` CLI). Before this, every fresh agent had to install Bun and dependencies by hand.

The `install` step:
- installs Bun to `~/.bun` only if it is not already present (idempotent — safe to re-run against cached state)
- adds Bun to `PATH` and runs `bun install`

Bun's installer appends `~/.bun/bin` to `~/.bashrc`, so subsequent interactive agent shells find `bun` automatically.

## Validation

Set up and exercised end-to-end in this Cloud Agent pod:
- `bun install` → 310 packages installed cleanly
- CLI runs: `bun run list`, `bun run dev --help`, and a real `convert . --to opencode` / `--to codex` producing 442 generated files
- `bun run release:validate` → metadata in sync (0 agents, 33 skills, 0 MCP servers)
- `bun run test` → 3650 pass, 1 skip; the 3 reported failures were per-test timeouts under parallel subprocess contention and each passes in isolation (`cli.test.ts` 38/38, `plugin-path.test.ts` 6/6, `ce-code-review-mechanics.test.ts` 19/19 — the latter takes ~30s serially)
- The install command was run verbatim as written (idempotent path: Bun present → skips install → `bun install` no-op) and succeeds
- A draft environment build was triggered to validate the install config from a clean base

Not baked into `install`: the `claude` CLI needed by `bun run plugin:validate` (a ~275MB npm payload). It stays out of every boot; run it on demand when validating plugin schema, matching how CI installs it as a separate cached step.

## Security Disclosure
Adds a `curl -fsSL https://bun.sh/install | bash` fetch-and-execute in the environment `install` step (standard Bun install path), guarded so it only runs when Bun is absent. No secrets, credentials, or permission changes; no product code or converter/writer output changed.

## Agent Disclosure
- **Model:** Cursor Cloud Agent · Claude Opus 4.8

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca3bbd79-6228-471e-88e4-13d6a5952c33?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca3bbd79-6228-471e-88e4-13d6a5952c33&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

