### PR TITLE
fix(ce-optimize): tighten activation and drop em dashes

### DIFF
--- a/docs/guides/ce-optimize.md
+++ b/docs/guides/ce-optimize.md
@@ -141,7 +141,7 @@ Use `ce-optimize` when:
 Skip it when:
 
 - You already know the change → make it, or use `/ce-work`
-- You are tracing a bug to its cause → `/ce-debug`
+- You are tracing a bug, or why something is slow → `/ce-debug`
 - Nothing can be measured or judged the same way twice
 - The target is a scored variant space with only one plausible answer, so a search is theater
 - Each evaluation is so expensive that multiple runs cannot pay for themselves

--- a/skills/ce-optimize/SKILL.md
+++ b/skills/ce-optimize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-optimize
-description: "Optimize a working system against a measurable target. Use when making it faster, cheaper, or leaner. Use when improving clustering, ranking, search, or prompt quality by scoring variants. Not for diagnosing a failure; that is ce-debug."
+description: "Optimize a working system against a measurable target. Use when a named workload's cost should drop and the change is not already known. Use when several variants must be scored and kept. Not for diagnosing failing or slow behavior (ce-debug), and not for implementing a change you already know (ce-work)."
 argument-hint: "[path to optimization spec YAML, or describe the optimization goal]"
 ---
 
@@ -14,7 +14,7 @@ argument-hint: "[path to optimization spec YAML, or describe the optimization go
 
 **Done when:** a stopping criterion fired, every declared required target is met or another stop fired first, the final state is written and verified on disk, and the user has been given the post-completion options. If the run instead stopped at a gate it could not clear, say what blocked it.
 
-Invoking this skill authorizes reading the repo, building the harness, and — after the Phase 1 approval gate — isolated experiments and keep/revert commits on `optimize/<spec-name>`. Ask when spend is uncapped, when a new dependency appears, when wrap-up would push or open a PR, or when only the user can choose among the post-completion options. Do not ask again to run the next in-envelope experiment.
+Invoking this skill authorizes reading the repo, building the harness, and (after the Phase 1 approval gate) isolated experiments and keep/revert commits on `optimize/<spec-name>`. Ask when spend is uncapped, when a new dependency appears, when wrap-up would push or open a PR, or when only the user can choose among the post-completion options. Do not ask again to run the next in-envelope experiment.
 
 Independent calls and dispatches that do not depend on each other go in one response. Serialize only real dependencies.
 
@@ -24,7 +24,7 @@ A step is done only after it ran. Describing a measurement, dispatch, or checkpo
 
 ## Interaction Method
 
-Use the host's blocking question tool already in the current tool list (match by capability, not by a host-specific name). Presence in the current tool list is proof the tool exists; never call a user-facing question tool to discover whether it exists. If a matching tool is listed but unloaded, use the host's tool-discovery primitive to load that capability — do not search for another host's tool name. Fall back to numbered options on the host's chat surface only when no such tool is in the list or a real question call errors. Never skip the question silently.
+Use the host's blocking question tool already in the current tool list (match by capability, not by a host-specific name). Presence in the current tool list is proof the tool exists; never call a user-facing question tool to discover whether it exists. If a matching tool is listed but unloaded, use the host's tool-discovery primitive to load that capability: do not search for another host's tool name. Fall back to numbered options on the host's chat surface only when no such tool is in the list or a real question call errors. Never skip the question silently.
 
 ## Artifact Root
 
@@ -46,17 +46,17 @@ The experiment log on disk is the source of truth. Write order is measure, write
 
 Four phases run in order. Each one names the reference it cannot start without. A fresh run skips none of them: a harder optimization spends longer in a phase, it does not run fewer phases.
 
-**A resume is not a fresh run.** On a resume, re-enter Phase 0 only far enough to detect the run and to recover any `result.yaml` markers the log is missing. Then continue from the phase the log records: skip the work the log proves finished, and re-enter any gate it does not. A checkpoint proves the work that produced it, never a user decision — the log holds no record of approval, so a resume that has not seen the user approve presents the Phase 1 gate again.
+**A resume is not a fresh run.** On a resume, re-enter Phase 0 only far enough to detect the run and to recover any `result.yaml` markers the log is missing. Then continue from the phase the log records: skip the work the log proves finished, and re-enter any gate it does not. A checkpoint proves the work that produced it, never a user decision: the log holds no record of approval, so a resume that has not seen the user approve presents the Phase 1 gate again.
 
-**Phase 0 — Setup.** The input is a goal, or a path to a spec YAML. It comes from the user or from a calling skill. If neither supplied one, ask: "What would you like to optimize? Describe the goal, or provide a path to an optimization spec YAML file." Load or build the spec and save it (CP-0) — **read `references/spec.md`**. Then search prior learnings, detect run identity, and create the branch and scratch space. **Read `references/measurement.md`** for the rest of Phase 0 and Phase 1.
+**Phase 0: Setup.** The input is a goal, or a path to a spec YAML. It comes from the user or from a calling skill. If neither supplied one, ask: "What would you like to optimize? Describe the goal, or provide a path to an optimization spec YAML file." Load or build the spec and save it (CP-0): **read `references/spec.md`**. Then search prior learnings, detect run identity, and create the branch and scratch space. **Read `references/measurement.md`** for the rest of Phase 0 and Phase 1.
 
-**Phase 1 — Measurement scaffolding.** Build or validate the harness, write the baseline (CP-1), probe parallelism, check the worktree budget. Two gates stop the run:
+**Phase 1: Measurement scaffolding.** Build or validate the harness, write the baseline (CP-1), probe parallelism, check the worktree budget. Two gates stop the run:
 
 - **Clean-tree gate.** Do not continue while any file in `scope.mutable` or `scope.immutable` has uncommitted changes. The reference owns the check and what to ask for.
-- **User approval gate.** Present what Phase 1 assembled; the reference lists what to include. If the primary type is `judge` and `max_total_cost_usd` is unset, say plainly that spend is uncapped. Offer proceed, fix issues, and adjust spec. Adjusting the spec is only available while the log holds nothing derived from it — no hypothesis backlog and no experiments — and it sends the run back through Phase 1 so the baseline matches the new spec. Once anything derived from the spec is on file, the spec is fixed for the run. **Do not enter Phase 2 until the user explicitly approves.** Then re-read the spec and baseline from disk.
+- **User approval gate.** Present what Phase 1 assembled; the reference lists what to include. If the primary type is `judge` and `max_total_cost_usd` is unset, say plainly that spend is uncapped. Offer proceed, fix issues, and adjust spec. Adjusting the spec is only available while the log holds nothing derived from it (no hypothesis backlog and no experiments) and it sends the run back through Phase 1 so the baseline matches the new spec. Once anything derived from the spec is on file, the spec is fixed for the run. **Do not enter Phase 2 until the user explicitly approves.** Then re-read the spec and baseline from disk.
 
-**Phase 2 — Hypothesis generation.** Analyze the current approach, rank the hypotheses, record the backlog (CP-2). Do not dispatch an implementation experiment while a cheaper locating measurement would change keep or skip. **Read `references/loop.md`** for this phase and Phase 3. One gate: **dependency pre-approval.** Collect every new dependency across all hypotheses and present the full list for bulk approval. A dependency the user does not approve stays in the backlog, is skipped in batch selection, and comes back at wrap-up.
+**Phase 2: Hypothesis generation.** Analyze the current approach, rank the hypotheses, record the backlog (CP-2). Do not dispatch an implementation experiment while a cheaper locating measurement would change keep or skip. **Read `references/loop.md`** for this phase and Phase 3. One gate: **dependency pre-approval.** Collect every new dependency across all hypotheses and present the full list for bulk approval. A dependency the user does not approve stays in the backlog, is skipped in batch selection, and comes back at wrap-up.
 
-**Phase 3 — Optimization loop.** Select a batch, dispatch experiments, persist each result as it lands (CP-3), evaluate with `scripts/decide.mjs`, update state and the digest (CP-4), then check whether to stop. Stop as soon as any one of seven criteria holds: every declared required target is met, max iterations, max hours, judge budget exhausted, plateau, a user interrupt, or no runnable hypothesis left. `references/loop.md` states each one exactly. Otherwise start the next batch.
+**Phase 3: Optimization loop.** Select a batch, dispatch experiments, persist each result as it lands (CP-3), evaluate with `scripts/decide.mjs`, update state and the digest (CP-4), then check whether to stop. Stop as soon as any one of seven criteria holds: every declared required target is met, max iterations, max hours, judge budget exhausted, plateau, a user interrupt, or no runnable hypothesis left. `references/loop.md` states each one exactly. Otherwise start the next batch.
 
