### PR TITLE
fix(ce-optimize): reject incomplete paired baselines

### DIFF
--- a/skills/ce-optimize/scripts/decide.mjs
+++ b/skills/ce-optimize/scripts/decide.mjs
@@ -240,9 +240,11 @@ export function compareObjective({
           : verdictFromSigned(delta, threshold) === "regressed"
             ? "regressed"
             : "inconclusive"
+    } else if (candSamples.length > baseSamples.length) {
+      verdict = "inconclusive"
     } else {
       const diffs = candSamples.map((value, index) =>
-        signedDelta(baseSamples[Math.min(index, baseSamples.length - 1)], value, direction),
+        signedDelta(baseSamples[index], value, direction),
       )
       const lo = Math.min(...diffs)
       const hi = Math.max(...diffs)
@@ -363,6 +365,7 @@ export function decide(input) {
   const improved = []
   const violated = []
   const missing = []
+  const incompleteBaselines = []
   const candidateBundles = {}
   const baselineBundles = {}
   const aggregation = spec.aggregation ?? "median"
@@ -375,6 +378,15 @@ export function decide(input) {
     if (!base || base.aggregate == null || !cand || cand.aggregate == null) {
       missing.push(objective.name)
       continue
+    }
+    if (comparison.method === "paired" && base.samples.length && cand.samples.length) {
+      const requiredSamples = Math.max(cand.samples.length, ladderEnabled ? confirmationRepeats : 1)
+      if (base.samples.length < requiredSamples) {
+        incompleteBaselines.push(
+          `${objective.name} (${base.samples.length} observed, ${requiredSamples} required)`,
+        )
+        continue
+      }
     }
     const result = compareObjective({
       baselineValue: base.aggregate,
@@ -396,6 +408,15 @@ export function decide(input) {
       decision: "error",
       comparisons,
       reason: `missing required metric: ${missing.join(", ")}`,
+    })
+  }
+
+  if (incompleteBaselines.length) {
+    // Ladder next steps collect candidate samples; they cannot repair the baseline.
+    return closedResult({
+      decision: "error",
+      comparisons,
+      reason: `insufficient paired baseline samples: ${incompleteBaselines.join(", ")}`,
     })
   }
 

--- a/tests/skills/ce-optimize-decide.test.ts
+++ b/tests/skills/ce-optimize-decide.test.ts
@@ -698,6 +698,98 @@ describe("noise-aware comparison from the observed suite run", () => {
   })
 })
 
+describe("sampled paired baseline evidence", () => {
+  const spec = hardSpec({
+    comparison: { method: "paired", relative_threshold: 0.05 },
+    stability_mode: "ladder",
+    ladder: { confirmation_repeats: 5 },
+  })
+
+  test.each([8, 12])("does not reuse the last baseline sample to compare candidate %s", (value) => {
+    const result = compareObjective({
+      baselineValue: 10,
+      candidateValue: value,
+      baselineSamples: [10],
+      candidateSamples: Array(5).fill(value),
+      direction: "minimize",
+      type: "hard",
+      comparison: { method: "paired", relative_threshold: 0.05 },
+      maxRegression: null,
+    })
+    expect(result.verdict).toBe("inconclusive")
+    expect(result.violated).toBe(false)
+  })
+
+  test.each([1, 5])("rejects a short ladder baseline with %s candidate samples", (count) => {
+    const result = decide({
+      spec,
+      baseline: snapshot(10, { sample_count: 5 }),
+      candidate: snapshot(8, { metrics: { wall_seconds: { samples: Array(count).fill(8) } } }),
+    })
+    expect(result.decision).toBe("error")
+    expect(result.eligible).toBe(false)
+    expect(result.next_measurement).toBe("none")
+    expect(result.reason).toBe("insufficient paired baseline samples: wall_seconds (1 observed, 5 required)")
+  })
+
+  test("rejects unpaired candidate samples even without a ladder", () => {
+    const result = decide({
+      spec: { ...spec, stability_mode: "stable" },
+      baseline: snapshot(10),
+      candidate: snapshot(8, { metrics: { wall_seconds: { samples: [8, 8] } } }),
+    })
+    expect(result.decision).toBe("error")
+    expect(result.eligible).toBe(false)
+    expect(result.reason).toBe("insufficient paired baseline samples: wall_seconds (1 observed, 2 required)")
+  })
+
+  test.each(["hard", "judge"])("checks the sampled baseline of a required non-primary %s objective", (type) => {
+    const result = decide({
+      spec: {
+        ...spec,
+        objectives: [{ name: "quality", type, direction: "maximize", role: "required" }],
+      },
+      baseline: snapshot(10, {
+        metrics: { wall_seconds: { samples: Array(5).fill(10) }, quality: { samples: [4] } },
+      }),
+      candidate: snapshot(8, {
+        metrics: { wall_seconds: { samples: Array(5).fill(8) }, quality: { samples: Array(5).fill(4) } },
+      }),
+    })
+    expect(result.decision).toBe("error")
+    expect(result.eligible).toBe(false)
+    expect(result.reason).toBe("insufficient paired baseline samples: quality (1 observed, 5 required)")
+  })
+
+  test.each([
+    [1, "promising", "confirm"],
+    [5, "keep", "none"],
+  ])("a complete baseline supports %s candidate samples", (count, decision, next) => {
+    const result = decide({
+      spec,
+      baseline: snapshot(10, { metrics: { wall_seconds: { samples: Array(5).fill(10) } } }),
+      candidate: snapshot(8, { metrics: { wall_seconds: { samples: Array(count).fill(8) } } }),
+    })
+    expect(result.decision).toBe(decision)
+    expect(result.eligible).toBe(true)
+    expect(result.next_measurement).toBe(next)
+  })
+
+  test("preserves scalar judge confirmation from sample_count with paired comparison", () => {
+    const result = decide({
+      spec: {
+        ...spec,
+        primary: { name: "mean_score", direction: "maximize", type: "judge" },
+      },
+      baseline: { judge: { mean_score: 4 } },
+      candidate: { gates: { suite_passed: 1 }, judge: { mean_score: 4.5 }, sample_count: 5 },
+    })
+    expect(result.decision).toBe("keep")
+    expect(result.eligible).toBe(true)
+    expect(result.next_measurement).toBe("none")
+  })
+})
+
 describe("cost-aware measurement ladder", () => {
   const spec = hardSpec({
     stability_mode: "ladder",


### PR DESCRIPTION
Sampled paired comparisons could reuse the last baseline observation when the candidate had more samples. With five confirmation repeats, baseline `[10]` and candidate `[8, 8, 8, 8, 8]` incorrectly produced a terminal `keep`.

Reject insufficient sampled baselines with the existing `error` result, identifying the objective and observed/required counts. Validate every required sampled objective against the candidate count and, when the ladder is enabled, the confirmation count. Pairwise comparison no longer duplicates baseline observations. A complete baseline still supports a shorter exploratory candidate, and scalar judge fallback remains unchanged.

Fixes #1650.

Validation:

- Added 10 focused cases: 7 regressions fail against the original script; 3 preservation cases pass before and after. The complete focused file passes all 81 tests.
- `bun run test`: 3,856 passed, 0 failed; 1 conditional skip because `omp` is unavailable.
- `bun run release:validate` and `bun run plugin:validate`: passed.
- Node CLI: 8 before/after cases passed, including the reproduced failure and unchanged output on preserved paths.

## Security Disclosure

The existing decision script now validates measurement sample counts. Execution permissions, filesystem access, credentials, and dependencies are unchanged.

## Agent Disclosure

- **Model:** Codex · `gpt-6-astra` (medium; implementation), GPT-6 (review and validation).