-**Phase 4 — Wrap-up.** **Read `references/wrap-up.md`** for the deferred hypotheses, the summary, what is preserved, cleanup, and the post-completion options to present. CP-5 marks the log final. **Write it only after the user picks an option that does not return to Phase 3.** Two options do return: Continue, and approving a deferred dependency.
+**Phase 4: Wrap-up.** **Read `references/wrap-up.md`** for the deferred hypotheses, the summary, what is preserved, cleanup, and the post-completion options to present. CP-5 marks the log final. **Write it only after the user picks an option that does not return to Phase 3.** Two options do return: Continue, and approving a deferred dependency.

--- a/skills/ce-optimize/references/agents/learnings-researcher.md
+++ b/skills/ce-optimize/references/agents/learnings-researcher.md
@@ -1,13 +1,13 @@
-You are a domain-agnostic institutional knowledge researcher. Your job is to find and distill applicable past learnings from the team's knowledge base before new work begins — bugs, architecture patterns, design patterns, tooling decisions, conventions, and workflow discoveries are all first-class. Your work helps callers avoid re-discovering what the team already learned.
+You are a domain-agnostic institutional knowledge researcher. Your job is to find and distill applicable past learnings from the team's knowledge base before new work begins: bugs, architecture patterns, design patterns, tooling decisions, conventions, and workflow discoveries are all first-class. Your work helps callers avoid re-discovering what the team already learned.
 
 Past learnings span multiple shapes:
 
-- **Bug learnings** — defects that were diagnosed and fixed (bug-track `problem_type` values like `runtime_error`, `performance_issue`, `security_issue`)
-- **Architecture patterns** — structural decisions about agents, skills, pipelines, or system boundaries
-- **Design patterns** — reusable non-architectural design approaches (content generation, interaction patterns, prompt shapes)
-- **Tooling decisions** — language, library, or tool choices with durable rationale
-- **Conventions** — team-agreed ways of doing something, captured so they survive turnover
-- **Workflow learnings** — process improvements, developer-experience insights, documentation gaps
+- **Bug learnings**: defects that were diagnosed and fixed (bug-track `problem_type` values like `runtime_error`, `performance_issue`, `security_issue`)
+- **Architecture patterns**: structural decisions about agents, skills, pipelines, or system boundaries
+- **Design patterns**: reusable non-architectural design approaches (content generation, interaction patterns, prompt shapes)
+- **Tooling decisions**: language, library, or tool choices with durable rationale
+- **Conventions**: team-agreed ways of doing something, captured so they survive turnover
+- **Workflow learnings**: process improvements, developer-experience insights, documentation gaps
 
 Treat all of these as candidates. Do not privilege bug-shaped learnings over the others; the caller's context determines which shape matters.
 
@@ -17,7 +17,7 @@ For optimization invocations, search the full learning corpus described below, t
 
 ## Step 0: Ground in CONCEPTS.md (if present)
 
-Before searching `<root>/solutions/`, check whether `CONCEPTS.md` exists at the repo root. If it does, read it as grounding — it defines the project's shared vocabulary (domain entities, named processes, status concepts) and the canonical names for things the caller may be asking about. Use those definitions to ground keyword extraction (Step 1) and to distill findings using the project's actual terminology rather than synonyms.
+Before searching `<root>/solutions/`, check whether `CONCEPTS.md` exists at the repo root. If it does, read it as grounding: it defines the project's shared vocabulary (domain entities, named processes, status concepts) and the canonical names for things the caller may be asking about. Use those definitions to ground keyword extraction (Step 1) and to distill findings using the project's actual terminology rather than synonyms.
 
 If `CONCEPTS.md` does not exist, skip this step entirely and proceed to Step 1.
 
@@ -36,7 +36,7 @@ Callers may pass a structured `<work-context>` block describing what they are do
 Activity: <brief description of what the caller is doing or considering>
 Concepts: <named ideas, abstractions, approaches the work touches>
 Decisions: <specific decisions under consideration, if any>
-Domains: <skill-design | workflow | code-implementation | agent-architecture | ... — optional hint>
+Domains: <skill-design | workflow | code-implementation | agent-architecture | ...: optional hint>
 </work-context>
 ```
 
@@ -46,20 +46,20 @@ When the caller passes free-form text instead of a structured block, treat it as
 
 Keyword dimensions to extract (applies to either input shape):
 
-- **Module names** — e.g., "BriefSystem", "EmailProcessing", "payments"
-- **Technical terms** — e.g., "N+1", "caching", "authentication"
-- **Problem indicators** — e.g., "slow", "error", "timeout", "memory" (applies when the work is bug-shaped)
-- **Component types** — e.g., "model", "controller", "job", "api"
-- **Concepts** — named ideas or abstractions: "per-finding walk-through", "fallback-with-warning", "pipeline separation"
-- **Decisions** — choices the caller is weighing: "split into units", "migrate to framework X", "add a new tier"
-- **Approaches** — strategies or patterns: "test-first", "state machine", "shared template"
-- **Domains** — functional areas: "skill-design", "workflow", "code-implementation", "agent-architecture"
+- **Module names**: e.g., "BriefSystem", "EmailProcessing", "payments"
+- **Technical terms**: e.g., "N+1", "caching", "authentication"
+- **Problem indicators**: e.g., "slow", "error", "timeout", "memory" (applies when the work is bug-shaped)
+- **Component types**: e.g., "model", "controller", "job", "api"
+- **Concepts**: named ideas or abstractions: "per-finding walk-through", "fallback-with-warning", "pipeline separation"
+- **Decisions**: choices the caller is weighing: "split into units", "migrate to framework X", "add a new tier"
+- **Approaches**: strategies or patterns: "test-first", "state machine", "shared template"
+- **Domains**: functional areas: "skill-design", "workflow", "code-implementation", "agent-architecture"
 
-The caller's context determines which dimensions carry weight. A code-bug query weights module + technical terms + problem indicators. A design-pattern query weights concepts + approaches + domains. A convention query weights decisions + domains. Do not force every dimension into every search — use the dimensions that match the input.
+The caller's context determines which dimensions carry weight. A code-bug query weights module + technical terms + problem indicators. A design-pattern query weights concepts + approaches + domains. A convention query weights decisions + domains. Do not force every dimension into every search: use the dimensions that match the input.
 
 ### Step 2: Probe Discovered Subdirectories
 
-Use the native file-search/glob tool (e.g., Glob in Claude Code) to discover which subdirectories actually exist under `<root>/solutions/` at invocation time. Do not assume a fixed list — subdirectory names are per-repo convention and may include any of:
+Use the native file-search/glob tool (e.g., Glob in Claude Code) to discover which subdirectories actually exist under `<root>/solutions/` at invocation time. Do not assume a fixed list: subdirectory names are per-repo convention and may include any of:
 
 - Bug-shaped: `build-errors/`, `test-failures/`, `runtime-errors/`, `performance-issues/`, `database-issues/`, `security-issues/`, `ui-bugs/`, `integration-issues/`, `logic-errors/`
 - Knowledge-shaped: `architecture-patterns/`, `design-patterns/`, `tooling-decisions/`, `conventions/`, `workflow/`, `workflow-issues/`, `developer-experience/`, `documentation-gaps/`, `best-practices/`, `skill-design/`, `integrations/`
@@ -83,7 +83,7 @@ content-search: pattern="problem_type:.*(architecture_pattern|design_pattern|too
 **Pattern construction tips:**
 
 - Use `|` for synonyms: `tags:.*(subagent|parallel|fan-out)` or `tags:.*(payment|billing|stripe|subscription)`
-- Include `title:` — often the most descriptive field
+- Include `title:`: often the most descriptive field
 - Search case-insensitively
 - Include related terms the user might not have mentioned
 - Match the fields to the input shape: bug-shaped queries search `symptoms:` and `root_cause:`; decision- and pattern-shaped queries search `tags:`, `title:`, and `problem_type:`
@@ -102,7 +102,7 @@ content-search: pattern="email" path=<root>/solutions/ files_only=true case_inse
 
 ### Step 3b: Conditionally Check Critical Patterns
 
-If `<root>/solutions/patterns/critical-patterns.md` exists in this repo, read it — it may contain must-know patterns that apply across all work. If it does not exist, skip this step; the convention is optional and not all repos follow it. Either way, follow the Output Format's Critical Patterns handling (omit the section entirely, or emit a one-line absence note — not both).
+If `<root>/solutions/patterns/critical-patterns.md` exists in this repo, read it: it may contain must-know patterns that apply across all work. If it does not exist, skip this step; the convention is optional and not all repos follow it. Either way, follow the Output Format's Critical Patterns handling (omit the section entirely, or emit a one-line absence note: not both).
 
 ### Step 4: Read Frontmatter of Candidates Only
 
@@ -115,15 +115,15 @@ Read: [file_path] with limit:30
 
 Extract these fields from the YAML frontmatter:
 
-- **module** — which module, system, or domain the learning applies to
-- **problem_type** — category (knowledge-track and bug-track values apply equally; see schema reference below)
-- **component** — technical component or area affected (when applicable)
-- **tags** — searchable keywords
-- **symptoms** — observable behaviors or friction (present on bug-track entries and sometimes on knowledge-track entries)
-- **root_cause** — underlying cause (present on bug-track entries; optional on knowledge-track entries)
-- **severity** — critical, high, medium, low
+- **module**: which module, system, or domain the learning applies to
+- **problem_type**: category (knowledge-track and bug-track values apply equally; see schema reference below)
+- **component**: technical component or area affected (when applicable)
+- **tags**: searchable keywords
+- **symptoms**: observable behaviors or friction (present on bug-track entries and sometimes on knowledge-track entries)
+- **root_cause**: underlying cause (present on bug-track entries; optional on knowledge-track entries)
+- **severity**: critical, high, medium, low
 
-Some non-bug entries may have looser frontmatter shapes (they do not require `symptoms` or `root_cause`). Do not discard these entries for missing bug-shaped fields — use whatever fields are present for matching.
+Some non-bug entries may have looser frontmatter shapes (they do not require `symptoms` or `root_cause`). Do not discard these entries for missing bug-shaped fields: use whatever fields are present for matching.
 
 ### Step 5: Score and Rank Relevance
 
@@ -161,7 +161,7 @@ When a learning's claim conflicts with what you can observe in the current code 
 
 ### Step 7: Return Distilled Summaries
 
-Render findings using the structure defined in **## Output Format** below. The `Feature/Task` field summarizes the caller's input — the `Activity` from the `<work-context>` block when present, or the free-form prose otherwise.
+Render findings using the structure defined in **## Output Format** below. The `Feature/Task` field summarizes the caller's input: the `Activity` from the `<work-context>` block when present, or the free-form prose otherwise.
 
 Return up to 5 findings, prioritized by relevance. If more strong matches exist, pick the ones most directly applicable and note briefly at the end of `Relevant Learnings` that additional matches exist. Including 1-2 adjacent / tangential entries with a clear relevance caveat is fine when they give useful context; returning every marginal match is not.
 
@@ -174,7 +174,7 @@ The two `problem_type` tracks:
 - **Knowledge-track:** `architecture_pattern`, `design_pattern`, `tooling_decision`, `convention`, `workflow_issue`, `developer_experience`, `documentation_gap`, `best_practice` (fallback).
 - **Bug-track:** `build_error`, `test_failure`, `runtime_error`, `performance_issue`, `database_issue`, `security_issue`, `ui_bug`, `integration_issue`, `logic_error`.
 
-Other frontmatter fields (`component`, `root_cause`, etc.) are repo-specific and evolve over time. Do not assume a fixed enum — read the value from each file as-is, and when summarizing a learning with an unrecognized value, pass it through verbatim rather than normalizing it.
+Other frontmatter fields (`component`, `root_cause`, etc.) are repo-specific and evolve over time. Do not assume a fixed enum: read the value from each file as-is, and when summarizing a learning with an unrecognized value, pass it through verbatim rather than normalizing it.
 
 Probe the live `<root>/solutions/` directory (Step 2) for what actually exists; do not hard-code subdirectory names.
 
@@ -186,13 +186,13 @@ Structure findings as follows:
 ## Institutional Learnings Search Results
 
 ### Search Context
-- **Feature/Task**: [Summary of the caller's activity, decision, or problem — works for bugs, architecture decisions, design patterns, tooling choices, or conventions.]
+- **Feature/Task**: [Summary of the caller's activity, decision, or problem: works for bugs, architecture decisions, design patterns, tooling choices, or conventions.]
 - **Keywords Used**: [tags, modules, concepts, domains searched]
 - **Files Scanned**: [X total files]
 - **Relevant Matches**: [Y files]
 
 ### Critical Patterns
-[Include only when `<root>/solutions/patterns/critical-patterns.md` exists and has relevant content. If the file does not exist in this repo, omit the section or note its absence in a single line — do not invent content.]
+[Include only when `<root>/solutions/patterns/critical-patterns.md` exists and has relevant content. If the file does not exist in this repo, omit the section or note its absence in a single line: do not invent content.]
 
 ### Relevant Learnings
 
@@ -213,7 +213,7 @@ Structure findings as follows:
 - [Past mis-steps worth avoiding, where applicable]
 ```
 
-When no relevant learnings are found, say so explicitly, include the search context so the caller can see what was looked for, and note that the caller's work may be worth capturing as a durable learning after it lands — the absence is itself useful signal.
+When no relevant learnings are found, say so explicitly, include the search context so the caller can see what was looked for, and note that the caller's work may be worth capturing as a durable learning after it lands: the absence is itself useful signal.
 
 ## Efficiency Guidelines
 
@@ -222,7 +222,7 @@ When no relevant learnings are found, say so explicitly, include the search cont
 - Use the native content-search tool to pre-filter files BEFORE reading any content (critical for 100+ files)
 - Run multiple content searches in PARALLEL across different keyword dimensions
 - Probe `<root>/solutions/` subdirectories dynamically rather than assuming a fixed list
-- Include `title:` in search patterns — often the most descriptive field
+- Include `title:` in search patterns: often the most descriptive field
 - Use OR patterns for synonyms and search case-insensitively
 - Narrow to discovered subdirectories when the caller's Domain hint makes one obvious
 - Broaden the content search as fallback if <3 candidates found; re-narrow if >25
@@ -233,14 +233,14 @@ When no relevant learnings are found, say so explicitly, include the search cont
 
 **DON'T:**
 
-- Skip the grep pre-filter and read frontmatter of every file in `<root>/solutions/` — pre-filter first, then read frontmatter of the shortlist
-- Read full content of every candidate — only the ones that pass relevance scoring
+- Skip the grep pre-filter and read frontmatter of every file in `<root>/solutions/`: pre-filter first, then read frontmatter of the shortlist
+- Read full content of every candidate: only the ones that pass relevance scoring
 - Run searches sequentially when they can be parallel
 - Use only exact keyword matches (include synonyms); skip `title:` in patterns; proceed with >25 candidates without narrowing
 - Return raw document contents instead of distilling them
-- Include every tangentially related match — 1-2 adjacent entries with a caveat is fine; a long tail of weak matches is noise
-- Discard a candidate because it lacks bug-shaped fields like `symptoms` or `root_cause` — non-bug entries legitimately omit them
-- Assume `<root>/solutions/patterns/critical-patterns.md` exists — read it only when present
+- Include every tangentially related match: 1-2 adjacent entries with a caveat is fine; a long tail of weak matches is noise
+- Discard a candidate because it lacks bug-shaped fields like `symptoms` or `root_cause`: non-bug entries legitimately omit them
+- Assume `<root>/solutions/patterns/critical-patterns.md` exists: read it only when present
 
 ## Consumption Contract
 

--- a/skills/ce-optimize/references/agents/repo-research-analyst.md
+++ b/skills/ce-optimize/references/agents/repo-research-analyst.md
@@ -152,7 +152,7 @@ This context informs all subsequent research phases -- use it to focus documenta
 **Core Responsibilities:**
 
 1. **Architecture and Structure Analysis**
-   - Examine key documentation files (ARCHITECTURE.md, README.md, CONTRIBUTING.md, and the project's root agent-instruction file for this harness — e.g., AGENTS.md, CLAUDE.md, GEMINI.md, or .cursor/rules — when present)
+   - Examine key documentation files (ARCHITECTURE.md, README.md, CONTRIBUTING.md, and the project's root agent-instruction file for this harness, for example AGENTS.md, CLAUDE.md, GEMINI.md, or .cursor/rules, when present)
    - Map out the repository's organizational structure
    - Identify architectural patterns and design decisions
    - Note any project-specific conventions or standards

--- a/skills/ce-optimize/references/experiment-log-schema.yaml
+++ b/skills/ce-optimize/references/experiment-log-schema.yaml
@@ -182,7 +182,7 @@ experiment_entry:
         - runner_up_kept          # file-disjoint runner-up that was cherry-picked and re-measured successfully
         - runner_up_reverted      # file-disjoint runner-up that was cherry-picked but combined measurement was not better
       description: >
-        Load-bearing state: the loop branches on this value.
+        The loop branches on this value.
         'measured' and 'promising' are non-terminal: CP-3 persists raw metrics
         before batch-level comparison, and 'promising' means the ladder still
         needs confirmation samples. An eligible decide `keep` stays `measured`

--- a/skills/ce-optimize/references/judge-prompt-template.md
+++ b/skills/ce-optimize/references/judge-prompt-template.md
@@ -108,4 +108,4 @@ Rules:
 - The `ambiguous` flag on items helps the orchestrator identify noisy evaluations without forcing bad scores
 - For singleton evaluation, the orchestrator provides cluster summaries (not full contents) to keep judge context lean
 - Each sub-agent evaluates one batch independently -- sub-agents do not see each other's results
-- **That independence is required, not merely preferred.** These scores gate accept/revert, so a judge must be a separate context from the one that authored the hypothesis and ran the experiment. Where no dispatch is available, block the judge pass rather than scoring inline — an orchestrator grading its own experiment is not a measurement.
+- **That independence is required, not merely preferred.** These scores gate accept/revert, so a judge must be a separate context from the one that authored the hypothesis and ran the experiment. Where no dispatch is available, block the judge pass rather than scoring inline: an orchestrator grading its own experiment is not a measurement.

--- a/skills/ce-optimize/references/loop.md
+++ b/skills/ce-optimize/references/loop.md
@@ -53,7 +53,7 @@ hypothesis_backlog:
       baseline: "CP-1 baseline"
       evidence: "judge rubric: boilerplate dilutes embeddings; no profile"
       expected_benefit: "unknown; cheapest resolve: one judged stripped-vs-current sample"
-      confidence: "low — unmeasured"
+      confidence: "low: unmeasured"
       cost_and_risk: "small edit; judge sample; no new deps"
   - description: "Try HDBSCAN clustering algorithm"
     category: "algorithm"
@@ -65,7 +65,7 @@ hypothesis_backlog:
       baseline: "CP-1 baseline"
       evidence: "algorithm family untried on this fixture"
       expected_benefit: "unknown; cheapest resolve: one exploratory run after dep approval"
-      confidence: "low — unmeasured"
+      confidence: "low: unmeasured"
       cost_and_risk: "new dependency scikit-learn; judge sample"
 ```
 
@@ -86,7 +86,7 @@ Select hypotheses for this batch:
 
 When a cheaper locating measurement would still change keep or skip, take that measurement and update the backlog before selecting a batch. Do not treat that state as an empty backlog.
 
-When no runnable hypothesis is left — the backlog is empty and no new one can be generated, locating would not change keep or skip, and everything remaining is blocked or awaiting approval — proceed to Phase 4 (wrap-up), where the user can approve deferred dependencies instead of the loop spinning forever.
+When no runnable hypothesis is left (the backlog is empty and no new one can be generated, locating would not change keep or skip, and everything remaining is blocked or awaiting approval), proceed to Phase 4 (wrap-up), where the user can approve deferred dependencies instead of the loop spinning forever.
 
 ### 3.2 Dispatch Experiments
 
@@ -94,9 +94,9 @@ The experiment's forecast is the backlog `opportunity` as of dispatch. Do not re
 
 For each hypothesis in the batch, dispatch according to `execution.mode`. In `serial` mode, run exactly one experiment to completion before selecting the next hypothesis. In `parallel` mode, dispatch the batch concurrently.
 
-**Bounded dispatch.** Do not assume the host will accept all concurrent subagents at once; the active-subagent cap varies by host and profile and is independent of `execution.max_concurrent` (which caps worktrees, a separate budget). Queue the selected experiments, dispatch only as many as the host accepts, and when a capacity or active-agent-limit error appears, treat it as backpressure — retry the queued experiment after a slot frees rather than marking it failed. Mark an experiment failed only when dispatch fails for a non-capacity reason that survives correcting the invocation, or a successfully dispatched experiment errors/times out.
+**Bounded dispatch.** Do not assume the host will accept all concurrent subagents at once; the active-subagent cap varies by host and profile and is independent of `execution.max_concurrent` (which caps worktrees, a separate budget). Queue the selected experiments, dispatch only as many as the host accepts, and when a capacity or active-agent-limit error appears, treat it as backpressure: retry the queued experiment after a slot frees rather than marking it failed. Mark an experiment failed only when dispatch fails for a non-capacity reason that survives correcting the invocation, or a successfully dispatched experiment errors/times out.
 
-The Phase 3 blocks below each set `SKILL_DIR` inline as well (the loaded `ce-optimize` skill directory; see the Bundled scripts note in Phase 1) — shell state does not persist from Phase 1, so each block carries its own assignment.
+The Phase 3 blocks below each set `SKILL_DIR` inline as well (the loaded `ce-optimize` skill directory; see the Bundled scripts note in Phase 1): shell state does not persist from Phase 1, so each block carries its own assignment.
 
 **Worktree backend:**
 1. Create experiment worktree:
@@ -132,18 +132,18 @@ The Phase 3 blocks below each set `SKILL_DIR` inline as well (the loaded `ce-opt
 
 Persist a `comparisons` record for each distinct reference, candidate, and workload pairing used in a decision. Each side's identity must uniquely identify the bytes that were measured; a shared HEAD is not enough when the candidate is uncommitted. Record the workload, both snapshots, and the decision's uncertainty and correctness evidence. Standalone and integrated pairings stay distinct in this array; a later in-place update must not replace a previously persisted distinct pairing. A runner-up's contribution is its confirmed change against the branch it was added to, not its standalone gain. These records explain results; `decide.mjs` still owns acceptance, using the existing snapshot fields.
 
-Process experiments as they complete — do NOT wait for the entire batch to finish before writing results.
+Process experiments as they complete: do NOT wait for the entire batch to finish before writing results.
 
 For each completed experiment, **immediately**:
 
-1. **Run measurement** in the experiment's worktree. Spend only the measurement the current decision needs (see Phase 1). When `stability.mode` is `ladder` and a smoke command is set, run that smoke check first: failure is terminally `degenerate`, and success proceeds to the first exploratory sample of `measurement.command` before comparison. Otherwise start with one exploratory sample. Pass `CE_OPTIMIZE_CENSOR_AFTER` to `measure.sh` only when elapsed wall time itself proves the candidate cannot become eligible — every required objective is already hopeless, not merely the primary. Otherwise let measurement finish so other required objectives can still win, and let `decide.mjs` assess futility after the payload is complete.
+1. **Run measurement** in the experiment's worktree. Spend only the measurement the current decision needs (see Phase 1). When `stability.mode` is `ladder` and a smoke command is set, run that smoke check first: failure is terminally `degenerate`, and success proceeds to the first exploratory sample of `measurement.command` before comparison. Otherwise start with one exploratory sample. Pass `CE_OPTIMIZE_CENSOR_AFTER` to `measure.sh` only when elapsed wall time itself proves the candidate cannot become eligible: every required objective is already hopeless, not merely the primary. Otherwise let measurement finish so other required objectives can still win, and let `decide.mjs` assess futility after the payload is complete.
    ```bash
    SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
    bash "$SKILL_DIR/scripts/measure.sh" "<measurement.command>" <timeout_seconds> "<worktree_path>/<measurement.working_directory or .>" <env_vars...>
    ```
    When mode is `repeat`, keep running `repeat_count` times and aggregating as in Phase 1. When mode is `stable`, run once.
 
-2. **Write crash-recovery marker** — immediately after measurement, write `result.yaml` in the experiment worktree containing the raw metrics. This ensures the measurement is recoverable even if the agent crashes before updating the main log.
+2. **Write crash-recovery marker**: immediately after measurement, write `result.yaml` in the experiment worktree containing the raw metrics. This ensures the measurement is recoverable even if the agent crashes before updating the main log.
 
 3. **Read raw JSON output** from the measurement script
 
@@ -153,17 +153,17 @@ For each completed experiment, **immediately**:
    - If ANY gate fails: mark outcome as `degenerate`, skip judge evaluation, save money
 
 5. **If gates pass AND primary type is `judge`**:
-   - **Independence gate — check before dispatching.** A judge must not have authored the hypothesis or run the experiment it is scoring, and must not see other judges' results; that independence is what makes these scores usable as an accept/revert gate. If the host exposes no way to dispatch judges as separate agents, do **not** score inline: mark the experiment's outcome `error` with the reason (judges undispatchable), skip judge evaluation exactly as a failed degenerate gate does, and continue to the log-and-append step so the entry is still written to disk. An experiment stopped here never carries judge metrics, so it is not eligible to become `best` and does not enter the accept/revert comparison — it is unmeasured, not poor-scoring. Report the blocker to the user at the batch summary.
+   - **Independence gate: check before dispatching.** A judge must not have authored the hypothesis or run the experiment it is scoring, and must not see other judges' results; that independence is what makes these scores usable as an accept/revert gate. If the host exposes no way to dispatch judges as separate agents, do **not** score inline: mark the experiment's outcome `error` with the reason (judges undispatchable), skip judge evaluation exactly as a failed degenerate gate does, and continue to the log-and-append step so the entry is still written to disk. An experiment stopped here never carries judge metrics, so it is not eligible to become `best` and does not enter the accept/revert comparison: it is unmeasured, not poor-scoring. Report the blocker to the user at the batch summary.
    - Read the experiment's output (cluster assignments, search results, etc.)
    - Apply stratified sampling per `metric.judge.stratification` config (using `sample_seed`)
    - Group samples into batches of `metric.judge.batch_size`
    - Fill the judge prompt template (`references/judge-prompt-template.md`) for each batch
-   - Dispatch the `ceil(sample_size / batch_size)` judge sub-agents using the same bounded dispatch as Phase 3.2 — queue them, dispatch to whatever concurrency the host accepts, and treat a capacity error as backpressure (retry the queued batch after a slot frees) rather than a scoring failure. These judge sub-agents are a separate budget from the experiment worktrees.
+   - Dispatch the `ceil(sample_size / batch_size)` judge sub-agents using the same bounded dispatch as Phase 3.2: queue them, dispatch to whatever concurrency the host accepts, and treat a capacity error as backpressure (retry the queued batch after a slot frees) rather than a scoring failure. These judge sub-agents are a separate budget from the experiment worktrees.
    - Each sub-agent returns structured JSON scores
    - Aggregate scores: compute the configured primary judge field from `metric.judge.scoring.primary` (which should match `metric.primary.name`) plus any `scoring.secondary` values
    - If `singleton_sample > 0`: also dispatch singleton evaluation sub-agents
 
-6. **Compare with `decide.mjs`.** Invoke it only after gates pass and the payload holds every required objective value — hard metrics from measurement, and judge scores when those were collected. The payload is the spec as loaded plus the baseline and candidate snapshots. The script reads the nested spec (`metric`, `measurement.stability`) and owns eligibility, noise, and the ladder next step. Do not reconstruct a flattened payload, and do not re-derive the threshold in prose.
+6. **Compare with `decide.mjs`.** Invoke it only after gates pass and the payload holds every required objective value: hard metrics from measurement, and judge scores when those were collected. The payload is the spec as loaded plus the baseline and candidate snapshots. The script reads the nested spec (`metric`, `measurement.stability`) and owns eligibility, noise, and the ladder next step. Do not reconstruct a flattened payload, and do not re-derive the threshold in prose.
    ```bash
    SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
    NODE="$(for c in node nodejs; do command -v "$c" >/dev/null 2>&1 && "$c" -e '' >/dev/null 2>&1 && { echo "$c"; break; }; done)";
@@ -172,11 +172,11 @@ For each completed experiment, **immediately**:
    ```
    If that probe finds no runtime, do not invoke an empty command: mark the experiment `error` with that reason and continue the batch. Use `decision` and `next_measurement`. Collect the requested measurement and repeat this sequence whenever `next_measurement` is not `none`. Do not keep a candidate until `next_measurement` is `none`. Record `inconclusive` and `censored` as those outcomes, not as `reverted`. Each extra sample belongs to this same experiment: write it onto the existing entry at CP-3, then decide again.
 
-7. **IMMEDIATELY persist this experiment on disk (CP-3)** — do not defer this to batch evaluation. The durable unit is one log entry per experiment at `.context/compound-engineering/ce-optimize/<spec-name>/experiment-log.yaml`. After the first measurement, append that entry. After every later ladder sample for the same experiment, write the accumulated metrics and current outcome onto that same entry. Do not append a second entry for the same hypothesis, and do not rewrite a different experiment's samples. Write a decide terminal only when `next_measurement` is `none`. Until then the entry stays nonterminal: `promising` while the keep path still needs samples, `measured` otherwise (including an inconclusive result that still wants samples). When `next_measurement` is `none`, an eligible result stays `measured` until its diff is on the optimization branch; a non-eligible result gets the decide terminal (`reverted`, `inconclusive`, `censored`, `degenerate`). `kept` and `runner_up_kept` wait until that integration. The raw metrics are on disk and safe from context compaction.
+7. **IMMEDIATELY persist this experiment on disk (CP-3)**: do not defer this to batch evaluation. The durable unit is one log entry per experiment at `.context/compound-engineering/ce-optimize/<spec-name>/experiment-log.yaml`. After the first measurement, append that entry. After every later ladder sample for the same experiment, write the accumulated metrics and current outcome onto that same entry. Do not append a second entry for the same hypothesis, and do not rewrite a different experiment's samples. Write a decide terminal only when `next_measurement` is `none`. Until then the entry stays nonterminal: `promising` while the keep path still needs samples, `measured` otherwise (including an inconclusive result that still wants samples). When `next_measurement` is `none`, an eligible result stays `measured` until its diff is on the optimization branch; a non-eligible result gets the decide terminal (`reverted`, `inconclusive`, `censored`, `degenerate`). `kept` and `runner_up_kept` wait until that integration. The raw metrics are on disk and safe from context compaction.
 
-8. **VERIFY the write (CP-3 verification)** — read the experiment log back from disk and confirm the entry just written is present. If verification fails, retry the write. Do NOT proceed to the next experiment until this entry is confirmed on disk.
+8. **VERIFY the write (CP-3 verification)**: read the experiment log back from disk and confirm the entry just written is present. If verification fails, retry the write. Do NOT proceed to the next experiment until this entry is confirmed on disk.
 
-**Why immediately + verify?** The agent's context window is NOT a durable store. Context compaction, session crashes, and restarts are expected during long runs — results that exist only in the agent's memory are lost. The verification step catches silent write failures that would otherwise lose data.
+**Why immediately + verify?** The agent's context window is NOT a durable store. Context compaction, session crashes, and restarts are expected during long runs: results that exist only in the agent's memory are lost. The verification step catches silent write failures that would otherwise lose data.
 
 ### 3.4 Evaluate Batch
 
@@ -197,7 +197,7 @@ After all experiments in the batch have been measured:
 4. **Check file-disjoint runners-up** (up to `max_runner_up_merges_per_batch`):
    - For each runner-up that also improved, check file-level disjointness with the kept experiment
    - **File-level disjointness**: two experiments are disjoint if they modified completely different files. Same file = overlapping, even if different lines.
-   - If disjoint: cherry-pick the runner-up onto the new baseline and run the same decide loop as step 3.3 against a fresh sample set for that combined snapshot — do not reuse the standalone experiment's accumulated samples, whose meaning is against the previous baseline. Collect further measurement whenever `next_measurement` is not `none`. Persist the combined pairing as `kind: integrated` on that same log entry without replacing the standalone comparison. Keep the original standalone log entry for audit.
+   - If disjoint: cherry-pick the runner-up onto the new baseline and run the same decide loop as step 3.3 against a fresh sample set for that combined snapshot: do not reuse the standalone experiment's accumulated samples, whose meaning is against the previous baseline. Collect further measurement whenever `next_measurement` is not `none`. Persist the combined pairing as `kind: integrated` on that same log entry without replacing the standalone comparison. Keep the original standalone log entry for audit.
    - Keep the cherry-pick only when that result is eligible and `next_measurement` is `none` (outcome: `runner_up_kept`); then clean up that runner-up's experiment worktree and branch
    - Otherwise: revert the cherry-pick, log as "promising alone but neutral/harmful in combination" (outcome: `runner_up_reverted`), then clean up the runner-up's experiment worktree and branch
    - Stop after first failed combination
@@ -210,9 +210,9 @@ After all experiments in the batch have been measured:
 
 **MANDATORY CHECKPOINT.** By this point, individual experiment results are already on disk (written in step 3.3). This step updates aggregate state and verifies.
 
-1. **Re-read the experiment log from disk** — do not trust in-memory state. The log is the source of truth.
+1. **Re-read the experiment log from disk**: do not trust in-memory state. The log is the source of truth.
 
-2. **Finalize outcomes** — update experiment entries from step 3.4 evaluation (mark `kept`, `reverted`, `runner_up_kept`, etc.). Write these outcome updates to disk immediately.
+2. **Finalize outcomes**: update experiment entries from step 3.4 evaluation (mark `kept`, `reverted`, `runner_up_kept`, etc.). Write these outcome updates to disk immediately.
 
 3. **Update the `best` section** in the experiment log if a new best was found. Write to disk.
 
@@ -229,7 +229,7 @@ After all experiments in the batch have been measured:
    - After a keep on a cost target, re-attribute the workload before adding implementation hypotheses; the previous cost shares are stale
    - Add new hypotheses to the backlog and write the updated backlog to disk
 
-6. **Write updated hypothesis backlog to disk** — the backlog section of the experiment log must reflect newly added hypotheses and removed (tested) ones.
+6. **Write updated hypothesis backlog to disk**: the backlog section of the experiment log must reflect newly added hypotheses and removed (tested) ones.
 
 **CP-4 Verification:** Read the experiment log back from disk. Confirm: (a) all experiment outcomes from this batch are finalized, (b) the `best` section reflects the current best, (c) the hypothesis backlog is updated. Read `strategy-digest.md` back and confirm it exists. Only THEN proceed to the next batch or stopping criteria check.
 
@@ -241,7 +241,7 @@ Stop the loop as soon as any one of these holds:
 
 - **Target reached**: `stopping.target_reached` is true and the current best meets every declared required target (`decide.mjs` `target_reached` on the current-best snapshot). When `metric.objectives` is absent, that is the single `metric.primary.target` if set. Do not stop for a primary-only hit while another required target is still unmet.
 - **Max iterations**: total experiments run >= `stopping.max_iterations`
-- **Max hours**: wall-clock time since Phase 3 started — not since the invocation — >= `stopping.max_hours`
+- **Max hours**: wall-clock time since Phase 3 started (not since the invocation) >= `stopping.max_hours`
 - **Judge budget exhausted**: `metric.judge.max_total_cost_usd` is set and cumulative judge spend has reached it
 - **Plateau**: no improvement for `stopping.plateau_iterations` **consecutive** experiments
 - **Manual stop**: the user interrupts. Save state, then go to Phase 4.
@@ -253,7 +253,7 @@ If none is met, proceed to the next batch (3.1).
 
 **Codex failure cascade**: Track consecutive Codex delegation failures. After 3 consecutive failures, auto-disable Codex for remaining experiments and fall back to subagent dispatch. Log the switch.
 
-**Error handling**: Classify a failed measurement from what `measure.sh` actually signaled. The censored stderr marker (with exit 125) is `censored`. Exit 124 is `timeout`. Any other non-zero exit — including 125 without that marker — is `error`. Log that outcome with the error message, revert the experiment, and continue the batch.
+**Error handling**: Classify a failed measurement from what `measure.sh` actually signaled. The censored stderr marker (with exit 125) is `censored`. Exit 124 is `timeout`. Any other non-zero exit (including 125 without that marker) is `error`. Log that outcome with the error message, revert the experiment, and continue the batch.
 
 **Progress reporting**: After each batch, report:
 - Batch N of estimated M (based on backlog size)
@@ -261,6 +261,6 @@ If none is met, proceed to the next batch (3.1).
 - Current best metric and improvement from baseline
 - Cumulative judge cost (if applicable)
 
-**Crash recovery**: See Persistence Discipline section. Per-experiment `result.yaml` markers are written in step 3.3. Individual experiment results are appended to the log immediately in step 3.3. Batch-level state (outcomes, best, digest) is written in step 3.5. On resume (Phase 0.4), the log on disk is the ground truth — scan for any `result.yaml` markers not yet reflected in the log.
+**Crash recovery**: See Persistence Discipline section. Per-experiment `result.yaml` markers are written in step 3.3. Individual experiment results are appended to the log immediately in step 3.3. Batch-level state (outcomes, best, digest) is written in step 3.5. On resume (Phase 0.4), the log on disk is the ground truth: scan for any `result.yaml` markers not yet reflected in the log.
 
 ---

--- a/skills/ce-optimize/references/measurement.md
+++ b/skills/ce-optimize/references/measurement.md
@@ -1,6 +1,6 @@
 # Phase 0.3-1.7: prior learnings, identity, and measurement scaffolding
 
-Read this after the spec is saved and follow it through the approval gate. The body owns the two gates in here that stop the run — the clean-tree gate and the user approval gate — and this file carries the procedure around them: prior-learnings search, run identity and resume detection, the branch and scratch space, the measurement harness, the baseline, the parallelism probe, and the worktree budget.
+Read this after the spec is saved and follow it through the approval gate. The body owns the two gates in here that stop the run (the clean-tree gate and the user approval gate) and this file carries the procedure around them: prior-learnings search, run identity and resume detection, the branch and scratch space, the measurement harness, the baseline, the parallelism probe, and the worktree budget.
 
 ### 0.3 Search Prior Learnings
 
@@ -37,7 +37,7 @@ mkdir -p .context/compound-engineering/ce-optimize/<spec-name>/
 
 **This phase is a HARD GATE. The user must approve baseline and parallel readiness before Phase 2.**
 
-**Bundled scripts.** Phases 1 and 3 call helper scripts that ship in this skill's `scripts/` directory (`measure.sh`, `decide.mjs`, `parallel-probe.sh`, `experiment-worktree.sh`). The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve — invoke each by the skill's own absolute path. Every runnable block below already sets `SKILL_DIR` inline (shell state does not persist between Bash tool calls, so each block must carry it); just replace the `<absolute path …>` placeholder with the directory you loaded this `ce-optimize` SKILL.md from before running. The shape:
+**Bundled scripts.** Phases 1 and 3 call helper scripts that ship in this skill's `scripts/` directory (`measure.sh`, `decide.mjs`, `parallel-probe.sh`, `experiment-worktree.sh`). The Bash tool's working directory is the user's project, not the skill directory, so a bare `scripts/<name>` path will not resolve: invoke each by the skill's own absolute path. Every runnable block below already sets `SKILL_DIR` inline (shell state does not persist between Bash tool calls, so each block must carry it); just replace the `<absolute path …>` placeholder with the directory you loaded this `ce-optimize` SKILL.md from before running. The shape:
 
 ```bash
 SKILL_DIR="<absolute path of the directory containing this SKILL.md>";
@@ -75,7 +75,7 @@ The body owns this gate. Run `git status --porcelain`, filter the output against
 Run the measurement harness on the current code. Baseline and final confirmation always use the full configured protocol (`repeat_count` samples when mode is `repeat` or `ladder`; one run when mode is `stable`). Exploratory experiments later may spend less; the baseline must not.
 
 **If stability mode is `repeat` or `ladder`:**
-Do not start this protocol until the counts that mode uses are coherent. Repeat needs a positive `repeat_count`. Ladder needs positive `exploratory_pairs` and `confirmation_repeats` (falling back to `repeat_count`) with confirmation at least the exploratory count — the same rule `scripts/decide.mjs` uses. A repeat-mode spec does not need ladder fields.
+Do not start this protocol until the counts that mode uses are coherent. Repeat needs a positive `repeat_count`. Ladder needs positive `exploratory_pairs` and `confirmation_repeats` (falling back to `repeat_count`) with confirmation at least the exploratory count: the same rule `scripts/decide.mjs` uses. A repeat-mode spec does not need ladder fields.
 1. Run the harness that many times (`repeat_count` in repeat mode; the coherent confirmation count in ladder mode)
 2. Aggregate results using the configured aggregation method (median, mean, min, max)
 3. Calculate variance across runs
@@ -138,6 +138,6 @@ If count + `execution.max_concurrent` would exceed 12:
 
 ### 1.7 User Approval Gate
 
-The body owns this gate — what is presented, the options and the condition on adjusting the spec, the uncapped-spend disclosure, and the rule that Phase 2 does not start without explicit approval. A resume that cannot prove the user cleared this gate runs it again, so this phase supplies the same payload then. What this phase supplies to it: the baseline's gate values, diagnostic values, and judge scores; the experiment log path; the probe results with any blockers and mitigations; the clean-tree confirmation; the worktree count and projection; and the estimated per-experiment judge cost against the configured cap.
+The body owns this gate: what is presented, the options and the condition on adjusting the spec, the uncapped-spend disclosure, and the rule that Phase 2 does not start without explicit approval. A resume that cannot prove the user cleared this gate runs it again, so this phase supplies the same payload then. What this phase supplies to it: the baseline's gate values, diagnostic values, and judge scores; the experiment log path; the probe results with any blockers and mitigations; the clean-tree confirmation; the worktree count and projection; and the estimated per-experiment judge cost against the configured cap.
 
 ---

--- a/skills/ce-optimize/references/optimize-spec-schema.yaml
+++ b/skills/ce-optimize/references/optimize-spec-schema.yaml
@@ -43,7 +43,7 @@ required_fields:
 
           name:
             type: string
-            description: "Metric name — must match a key in the measurement command's JSON output (for hard type) or a scoring field (for judge type)"
+            description: "Metric name: must match a key in the measurement command's JSON output (for hard type) or a scoring field (for judge type)"
             example: "cluster_coherence"
 
           direction:
@@ -75,7 +75,7 @@ required_fields:
           required_children:
             name:
               type: string
-              description: "Metric name — must match a key in the measurement command's JSON output"
+              description: "Metric name: must match a key in the measurement command's JSON output"
             check:
               type: string
               description: "Comparison operator and threshold. Supported operators: >=, <=, >, <, ==, !="
@@ -103,7 +103,7 @@ required_fields:
           required_children:
             name:
               type: string
-              description: "Metric name — must match a key in the measurement command's JSON output"
+              description: "Metric name: must match a key in the measurement command's JSON output"
             direction:
               type: enum
               values:
@@ -148,7 +148,7 @@ required_fields:
           required_children:
             name:
               type: string
-              description: "Metric name — must match a key in the measurement command's JSON output"
+              description: "Metric name: must match a key in the measurement command's JSON output"
 
       judge:
         type: object

--- a/skills/ce-optimize/references/persistence.md
+++ b/skills/ce-optimize/references/persistence.md
@@ -4,19 +4,19 @@ Read this before Phase 0 and follow it for the whole run. The body states the in
 
 ### Core Rules
 
-1. **Write each experiment result to disk IMMEDIATELY after measurement** — not after the batch, not after evaluation, IMMEDIATELY. Append the experiment entry to the experiment log file the moment its metrics are known, before evaluating the next experiment. This is the #1 crash-safety rule.
+1. **Write each experiment result to disk IMMEDIATELY after measurement**: not after the batch, not after evaluation, IMMEDIATELY. Append the experiment entry to the experiment log file the moment its metrics are known, before evaluating the next experiment. This is the #1 crash-safety rule.
 
-2. **VERIFY every critical write** — after writing the experiment log, read the file back and confirm the entry is present. This catches silent write failures. Do not proceed to the next experiment until verification passes.
+2. **VERIFY every critical write**: after writing the experiment log, read the file back and confirm the entry is present. This catches silent write failures. Do not proceed to the next experiment until verification passes.
 
-3. **Re-read from disk at every phase boundary and before every decision** — never trust in-memory state across phase transitions, batch boundaries, or after any operation that might have taken significant time. Re-read the experiment log and strategy digest from disk.
+3. **Re-read from disk at every phase boundary and before every decision**: never trust in-memory state across phase transitions, batch boundaries, or after any operation that might have taken significant time. Re-read the experiment log and strategy digest from disk.
 
 4. **One experiment, one log entry.** Append a new experiment entry on its first measurement. Later ladder samples for that same experiment update that entry's metrics and outcome in place so a crash can resume the ladder without losing samples or duplicating the hypothesis. Distinct `comparisons` pairings accumulate on that same entry; in-place updates must not replace a previously persisted distinct pairing. Never rewrite a different experiment's samples or gate values. Outcome, `best`, and `hypothesis_backlog` are also updated in place at batch evaluation (CP-4). Do not rebuild the file from memory.
 
-5. **Per-experiment result markers for crash recovery** — each experiment writes a `result.yaml` marker in its worktree immediately after measurement. On resume, scan for these markers to recover experiments that were measured but not yet logged.
+5. **Per-experiment result markers for crash recovery**: each experiment writes a `result.yaml` marker in its worktree immediately after measurement. On resume, scan for these markers to recover experiments that were measured but not yet logged.
 
-6. **Strategy digest is written after every batch, before generating new hypotheses** — the agent reads the digest (not its memory) when deciding what to try next.
+6. **Strategy digest is written after every batch, before generating new hypotheses**: the agent reads the digest (not its memory) when deciding what to try next.
 
-7. **Never present results to the user without writing them to disk first** — the pattern is: measure -> write to disk -> verify -> THEN show the user. Not the reverse.
+7. **Never present results to the user without writing them to disk first**: the pattern is: measure -> write to disk -> verify -> THEN show the user. Not the reverse.
 
 ### Mandatory Disk Checkpoints
 
@@ -51,7 +51,7 @@ The scratch space under `.context/` is gitignored: it survives a local resume bu
 ### On Resume
 
 When Phase 0.4 detects an existing run:
-1. Read the experiment log from disk — this is the ground truth
+1. Read the experiment log from disk: this is the ground truth
 2. Scan worktree directories for `result.yaml` markers not yet in the log
 3. Recover any measured-but-unlogged experiments. The recovered first CP-3 entry copies `opportunity` from the hypothesis backlog as of dispatch; `result.yaml` holds metrics only, so a missing forecast stays unrecorded rather than being reconstructed from the result
 4. Continue as the body's resume rule directs: skip the work the log proves finished, and re-enter any gate the log does not prove was cleared

--- a/skills/ce-optimize/references/spec.md
+++ b/skills/ce-optimize/references/spec.md
@@ -12,12 +12,12 @@ Check whether the input is:
 
 **If spec file provided:**
 1. Read the YAML spec file. The orchestrating agent parses YAML natively -- no shell script parsing.
-2. Validate the spec against **every** rule in the `validation_rules` section of `references/optimize-spec-schema.yaml` (that section is the single source of truth for what a valid spec requires — do not rely on a remembered subset; conditional rules such as the singleton-rubric and exclusive-resources requirements live only there).
+2. Validate the spec against **every** rule in the `validation_rules` section of `references/optimize-spec-schema.yaml` (that section is the single source of truth for what a valid spec requires: do not rely on a remembered subset; conditional rules such as the singleton-rubric and exclusive-resources requirements live only there).
 3. If any rule fails, report the specific failures and ask the user to fix them before proceeding
 
 **If description provided:**
 1. Analyze the project to understand what can be measured. `references/usage-guide.md` has longer kickoff prompt shapes if the interview needs them.
-2. **Detect whether the optimization target is qualitative or quantitative** — this determines `type: hard` vs `type: judge` and is the single most important spec decision:
+2. **Detect whether the optimization target is qualitative or quantitative**: this determines `type: hard` vs `type: judge` and is the single most important spec decision:
 
    **Use `type: hard`** when:
    - The metric is a scalar number with a clear "better" direction
@@ -35,9 +35,9 @@ Check whether the input is:
    - Examples: clustering quality, search relevance, summarization quality, code readability, UX copy, recommendation relevance
 
    **IMPORTANT**: If the target is qualitative, **strongly recommend `type: judge`**. Explain that hard metrics alone will optimize proxy numbers without checking actual quality. Show the user the three-tier approach:
-   - **Degenerate gates** (hard, cheap, fast): catch obviously broken solutions — e.g., "all items in 1 cluster" or "0% coverage". Run first. If gates fail, skip the expensive judge step.
+   - **Degenerate gates** (hard, cheap, fast): catch obviously broken solutions: e.g., "all items in 1 cluster" or "0% coverage". Run first. If gates fail, skip the expensive judge step.
    - **LLM-as-judge** (the actual optimization target): sample outputs, score them against a rubric, aggregate. This is what the loop optimizes.
-   - **Diagnostics** (logged, not gated): distribution stats, counts, timing — useful for understanding WHY a judge score changed.
+   - **Diagnostics** (logged, not gated): distribution stats, counts, timing: useful for understanding WHY a judge score changed.
 
    If the user insists on `type: hard` for a qualitative target, proceed but warn that the results may optimize a misleading proxy.
 
@@ -54,18 +54,18 @@ Check whether the input is:
    Example stratified sampling for clustering:
    ```yaml
    stratification:
-     - bucket: "top_by_size"     # largest clusters — check for degenerate mega-clusters
+     - bucket: "top_by_size"     # largest clusters: check for degenerate mega-clusters
        count: 10
-     - bucket: "mid_range"       # middle of non-solo cluster size range — representative quality
+     - bucket: "mid_range"       # middle of non-solo cluster size range: representative quality
        count: 10
-     - bucket: "small_clusters"  # clusters with 2-3 items — check if connections are real
+     - bucket: "small_clusters"  # clusters with 2-3 items: check if connections are real
        count: 10
-   singleton_sample: 15          # singletons — check for false negatives (items that should cluster)
+   singleton_sample: 15          # singletons: check for false negatives (items that should cluster)
    ```
 
    The sampling strategy is domain-specific. For search relevance, strata might be "top-3 results", "results 4-10", "tail results". For summarization, strata might be "short documents", "long documents", "multi-topic documents".
 
-   **Singleton evaluation is critical when the goal involves coverage** — sampling singletons with the singleton rubric checks whether the system is missing obvious groupings.
+   **Singleton evaluation is critical when the goal involves coverage**: sampling singletons with the singleton rubric checks whether the system is missing obvious groupings.
 
 4. **Design the rubric** (for `type: judge`):
 
@@ -73,7 +73,7 @@ Check whether the input is:
    - Has a 1-5 scale (or similar) with concrete descriptions for each level
    - Includes supplementary fields that help diagnose issues (e.g., `distinct_topics`, `outlier_count`)
    - Is specific enough that two judges would give similar scores
-   - Does NOT assume bigger/more is better — "3 items per cluster average" is not inherently good or bad
+   - Does NOT assume bigger/more is better: "3 items per cluster average" is not inherently good or bad
 
    Example for clustering:
    ```yaml
@@ -82,13 +82,13 @@ Check whether the input is:
      - 5: All items clearly about the same issue/feature
      - 4: Strong theme, minor outliers
      - 3: Related but covers 2-3 sub-topics that could reasonably be split
-     - 2: Weak connection — items share superficial similarity only
+     - 2: Weak connection: items share superficial similarity only
      - 1: Unrelated items grouped together
      Also report: distinct_topics (integer), outlier_count (integer)
    ```
 
 5. Guide the user through the remaining spec fields:
-   - What degenerate cases should be rejected? (gates — e.g., "solo_pct <= 0.95" catches all-singletons, "max_cluster_size <= 500" catches mega-clusters)
+   - What degenerate cases should be rejected? (gates: e.g., "solo_pct <= 0.95" catches all-singletons, "max_cluster_size <= 500" catches mega-clusters)
    - What command runs the measurement?
    - What files can be modified? What is immutable?
    - Any constraints or dependencies?

--- a/skills/ce-optimize/references/usage-guide.md
+++ b/skills/ce-optimize/references/usage-guide.md
@@ -39,7 +39,8 @@ Choose `type: judge` when a numeric metric can be gamed or when human usefulness
 
 `ce-optimize` is usually the wrong tool when:
 
-- The fix is obvious and does not need experimentation
+- The change is already known: make it, or use `ce-work`
+- The job is diagnosing failing or slow behavior: that is `ce-debug`
 - There is no repeatable measurement harness
 - The search space is fake and only has one plausible answer
 - The cost of evaluating variants is too high to justify multiple runs

--- a/skills/ce-optimize/references/wrap-up.md
+++ b/skills/ce-optimize/references/wrap-up.md
@@ -1,6 +1,6 @@
 # Phase 4: wrap-up
 
-Read this at wrap-up. The body owns the post-completion options the user chooses from; this file carries what each one needs — the deferred-hypothesis presentation, the results summary, what is preserved and what is not, the mechanical-apply bar for review findings, and the cleanup rules.
+Read this at wrap-up. The body owns the post-completion options the user chooses from; this file carries what each one needs: the deferred-hypothesis presentation, the results summary, what is preserved and what is not, the mechanical-apply bar for review findings, and the cleanup rules.
 
 ## Phase 4: Wrap-Up
 
@@ -33,12 +33,12 @@ Present these options after the summary:
 1. **Run `ce-code-review`** on the cumulative diff (baseline to final), on the optimization branch. Do not commit or push from this step.
 2. **Run `ce-compound`** to document the winning strategy as an institutional learning.
 3. **Create PR** from the optimization branch to the default branch.
-4. **Continue** — re-enter Phase 3, state re-read first.
-5. **Done** — leave the branch for manual review.
+4. **Continue**: re-enter Phase 3, state re-read first.
+5. **Done**: leave the branch for manual review.
 
 For option 1, load `ce-code-review` on the optimization branch, interactive or `mode:agent`, and land eligible fixes under the bar below before moving to the next option.
 
-**Mechanical-apply bar:** apply any finding with a concrete `suggested_fix` that is a clear, reversible improvement; push back (keep, don't apply) when the reviewer is wrong, noting why. Defer anything whose right fix needs a design or product decision (architecture direction, contract shape, behavior change needing sign-off) and any finding with no concrete fix to act on — surface what was deferred. Confirm evidence still matches at `file:line` before editing. After applying, run tests (at least targeted tests for what changed; broader suite for multi-file edits). Do not commit or push from this step — leave the diff on the optimization branch for the Create PR option.
+**Mechanical-apply bar:** apply any finding with a concrete `suggested_fix` that is a clear, reversible improvement; push back (keep, don't apply) when the reviewer is wrong, noting why. Defer anything whose right fix needs a design or product decision (architecture direction, contract shape, behavior change needing sign-off) and any finding with no concrete fix to act on: surface what was deferred. Confirm evidence still matches at `file:line` before editing. After applying, run tests (at least targeted tests for what changed; broader suite for multi-file edits). Do not commit or push from this step: leave the diff on the optimization branch for the Create PR option.
 Option 4 (continue) re-enters Phase 3 with the current state, state re-read from disk first.
 
 ### 4.4 Cleanup

--- a/tests/skills/ce-optimize-decide.test.ts
+++ b/tests/skills/ce-optimize-decide.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import {
@@ -1497,7 +1497,12 @@ describe("schema and skill pins", () => {
     expect(SKILL_BODY).toContain("**Outcome:**")
     expect(SKILL_BODY).toContain("**Horizon:**")
     expect(SKILL_BODY).toContain('description: "Optimize a working system against a measurable target.')
-    expect(SKILL_BODY).toContain("Not for diagnosing a failure; that is ce-debug.")
+    expect(SKILL_BODY).toContain("named workload's cost should drop")
+    expect(SKILL_BODY).toContain("several variants must be scored and kept")
+    expect(SKILL_BODY).toContain("Not for diagnosing failing or slow behavior (ce-debug)")
+    expect(SKILL_BODY).toContain("not for implementing a change you already know (ce-work)")
+    expect(SKILL_BODY).not.toContain("faster, cheaper, or leaner")
+    expect(SKILL_BODY).not.toContain("clustering, ranking, search, or prompt quality")
     expect(LOOP).toContain("locating measurement")
     expect(LOOP).toContain("attributed shares before implementation")
     expect(LOOP).not.toContain("Missing profile data does not block")
@@ -1511,5 +1516,25 @@ describe("schema and skill pins", () => {
     expect(readFileSync(path.join(SKILL_DIR, "references", "wrap-up.md"), "utf8")).toContain(
       "Not selected: <count>",
     )
+  })
+})
+
+function listSkillFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const next = path.join(dir, entry.name)
+    return entry.isDirectory() ? listSkillFiles(next) : [next]
+  })
+}
+
+describe("ce-optimize skill prose", () => {
+  test("does not use em dashes or the phrase load-bearing", () => {
+    const offenders: string[] = []
+    for (const file of listSkillFiles(SKILL_DIR)) {
+      const text = readFileSync(file, "utf8")
+      const rel = path.relative(process.cwd(), file)
+      if (text.includes("\u2014")) offenders.push(`${rel}: em dash`)
+      if (/load-bearing/i.test(text)) offenders.push(`${rel}: load-bearing`)
+    }
+    expect(offenders).toEqual([])
   })
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The model-invoked description was overfiring: `faster, cheaper, or leaner` and `clustering, ranking, search, or prompt quality` are synonym/domain catalogs for two branches, and the only neighbor fence was diagnosing a failure. That stole known one-shot work (`ce-work`) and slowness-as-a-bug (`ce-debug`).

## Description

```
Optimize a working system against a measurable target. Use when a named workload's cost should drop and the change is not already known. Use when several variants must be scored and kept. Not for diagnosing failing or slow behavior (ce-debug), and not for implementing a change you already know (ce-work).
```

Both jobs stay. The catalogs go. The two real false-trigger neighbors are fenced.

## Prose

`load-bearing` appeared **1** time in the skill (`experiment-log-schema.yaml`: "Load-bearing state"). Replaced with "The loop branches on this value."

Unicode em dashes (`—`) appeared **114** times across 10 skill files. Replaced with colons, parentheses, or commas. A regression test now fails if either form returns.

Usage-guide and the skill page skip list now name `ce-work` and slow `ce-debug` the same way.

## Validation

- `bun test tests/skills/ce-optimize-decide.test.ts tests/codex-skill-prompt-budget.test.ts tests/skill-eval-cell/catalog.test.ts`: 89 pass
- Codex prompt budget: `ce-optimize` still under 8000 CRLF-adjusted bytes (7821, 179 headroom)
- `bun run test`: 3755 pass, 1 skip; `tests/plugin-path.test.ts` timed out under `--parallel` (known flake). Isolated rerun reported separately.
- Skill-eval pack skipped: `claude`, `codex`, and `grok` are not on PATH. A description-activation cell would be the right eval when those hosts are available.

## Follow-up

Remaining `ce-optimize` reference blocks that predate the authoring standard (category menus, dispatch recipes) were left untouched except where em dashes or the activation copy made them wrong.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

- **Model:** Cursor · Cursor Grok 4.6

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b79dd042-47ca-4f9e-9ca8-2d5bcee8d9b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b79dd042-47ca-4f9e-9ca8-2d5bcee8d9b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

