### PR TITLE
fix: let explain and pov support calling workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ It runs on 14 agent hosts, including Claude Code, Cursor, and Codex.
 
 Maintained by [Kieran Klaassen](https://github.com/kieranklaassen) and [Trevin Chow](https://github.com/tmchow), with contributions from the open-source community.
 
+For understanding before a change, ask `ce-explain` how the relevant behavior works and why it exists. For a recommendation, use `ce-pov`; “oracle this” adds independent model opinions. Both can contribute to another workflow without requiring a separate human interaction.
+
 ## Install
 
 ### Claude Code

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -66,8 +66,8 @@ Invoked when a specific need arises, not part of any chain.
 | Skill | Description |
 |-------|-------------|
 | [`/ce-bakeoff`](./ce-bakeoff.md) | Independent approach development and selection for better brainstorming and planning decisions. Explicitly requested from those workflows, or used standalone. |
-| [`/ce-pov`](./ce-pov.md) | A project-grounded verdict: adopt/hold/reject, a document take, or a position on supplied approaches. Optional named/`oracle` panel. |
-| [`/ce-explain`](./ce-explain.md) | A durable teaching document for a concept, a diff, an idea, or a window of recent work, with a self-check section when the material warrants one. |
+| [`/ce-pov`](./ce-pov.md) | A project-grounded judgment on adoption, documents, or supplied approaches, with an oracle panel for independent model opinions. |
+| [`/ce-explain`](./ce-explain.md) | An evidence-backed explanation of how something works and why, delivered for learning or further work; standalone teaching artifacts when useful. |
 | [`/ce-prototype`](./ce-prototype.md) | Build a throwaway prototype so someone can experience how the product should work, feel, or read, then write those decisions into an existing plan or continue into brainstorm or plan |
 | [`/ce-debug`](./ce-debug.md) | Find the root cause of broken behavior: causal chain, predictions, then an optional fix and PR handoff |
 | [`/ce-code-review`](./ce-code-review.md) | Structured review of a diff or PR: skill-local personas, confidence-gated findings, and the rules you write in `CODING_STANDARDS.md` |

--- a/docs/guides/ce-brainstorm.md
+++ b/docs/guides/ce-brainstorm.md
@@ -257,6 +257,10 @@ This works on any harness. The host serves the chosen model natively where it ca
 - [`lfg`](./lfg.md): autonomous plan-then-ship from a requirements-only artifact
 - [`ce-proof`](./ce-proof.md): publish a non-software summary (or any markdown file you ask to share)
 
+## Understanding existing behavior and rationale
+
+When an unanswered question about behavior or rationale would materially change the work, this skill can use `ce-explain`. It passes the question, its scope, and its intended use, then uses the resulting evidence, constraints, and unknowns. The calling skill remains responsible for the plan or requirements. It reuses sufficient existing research and follows the same source restrictions. Explanation is not a mandatory extra stage.
+
 ## Bake-off
 
 Explicitly request a Bake-off when alternatives need concrete development before choosing. See [ce-bakeoff](./ce-bakeoff.md) for the independent candidate contract and limits. General automatic routing is not enabled. The existing model choice is passed to Bake-off as a candidate preference; an explicitly requested candidate mix takes precedence. Bake-off owns dispatch: native model-family diversity when no preference is set, then available authorized CLIs, then fresh same-host agents if those routes fail. It does not use the ordinary elevation adapter for bakers.

--- a/docs/guides/ce-explain.md
+++ b/docs/guides/ce-explain.md
@@ -1,219 +1,59 @@
 # `ce-explain`
 
-> Build a dense visual document about a concept, a diff, an idea, or a window of your own recent work. Keep it. Check yourself on it from the document.
+> Understand how something works and why it has its current shape, for learning or the next piece of work.
 
-`ce-explain` is the on-demand **teaching** skill. Point it at something worth understanding and it writes a self-contained explainer, grounded in repo evidence when the material lives here, saved to disk before you are asked where to put it.
+`ce-explain` produces an evidence-backed explanation. It follows behavior through source and tests, investigates documented design rationale, and separates what is known from inference and unanswered questions. It explains; [`ce-pov`](./ce-pov.md) judges what to do.
 
-It is not a status memo. A recap from this skill is a document you can study or speak from; if you ask for the terse update itself, it declines that form. Ordinary Q&A stays in chat. Operational questions ("why is X doing Y") get a direct answer first, and an explainer is offered only when a real concept sits behind the question.
+## When to use it
 
-It also is not `ce-compound` (that teaches the repo) and not `ce-pov` (that returns a verdict). The check-in is a `Check yourself` section at the end of the document, included when you ask for it or the material warrants it; the run never stops to quiz you in chat.
+Use it to understand a subsystem before changing it, investigate the reasons behind an existing design, learn a concept introduced in a PR, explain a supplied idea, or reconstruct a window of work. A request to diagnose or fix a failure belongs to `ce-debug`; explaining the existing mechanism remains here.
 
----
+The result follows its intended use. A planning input can be an answer with citations and constraints. Explanatory material for a PR can be returned for its authoring workflow to incorporate. A deeper teaching request can produce a standalone document to study and keep. The caller's identity does not choose the format: an agent can request a teaching document for a person, and a person can request a working answer.
 
-## TL;DR
-
-| Question | Answer |
-|----------|--------|
-| What does it do? | Classifies the request as concept, diff, idea, or recap, grounds it, writes one visual explainer, then asks where to put it |
-| When to use it | You want a document to keep about a change, a topic, an idea, or what you actually did in a window |
-| What it produces | One self-contained HTML file (markdown if you ask), written to a temp run dir first, then copied or published if you pick a destination |
-| What's next | Keep the file, work through its `Check yourself` section when it has one, then optional offers into `/ce-ideate`, `/ce-simplify-code`, `/ce-polish`, or `/ce-compound-refresh` |
-
----
-
-## Example invocations
-
-Plain language is the ordinary path. Tokens force a mode when inference could go either way.
+## Examples
 
 ```text
-# Asks what to explain. Offers a recent-work recap as a shortcut
-/ce-explain
-
-# A window in prose is a recap, not a topic named "since last Monday"
-/ce-explain since last Monday
-
-# Force recap when the prompt could be a window or a topic
-/ce-explain since:7d
-
-# Catch yourself up before you speak. Still a teaching doc, not a status memo
-/ce-explain catch me up on what I did this week
-
-# Force diff mode on a range
+/ce-explain how does cancellation propagate, and why do we retain polling? This informs the readiness plan.
+/ce-explain explain this queue's lease for reviewers, in two paragraphs for the PR body
+/ce-explain teach me the concept introduced in this PR; make an explainer I can keep
 /ce-explain diff:main..HEAD
-
-# A PR, same force
-/ce-explain diff:PR#42
-
-# An idea, taken as given. Not scoped, not ranked
+/ce-explain since last Monday
 /ce-explain my idea of caching explainers per repository
-
-# External concept. No repo grounding
-/ce-explain Ruby garbage compaction
-
-# Markdown instead of the default HTML
-/ce-explain the parser split output:md
-
-# Someone else will read it. Same depth, not a status memo
-/ce-explain write this up for the team audience:team
+/ce-explain the parser split output:md audience:team
 ```
 
-`since last Monday` and `since:monday` resolve to the same window. A colon in a sentence is not a flag: "walk me through the diff: why did we split the parser" is prose, not `diff:why`.
+Plain language is the ordinary path. `diff:` and `since:` select the subject, `audience:` names the reader, and `output:md` or `output:html` requests that artifact format. Colons in ordinary prose are not flags. A bare invocation resolves its subject from context or asks what to explain when a person is available.
 
----
+## How it works
 
-## The Problem
+The skill establishes the question and intended use before researching or creating files. It reuses adequate current evidence and investigates missing or disputed claims.
 
-Agent-driven work detaches you from what shipped in two ways.
+For **how**, it follows the relevant trigger, state changes, ownership boundaries, and effect. For **why**, it follows decision records, comments, history, PRs, and linked issues within the allowed sources. It does not search every available service by default, and it preserves a calling workflow's opt-in restrictions on team chat.
 
-You cannot account for it. A week of agent commits later, git has the record and you cannot read it in three minutes.
+Code demonstrates behavior, not necessarily the author's motivation. A missing historical reason stays unknown. Historical constraints are checked before being treated as current requirements. When the explanation informs a change, it identifies the relevant constraints and risks without choosing the implementation.
 
-You cannot explain it. Writing the code forced comprehension; reviewing agent output does not, and the debt accumulates on your own projects.
+A recap uses an evidence scout before forming a narrative about the window. It cites the sources and says which activity it included or left out. Missing subjects and empty windows are reported rather than replaced with an unrelated explanation.
 
-The first wants a report. The second wants a report and, sometimes, a way to make it stick. `/ce-compound` stores knowledge for the repo and `/ce-pov` returns a verdict; neither covers this.
+## Delivery and teaching
 
-## The Solution
+Answers and content for another document return directly. Standalone teaching artifacts use HTML by default, or markdown when requested. Layout, visuals, terminology, and depth follow the reader's needs; there is no fixed visual quota or required prose arrangement.
 
-One artifact contract, four input shapes:
+Standalone HTML remains self-contained and readable offline. Existing metadata records the subject, date, input shape, and named audience. Source links remain available, and unsupported external knowledge is visibly labeled unverified.
 
-| Input | What you get |
-|------|--------------|
-| Work recap ("what did I do this week?") | A date-ordered timeline of real commits, PRs, and the plan or solution docs behind them |
-| Diff (a sha, range, PR, or "the last change") | What the change actually does, with annotated hunks and the why per hunk |
-| Concept (a topic, subsystem, or external subject) | An explainer grounded in this repo when the topic touches it, fully external when it does not |
-| Idea (a proposal of yours) | Implications, mechanics, and trade-offs, taken as a fixed given |
+Teaching exercises are included when requested or when they would help the reader remember and apply the material. They live in a static `Check yourself` section with answers afterward. The run never waits for the reader to answer a quiz.
 
-Recap mode dispatches a scout that walks git activity, PRs (only when a PR interface is reachable), and project docs for the window, then writes an evidence file with shas and `file:line` pointers before any prose is composed. The main conversation does not pre-scan the window. An empty window says so and writes nothing.
+A local artifact is delivered with a summary and its path. There is no mandatory destination menu. A requested destination uses the available adapter; public ht-ml.app publishing still requires confirmation after its public-publishing warning. If it cannot complete, the local file remains available.
 
-Idea mode never scopes (`ce-brainstorm`) and never ranks alternatives (`ce-ideate`).
+## In a workflow
 
----
+`ce-plan`, `ce-brainstorm`, and `ce-pov` can use `ce-explain` when an unresolved behavior or rationale question materially affects their work. The skill reuses existing research when it is sufficient. The caller gets evidence, constraints, and unanswered questions, then continues under its own authority. No return flag is required.
 
-## What Makes It Novel
+`ce-commit-push-pr` continues composing its own `New concepts` section and offering `ce-explain` for deeper learning. This skill can also supply an explanation for a surrounding document without taking over placement or publication.
 
-### Evidence first, including an honest empty
+## Related skills
 
-The scout gathers before anything is characterized, because an early `git --all` glance would seed a false model of what happened. Unreachable PRs become one honest line, not a guess from branch names. An empty `diff:` range names what it resolved to and asks before substituting. An external topic with no web access is labeled in the header: *Unverified, from model knowledge, not checked against current sources*.
-
-### Offline, one file, written before the ask
-
-Default output is one self-contained HTML file (markdown via `output:md`). CSS and SVG are inline, images are data URIs, fonts are system fonts. No scripts, forms, or interactive quiz. A reader who skips every visual still gets the full explanation in prose. The form follows the material: diagram for architecture, annotated snippets for code, numbered flow for a lifecycle, timeline for a recap, two-column contrast for a trade-off.
-
-The header is visible text with fixed field names (`Date`, `Input shape`, `Subject`) so a later library can index them.
-
-The file lands in `/tmp/compound-engineering-<effective-uid>/ce-explain/<run-id>/` before the destination ask, so declining every destination loses nothing. That path is temporary; pick a destination if you want to keep the file.
-
-### The destination menu comes from this session
-
-The menu offers only what this session actually has. Local file and Leave it are always there. HTML prefers a Claude Artifact in Claude Code when that tool is present, otherwise a public ht-ml.app URL. ht-ml.app is never chosen headlessly, and the option itself warns that the page may be indexed, crawled, copied, or archived. Proof is offered on markdown runs. Thinkroom appears only when that capability is detected.
-
-### Written for you, or re-rendered for a reader
-
-Default voice is second person and assumes the context you already have. `audience:team` (or "write this up for the team") drops second person, names the subject in third person when the evidence supplies a name, and adds the minimum orientation an outside reader needs. Depth, real code, and honesty labels do not change. Wanting to *speak* from the material (standup prep, meeting prep) stays personal; you are still the reader.
-
-If you compose the personal default and then pick a destination that puts it in front of other people, it offers once to re-render before sending.
-
-### The check-in lives in the document
-
-The skill never stops to ask whether you want a quiz, and never poses questions in chat. When you ask for a check-in, or the material warrants active recall (a gnarly diff, a hard concept, a dense recap window) and you did not decline one, the document ends with a `Check yourself` section: two to four questions listed first, then their answers under an `Answers` label, so you can attempt every question before any answer is in view. Each answer says what a correct response contains and names the gap a plausible wrong answer exposes. Routine material gets no section.
-
-Saying "no quiz" omits the section; asking for one includes it whatever the material.
-
----
-
-## Quick Example
-
-You type `/ce-explain since last Monday`. That is a recap. A scout walks the window and writes evidence with shas. The week has real commits, so a document is composed: a timeline, each entry naming what changed and why it mattered.
-
-The material is routine, so the document carries no `Check yourself` section. The HTML lands in the run dir, you are asked where to put it, and you pick a local file and open it.
-
-The evidence includes a plan that shipped work has since contradicted. After the destination is settled, the skill offers `/ce-compound-refresh` on that doc. Take it or leave it.
-
----
-
-## When to Reach For It
-
-Use `ce-explain` when:
-
-- You need a written breakdown of a change you did not type, to keep
-- You want to learn a concept or subsystem, in this repo or outside it
-- You have an early idea and want its implications laid out before committing to it
-- You cannot account for a window of your own work and want a document you can study or speak from
-
-Skip it when:
-
-- You want a standup blurb or status memo. This skill will not write one, though recap mode can catch you up so you can
-- Ordinary Q&A, a quick "why?", or a trade-off that belongs in chat
-- Operational diagnosis ("why is X doing Y") unless you then accept the explainer offer
-- You need a verdict on whether to adopt something → `/ce-pov`
-- The knowledge belongs to the repo's future work → `/ce-compound`
-
----
-
-## Use as Part of the Workflow
-
-`ce-explain` sits outside the core loop. Invoke it when your account of the work, or your understanding of it, lags behind what shipped.
-
-Closing offers, only after the destination is settled:
-
-- New-capability ideas → `/ce-ideate`
-- Code-clarity findings → `/ce-simplify-code`
-- UI/UX polish → you invoke `/ce-polish` yourself (`ce-polish` is user-invoked only)
-- A plan or solution doc the evidence has overtaken → `/ce-compound-refresh`
-
-Those are offers, never auto-fired. An unattended run reports the temp path and skips them.
-
----
-
-## Use Standalone
-
-No plan and no brainstorm required. It works in any repo, and with no repo at all for an external topic.
-
-A bare `/ce-explain` asks what to explain. It does not invent a default artifact.
-
----
-
-## Reference
-
-| Argument | Effect |
-|----------|--------|
-| _(empty)_ | Asks "What should I explain?" and offers a recap shortcut |
-| free text | Classified as concept, idea, diff, or recap by shape |
-| `diff:<ref-or-range>` | Force diff mode (`diff:abc1234`, `diff:main..HEAD`, `diff:PR#42`) |
-| `since:<window\|date\|ref>` | Force recap mode (`since:monday`, `since:7d`, `since:v2.1.0`). Last 7 days only when no window was named |
-| `output:md` | Markdown artifact instead of HTML (`output:html` forces HTML) |
-| `audience:<who>` | Render for that reader instead of you personally |
-
-A token in flag position beats inference; a colon inside a sentence does not. `diff:` and `since:` together conflict, and the skill asks which you meant. An unrecognized `word:value` (including `feat:` inside a topic) stays as request text.
-
----
-
-## FAQ
-
-**Do I have to do the quiz?**
-No. The `Check yourself` section sits at the end of the document for whenever you want it, and the run never waits on you for it. Say "no quiz" and the section is omitted; routine material gets none anyway.
-
-**Can I use this for standup?**
-Recap mode can catch you up so you can speak; the skill will not write the status update itself. If the document is going to a team, say so (or pass `audience:`) and it renders for them at full depth.
-
-**Can I share the report?**
-Yes. Ask for that audience up front, or take the re-render offer when you pick a shared destination.
-
-**Where does the artifact go?**
-`$RUN_DIR` under `/tmp/compound-engineering-<effective-uid>/ce-explain/` first. A destination copies or publishes it; leave it and the path is temporary.
-
-**Is this `ce-compound` for humans?**
-Roughly. A Learning teaches the repo's future work; an explainer documents something for you. They are complements.
-
-**Can it track what I have learned?**
-Not in v1. No library, no spaced repetition, no progress state. The `Check yourself` section is yours to revisit; the stable run-dir layout and fixed header fields are what a later library could build on.
-
----
-
-## See Also
-
-- [`ce-pov`](./ce-pov.md): a verdict on something external, not a document about it
-- [`ce-compound`](./ce-compound.md): knowledge that belongs to the repo
-- [`ce-ideate`](./ce-ideate.md): where new-capability observations can go next
-- [`ce-simplify-code`](./ce-simplify-code.md): where code-clarity findings can go next
-- [`ce-polish`](./ce-polish.md): late polish you invoke yourself
-- [`ce-compound-refresh`](./ce-compound-refresh.md): a plan or solution doc the recap just contradicted
+- [`ce-pov`](./ce-pov.md): judge what should happen given the evidence.
+- [`ce-plan`](./ce-plan.md): turn requirements and constraints into a technical plan.
+- [`ce-brainstorm`](./ce-brainstorm.md): explore and scope the product direction.
+- [`ce-compound`](./ce-compound.md): capture durable project learning.
+- [`ce-debug`](./ce-debug.md): diagnose observed failure.

--- a/docs/guides/ce-plan.md
+++ b/docs/guides/ce-plan.md
@@ -290,6 +290,10 @@ This works on any harness. The host serves the chosen model natively where it ca
 - [`ce-strategy`](./ce-strategy.md): anchor plans to documented product strategy
 - [`ce-proof`](./ce-proof.md): publish a non-software plan, or any markdown plan you ask to share
 
+## Understanding existing behavior and rationale
+
+When an unanswered question about behavior or rationale would materially change the work, this skill can use `ce-explain`. It passes the question, its scope, and its intended use, then uses the resulting evidence, constraints, and unknowns. The calling skill remains responsible for the plan or requirements. It reuses sufficient existing research and follows the same source restrictions. Explanation is not a mandatory extra stage.
+
 ## Bake-off
 
 Explicitly request a Bake-off when alternatives need concrete development before choosing. See [ce-bakeoff](./ce-bakeoff.md) for the independent candidate contract and limits. General automatic routing is not enabled. The existing model choice is passed to Bake-off as a candidate preference; an explicitly requested candidate mix takes precedence. Bake-off owns dispatch: native model-family diversity when no preference is set, then available authorized CLIs, then fresh same-host agents if those routes fail. It does not use the ordinary elevation adapter for bakers.

--- a/docs/guides/ce-pov.md
+++ b/docs/guides/ce-pov.md
@@ -1,188 +1,55 @@
 # `ce-pov`
 
-> Get a decisive, project-grounded point of view: an adoption verdict, a take on a document, or a position on approaches already on the table.
+> Judge a supplied subject against this project's evidence and constraints, with an oracle panel when requested.
 
-`ce-pov` is the on-demand judgment skill. Give it an adoption question, a plan or spec to react to as a whole, or a set of approaches, and it answers in that subject's shape: **Adopt / Trial / Hold / Reject / Not-our-problem** for adoption, a bottom line with strengths and risks for a document, a preferred approach (or an honest toss-up) for supplied options.
+`ce-pov` answers what should happen and why. It returns a supported judgment on an external-adoption question, a document's direction, or supplied approaches. [`ce-explain`](./ce-explain.md) answers how something works and why it has its current shape. Investigating a past decision does not establish that it remains the right decision today.
 
-It is not research. Research explains a topic; this skill decides what the topic means for your project, and it refuses to decide without a verified project fact behind the answer. Adoption verdicts also need a verified external source. It is not a findings review either: `ce-doc-review` finds issues in a document, `ce-code-review` finds issues in a diff, `ce-debug` handles things that are actually broken.
-
-After a position lands, it proposes one next step (edit, plan, scope, or spike). Invoked bare mid-session, it infers the question from the conversation, returns the POV, and hands control back.
-
----
-
-## TL;DR
-
-| Question | Answer |
-|----------|--------|
-| What does it do? | Grounds a question, document, or approach set against this project and returns a decisive POV in the same shape |
-| When to use it | "Should we adopt X?", "what do you think of this plan?", "A or B here?", or a mid-session second opinion |
-| What it produces | A compact chat POV. A shareable write-up, a captured decision, or a cross-model panel note are all opt-in |
-| What's next | One handoff reasoned from the POV: edits, `/ce-plan`, `/ce-brainstorm`, or a spike with `/ce-work`. Warm invokes skip the offer |
-
----
-
-## Example invocations
+## Examples
 
 ```text
-# Decide whether an external tool fits this project
 /ce-pov should we adopt Drizzle ORM here?
-
-# Holistic take on a document. Use ce-doc-review for issue-by-issue findings.
 /ce-pov what do you think of docs/plans/new-checkout.md?
-
-# Choose among approaches already on the table
-/ce-pov for this service, should we use polling or webhooks?
-
-# Bare link: fetches enough to name the thing, then proposes possible questions
-/ce-pov https://example.com/tool
-
-# Exposure: is this CVE or deprecation ours?
+/ce-pov should we keep polling or rely only on notifications?
 /ce-pov does this CVE affect us?
-
-# Revisit a past decision
-/ce-pov we passed on Redis last year. still right?
-
-# Named peers: forms its own POV, then consults every named model
-/ce-pov compare your take on docs/plans/new-checkout.md with Grok and Composer
-
-# oracle: up to two reachable different-model peers, then bounded reconciliation
-/ce-pov oracle that proposal
-
-# Warm: infers the question from this conversation, returns a POV, hands control back
-/ce-pov
+/ce-pov oracle this proposal
+/ce-pov compare your take with Grok and Claude
 ```
+
+“Oracle this” in an ongoing discussion requests the same panel as an explicit invocation. Other requests for independent model opinions also work; merely mentioning or declining a panel does not trigger one.
 
 Use `ce-bakeoff` when a defined brief needs concrete competing solutions developed before selection. Use `ce-ideate` to discover an open field of opportunities. Use `ce-doc-review` when you want findings, not a take.
 
----
+## Grounding and judgment
 
-## The problem
+Every judgment must rest on concrete verified project evidence. External adoption also requires a verified external source. For document takes and supplied approaches, external evidence is required when an external claim carries the conclusion. Conversation claims are hypotheses until corroborated.
 
-Ask a bare agent "what's your POV on X?" and it fails in predictable ways. It answers in the abstract without checking your dependencies, conventions, or call-sites. It agrees with your framing and ratifies whatever you already wanted. It stops at the first source, or cites things it never verified. The answer scrolls away and the next person re-asks. Or it guesses the question: a bare link becomes "should we migrate" when you only wanted a comparison.
+A failed evidence floor returns a Hold or explicit blocker with the missing evidence. The skill does not manufacture a confident recommendation. A valid conclusion may also be to wait, reject a candidate, or leave a choice open because either approach is viable.
 
-`ce-pov` puts gates in front of each failure. It settles the intent before grounding and never guesses. Every POV needs a concrete project fact; external evidence is required wherever an external claim carries the conclusion. It hunts for disconfirming evidence, and "no" and "not our problem" are real answers, not fallbacks. Effort scales with reversibility, so a one-way door gets the full workup and a reversible `npm i` gets one screen. The next step is computed from the POV, not assumed.
+The question determines the content:
 
----
+| Subject | Result |
+|---|---|
+| External adoption or exposure | Adopt, Trial, Hold, Reject, or Not-our-problem, with evidence and conditions |
+| Document | Overall direction, decisive strengths and risks, and recommended next action when justified |
+| Supplied approaches | A supported position or honest toss-up, with the material tradeoffs |
 
-## How it works
+These are content contracts, not mandatory visible headings. Presentation follows the consumer's needs. Research effort scales with reversibility and consequences, rather than imposing a screen count on the answer.
 
-### Grounding floors
+The skill investigates directly. When a judgment requires an explanation of unresolved behavior or rationale, it can call `ce-explain` with the question and the decision it informs. It reuses adequate evidence and retains ownership of the judgment. If `ce-explain` is unavailable, `ce-pov` must still gather the required evidence.
 
-Every POV must clear a project floor: a verified fact about this project relevant to the decision. Adoption questions also require a verified external source. Document and approach subjects need one only when an external claim carries the bottom line.
+## Interaction and return
 
-A failed adoption floor returns a `Hold` subtype (`Hold: insufficient project grounding` or `Hold: external evidence unavailable`). A failed document or approach floor returns an explicit `Blocked` result. Neither turns into a confident guess.
+Clear questions proceed without confirmation. The skill investigates discoverable facts before asking for missing framing. When no person can answer, it returns the missing information and its consequence instead of choosing requirements or waiting indefinitely.
 
-### Propose the frame, never guess it
+A calling workflow receives the judgment and control back, without a menu or capture offer. An explicit oracle request still runs the panel. A recommendation alone does not authorize implementing it; requested downstream work must remain within scope, authorized, non-destructive, and supported by a result that resolves the decision needed for that action.
 
-Before grounding, the skill orients on what you gave it (fetching a bare link to learn what it is) and settles the intent: adopt, migrate, compare, is-this-our-problem, document-take, approach-set, or plain explainer. Clear input gets a one-line inferred frame. Ambiguous input gets proposed framings to confirm. A pure explainer is answered as research, never forced into a verdict.
+A requested write-up expands the judgment in the needed format. Ordinary answers need no file. Publication and durable capture are separate requested actions.
 
-A selection question ("what should we use for auth?") belongs here only when the field is bounded, roughly five or fewer real candidates with knowable criteria. Otherwise it Holds and routes to `ce-ideate` or `ce-brainstorm`.
+## Oracle panels
 
-### Grounding a generic tool can't do
+The skill forms its own position before consulting peers. Bare oracle selects up to two reachable different-model peers; named peers are honored exactly without that cap. Peer opinions inform the decision rather than voting on it. Material disagreement receives bounded reconciliation, and the result reports alignment or dissent honestly.
 
-The skill reads this project: dependency manifests and lockfiles, license compatibility, the incumbent and its call-sites, conventions, git history, the issue tracker, and PR descriptions and comments (never diffs). It also checks prior decisions (`docs/solutions/`, ADRs, closed issues, abandoned PRs) so a verdict does not re-litigate something the team already settled. A non-code project folder works too; only the no-local-context case is out of scope.
-
-Grounding runs in scout sub-agents that return a compact dossier, and the orchestrator reasons over the verdict on a clean context. A reversible Tier-1 call runs a single combined pass; the full fleet is reserved for one-way decisions. When the load-bearing facts are already located and verified, bounded inline reads can replace the scouts. The prior-decision scan runs either way.
-
-### Cold and warm invocation
-
-Run it cold (you state the question) or warm (drop `/ce-pov` into a live session). In warm mode the conversation supplies the question and the claims to verify, never the grounding itself. Provenance buckets keep "things the chat assumed" out of the verified-facts column. Warm mode behaves like a guest: a POV block, then control handed back. No peers unless you ask, no next-step menu.
-
-### Reversibility tiers
-
-The skill classifies the decision and sizes the work to match:
-
-- **Tier 1** (two-way door): a dependency, lint rule, or config. One-screen verdict, no reversal trigger
-- **Tier 2** (one-way but bounded): a data store, internal contract, or in-repo migration. Full scout fleet plus alternatives
-- **Tier 3** (one-way and high-stakes): security, legal, privacy, a public contract, an irreversible data migration. Deep external research, a precedent search, and a durable-record offer
-
-The classification is stated in the output, so a shallow verdict is defensible.
-
-### Output in the subject's shape
-
-Adoption verdicts use the five grades and a fixed schema: incumbent, verified facts, conditions, handoff, and a reversal trigger on Tier 2/3. Document takes lead with a bottom line, then strengths, risks, and a recommendation. Approach-set positions pick one supplied option, or say "either is viable" with the material tradeoffs rather than forcing a scoreboard winner.
-
-### Cross-model panels
-
-A peer never replaces the skill's own judgment. Name one or more providers to cross-check, ask for independent opinions in ordinary language, use `oracle` as shorthand for up to two reachable different-model peers, or accept a proactive offer on a decision with meaningful correction cost. Named peers are honored exactly and not capped. Warm invocations never offer a panel.
-
-Peers inspect the shared working tree directly. The first round carries the framed question, subject, read scope, and evidence, but withholds this skill's own conclusion so peers stay independent. When the subject is itself an already-formed position, that position ships as the subject and peers give their own verdict on the underlying question.
-
-A default panel is one blind round plus at most two reconciliations. Before each exchange, disputed project claims get verified and every voice sees the same evidence. Convergence is reasoned confidence, not a vote. At the cap, automatic dispatch stops and further rounds need your approval unless you supplied a larger limit up front. A failed peer never blocks the solo POV. Any POV that follows a panel request states which peers ran, or that none did and why.
-
-### Follow-up
-
-The chat verdict is the deliverable; implementation is outside this read-only contract.
-
-- **Adopt** with clear scope proposes `/ce-plan`; fuzzy scope proposes `/ce-brainstorm`
-- **Trial** proposes a timeboxed spike with `/ce-work`
-- **Hold / Reject / Not-our-problem** ends
-- A document take with actionable revisions offers to apply them through the workflow that owns the document
-- A chosen, defined approach proceeds through planning or execution. A toss-up or a Blocked result does not
-
-Handoff happens without another question only when the original request named that downstream action. Otherwise it offers one continuation and waits. A shareable write-up (HTML by default) and a `ce-compound` capture into `docs/solutions/` are both opt-in. Warm invocations skip all of this unless you ask.
-
----
-
-## Quick example
-
-You paste a link to a new auth service. The intent is ambiguous, so the skill fetches the link, learns it is a passkeys provider, and proposes: adopt passkeys, migrate auth to them, or compare them to current sign-in? You pick "adopt."
-
-It classifies the decision as Tier 3 (auth is hard to reverse) and runs the full scout fleet. A project-grounding scout finds password + email today, with the auth code centralized in one module. A precedent scout finds no prior decision. An external researcher verifies passkey maturity and migration pitfalls.
-
-Both floors pass. The skill returns `Trial` ("yes, if we pilot it on the internal admin app first") with conditions, a reversal trigger ("re-evaluate if enterprise SSO becomes a requirement"), and a proposed spike with `/ce-work`. It offers to take the decision into `/ce-plan` or write up the full case. You take it to `/ce-plan`, seeded with the verdict.
-
----
-
-## When to reach for it
-
-Use `ce-pov` when:
-
-- You read about a framework, library, or pattern and want to know if it fits this project
-- You are weighing a migration off something you already use
-- You need to pick from a bounded field of real options
-- A CVE or deprecation lands and you need to know if it is your problem
-- You want to revisit a past decision
-- You want a holistic take on a plan, spec, or brainstorm rather than an issue list
-- You supplied competing approaches and want a project-grounded choice or honest tradeoff
-- You want the take cross-checked by named different-model peers or `oracle`
-- You are mid-session and want a grounded second opinion on the current direction
-
-Skip `ce-pov` when:
-
-- You just want to understand a topic with no project angle → general research
-- You want options generated from a blank slate → `/ce-ideate`
-- You want an issue-by-issue review of a document → `/ce-doc-review`
-- You want findings on a code diff → `/ce-code-review`
-- You have already decided and want to scope or build it → `/ce-brainstorm` or `/ce-plan`
-- You are diagnosing broken behavior → `/ce-debug`
-
----
-
-## Use as part of the workflow
-
-`ce-pov` is an on-demand insert, not a required pipeline stage.
-
-- **Offered from `/ce-brainstorm`** when a request is really a whether-to-adopt verdict on a specific external candidate. The offer is explicit, never a silent switch
-- **Routes into `/ce-plan`** when an accepted Adopt has clear scope
-- **Routes into `/ce-brainstorm`** when adopt is not pinned down, or a selection field is too open to bound
-- **Routes into `/ce-work`** for a Trial spike
-- **Captures into `/ce-compound`** on request, as a `tooling_decision` or `architecture_pattern` record so the next run's precedent check can find it
-- **Mid-session second opinion** in any skill's session. Returns a POV and hands control back
-
----
-
-## Reference
-
-| Argument | Effect |
-|----------|--------|
-| _(empty, mid-session)_ | Warm second opinion. Infers the question from the conversation and confirms it if needed |
-| `<a question>` | Cold evaluation, e.g. "should we adopt X?", "does this CVE affect us?" |
-| `<a bare link>` | Orients on the link, then proposes candidate framings before grounding |
-| `<a selection question>` | Picks from a bounded field. Routes to `/ce-ideate` if the field cannot be bounded |
-| `<a document or supplied approach set>` | Returns a holistic take or a project-grounded position in that subject's shape |
-| `compare/cross-check with <peers>` | Forms its own POV, then consults every named peer |
-| `oracle` | Blind initial cross-check with up to two reachable different-model peers, then bounded reconciliation when needed |
+A failed peer does not block the solo judgment, but the result discloses who ran and who could not. Serving-model attribution comes from receipts, not requested model names. Ongoing workflows do not get unsolicited panel offers; explicit requests still take the panel path.
 
 ### Peer target names
 
@@ -198,37 +65,8 @@ Cursor Auto is labeled unverified unless a serving-model receipt exists. Without
 
 ---
 
-## FAQ
+## In a workflow
 
-**How is this different from a general "deep research" tool?**
-A research tool explains a topic in the abstract. `ce-pov` refuses to issue a verdict unless it cites a concrete fact about this project. It ends in a decision, not a report.
+Use `ce-pov` when an existing subject needs a judgment. Use `ce-explain` when understanding is the result needed. Neither is a mandatory stage before planning. Open-ended option generation belongs to `ce-ideate` or `ce-brainstorm`; findings review belongs to `ce-doc-review`.
 
-**Why are the floors subject-aware?**
-An adoption verdict built only on web evidence is abstract, so adoption always needs both floors. A document take does not need ceremonial web research unless an external claim actually carries its conclusion. The project floor always applies.
-
-**How is this different from `ce-doc-review`?**
-Use `ce-pov` for "what do you think of this doc?": a bottom line with strengths and risks. Use `ce-doc-review` for "review this doc" or "find the issues": structured findings and remediation.
-
-**Why only two reconciliation rounds?**
-Two is the cap on automatic spend, not on the debate. A default run is up to three exchanges (one blind round plus two reconciliations), and most runs stop earlier because the skill ends on reasoned confidence rather than a round count. When a decision needs more, it proposes a bounded extension with the specific unresolved question, or you supply a larger limit up front.
-
-**Does it always write a document?**
-No. The default is a compact chat POV. A full write-up and a durable `ce-compound` capture are both opt-in.
-
-**Will it nag me with clarifying questions?**
-Only when the intent is genuinely ambiguous, like a bare link with no stated intent. A clear question gets a one-line inferred frame and proceeds.
-
-**Does it work without a code repo?**
-Yes, for any project folder with real material (docs, decks, data) to ground against. Only the no-local-context case is out of scope; there it asks for context rather than dispensing generic advice.
-
----
-
-## See also
-
-- [`ce-ideate`](./ce-ideate.md): generate options from a blank slate. `ce-pov` judges a given external thing
-- [`ce-brainstorm`](./ce-brainstorm.md): scope a decision once it is a yes. `ce-pov` decides whether
-- [`ce-plan`](./ce-plan.md): the build-side handoff when a verdict is accepted
-- [`ce-doc-review`](./ce-doc-review.md): issue-shaped findings for a document. `ce-pov` gives the holistic take
-- [`ce-code-review`](./ce-code-review.md): findings on a diff, not a verdict
-- [`ce-debug`](./ce-debug.md): investigate observed broken behavior. `ce-pov` assesses exposure (is this CVE ours?)
-- [`ce-compound`](./ce-compound.md): capture a weighty verdict into `docs/solutions/` for future precedent
+A bounded selection question can be assessed when the realistic options and criteria are knowable. An open field or missing criteria returns that unresolved scope to its owner rather than disguising requirements discovery as a verdict.

--- a/skills/ce-brainstorm/references/dialogue.md
+++ b/skills/ce-brainstorm/references/dialogue.md
@@ -42,6 +42,8 @@ If the scan and scout surface nothing relevant, say so and continue. Two rules g
 - **Tools available + user didn't ask**: Note in output: "Slack tools detected. Ask me to search Slack for organizational context at any point, or include it in your next prompt."
 - **No tools + user asked**: Note in output: "Slack context was requested but no Slack tools are available. Install and authenticate the Slack plugin to enable organizational context search."
 
+When an unanswered question about system behavior or design rationale would materially change this work, use `ce-explain`. Pass the question, its scope, its intended use, and pointers to existing evidence. Reuse adequate current research rather than repeating it. Use the explanation’s evidence, constraints, and unanswered questions in this work. Requirements and design decisions remain this skill’s responsibility. The existing source restrictions still apply, including the opt-in rule for Slack research.
+
 #### 1.2 Product Pressure Test
 
 Before generating approaches, scan the user's opening for rigor gaps. This is agent-internal analysis, not a user-facing checklist: read the opening, note which gaps actually exist, and raise only those during Phase 1.3 — folded into the normal flow of dialogue, not fired as a pre-flight gauntlet. A fuzzy opening may earn three or four probes; a concrete, well-framed one may earn zero because no scope-appropriate gaps were found.

--- a/skills/ce-explain/SKILL.md
+++ b/skills/ce-explain/SKILL.md
@@ -1,19 +1,22 @@
 ---
 name: ce-explain
-description: "Create a durable visual teaching artifact for something worth learning. Use when the user wants to be taught, wants a deep explainer, wants to understand a substantial change, or wants a work recap built for retention. Not for ordinary Q&A, operational diagnosis, or a concise trade-off that belongs in chat. For learning, not repo docs or verdicts."
-argument-hint: "[a concept, a diff ref, an idea, or 'what happened this week?'] — or invoke bare to be asked"
+description: "Explain how something works and why it has its current shape, grounding behavior in evidence and separating documented rationale from inference. Use when understanding a system, change, idea, or recent work is needed for learning or further work, including deeper teaching explanations. Use ce-pov for a judgment or recommendation."
+argument-hint: "[question, concept, change, or work window] [intended use or reader]"
 ---
 
-# Explain It To Me
+# Explain How and Why
 
-Teach the user one thing well: a concept, a change, an idea, or a window of their own recent work. Agent-driven development removed the learning that writing code by hand used to provide; this skill is the replacement. What to explain is the input this skill was invoked with, present in the current prompt or conversation — whether the user asked directly or a calling skill passed it.
+Produce an explanation that answers the scoped question and gives its consumer enough understanding for the intended use. The subject and purpose come from the request and available context, whether a person or another workflow supplied them. Ground project behavior in source evidence; distinguish documented rationale, inference, and unknowns.
 
-**Done:** a durable artifact exists at `$RUN_DIR`, the user has seen it, and the destination they chose has been honored (or declined). A run that correctly ends without an artifact — the operational-question gate answered it in chat, an empty window, a bare invocation the user did not answer — is equally done.
+**Done:** deliver the explanation with supporting evidence and material unanswered questions, or return the specific blocker. When an artifact is requested, deliver the artifact and its location. Publication is a separate action, not a condition of having explained the subject.
 
-**Note: The current year is 2026.** Use this when weighting external sources and dating artifacts.
+## Consumer and interaction
 
-**Read `references/orchestration.md` before the first blocking question, subagent dispatch, or run-directory creation** — it owns the per-harness ask tool, the model tiers and their degradation rule, grounding by input shape, and menu sizing.
+Adapt depth and presentation to the intended readers and use. A person may need a working answer; a calling agent may need a teaching artifact for someone else. Do not infer the output from the caller's identity alone. When contributing to an ongoing workflow, deliver the requested result and leave continuation to its owner. Do not add destination menus or follow-up offers to that return.
 
+Resolve discoverable facts before asking. Ask only when missing information materially changes the answer and cannot be resolved from the request or evidence. If interaction is unavailable, return the unresolved question and its consequence rather than waiting or inventing an answer. A result may explain verified behavior while reporting that its historical rationale is unknown.
+
+**Read `references/orchestration.md` before grounding, the first blocking question, or subagent dispatch.** It owns evidence gathering, tool use, model tiers, and their degradation rules.
 
 ## Artifact Root
 
@@ -29,15 +32,15 @@ An explainer lands under `<root>/explainers/` only when archived to the repo, an
 
 ## Execution Flow
 
-### Phase 1: Classify the input
+### Phase 1: Establish the question and use
 
-Read `references/intake.md` now and classify the request into one of the four input shapes — concept, diff, idea, or work-recap window — plus its audience. It owns the token table, the reads-as-a-flag guard, window and audience resolution, the concept-vs-diff tiebreak, conflict handling, and the operational-question gate that answers a diagnostic question in chat instead of teaching it. Most requests arrive as plain language with no token; classify those by meaning rather than improvising.
-
-**Bare invocation** (no input at all): ask one blocking question — "What should I explain?" — offering a shortcut option for a recap of recent work in this repo alongside free-text. Do not produce a default artifact unprompted.
+Read `references/intake.md` now. It owns subject and window resolution, existing input tokens, and delivery selection. Explain only the requested subject. A bare invocation with no recoverable subject needs clarification under the interaction rule above, not an invented topic or default artifact.
 
 ### Phase 2: Ground
 
-Create the run directory first — every run gets one, before any artifact exists. It holds the explainer and the recap evidence, so run this block as written rather than improvising a `mkdir`: the checks it makes refuse a scratch root you do not own or one reached through a symlink.
+Follow `references/orchestration.md` for the scoped evidence pass. Use existing evidence when it is adequate and current; check claims whose support is missing, disputed, or affected by source changes.
+
+Create a run directory only when an artifact or an evidence dossier needs one. Use this block before writing either; it rejects a symlink or a scratch root owned by another user:
 
 ```bash
 SCRATCH_ROOT="/tmp/compound-engineering-$(id -u)";
@@ -51,26 +54,26 @@ RUN_DIR="$SCRATCH_ROOT/ce-explain/$(date +%Y%m%d)-$(openssl rand -hex 3)";
 echo "$RUN_DIR";
 ```
 
-Then match grounding to the input shape per `references/orchestration.md`'s grounding section, which also owns the empty-window and unreachable-web paths. Two rules govern what reaches the user while you gather, so they hold here:
+- **Diff mode.** **Empty range** or missing subject: do not silently explain something else. Report that before explaining an adjacent thing. Use a substitute only when the request permits it or the user agrees; name the substitution in the result and artifact `Subject` when present. Otherwise return the unresolved scope to the caller.
+- **Recap mode.** Do not pre-scan, count, or characterize the window in the main conversation. Instead dispatch a generic subagent directly at the extraction tier, seeded with `references/agents/work-recap-scout.md` and passed the resolved window, repo root, and `$RUN_DIR`. **Empty window:** report the absence of activity and finish without an explainer artifact. **When the harness exposes no subagent primitive**, run the scout inline with its prompt's sources and budgets, still write `recap-evidence.md`, and form no view of the window until it is done. Dispatch failures follow the orchestration reference's degradation rule.
 
-- **Diff mode.** The one rule here is the **Empty range** case (the ref resolves to no commits — e.g. `main..HEAD` where the work is still uncommitted): do not silently explain something else. Say what the ref resolved to, name the nearest real candidate (the working tree, the last commit), and use it only after the user agrees — or, when they can't be asked, use it and state the substitution in the artifact's `Subject`. Apply the same rule when the named subject doesn't exist in this repo at all ("the retry logic" where there is none): report that before explaining an adjacent thing.
-- **Recap mode.** Do not pre-scan, count, or characterize the window in the main conversation: an early `git --all` summary seeds the run with a false branch or activity model. Instead dispatch a generic subagent directly at the extraction tier, seeded with `references/agents/work-recap-scout.md` and passed the resolved window, the repo root, and `$RUN_DIR`. **Empty window** (no git activity, no doc changes): say so, offer to widen it, write no artifact, and end the run after the user responds. **When the harness exposes no subagent primitive**, the degradation rule applies: run the scout inline against its own prompt's sources and budgets, and still write `recap-evidence.md`; the no-pre-scan rule then means what it protects rather than where it runs — do the scout's evidence pass first and form no view of the window until it is done.
+### Phase 3: Compose the explanation
 
-### Phase 3: Compose the explainer
+Answer the question using the evidence, preserving material constraints and uncertainty. Before delivery, check every factual claim against its source. A function call does not establish guarantees about its uninspected implementation. Remove unsupported claims or state their uncertainty where they appear, including in diagrams and exercise answers. Choose prose, code, tables, or visuals when they improve understanding; no particular arrangement is required. Keep attribution accurate when explaining work by multiple people. When selecting from more evidence than the requested scope or depth can hold, disclose the selection; never silently present a partial account as exhaustive.
 
-Read the rendering reference for the resolved format **now**, not earlier: `references/explainer-html.md` (default) or `references/explainer-markdown.md` (when intake resolved `output:md`). Each owns the artifact's invariants and the voice for the audience intake resolved — personal by default, adapted for another reader on request, at unchanged depth. Read `references/check-in.md` with it: it owns whether the artifact ends with a `Check yourself` section and that section's shape. The run never blocks on the check-in — no offer, no prediction turn, no exercise posed in chat; the section is static text the reader works through alone. Compose per those contracts and write the artifact to `$RUN_DIR/explainer.html` (or `explainer.md`) before anything else happens with it, then display it (inline summary plus the file path). The artifact exists at that stable path from this moment — a declined destination ask never loses it.
+For an answer or material another workflow will incorporate, return that content directly. Each passage must carry the qualifications needed to use it accurately without separate notes. Do not create a standalone artifact unless the intended use needs one.
 
-### Phase 4: Destination ask and close
+For a standalone artifact, read `references/explainer-html.md` or `references/explainer-markdown.md` at compose time for the selected format's compatibility and metadata requirements. For teaching artifacts, also read `references/check-in.md`. The run never blocks on the check-in; any exercises are static content in the artifact. Write `$RUN_DIR/explainer.html` or `explainer.md`, then deliver an inline summary plus the file path.
 
-**Required read before you render anything in this phase: `references/destinations.md`.** It owns the destination menu, the per-option routing, each destination's sub-flow, the audience re-render offer and its ordering against a publisher's consent gate, and the improvement observations the run closes on. Read it now; do not render the menu and do not act on the user's selection without it.
+### Phase 4: Deliver
 
-Ask for the destination once with the blocking question tool — that governs the menu itself, not the consent a chosen destination then requires. Publishing is never headless and never inferred: ht-ml.app puts the page in public, so it may only publish once the user has seen the full warning and confirmed after it, and a destination they named up front is a choice of destination rather than that confirmation. Reaching that point takes more than one ask, in an order the reference sets — do not run the sequence from this paragraph. If it cannot be completed, do not publish; preserve the canonical HTML and report its local `$RUN_DIR/explainer.html` path. The handoffs the phase closes on are offered before anything fires; once the user accepts one, invoke it through the skill primitive rather than describing it, except `ce-polish`, which is user-run only.
+A delivered answer or local artifact completes the explanation. Do not require a destination choice or manufacture follow-on work. If a destination was requested, read `references/destinations.md` before acting; it owns the destination adapters and publication consent. Return content to a workflow that owns the surrounding document rather than placing or publishing it yourself.
 
-**Non-interactive degradation:** when no interaction is possible at this ask (no blocking tool and no reply), do not hang and do not discard — the artifact is already at `$RUN_DIR`; report that path and end, skipping the reference's offers.
+Publishing to ht-ml.app is never headless and never inferred. Naming it is a choice of destination rather than confirmation after its public-publishing warning. If confirmation cannot be obtained, do not publish; preserve the canonical HTML and report its local `$RUN_DIR/explainer.html` path.
 
 ## Boundaries
 
-- **Not a verdict.** "Should we adopt X?" is `ce-pov`. ce-explain teaches what X is and how it works.
-- **Not repo memory.** Documenting a solved problem for future work is `ce-compound`. ce-explain teaches the human, not the repo.
-- **Not ideation or scoping.** An idea input is explained as given — implications and trade-offs — never expanded into options or a requirements dialogue.
-- **The check-in never blocks the run.** It is a section of the artifact the reader works through alone; the run asks no question about it.
+- Use `ce-pov` to judge whether an approach should be adopted or changed. Explaining a historical choice is not endorsing it today.
+- Use `ce-compound` to capture durable project learning. Producing an explanation does not authorize maintaining repo memory.
+- Explain an idea as supplied; generating alternatives and scoping implementation belong to `ce-ideate`, `ce-brainstorm`, and `ce-plan`.
+- A reported failure to diagnose or fix belongs to `ce-debug`; a factual explanation of current behavior remains here.

--- a/skills/ce-explain/references/check-in.md
+++ b/skills/ce-explain/references/check-in.md
@@ -11,16 +11,8 @@ The reader does not change the decision. An artifact rendered for another reader
 ## Shape
 
 - One section headed `Check yourself`, placed last: after the explanation and before the HTML footer.
-- Two to four numbered questions, listed first. Then the answers under an `Answers` label, numbered to match, so a reader can attempt every question before any answer is in view.
+- Questions first, then their answers under an `Answers` label, so a reader can attempt every question before any answer is in view. Choose the number according to what is worth practicing.
 - Each answer states what a correct response contains and names the gap a plausible wrong answer exposes. One correction per question — do not lecture past the gap.
 - Static only: no forms, scripts, click handlers, or collapsing widgets. The label and spacing set the answers apart; nothing hides them.
 
-## Question kinds
-
-Design questions to expose understanding, not recall of the artifact's phrasing. Use the kinds the material supports:
-
-- **Apply:** a small scenario the concept decides ("given X, what happens / what would you choose?").
-- **Explain-back:** restate the core mechanism in your own words; the answer names the pieces a complete restatement carries.
-- **Boundary:** a case where the concept does not apply, or where the naive reading fails.
-- **Change (diff mode):** what the change does and why it was made; the answer names the intent behind the hunks, not the hunks.
-- **Recap recall (recap mode):** why a notable change in the window was made, or what its consequence was.
+Questions should test applying the mechanism or recognizing its limits rather than recalling the explanation's wording.

--- a/skills/ce-explain/references/destinations.md
+++ b/skills/ce-explain/references/destinations.md
@@ -1,46 +1,18 @@
-# Destinations and Close
+# Requested Destinations
 
-Everything the destination phase does: the destination menu, the action to fire for each option, each destination's sub-flow, the audience re-render offer, and the improvement observations the run closes on. SKILL.md names this file as a required read before the destination phase renders anything, and keeps the stop classes that must hold even if this file is never opened. Detection is by capability: probe the current session's tools and context; a missing binary, env var, or unloaded MCP tool is not proof of absence when a connector could supply the capability. Local file is the always-present floor.
+Load only when delivery to a destination was requested. Use the available capability for that destination and verify the resulting file, URL, or document reference. A calling workflow that owns the surrounding artifact also owns placement and publication; return the explanation to it instead.
 
-## The menu, and what fires for each option
-
-Size and detect the menu per `references/orchestration.md`'s menu section: it decides which destinations are visible, that only one publisher is offered, and what to do when the visible set exceeds the host's option cap. If the user names a publisher that the one-preferred-publisher rule kept off the menu, honor it by the bypassed-menu path below (full warning, then explicit confirmation), never as though the menu had warned them — it didn't.
-
-When the user picks an option, fire its action rather than acknowledging the choice in prose:
-
-- **Claude Artifact** (HTML only) — create an artifact from the canonical explainer per that destination's section below.
-- **Publish publicly to ht-ml.app** (HTML only) — label it Recommended, and state in the option description that the page is public and may be indexed, crawled, copied, or archived. Then follow the ht-ml.app sub-flow below, passing the complete canonical HTML to the resolved publisher. Do not assume a particular skill exists, and do not add a ce-explain-specific publisher. On a menu bypass, give that same warning in chat and get explicit confirmation after it; the pre-warning request does not count as confirmation. If confirmation cannot be obtained, do not publish; preserve the canonical HTML and report its local `$RUN_DIR/explainer.html` path.
-- **Local file** — copy it out of `$RUN_DIR` to the path the user names, then offer to open it where the platform exposes `open` / `xdg-open` / `start`; otherwise print the absolute path.
-- **Publish to Proof** (markdown only) — publish per that destination's section below and surface the share URL; on failure retry once, then report and move on.
-- **Send to Thinkroom** (only when a Thinkroom capability is detected) — send per that destination's section below.
-- **Leave it** — report the `$RUN_DIR` path, noting it is temporary and does not survive reboot; nothing else is written.
-
-## Audience mismatch — offered before the destination's own consent gate
-
-Some destinations put the artifact in front of other people: ht-ml.app, Proof, and Thinkroom, but not Claude Artifact, which stays private until the user shares it. When a personally-composed artifact is headed to one of those, offer once to re-render it for that audience per the compose-time reference before sending. Take their answer and proceed either way; never re-render unasked, and never block the send on it.
-
-**This offer comes first**, before any publish warning or confirmation the destination requires. Consent must attach to the artifact actually being published, and the adapted rendering differs materially: it names a person where the personal one says "you". Ask one question at a time: settle the rendering, then run the destination's own consent gate. When the destination needs no confirmation, this is the only ask.
-
-## Improvement observations
-
-Things the composition surfaced as improvable are routed by type once the destination is settled — offered, never auto-fired. "Settled" means the artifact was sent, the user declined, or the run stopped at an unanswered consent gate; in that last case the run ends there and these offers are skipped. Never raise them while any of the asks above is still open — the destination question, the audience re-render offer, or a publisher's consent gate.
-
-**User-runnable invocation rendering.** Only the user-run handoff below uses printed invocation syntax. Default to `/ce-polish`; use `$ce-polish` only when the active host is Codex or explicitly documents dollar-prefixed skill invocation. On oh-my-pi (`omp`), use `/skill:ce-polish`. Render only the invocation as inline code and output one form only.
-
-- **New-capability ideas** — offer first; on acceptance invoke the `ce-ideate` skill via the skill-invocation primitive with the observations as seed context, rather than telling the user to run it.
-- **Code-clarity findings** — offer first; on acceptance invoke the `ce-simplify-code` skill via the skill-invocation primitive with the observations and the files they concern, rather than telling the user to run it.
-- **UI/UX polish opportunities** — present the observations in chat and tell the user to invoke `ce-polish` themselves using the rendering rule above; it is user-invoked only (`disable-model-invocation`), so never fire it via the skill primitive.
-- **A repo doc the evidence contradicts** — grounding reads plans and solution docs, so a recap or diff routinely surfaces one that is now stale, superseded, or contradicted by what shipped. Offer first; on acceptance invoke the `ce-compound-refresh` skill via the skill-invocation primitive, naming the doc and the evidence that supersedes it. Do not edit the doc here — this skill teaches, it does not maintain repo memory.
+Resolve only the destination information needed to complete the request. Do not require a menu or offer to rewrite or improve the explanation. Adapt the content for its intended reader before asking for any required consent to publish it. On a delivery failure, preserve the canonical local artifact and report what did not complete. Do not substitute another publisher without authorization.
 
 ## Claude Artifact
 
-Offered for HTML output when the session is Claude Code and its Artifact tool is present. Give the tool the canonical `$RUN_DIR/explainer.html`, follow its current contract, and confirm the returned URL or reference to the user. The tool owns any adaptation needed for its artifact runtime; do not pre-process the HTML for it.
+Available for HTML output when the session is Claude Code and its Artifact tool is present. Give the tool the canonical `$RUN_DIR/explainer.html`, follow its current contract, and confirm the returned URL or reference to the user. The tool owns any adaptation needed for its artifact runtime; do not pre-process the HTML for it.
 
 ## Publish publicly to ht-ml.app
 
 This is the preferred HTML publisher when the Claude Artifact adapter is not selected. ht-ml.app accepts the complete standalone HTML document and works through ordinary HTTP, independent of the agent harness.
 
-Before publishing, the destination option itself must state: **the page is public and may be indexed, crawled, copied, or archived**. Whenever ht-ml.app is chosen without that warned option in front of the user — their initial request selected it and the menu was skipped, or they named it after the one-preferred-publisher rule kept it off a menu that *was* shown — state the same full warning in chat and ask for explicit confirmation after the warning before any publish; “this is public” is not the complete warning, and the initial request itself does not count as confirmation. Only a warned menu selection or explicit post-warning confirmation permits publishing. If confirmation cannot be obtained, do not publish; preserve the canonical `$RUN_DIR/explainer.html` and report its local path. Never publish headlessly or infer consent from the fact that an explainer was requested. If the content is sensitive, route to Local file instead.
+Before publishing, state that **the page is public and may be indexed, crawled, copied, or archived** and obtain explicit confirmation after that warning for the actual artifact being sent. The initial request itself does not count as confirmation. Confirmation given after the warning covers the same artifact. If the artifact changes materially, obtain confirmation for the changed content. If confirmation cannot be obtained, do not publish; preserve the canonical `$RUN_DIR/explainer.html` and report its local path. Never publish headlessly. If the content is sensitive, keep it local.
 
 After the user selects the warned option or explicitly confirms after the warning:
 
@@ -50,9 +22,9 @@ After the user selects the warned option or explicitly confirms after the warnin
 
 ## Local file
 
-1. Ask nothing extra if the user already named a path; otherwise accept the path from their menu answer's free-text.
+1. Ask nothing extra if the user already named a path; otherwise ask for the missing path under the skill body's interaction rule.
 2. Copy the artifact out of the run dir to that path (`cp "$RUN_DIR/explainer.html" <path>` — or `explainer.md` for a markdown run), creating parent directories if needed.
-3. Where the platform exposes a browser-opening primitive (`open` on macOS, `xdg-open` on Linux, `start` on Windows), offer to open it; otherwise print the absolute path.
+3. Report the absolute path. Open it when requested and the host supports that action.
 
 ## Publish to Proof (markdown output only)
 

--- a/skills/ce-explain/references/explainer-html.md
+++ b/skills/ce-explain/references/explainer-html.md
@@ -1,48 +1,29 @@
 # Explainer HTML Rendering
 
-How an explainer renders as HTML. Load at compose time, not earlier. The explainer is a personal teaching artifact — these rules keep it self-contained, readable, and honest about its own provenance. It is not a plan artifact: no navigation region, no R/U-ID anchors, no contract sections.
+How an explainer renders as HTML. Load at compose time, not earlier. These requirements keep a standalone artifact portable and honest about its provenance.
 
 ## Hard invariants
 
 - **Single self-contained HTML5 file.** No companion `.css`, `.js`, or `.svg` files. CSS lives in `<style>`. SVG lives inline. Images are base64 data URIs or inline SVG. No external requests of any kind — explainers must read identically offline and inside CSP-restricted viewers, so unlike the plan-artifact convention there is **no webfont exception**: use a system font stack.
-- **All metadata appears as visible text — single source of truth.** The visible `<h1>` is the title. A visible header `<dl>` uses the exact field labels `Date`, `Input shape`, and `Subject`; `Input shape` is exactly one of `concept`, `diff`, `idea`, or `recap`, and `Subject` names the topic, ref, or recap window. When grounding fell back to model knowledge, the same header also carries the label `Unverified — from model knowledge, not checked against current sources`. When the run rendered for another reader, the header carries one more row labelled exactly `Rendered for`, naming that reader; a personal rendering omits the row entirely rather than saying "the user". No hidden machine-readable copy: no JSON script block, no `data-*` mirror, no `<meta>` duplication. This header is what a future library layer indexes, so do not rename the fields, prettify the enum values, or invent additional rows beyond these.
+- **All metadata appears as visible text — single source of truth.** The visible `<h1>` is the title. A visible header `<dl>` uses the exact field labels `Date`, `Input shape`, and `Subject`; `Input shape` is exactly one of `concept`, `diff`, `idea`, or `recap`, and `Subject` names the topic, ref, or recap window. When grounding fell back to model knowledge, the same header also carries the label `Unverified — from model knowledge, not checked against current sources`. When the request identifies another reader, the header carries one more row labelled exactly `Rendered for`, naming that reader; a personal rendering omits the row entirely rather than saying "the user". No hidden machine-readable copy: no JSON script block, no `data-*` mirror, no `<meta>` duplication. Keep these existing artifact field names and enum values stable. Do not invent additional metadata rows.
 - **Display-only.** No forms, no click handlers, no interactive quizzes, no "submit" affordances, no scripts. The check-in, when present, is the static `Check yourself` section that `references/check-in.md` owns: questions first, then their answers, all visible text.
 - **ASCII identifiers.** Class names and element IDs are ASCII-only.
 - **Composition signal.** A visible footer names the composition timestamp and the composing skill: `Composed 2026-07-02 by ce-explain`.
 
-## Show-n-tell: match the form to the material
+## Presentation
 
-Show, then tell — every explainer leads with something to look at, chosen by what the material actually is. One visual per load-bearing concept; never decoration.
+The skill body's consumer contract governs depth, voice, and layout. Give the reader enough project context to follow the explanation without the original conversation. Adapt that context to what the reader already knows.
 
-| Material | Show |
-|----------|------|
-| Architecture, relationships, boundaries | Inline SVG diagram (boxes and labeled arrows; halo/contrast so labels stay legible) |
-| Code behavior, a diff's mechanics | Annotated snippet: the real lines, with margin notes explaining the *why* per hunk |
-| A process, lifecycle, or state change | Numbered flow or state strip |
-| A window of work (recap) | Timeline: date-ordered entries, each with what changed and why it mattered |
-| A comparison or trade-off | Two-column contrast, prose verdict underneath |
+Use visuals when they clarify the explanation. Keep these HTML rendering requirements:
 
-Diagrams complement prose; they never replace it. A reader who skips every visual still gets the full explanation in text.
+- Keep prose near 70 characters per line with `max-width: 70ch` on text blocks. Diagrams and code may use the full width.
+- Use inline SVG for diagrams. Keep labels legible with sufficient contrast, using a halo behind text when needed.
+- Syntax-highlight code samples with classes defined in the file's `<style>` block, without scripts or external assets.
 
-## Voice — personal by default, adapted on request
+Diagrams complement prose; a reader who skips them still gets the full explanation in text. Preserve source citations. Use real code from the inspected evidence for project behavior. Reserve invented minimal examples for external topics, and label them as examples.
 
-Default: the user personally. Second person, and no orientation they already have. In a shared repo this still means naming *other* contributors in third person — second person is reserved for the user, and a personal recap of team work uses both.
-
-When intake resolved another reader, render for that reader instead. What changes:
-
-- **No second person.** The subject goes to third person when a name is available — recap mode's commit authors, or a name the user supplied — and impersonal ("the retry path was rewritten") when none is.
-- **Minimum orientation added.** One or two sentences of what the project or area is, where the personal rendering would assume it. Add only what the reader cannot follow without.
-- **Nothing else changes.** Same depth, same real code from evidence, same `Unverified` label when it applies, same one-sitting length.
-- **The form does not become a status update or a deck.** A share-out request often sounds like one ("something for the #eng channel"), and rendering for that reader is right — but they are getting the explainer, at full depth, not a summary. Adapting the audience never licenses thinning the content.
-
-## Reading ergonomics
-
-- Hold prose to ~70ch (`max-width` on text blocks); full-width only for diagrams and code.
-- Lead each section with the point, then the mechanism, then the caveat.
-- Dense is good; long is not. The explainer is one sitting's read — cut background that doesn't change understanding.
-- **When the evidence exceeds one sitting** (a busy recap window is routinely 50+ commits), select rather than truncate: lead with the few threads that changed how the project works, carry the rest as a compact roll-up, and say plainly what you set aside so the reader knows the timeline isn't the whole log. Never silently drop the tail.
-- Code samples: real code from the grounding evidence where it exists, invented minimal examples only for external topics, always syntax-highlighted with inline `<style>` classes.
+When the evidence exceeds the requested scope or depth, select the relevant threads and disclose what was left out. Never silently drop the tail of a recap and present it as the full window.
 
 ## Post-compose audit
 
-Before presenting: no external URLs anywhere in the file; metadata header complete and visible; every visual has a prose equivalent; the file opens correctly standalone (`open <path>`).
+Verify the file opens standalone, makes no external resource requests, and carries the required visible metadata. Check that every visual has a prose equivalent. Ordinary source hyperlinks are allowed; offline readability must not depend on fetching them.

--- a/skills/ce-explain/references/explainer-markdown.md
+++ b/skills/ce-explain/references/explainer-markdown.md
@@ -1,42 +1,24 @@
 # Explainer Markdown Rendering
 
-How an explainer renders as markdown — the fallback format when intake resolved `output:md`. Load at compose time, not earlier. Content rules match the HTML reference; only the presentation medium differs.
+How an explainer renders as markdown — the fallback format when intake resolved `output:md`. Load at compose time, not earlier. The skill body owns content and consumer adaptation; this reference owns markdown compatibility.
 
 ## Hard invariants
 
-- **YAML frontmatter carries the metadata:** `title`, `date`, `input_shape` (concept / diff / idea / recap), `subject`, `unverified: true` when grounding fell back to model knowledge, and `rendered_for: <reader>` when the run rendered for another reader (omitted entirely for a personal rendering). Field names are stable — a future library layer indexes them.
+- **YAML frontmatter carries the metadata:** `title`, `date`, `input_shape` (concept / diff / idea / recap), `subject`, `unverified: true` when grounding fell back to model knowledge, and `rendered_for: <reader>` when the request identifies another reader (omitted entirely for a personal rendering). Keep these existing artifact field names stable across formats.
 - **Pure markdown.** No HTML elements, no `<details>`, no inline styles.
 - **Display-only.** No interactive exercise or quiz content. The check-in, when present, is the static `## Check yourself` section that `references/check-in.md` owns: questions first, then their answers, all visible text.
 - **Repo-relative paths** for any file reference; never absolute paths.
 
-## Show-n-tell in markdown
+## Presentation
 
-Markdown's visual affordances are narrower than HTML's — compensate, don't skip:
+The skill body's consumer contract governs depth, voice, and layout. Give the reader enough project context to follow the explanation without the original conversation. Adapt that context to what the reader already knows.
 
-| Material | Show |
-|----------|------|
-| Architecture, relationships, boundaries | Fenced `mermaid` block (`flowchart TB`) |
-| Code behavior, a diff's mechanics | Fenced code block per hunk with a one-line *why* comment above each |
-| A process, lifecycle, or state change | `mermaid` state/sequence diagram or a numbered list |
-| A window of work (recap) | Date-ordered list, each entry: what changed and why it mattered |
-| A comparison or trade-off | Pipe-delimited table, prose verdict underneath |
+Use visuals when they clarify the explanation. The Markdown rendering rules still apply:
 
-Never hand-draw box-drawing/ASCII diagrams — mermaid or prose. Diagrams complement prose; a reader who skips them still gets the full explanation in text.
+- Use fenced `mermaid` blocks for diagrams. Never hand-draw box-drawing or ASCII diagrams.
+- Use pipe-delimited Markdown tables for tabular material.
+- Label every fenced code block with its language. Put source locations in repo-relative links outside the fence; a host-specific file-and-line citation is not a language label.
 
-## Voice — personal by default, adapted on request
+Diagrams complement prose; a reader who skips them still gets the full explanation in text. Preserve source citations. Use real code when explaining project behavior, and identify invented examples as examples.
 
-Default: the user personally. Second person, and no orientation they already have. In a shared repo this still means naming *other* contributors in third person — second person is reserved for the user, and a personal recap of team work uses both.
-
-When intake resolved another reader, render for that reader instead. What changes:
-
-- **No second person.** The subject goes to third person when a name is available — recap mode's commit authors, or a name the user supplied — and impersonal ("the retry path was rewritten") when none is.
-- **Minimum orientation added.** One or two sentences of what the project or area is, where the personal rendering would assume it. Add only what the reader cannot follow without.
-- **Nothing else changes.** Same depth, same real code from evidence, same `unverified` flag when it applies, same one-sitting length.
-- **The form does not become a status update or a deck.** A share-out request often sounds like one ("something for the #eng channel"), and rendering for that reader is right — but they are getting the explainer, at full depth, not a summary. Adapting the audience never licenses thinning the content.
-
-## Reading ergonomics
-
-- Lead each section with the point, then the mechanism, then the caveat.
-- Dense is good; long is not — one sitting's read.
-- **When the evidence exceeds one sitting** (a busy recap window is routinely 50+ commits), select rather than truncate: lead with the few threads that changed how the project works, carry the rest as a compact roll-up, and say plainly what you set aside so the reader knows the timeline isn't the whole log. Never silently drop the tail.
-- Real code from the grounding evidence where it exists; language-tagged fences always.
+When the evidence exceeds the requested scope or depth, select the relevant threads and disclose what was left out. Never silently drop the tail of a recap and present it as the full window.

--- a/skills/ce-explain/references/intake.md
+++ b/skills/ce-explain/references/intake.md
@@ -21,7 +21,7 @@ Tokens exist so automation and chained calls can force a decision. Plain languag
 - `diff:main..HEAD`, or `audience:team` leading a request — genuine flags: nothing is left to garble.
 
 - A token in flag position beats inference. A colon inside prose does not.
-- `diff:` and `since:` together conflict — say so and ask which mode the user wants.
+- `diff:` and `since:` together conflict — resolve the intended subject under the skill body's interaction rule.
 - An unrecognized `<word>:<word>` token (including conventional-commit prefixes like `feat:` appearing inside a topic) is not a flag — it passes through verbatim as request text. The same holds for a *recognized* token that fails the reads-as-a-flag test above.
 - A token with an empty or missing value is not a flag — treat it as prose.
 - `output:` with an unknown value: drop the token, note `Ignored unknown output: value '<value>' — using html`, and continue.
@@ -41,16 +41,10 @@ Classify the remaining text by shape:
 
 **Repo footprint check (concept mode):** a concept grounds in the repo only when it actually touches it. An external subject (a language feature, an interview topic, a paper) gets no repo grounding — do not force it.
 
-## Audience resolution
+## Reader and delivery
 
-Audience is orthogonal to input shape — resolve it for every shape, including recaps.
+Resolve who will use the explanation and for what purpose from the request and context. The user is the default reader. Someone preparing to speak from the explanation is still its reader. When someone requests content for others, those people are the intended readers. Adapt terminology, orientation, depth, and presentation to that use without changing the evidence or attributing others' work to the user.
 
-- **Default: the user personally.** Absent a signal, do not ask and do not adapt.
-- **Another reader** when the `audience:` token is present, or when the request plainly says someone else will read it — "write this up for the team", "I'm sharing this with <person/group>", "for the design review", "a share-out", "something I can post in <channel>". The test is whether the *artifact itself* lands in front of other people. Carry the named reader forward verbatim; the rendering rule lives in the compose-time reference.
-- Wanting to *speak* from the material is not an audience signal. "Prep me for standup", "catch me up before the meeting", "walk engineering through it — get me ready", and "so I can explain it to them" all stay personal: the user is still the reader. That resolves the case, so no re-render note is needed.
-- **A request to share is not a request for a status update.** "Something I can drop in the #eng channel about this week's work" reads like a status-update ask in ordinary usage, and this skill does not write status updates. Honor the *audience* and refuse the *form*: render the explainer for that reader at full depth. Decline only if the user wants the terse update itself rather than an explainer for it — and say which you're doing.
-- Ambiguous between personal and another reader (for example, "write up what shipped this week"), default to personal and say in one line that it can be re-rendered for a reader. Do not spend a blocking question on this.
+Return an answer or text for another document when that satisfies the request. A request to learn deeply, keep an explainer, or produce a standalone document warrants an artifact; use HTML by default for that artifact and markdown when requested. A named `diff:` or `since:` selects the subject, not whether a document must be created. An explicit `output:` selects the artifact format. Honor requests for a shorter explanation or a shareable excerpt without requiring a full teaching document.
 
-## Operational-question gate
-
-Not every *concept by inference* wants the teaching flow this skill runs — many just want a direct answer. When such a request (no `diff:`/`since:` token, no wording that plainly asks to learn or build like "teach me how X works") reads as one better answered in chat — e.g. diagnosing or operating current behavior ("why is X doing Y", "is X configured right") — answer it directly. Then offer to teach it only when a real underlying concept sits behind the question that the user would plausibly want to learn — not as a reflexive add-on to every answer — phrased plainly, e.g. "Want me to actually walk you through how this works? I can build you a visual explainer to keep." Create the run directory and profile the repo only if they take it. A request that plainly wants to learn, or that carries a build signal, skips the gate and is taught in full.
+Select delivery before creating a run directory or loading rendering instructions. No extra mode or confirmation is needed when the intended use is clear. Missing subject or material ambiguity follows the skill body's interaction rule.

--- a/skills/ce-explain/references/orchestration.md
+++ b/skills/ce-explain/references/orchestration.md
@@ -1,10 +1,10 @@
-# Orchestration: asking, dispatching, scratch, and menu shape
+# Evidence and Delegation
 
-Required read before the first blocking question, the first subagent dispatch, or the run-directory creation in the grounding phase — whichever comes first. The skill body carries the phase order and the ordering rules; `references/destinations.md` carries the destination phase's menu and per-option routing.
+Read before grounding or delegation. The skill body owns interaction, completion, and scratch creation; this reference owns the evidence pass and capability fallbacks.
 
 ## Interaction method
 
-When you must ask the user a question, use the host's blocking question tool already in the current tool list (match by capability, not by a host-specific name). Presence in the current tool list is proof the tool exists; never call a user-facing question tool to discover whether it exists. If a matching tool is listed but unloaded, use the host's tool-discovery primitive to load that capability — do not search for another host's tool name. Fall back to numbered options on the host's user-visible chat surface only when no such tool is in the list or a real question call errors. In the fallback, stop and wait for the user's reply. Never silently skip the question. Ask one question at a time.
+The skill body's interaction rule decides whether a question is needed. When it is, use the host's question capability already in the current tool list; never call a user-facing question tool to discover whether it exists. If no such tool is available, ask in chat only when a person is participating. Otherwise return the missing information to the calling workflow.
 
 ## Model tiers
 
@@ -25,14 +25,16 @@ The skill body carries the ownership-checked block that creates `$RUN_DIR`; run 
 
 **Diff mode:** resolve the change (the `diff:` ref, or the most recent substantial change when the request points at one implicitly) and gather its evidence — the diff itself, the files it touches, any plan or solution doc that motivated it.
 
-**Recap mode:** seed the scout with `references/agents/work-recap-scout.md` (extraction tier), passing the resolved window, the repo root, and `$RUN_DIR`. It returns an evidence summary with commit shas and `file:line` pointers, and writes `recap-evidence.md`. **Empty window** (no git activity, no doc changes): say so, offer to widen the window, write no artifact, and end the run after the user responds.
+**Recap mode:** seed the scout with `references/agents/work-recap-scout.md` (extraction tier), passing the resolved window, the repo root, and `$RUN_DIR`. It returns an evidence summary with commit shas and `file:line` pointers, and writes `recap-evidence.md`. **Empty window** follows the skill body: report the absence of activity without an explainer artifact.
 
-**External concepts** (no footprint in this repo): skip repo grounding entirely — do not force repo context into the output. Research with whatever web tools are reachable. When none are, you may explain from model knowledge, but the artifact must label that content **Unverified — from model knowledge, not checked against current sources** in its metadata header.
+**External concepts** (no footprint in this repo): skip repo grounding entirely — do not force repo context into the output. Research with whatever web tools are reachable. When none are, you may explain from model knowledge, but label that content **Unverified — from model knowledge, not checked against current sources** in the response or artifact metadata.
 
 **Idea mode:** the idea is a fixed given. Explain its implications, mechanics, and trade-offs for the user's understanding. Never scope it (`ce-brainstorm`'s job), never generate and rank alternatives (`ce-ideate`'s job).
 
-## Destination menu shape
+## Behavior and rationale
 
-Detect destinations by capability — probe the agent's own toolset and session context, never a closed list, and never treat a missing binary, env var, or unloaded MCP tool as proof a destination is unavailable when a connector could supply it. Local file and Leave it are ungated and always offered. For default HTML runs, offer one preferred publisher: Claude Artifact when running in Claude Code with its Artifact tool present; otherwise ht-ml.app. Do not show both by default, but honor an explicit user request for either. Offer only what is detected; absence hides an option silently.
+For a how question, trace the relevant trigger through its state changes, ownership boundaries, and effect. Inspect actual source and relevant tests; a filename or conversation claim does not establish behavior. Preserve the conditions and failure paths that matter to the requested use.
 
-Count visible options against the platform's cap first (Claude Code's `AskUserQuestion` allows up to 4 explicit options; Codex's `request_user_input` only 2-3): when the visible set exceeds the cap, render a numbered list in chat with "Pick a number or describe what you want." and wait instead.
+For a why question, look for the decision record: motivating docs, comments, git history, PR discussions, or linked issues. Follow evidence to available sources when the local record cannot answer the question, within the request's source restrictions. Access to team chat is not permission to search it when the calling workflow makes that opt-in. Expand investigation to resolve material gaps, not to satisfy a source quota.
+
+Code shows behavior, not necessarily intent. Cite documented reasons separately from supported inferences; report contradictions and unknowns. A missing search result does not prove there was no reason. Establish whether a historical constraint still applies before presenting it as a current requirement. When the explanation informs a change, make the relevant constraints and unresolved risks usable by that next step without selecting an approach for it.

--- a/skills/ce-plan/references/research.md
+++ b/skills/ce-plan/references/research.md
@@ -51,6 +51,8 @@ Collect:
 - **Tools available + user didn't ask**: Note in output: "Slack tools detected. Ask me to search Slack for organizational context at any point, or include it in your next prompt."
 - **No tools + user asked**: Note in output: "Slack context was requested but no Slack tools are available. Install and authenticate the Slack plugin to enable organizational context search."
 
+When an unanswered question about system behavior or design rationale would materially change this work, use `ce-explain`. Pass the question, its scope, its intended use, and pointers to existing evidence. Reuse adequate current research rather than repeating it. Use the explanation’s evidence, constraints, and unanswered questions in this work. Requirements and design decisions remain this skill’s responsibility. The existing source restrictions still apply, including the opt-in rule for Slack research.
+
 #### 1.1b Detect Execution Direction Signals
 
 Decide whether the plan should carry a lightweight execution direction signal.

--- a/skills/ce-pov/SKILL.md
+++ b/skills/ce-pov/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ce-pov
-description: "Give a decisive, project-grounded point of view: a graded verdict on an external-adoption question, a holistic take on a document, or a position on a supplied approach set. Use for a solo POV. Use when asked to consult other models, reconcile their opinions, or `oracle`. Use ce-bakeoff to develop competing solutions to a defined brief; use ce-ideate for open-field opportunities or ce-brainstorm to establish goals. Not for findings review (use ce-doc-review) or neutral explainers."
+description: "Judge a supplied subject against the project's evidence and constraints, returning a supported position, tradeoffs, and conditions. Use when assessing an external-adoption question, a holistic take on a document, or a supplied approach set. Use for an oracle panel to consult other models and reconcile their opinions. Use ce-explain for understanding and ce-doc-review for findings review. Use ce-bakeoff to develop competing solutions to a defined brief, ce-ideate to explore opportunities, or ce-brainstorm to establish goals."
 argument-hint: "[question, document, or approaches] [cross-check] — or bare"
 ---
 
@@ -13,13 +13,15 @@ Produce a decisive, project-grounded point of view in the subject's own shape: a
 
 **Never issue a POV you did not earn against the project's own context.** Every subject must clear the **project floor** in `references/method.md`. An external-adoption verdict must also clear the full external floor. A document or approach-set POV must externally verify any external claim that is load-bearing to its bottom line. Nothing the conversation asserts substitutes for grounding.
 
-## User-facing communication
+## Consumer and interaction
 
-Write for the person deciding what to do. Lead with the decision, question, or recommendation. Keep internal workflow vocabulary and mechanics out of chat unless asked, and put any consequence they need into ordinary language. Call the codebase "this project" or "the repository" unless the user supplied a recognizable name. Never promote a directory, worktree, checkout, branch, or path into the project name.
+Deliver a supported position in the form the intended consumer can use. Lead with the decision and preserve the evidence, material tradeoffs, uncertainty, and conditions that determine it. Make identifiers understandable without requiring the reader to reopen the subject. A person's request may need a brief answer or a shareable document; another workflow may need a decision embedded in its own work.
 
-## Interaction Method
+When contributing to an ongoing workflow, return the result and leave continuation to its owner. Do not add follow-up or panel offers to that return. An explicit oracle or named-peer request still runs the panel, including when it comes from a calling workflow.
 
-Ask through the host's blocking question tool, one question at a time: the host's blocking question tool already in the current tool list (match by capability, not by a host-specific name). Presence in the current tool list is proof the tool exists; never call a user-facing question tool to discover whether it exists. If a matching tool is listed but unloaded, use the host's tool-discovery primitive to load that capability — do not search for another host's tool name. Fall back to numbered chat options only when no such tool is in the list or a real question call errors. Never skip the question.
+Resolve the question from the request and context, and investigate discoverable facts before asking. Ask only when missing information materially changes the judgment and cannot be resolved from evidence. If interaction is unavailable, return the missing framing or evidence and why it blocks the judgment rather than waiting or choosing the caller's requirements.
+
+When a question is necessary, use the host's question capability already in the current tool list; never call a user-facing question tool to discover whether it exists. If no tool is available, ask in chat only when a person is participating. Do not turn framing into an interview.
 
 ## Artifact Root
 
@@ -43,6 +45,8 @@ Resolve `<root>` the first time you compose a `<root>/` path; a read of `<root>/
 
 Send scouts directly to candidate-specific current evidence, never a generic repo profile. They search in their own context and return a dossier path plus a gist, which you read on demand. Where the load-bearing facts are already located, confirm them with bounded reads of the authoritative source instead of dispatching scouts; unscoped or noisy grounding still dispatches. A claim made in the conversation is a pointer to check, never self-verifying. The prior-decision scan (`<root>/solutions/`, ADRs, design docs) stays mandatory on either path.
 
+When the judgment requires an explanation of unresolved behavior or design rationale, invoke `ce-explain`. Pass the question, its scope, and the decision it informs. Use adequate current evidence instead of repeating an investigation. Treat its cited findings as evidence to assess under the same grounding gate, not as authority for the recommendation. Keep ownership of the judgment here. If `ce-explain` is unavailable, gather the evidence directly or report what is missing.
+
 ### Phase 2: Verify Grounding
 
 **Read `references/method.md` now**, before reasoning about the POV. It owns the Verify and POV steps, the skeptic stance, tiering, and the gate. Apply that gate over the grounded evidence. A failed floor forbids a confident result in any subject shape; that reference names the failure result each shape returns instead.
@@ -53,10 +57,8 @@ First form ce-pov's own independent POV under the active subject-shape contract 
 
 A summons is an affirmative request to consult or reconcile peers — a panel, a cross-check, `oracle` — anywhere in the invocation context. Declining one, or merely recounting one, is not a summons. On a summons, or when a cold POV may qualify for a proactive offer, read `references/cross-model-panel.md` before resolving participation or deciding whether to offer. Finish the panel branch before composing the result. A POV that follows a summons states which peers ran, or that none did and why. A POV with no summons carries no panel note.
 
-Only then emit the subject shape's contract, as a **compact chat block, not a research report**. Lead with the grade, bottom line, or position, and never reprint dossiers or raw output.
+Only then deliver the position with the content required by `references/method.md`. Adapt its presentation to the intended use; cite supporting evidence rather than reprinting dossiers or raw peer output.
 
-### Phase 4: Follow-up
+### Phase 4: Deliver and return
 
-The chat POV is the deliverable; implementation is not. **Read `references/followup.md`** for the four-part handoff gate, the routing, and the continuations. Hand the POV on without another question only when that gate passes. Otherwise offer one continuation and wait. Reason that offer from the active subject shape's result — external adoption, Document take, or Approach-set position — never from a fixed menu, and never assume everything routes to a plan. Block only where that reference says the user must choose.
-
-**Warm invocations stay a guest:** output the POV block, hand control back, and offer none of this unless asked.
+The judgment is the deliverable; implementation is not. A calling workflow receives the result and control back. For a requested write-up or continuation, read `references/followup.md`; it owns artifact delivery and the authority gate for downstream actions. Do not require a next-step choice to complete a POV.

--- a/skills/ce-pov/references/boundaries.md
+++ b/skills/ce-pov/references/boundaries.md
@@ -10,12 +10,12 @@ Load this when the input's fit for `ce-pov` is in doubt, or to route a Hold (SKI
 
 | If the user wants... | Route to | The line |
 |---|---|---|
-| A neutral explainer ("tell me about X") | general research / answer it directly | `ce-pov` only returns a project-grounded verdict; with no project angle, answer it as a normal research question — or a dedicated deep-research-style tool *if the environment has one* — rather than forcing a verdict |
-| A holistic take on a supplied document ("what do you think of this doc?") | `ce-pov` | A take judges the document's direction, strengths, risks, and bottom line; "review this doc" or "find the issues" asks for findings and routes to `ce-doc-review`. When the wording is ambiguous, ask one clarifying line rather than guessing |
+| A neutral explainer ("tell me about X") | `ce-explain` | `ce-pov` only returns a project-grounded verdict; with no project angle, invoke `ce-explain` with the question and intended use rather than forcing a verdict |
+| A holistic take on a supplied document ("what do you think of this doc?") | `ce-pov` | A take judges the document's direction, strengths, risks, and bottom line; "review this doc" or "find the issues" asks for findings and routes to `ce-doc-review`. When the wording is ambiguous, resolve it under the skill body's interaction rule |
 | A judgment among approaches the user already supplied | `ce-pov` | Options developed → judge against the project; rough options needing development for a defined brief → `ce-bakeoff` |
 | Options invented from an open field | `ce-ideate` | Invented vs. discovered: ideate invents; `ce-pov` judges/selects from a discoverable field |
 | To scope an idea already chosen | `ce-brainstorm` | `ce-pov` decides *whether*; brainstorm scopes *what* once it's a yes |
-| To know how to build something decided | `ce-plan` | Verdict accepted → offer the handoff, or perform it only when the original request authorized that named action and the Phase 4 authority gate passes; `ce-pov` does no task breakdown |
+| To know how to build something decided | `ce-plan` | Perform a requested handoff only when the Phase 4 authority gate passes; `ce-pov` does no task breakdown |
 | To fix observed broken behavior | `ce-debug` | `ce-pov` assesses *exposure and priority* of a CVE; debug investigates an *actual failure* |
 | Product thesis / company direction | `ce-strategy` | `ce-pov` is bounded to a specific external input |
 
@@ -26,11 +26,11 @@ A *selection* question ("what should we use for auth?") is a `ce-pov` verdict on
 When the field cannot be bounded without inventing options, or the criteria are unclear, **Hold and route out**:
 
 - Defined solution brief, but candidates need concrete development → `ce-bakeoff`.
-- Field too open to enumerate → Hold → `ce-ideate` to enumerate the candidates → offer to re-run `ce-pov` on the shortlist.
-- Criteria unclear / unstated requirements → Hold → `ce-brainstorm` to surface them → offer to re-run.
+- Field too open to enumerate → Hold → `ce-ideate` to enumerate the candidates → return the shortlist requirement to the caller.
+- Criteria unclear / unstated requirements → Hold → `ce-brainstorm` to surface them → return the missing criteria to the caller.
 
 Running a verdict on an unbounded field turns `ce-pov` into disguised requirements discovery — the escape hatch is what keeps it a judgment skill.
 
 ## Universal grounding (designed-in, deferred)
 
-`ce-pov` grounds against the project's available context, and "project" includes a non-code folder (docs, decks, markdown, data), not only a git repo. The only case out of scope is *no local material at all* — a pure user-described situation with nothing to ground against. Treat that as out of scope: say the verdict would be ungrounded and ask for the project context, rather than dispensing generic advice dressed as a POV.
+`ce-pov` grounds against the project's available context, and "project" includes a non-code folder (docs, decks, markdown, data), not only a git repo. The only case out of scope is *no local material at all* — a pure user-described situation with nothing to ground against. Treat that as out of scope: return the missing project context under the skill body's interaction rule, rather than dispensing generic advice dressed as a POV.

--- a/skills/ce-pov/references/cross-model-panel.md
+++ b/skills/ce-pov/references/cross-model-panel.md
@@ -477,7 +477,7 @@ The panel itself never mutates. After delivery, apply SKILL.md Phase 4's
 four-part conjunction: the original prompt explicitly authorized the named
 downstream action, the result is non-stalemated, the action stays in inherited
 scope, and it is non-destructive and otherwise authorized. All four must pass
-for handoff; otherwise offer one logical next step and wait.
+for handoff; otherwise return the judgment without starting downstream work. A calling workflow retains ownership of continuation.
 
 ## 7. Skeptic mode and degradation
 

--- a/skills/ce-pov/references/followup.md
+++ b/skills/ce-pov/references/followup.md
@@ -1,27 +1,9 @@
-# Follow-up routing (Phase 4)
+# Requested continuation
 
-The chat POV (the TL;DR) is the deliverable. Any implementation is outside this read-only contract. Before any handoff, apply this four-part gate: **(1)** the original prompt explicitly authorized the named downstream action, **(2)** the final result is non-stalemated, **(3)** the action remains inside the inherited scope, and **(4)** the action is non-destructive and otherwise authorized. Only when all four pass may the settled POV be handed to the owning skill without another question. Otherwise offer one logical continuation and wait; a later user selection supplies the fresh authority for that continuation. What you offer next is **reasoned from the POV and its active subject shape — never a fixed menu, and never an assumption that everything routes to a plan.**
+The judgment itself completes `ce-pov`. When another workflow called it, return the result; that workflow owns the next action. Do not add a menu or capture offer.
 
-**Compute the next step.** From the active subject shape's result and its Handoff field when present, reason about the single best next move and a one-clause why:
+A standalone invocation may hand off to another workflow only when the original request authorized the downstream action. The result must resolve the decision needed for that action. The action must remain within the inherited scope and be non-destructive and otherwise authorized. A recommendation alone grants no implementation authority. When a consequential choice remains with the user, ask under the skill body's interaction rule; otherwise finish with the result.
 
-- **External adoption:** **Adopt** with clear scope → `ce-plan`; **Adopt** with fuzzy scope → `ce-brainstorm`; **Trial** → a timeboxed spike with `ce-work`; **Hold / Reject / Not-our-problem** → no handoff.
-- **Document take:** actionable revisions → offer to apply the specific edits through the workflow that owns that document; no requested change or a Blocked result → no handoff.
-- **Approach-set position:** a chosen, sufficiently defined option → proceed through the owning planning or execution workflow; a choice that still needs scope → `ce-brainstorm`; an honest toss-up or Blocked result → no handoff.
+Choose any authorized continuation from the actual outcome, not a fixed menu. Adoption may need planning or a trial; a document take may inform revisions; an approach-set position may return to design or execution. Invoke the owning skill through the host's skill-invocation capability with the decision, evidence, conditions, and inherited scope. Never assume every positive result requires a plan.
 
-**Shape-gate the offer (anti-ritual):**
-
-- **For adoption subjects, Tier 1 or a Reject / Not-our-problem grade** → end with a single prose line — e.g. "Want the full write-up, or `<computed next step>`? Otherwise we're done." No blocking menu; silence means done.
-- **For adoption subjects, Tier 2/3 with an actionable grade** → use the platform's blocking question tool.
-- **For document takes and approach-set positions**, use one prose line for an optional or lightweight continuation; use the blocking question tool only when the POV recommends consequential follow-on work and the user must choose whether to begin it. A no-handoff result offers only the optional full write-up, if useful.
-- When using the blocking question tool, make the *computed* next step the first, dynamically labeled option:
-  1. **`<computed next step>`** (e.g. "Plan the adoption with `ce-plan`", "Apply the document edits", or "Proceed with approach A") — seeded with the POV substance, not a file pointer.
-  2. **Full write-up** — the expanded, shareable artifact.
-  3. **Done.**
-  Add `ce-compound` as a one-line prose nudge under the menu, **not** a slot, only when the POV is a durable decision that fits an existing capture type: "Want it in our decision history? say 'compound it.'" It is never the first thing offered.
-
-**On a pre-authorized handoff or later user selection:**
-
-- **Computed next step** → after the four-part gate passes, invoke the owning skill via the platform's skill-invocation primitive, seeding it with the POV substance (the decision, conditions, requested edits or chosen approach, and verified facts). A stalemate, scope expansion, destructive action, or insufficient authority always returns to the user first.
-- **Full write-up** → read `references/report.md` and follow it (HTML by default; opened locally or published via Proof / an available HTML tool). Opt-in; the default stays chat-only.
-- **"compound it"** → invoke `ce-compound` with `mode:non-interactive`, seeding it with the structured POV and the fitting existing capture type (no schema change; non-interactive avoids its interactive prompts). Never mandatory.
-
+For a requested full write-up, read `references/report.md`. For a requested durable decision capture, invoke `ce-compound` with `mode:non-interactive` and the structured decision fitting an existing capture type. Neither is a required follow-up to a POV.

--- a/skills/ce-pov/references/intake.md
+++ b/skills/ce-pov/references/intake.md
@@ -1,14 +1,14 @@
 # Establish the Frame Before Grounding
 
-Every Phase 0 loads this, because every run has to settle a frame before spending the scout fan-out. What happens after that follows from the frame.
+Settle the question before gathering decision-specific evidence. The skill body owns interaction and return to the caller.
 
-An intent that routes out of this skill — an explainer, or anything `references/boundaries.md` sends elsewhere — finishes here: say where the request belongs, and stop. No tier, no hatch, no grounding.
+If the request belongs to another skill, finish intake by routing it there. Send understanding questions to `ce-explain` with the subject and intended use. For other work outside this skill’s scope, return the route identified in `references/boundaries.md`. Do not issue a verdict or continue to tiering, selection, or evidence gathering. If the named capability is unavailable, report that limitation to the caller.
 
-Every invocation whose settled frame is a POV takes the **reversibility tier and the selection escape hatch** (in *Tier, sizing, and the selection hatch* at the end), including one whose subject and intent were obvious from the start. The orienting and proposing steps (Steps 1-3) are the path for an input that does not already say what POV the user wants — a bare link, a bare topic, a warm invocation with no stated question; on a clear frame, state it in one line and go straight to the tier and the hatch. Either way the rule is the same: propose, **never guess**.
+Every settled POV applies the reversibility tier and selection escape hatch below. A clear frame can proceed directly to those checks; an ambiguous one follows the skill body's interaction rule before decision-specific research.
 
 ## Output mode and warm invocations
 
-By default this skill writes no document. The POV is a compact chat block, and a write-up or a `ce-compound` capture is offered at Phase 4. Do not resolve an output format or load a rendering reference up front.
+By default this skill writes no document. Deliver the POV to its consumer. A requested write-up uses Phase 4; do not load rendering instructions for an ordinary answer.
 
 A **warm** invocation is a mid-session second opinion, with the question sitting in the conversation or absent. On one, read `references/invocation.md`, and take only the *question and claims-to-verify* from the conversation, never grounding.
 
@@ -18,7 +18,7 @@ The same subject supports very different verdicts. A link to a new sign-in metho
 
 ## Step 1 — Orient on what was provided (cheap, pre-grounding)
 
-- **A bare link** → fetch it lightly (one fetch) to learn what the thing *is*; name it. If you cannot fetch it (no web tool, paywalled), ask the user what it is rather than assuming.
+- **A bare link** → fetch it lightly (one fetch) to learn what the thing *is*; name it. If you cannot fetch it (no web tool, paywalled), return the missing subject information under the skill body's interaction rule.
 - **A bare topic or name** → recognize it from your own knowledge; a single search only if you genuinely can't place it.
 - **A document path** → read its headings to learn its purpose and shape; do not review it for findings yet.
 - **An approach set** → identify the options already on the table; do not invent additional options during orientation.
@@ -36,28 +36,19 @@ The subject is usually recoverable; the **intent** is the ambiguous part. Classi
 - **Exposure** — is this (a CVE, deprecation, or ecosystem change) *our problem*?
 - **Document-take** — what is the holistic take on this document: its strengths, risks, and bottom line, rather than a findings review?
 - **Approach-set** — which of the supplied approaches fits this project, and why, or are the options honestly viable either way?
-- **Explainer** — they just want to understand it. This is **not** a verdict — handle it as a general research question (or a dedicated deep-research-style tool, *if the environment has one*), rather than forcing one.
+- **Explainer** — the requested result is understanding. Route to `ce-explain`, preserving the question and intended use.
 
-## Step 3 — Infer, or propose; never guess
+## Step 3 — Resolve the frame
 
-- **Conversational shorthand** — resolve deictic subjects such as "the approach," "these options," or "the three options presented" from the active conversation when exactly one referent fits. Do not require a standalone restatement. If multiple plausible referents would materially change the POV, ask one focused clarification naming the competing referents before grounding or peer spend.
-- **Subject AND intent clear** → state the frame in one line and proceed. Do not ask a question you can already answer: "Framing this as: should we replace `<incumbent>` with `<X>`? Say if you meant something else."
-- **Intent ambiguous** → propose, built from Step 1's orientation. Use the blocking question tool with the **2-3 strongest concrete candidate framings this specific input suggests** (naming the incumbent where you know it), and rely on the tool's built-in free-text path for "something else" rather than adding it as an explicit option — some tools (e.g. Codex's `request_user_input`) cap explicit options at 2-3 and already provide the free-form fallback, so an extra explicit option can error or get trimmed. Do not offer a generic checklist; offer the real readings of *this* input. Example for a passkeys link on a password-auth project: *adopt passkeys* · *migrate auth to them (and at what cost)* · *compare them to our current sign-in*.
-- **Reads as an explainer** → say so and answer it as a general research question (or hand to a dedicated research tool if one is available), rather than manufacturing a verdict.
+Resolve shorthand from the active conversation when one referent fits. A clear subject and intent need no confirmation. When competing readings would materially change the judgment, investigate what can be established and ask only for the remaining user-owned decision under the skill body's interaction rule. A calling workflow receives missing framing back rather than a clarification interview.
 
-## Discipline
-
-`ce-pov` is not `ce-brainstorm`. **One** orientation read, **at most one** clarifying question, then go. If the user already stated the intent, skip straight to the one-line frame — do not interrogate. The cost of one cheap question is trivial; the cost of grounding the wrong frame is the whole run.
-
-## Warm invocations
-
-A warm invocation with no clear question is this same gate — the conversation is the material you orient on. Infer the decision from it, propose/confirm it, then proceed. For the rest of the warm contract (guest output, provenance buckets), see `references/invocation.md`.
+An understanding request belongs to `ce-explain`; no reversibility tier, selection workup, or verdict is required on that route.
 
 ## Tier, sizing, and the selection hatch
 
 These two decide **every** invocation, however clear the frame already was.
 
-**Apply the selection escape hatch.** If the input is a *selection* over a field ("what should we use for auth?"), it belongs here only when the realistic field is bounded (roughly five or fewer real candidates) and the criteria are knowable. If the field can't be bounded without inventing options, or the criteria are unclear, **stop**: return a Hold and route by the missing work: `ce-bakeoff` to develop competing solutions to a defined brief, `ce-ideate` to explore an open opportunity field, or `ce-brainstorm` to surface goals and criteria. Bake-off returns its own selected synthesis; a subsequent POV is an optional second opinion. For discovery routes, offer to judge the resulting developed shortlist.
+**Apply the selection escape hatch.** If the input is a *selection* over a field ("what should we use for auth?"), it belongs here only when the realistic field is bounded (roughly five or fewer real candidates) and the criteria are knowable. If judging the field would require inventing options, or the criteria are unclear, **stop**. Return a Hold that explains what is missing and identifies the skill that can resolve it. Use `ce-bakeoff` to develop competing solutions to a defined brief, `ce-ideate` to explore an open opportunity field, or `ce-brainstorm` to surface goals and criteria. Bake-off selects and synthesizes its own result. A subsequent POV is an optional second opinion. Continuing through that route follows the existing follow-up authority gate.
 
 **Classify the reversibility tier — three levels.** Infer it from project signals:
 
@@ -65,4 +56,4 @@ These two decide **every** invocation, however clear the frame already was.
 - **Tier 2 — one-way but bounded:** a data store, an internal API/contract, or a migration whose blast radius stays inside this codebase.
 - **Tier 3 — one-way and high-stakes:** a security, legal, or privacy surface; a public API/contract; or an irreversible data migration.
 
-State the tier in the verdict and let the user override. The tier sizes the rest of the run (Phase 1 scout count, Phase 2 depth, Phase 3 reversal trigger): Tier 1 stays a one-screen verdict off a single combined grounding pass; Tier 2 adds the full scout fleet and an alternatives pass; Tier 3 adds deep external research, a precedent search, and a durable-record offer. Do not run a Tier-3 workup on a trivially reversible `npm i`, or hand a security-surface decision the moderate Tier-2 treatment.
+The tier determines how much investigation and verification to do, not the answer’s format. Tier 1 uses a combined grounding pass. Tier 2 adds the full scout fleet and an alternatives pass. Tier 3 adds deep external research and precedent search. Explain the stakes when they affect the recommendation. Do not run a Tier-3 workup on a trivially reversible `npm i`, or hand a security-surface decision the moderate Tier-2 treatment.

--- a/skills/ce-pov/references/invocation.md
+++ b/skills/ce-pov/references/invocation.md
@@ -24,7 +24,7 @@ If the conversation says "we have 40 call-sites on X," the project-grounding sco
 
 ## Establishing the question (frame gate)
 
-A warm invocation with **no explicit question**, or a materially ambiguous one, goes through the frame gate in `references/intake.md` — infer the decision from the conversation, propose/confirm it, then proceed. Rendering a confident POV on the wrong question is the warm-mode failure that gate prevents. **Skip the gate** when the user named the question ("ce-pov: should we use X?") — a mandatory confirm on every warm run is the bureaucratic ritual the skill avoids.
+A warm invocation with **no explicit question**, or a materially ambiguous one, goes through the frame gate in `references/intake.md` — resolve the decision from context and evidence; return material missing framing to the caller when no person can supply it. Rendering a confident POV on the wrong question is the warm-mode failure that gate prevents. **Skip the gate** when the user named the question ("ce-pov: should we use X?") — a mandatory confirm on every warm run is the bureaucratic ritual the skill avoids.
 
 Short references are intentional: "on the approach," "these options," or "the three options presented" resolve from the active conversation when one referent fits. Ask once only when competing referents would materially change the POV. `oracle` requests immediate panel convergence; explicit peer names in the same invocation select those exact participants and override oracle discovery and its automatic cap. `Cursor` means the Cursor harness's configured default/Auto model; `Composer` means a Composer model reached through Cursor, not an alias for Cursor.
 
@@ -42,6 +42,6 @@ The conversation's momentum pulls toward agreement, and a second opinion that ru
 Warm is a guest, not a host:
 
 - Consult a peer only when the warm invocation explicitly requests one; never make a proactive panel offer mid-session.
-- Output a **POV block only** — no reframing of the host session, no taking over the brainstorm.
+- Output a **requested POV only** — no reframing of the host session, no taking over the brainstorm.
 - **Hand control back** after the POV.
 - **Skip the capture offer** unless the user asks — a mid-session interjection should not push a durable-record decision.

--- a/skills/ce-pov/references/method.md
+++ b/skills/ce-pov/references/method.md
@@ -12,11 +12,13 @@ Load this before reasoning about the POV (SKILL.md Phase 2). It defines the Veri
 ## Two cross-cutting properties (not phases)
 
 - **Skeptic stance.** At every step, seek disconfirming evidence and name the real alternatives — including "keep the incumbent" and "do nothing." "No", "Reject", and "Not-our-problem" are first-class outcomes, not failures to complete. Do not let the framing (or, in warm mode, the conversation's momentum) pull the grade upward.
-- **Reversibility-tiered effort.** The Phase 0 tier sizes the work. Tier 1 (two-way door): one screen, 1-2 external + 1-2 project facts, no reversal trigger, single combined grounding pass. Tier 2 (one-way but bounded): the full scout fleet and a fuller alternatives pass. Tier 3 (one-way and high-stakes — security/legal/privacy, public contract, or irreversible migration): deep research, precedent search, durable record offered. A shallow Tier 1 verdict is defensible *because* the tier is stated — not lazy.
+- **Reversibility-tiered effort.** Scale evidence gathering and verification with the cost of being wrong. The intake tier governs research depth; presentation follows the consumer's needs. Preserve material alternatives and the conditions that would change a consequential judgment.
 
 ## The grounding gate
 
 The project floor always applies. The external floor applies in full to an external-adoption question. For a document or approach set, it applies only to external claims that materially support the POV's bottom line; when no external claim is load-bearing, no external source is required. A conversation claim (warm mode) never satisfies either floor until a scout or a bounded inline read of the authoritative source corroborated it — it sits in the *conversation hypotheses* bucket, never the *verified facts* bucket.
+
+A call to another function establishes that the call occurs, not how that function behaves. Verify guarantees against the implementation or tests that establish them. When those sources are unavailable, keep the guarantee unknown in the explanation or recommendation. Label inferred purpose where you state it; a later caveat does not make an unsupported claim safe to use.
 
 ### External-adoption questions: the two-floor Invalid-Verdict gate
 
@@ -33,7 +35,7 @@ Apply the same project-floor proof standard to a document or approach set, using
 
 ## External-adoption verdict contract
 
-Every verdict carries a fixed vocabulary and a fixed shape so it is comparable and the next run's precedent search can find it.
+Every verdict preserves the grade vocabulary so decisions remain comparable and discoverable in precedent searches.
 
 **Grade** — exactly one of:
 
@@ -43,43 +45,20 @@ Every verdict carries a fixed vocabulary and a fixed shape so it is comparable a
 - **Reject** — judged not worth it for us.
 - **Not-our-problem** — for an exposure question (CVE / deprecation) that does not reach us — avoids forcing an adopt/reject.
 
-**Render the grade so the reader never has to decode it.** Lead the chat verdict with the call in plain words and attach the label — "Hold — wait, don't switch now," "Trial — pilot it on a low-risk slice first" — not a bare "Grade: Trial." The fixed vocabulary exists for the durable record and precedent search; it tags a plain-language verdict, it does not replace one.
-
-**Schema** — every verdict states these fields:
-
-`Grade` (the label **plus** its one-line plain-language meaning — never the bare token, e.g. *Trial — promising; pilot it on a low-risk slice first*) · `Incumbent` · `Verified facts (project + external, kept distinct)` · `Conversation hypotheses (unverified — warm only)` · `Conditions ("yes, if ...")` · `Handoff (recommended next skill)` · `Reversal trigger (Tier 2/3 only — what would flip this verdict)`
-
-Keep the verified-facts field split into its project and external halves, and keep conversation hypotheses in their own field — never let an unverified claim sit among verified facts.
+Preserve the grade and its meaning, incumbent or integration point, verified project and external evidence, material conditions, and what would change a consequential verdict. Keep unverified conversation claims distinguishable from evidence. These are content requirements, not mandatory headings or a fixed layout. A recommended next action is useful only when the result calls for one; it is not permission to execute it.
 
 ## Document-take contract
 
-A document POV is a holistic take, not a findings review. Lead with a plain-language **Bottom line**, then state:
-
-`Strengths` · `Risks` · `Verified facts (project + load-bearing external claims, kept distinct)` · `Conversation hypotheses (unverified — warm only)` · `Recommendation` · `Handoff (optional separate continuation)`
-
-Name the few strengths and risks that actually determine the bottom line; do not turn the response into an issue inventory. Recommend what should happen next when the evidence supplies a real basis. Applying edits is never part of the POV itself. An analysis-only request offers the logical continuation and waits; an originally authorized continuation may route to the owning workflow only after the non-stalemated, in-scope, non-destructive authority gate in SKILL.md Phase 4 passes.
+A document POV judges its overall direction rather than inventorying findings. Explain the bottom line and the strengths, risks, and verified project facts that determine it. Verify load-bearing external claims and distinguish unverified conversation claims. Applying revisions belongs to the workflow that owns the document, under the follow-up authority gate.
 
 ## Approach-set position contract
 
-An approach-set POV judges developed options supplied by the user, conversation, or calling skill. When comparison requires developing concrete solutions beyond their current form, route to `ce-bakeoff`; discovering an open field belongs to `ce-ideate`, and establishing goals or criteria belongs to `ce-brainstorm`. Lead with a plain-language **Position**. Then state:
+An approach-set POV judges developed options supplied by the user, conversation, or calling skill. When comparison requires developing concrete solutions beyond their current form, route to `ce-bakeoff`; discovering an open field belongs to `ce-ideate`, and establishing goals or criteria belongs to `ce-brainstorm`. Preserve the reasons, material tradeoffs, evidence, and conditions behind the position.
 
-`Why` · `Tradeoffs by supplied approach` · `Verified facts (project + load-bearing external claims, kept distinct)` · `Conversation hypotheses (unverified — warm only)` · `Conditions` · `Handoff (optional separate continuation)`
+Choose when evidence provides a real basis. When the options are genuinely viable either way, say **"Either is viable"** and explain the tradeoffs. Never manufacture certainty with a scorecard or a mechanical count of advantages. Proceeding with an approach is a separate action governed by the follow-up authority gate.
 
-Choose an approach and recommend it when verified project facts and the material tradeoffs provide a real basis. When the options are genuinely viable either way, say **"Either is viable"** and lay out the pros and cons instead of forcing a pick. Never manufacture certainty with a scorecard or mechanically select the option with the most checked boxes. Proceeding with an approach is never part of the POV itself; an analysis-only request offers it and waits, while an originally authorized continuation still must pass the Phase 4 authority gate.
+## Delivery
 
-## Output economy
+Write the chat block through the `ce-noslop` skill.
 
-Write the chat block through the `ce-noslop` skill. The rules in this section are what this skill adds on top.
-
-`ce-pov` writes no document, so the chat block *is* the whole deliverable — make it a tight POV, not a transcript of the investigation.
-
-Lead with the grade for an external-adoption question and with the bottom line or position for the other shapes. Keep each schema field to one line or a few bullets. The `Verified facts` field **cites** from the dossiers (`file:line`, issue/PR number, url) rather than reproducing them, and the dossiers themselves are never printed to chat.
-
-**Name what identifiers refer to.** When the POV references an identifier the subject defines rather than the reader — a supplied option label like "Option A", a document requirement or unit ID like `R8` or `U3` — pair it with a short distinguishing gloss at first mention (`R8 (elevated-call read access)`, not bare `R8`), so the block stands alone for someone who never saw the option list or does not have the document open. Keep the identifier; keep the gloss to a few words. Resolve the gloss from the material already in context — the supplied list, or the document `ce-pov` read. This governs the whole delivered block, including any peer position folded in during reconciliation: a peer that wrote a bare label does not license relaying one.
-
-For adoption subjects, length is governed by the tier, not by how much was found:
-
-- **Tier 1** — one screen: the grade, the incumbent, 1-2 project + 1-2 external cited facts, the conditions, the handoff. No reversal trigger, no alternatives walk-through.
-- **Tier 2/3** — fuller (alternatives, the reversal trigger, deeper conditions), but still leads with the grade and keeps evidence to cited bullets, never walls of quoted text.
-
-If the verdict is running past its tier's budget, you are pasting evidence that belongs in a citation — cut it.
+The skill body owns consumer adaptation. Keep enough cited evidence to assess the judgment, name what remains uncertain, and make any option or requirement identifiers understandable. Do not reproduce research transcripts. Requested artifacts use `references/report.md`; ordinary answers need no artifact or continuation menu.

--- a/skills/ce-pov/references/report.md
+++ b/skills/ce-pov/references/report.md
@@ -1,28 +1,7 @@
-# The Optional Full Write-Up
+# Requested Write-Up
 
-Load this only when the user asks for the full write-up (SKILL.md Phase 4). The default deliverable is the compact chat TL;DR; this is the opt-in expanded artifact — for reading, sharing, or handing to the next skill.
+Expand the judgment for its intended readers and destination. Preserve the active subject's evidence and conditions from `references/method.md`: an adoption grade, a document's overall take, or a position among supplied approaches. Do not turn a document take or approach comparison into an adoption report.
 
-## What it contains
+Use the requested format or the destination's supported format. When none is specified, choose what makes the result usable. Cite project sources and any external sources the judgment depends on. Distinguish inference from evidence and retain the conditions that could change the judgment. Do not paste raw dossiers.
 
-The verdict, expanded — lead with the decision, then the evidence the TL;DR omitted:
-
-- **Verdict** — the grade and the conditions ("yes, if ..."), up top.
-- **Question framed** — subject, intent, the incumbent, and the reversibility tier.
-- **Evidence** — the **project leg** and the **external leg** as cited bullets (`file:line`, issue/PR number, url) drawn from the scout dossiers. This is where the depth lives.
-- **Alternatives considered** — including "keep the incumbent" and "do nothing."
-- **Reversal trigger** (Tier 2/3) — what would flip this verdict.
-- **Provenance** — what was verified vs. any unconfirmed conversation hypothesis (warm only).
-
-## Format and economy
-
-- **HTML by default** — a single self-contained file (a verdict is a thing people share). Use markdown when the user asks, or when the write-up will feed `ce-brainstorm`/`ce-plan`.
-- Write to a temp path, or under `docs/` when the user wants it kept; announce the absolute path. Do **not** introduce a new mandated `docs/` location — that store is deferred.
-- Lead with the verdict, and **cite** evidence rather than pasting dossiers wholesale — the report is a tighter case for a human, not a research dump.
-
-## Sharing
-
-Publish via whatever the user has — best available, never required:
-
-- `ce-proof` (Proof) — markdown-only, so if the report is HTML, render a throwaway markdown copy of it as the Proof source.
-- Otherwise an available HTML publishing tool the user has connected.
-- If neither is reachable, the local file is the deliverable — announce its path.
+Use private scratch for a standalone file and deliver its path. Resolve the CE artifact root before writing to a requested project location. When another workflow owns the surrounding document, return the content for it to incorporate. A request for a write-up does not authorize publishing it. When publication is requested, use the destination’s available tools and follow its authorization requirements. If publication cannot complete, retain the local result and report the limitation.

--- a/tests/pov-skill-contract.test.ts
+++ b/tests/pov-skill-contract.test.ts
@@ -57,15 +57,14 @@ describe("ce-pov subject-shape contract", () => {
     expect(phaseZero).toContain("Approach-set")
   })
 
-  test("keeps user-facing copy decision-oriented without exposing project internals", async () => {
+  test("consumer adaptation preserves decision substance and oracle activation", async () => {
     const skill = await skillFile("SKILL.md")
-    const userCopy = between(skill, "## User-facing communication", "## Interaction Method")
-
-    expect(userCopy).toContain("person deciding")
-    expect(userCopy).toContain("decision, question, or recommendation")
-    expect(userCopy).toContain("internal workflow vocabulary")
-    expect(userCopy).toContain('"this project" or "the repository"')
-    expect(userCopy).toMatch(/never promote.*directory.*worktree.*checkout.*branch/i)
+    const consumer = between(skill, "## Consumer and interaction", "## Artifact Root")
+    expect(consumer).toContain("Lead with the decision")
+    expect(consumer).toContain("evidence, material tradeoffs, uncertainty, and conditions")
+    expect(consumer).toContain("return the result and leave continuation to its owner")
+    expect(consumer).toContain("explicit oracle or named-peer request still runs the panel")
+    expect(skill.split("---", 3)[1]).toContain("oracle panel")
   })
 
   test("intake and boundaries distinguish takes, findings reviews, and supplied approaches", async () => {
@@ -105,7 +104,7 @@ describe("ce-pov cross-model panel contract", () => {
   // approval, the shared tree — live in the reference the pointer mandates.
   test("loads the panel protocol before deciding whether to offer", async () => {
     const skill = await skillFile("SKILL.md")
-    const phaseThree = between(skill, "### Phase 3: Point of View", "### Phase 4: Follow-up")
+    const phaseThree = between(skill, "### Phase 3: Point of View", "### Phase 4: Deliver and return")
 
     expect(phaseThree).toContain("may qualify for a proactive offer")
     expect(phaseThree).toContain("before resolving participation or deciding whether to offer")
@@ -123,11 +122,11 @@ describe("ce-pov cross-model panel contract", () => {
 
   test("forms an independent solo POV before the panel and emits only after it finishes", async () => {
     const skill = await skillFile("SKILL.md")
-    const phaseThree = between(skill, "### Phase 3: Point of View", "### Phase 4: Follow-up")
+    const phaseThree = between(skill, "### Phase 3: Point of View", "### Phase 4: Deliver and return")
 
     const formSolo = phaseThree.indexOf("form ce-pov's own independent POV")
     const runPanel = phaseThree.search(/[Ff]inish the panel branch/)
-    const emitFinal = phaseThree.indexOf("Only then emit")
+    const emitFinal = phaseThree.indexOf("Only then deliver")
 
     expect(formSolo).toBeGreaterThan(-1)
     expect(runPanel).toBeGreaterThan(formSolo)
@@ -140,7 +139,7 @@ describe("ce-pov cross-model panel contract", () => {
   test("discloses panel status after any summons even when no panel runs", async () => {
     const skill = await skillFile("SKILL.md")
     const panel = await skillFile("references/cross-model-panel.md")
-    const phaseThree = between(skill, "### Phase 3: Point of View", "### Phase 4: Follow-up")
+    const phaseThree = between(skill, "### Phase 3: Point of View", "### Phase 4: Deliver and return")
 
     // Body pin: the disclosure itself must fire when the result is composed.
     // Corpus pins: how a summons is recognized across channels, and the
@@ -151,28 +150,24 @@ describe("ce-pov cross-model panel contract", () => {
     expect(panel).toMatch(/summons was present but the panel branch never entered/)
   })
 
-  // Split by load-time: Phase 4 always reads followup.md, so the body pins the
-  // shapes the offer is reasoned from and the reference owns the tier gates.
-  test("follow-up covers every subject shape while retaining adoption tier gates", async () => {
+  test("continuation preserves authority without obligatory menus", async () => {
     const skill = await skillFile("SKILL.md")
-    const phaseFour = skill.slice(skill.indexOf("### Phase 4: Follow-up"))
     const followup = await skillFile("references/followup.md")
-
-    expect(phaseFour).toContain("references/followup.md")
-    expect(phaseFour).toContain("active subject shape")
-    expect(phaseFour).toContain("Document take")
-    expect(phaseFour).toContain("Approach-set position")
-    expect(followup).toContain("For adoption subjects")
-    expect(followup).toContain("Tier 1")
-    expect(followup).toContain("Tier 2/3")
+    expect(skill).toContain("For a requested write-up or continuation, read `references/followup.md`")
+    expect(followup).toContain("original request authorized the downstream action")
+    expect(followup).toContain("result must resolve the decision needed for that action")
+    expect(followup).toContain("inherited scope")
+    expect(followup).toContain("non-destructive and otherwise authorized")
+    expect(followup).toContain("Do not add a menu or capture offer")
   })
 
-  test("warm invocations return a POV block without proactive follow-up", async () => {
+  test("delegates only an unresolved understanding question and retains the judgment", async () => {
     const skill = await skillFile("SKILL.md")
-    const phaseFour = skill.slice(skill.indexOf("### Phase 4: Follow-up"))
-
-    expect(phaseFour).toContain("output the POV block")
-    expect(phaseFour).not.toContain("output the verdict block")
+    expect(skill).toContain("judgment requires an explanation of unresolved behavior or design rationale")
+    expect(skill).toContain("invoke `ce-explain`")
+    expect(skill).toContain("Use adequate current evidence instead of repeating an investigation")
+    expect(skill).toContain("Keep ownership of the judgment here")
+    expect(skill).not.toContain("mode:return-to-caller")
   })
 
   test("uses the JSON Schema draft supported by the Claude CLI", async () => {

--- a/tests/skill-eval-cell/catalog.ts
+++ b/tests/skill-eval-cell/catalog.ts
@@ -108,6 +108,8 @@ export type Scenario = {
   baseline_ref?: string
 }
 
+const UNDERSTANDING_BASE_REF = "8df67793b9733d2220fa9a7fc37139931471af62"
+
 const FIX = "tests/skill-eval-cell/fixtures"
 
 const SETUP_INSTRUCTIONS_TASK =
@@ -755,6 +757,76 @@ The same decision owns open review thread PRRT_ci_contract_7 at https://github.c
       // asking would otherwise leave a clean tree and pass.
       committed_must_not: ["seat-cap.js"],
     },
+  },
+  {
+    id: "ce-explain/planning-understanding",
+    skill: "ce-explain",
+    cohort: "resized",
+    key_behavior: "judgment",
+    read_only: false,
+    fixture: `${FIX}/understanding-queue`,
+    baseline_ref: UNDERSTANDING_BASE_REF,
+    timeout_secs: 180,
+    why: "The old Codex path created HTML for a planning input. The answer must preserve undocumented rationale and return without artifact work; inspect prose for unsupported concurrency guarantees.",
+    pre_contract: "Teaching artifacts are the primary result; operational questions may answer directly in chat.",
+    task: "I am planning an event-driven queue worker. Explain how claim works and why polling and the 30-second lease exist. I need the explanation as input to my next planning step.",
+    grade: { workspace_read: ["queue.js", "DECISION.md"], must_include: ["polling", "30"], actions: "none" },
+  },
+  {
+    id: "ce-explain/embedded-pr-explanation",
+    skill: "ce-explain",
+    cohort: "resized",
+    key_behavior: "judgment",
+    read_only: false,
+    fixture: `${FIX}/understanding-queue`,
+    baseline_ref: UNDERSTANDING_BASE_REF,
+    timeout_secs: 180,
+    why: "An explanation for PR readers must be incorporable content, not an obligatory full-depth standalone lesson or a publication action.",
+    pre_contract: "Audience adaptation retains teaching depth and refuses a status-update form.",
+    task: "The PR-writing workflow needs a short explanation for reviewers of why this queue still polls despite notifications. Supply two paragraphs it can incorporate into the PR body.",
+    grade: { workspace_read: ["DECISION.md"], must_include: ["notification"], actions: "none" },
+  },
+  {
+    id: "ce-explain/teaching-artifact",
+    skill: "ce-explain",
+    cohort: "resized",
+    key_behavior: "judgment",
+    read_only: false,
+    fixture: `${FIX}/understanding-queue`,
+    baseline_ref: UNDERSTANDING_BASE_REF,
+    timeout_secs: 180,
+    why: "The PR concept handoff's deeper teaching use still creates a usable artifact and static exercises without blocking or publishing.",
+    pre_contract: "A teaching request creates an artifact; exercises are static and never block the run.",
+    task: "I followed the PR's suggestion to learn more. Teach me how this queue's polling and lease work. Make a standalone markdown explainer with exercises I can keep, and save it as queue-explainer.md here.",
+    grade: { workspace_contains: [{ path: "queue-explainer.md", needle: "Check yourself" }, { path: "queue-explainer.md", needle: "Answers" }], must_exclude: ["publish", "upload"] },
+  },
+  {
+    id: "ce-pov/caller-judgment",
+    skill: "ce-pov",
+    cohort: "resized",
+    key_behavior: "judgment",
+    read_only: false,
+    fixture: `${FIX}/understanding-queue`,
+    baseline_ref: UNDERSTANDING_BASE_REF,
+    timeout_secs: 180,
+    why: "A bounded planning decision should return a grounded judgment without redundant explanation dispatch or a continuation menu.",
+    pre_contract: "A warm invocation returns a POV as a guest, independently verifying conversation claims.",
+    task: "Our planning workflow needs your judgment: keep the current one-second recovery poll, or remove it and rely solely on notifications? Use the local queue and decision record. This decision is input to the plan I am writing.",
+    grade: { workspace_read: ["DECISION.md"], must_include: ["poll"], actions: "none", delegates: "none" },
+  },
+  {
+    id: "ce-explain/unavailable-framing",
+    skill: "ce-explain",
+    cohort: "resized",
+    key_behavior: "judgment",
+    read_only: false,
+    fixture: `${FIX}/understanding-queue`,
+    baseline_ref: UNDERSTANDING_BASE_REF,
+    timeout_secs: 180,
+    why: "An unattended caller with no recoverable subject needs the missing question returned, not an invented subject or clarification dialogue.",
+    pre_contract: "A bare subject requires asking what to explain; never invent a default artifact.",
+    task: "An unattended workflow delegated this task: explain why they chose that instead. The delegation contains no other context.",
+    grade: { must_include: ["subject"], actions: "none", delegates: "none" },
   },
   {
     id: "ce-pov/stay-read-only",

--- a/tests/skill-eval-cell/fixtures/understanding-queue/DECISION.md
+++ b/tests/skill-eval-cell/fixtures/understanding-queue/DECISION.md
@@ -1,0 +1,2 @@
+# Queue notifications
+Notifications are best-effort. A reconnect can miss a notification, so polling remains a recovery path. The 30-second lease is current behavior; this record does not document why that duration was chosen. Replacing polling requires another way to discover jobs after missed notifications.

--- a/tests/skill-eval-cell/fixtures/understanding-queue/README.md
+++ b/tests/skill-eval-cell/fixtures/understanding-queue/README.md
@@ -1,0 +1,3 @@
+# Delivery queue
+The worker calls claim() every second and also when a notification arrives.
+Read queue.js and DECISION.md for the claim contract.

--- a/tests/skill-eval-cell/fixtures/understanding-queue/queue.js
+++ b/tests/skill-eval-cell/fixtures/understanding-queue/queue.js
@@ -1,0 +1,8 @@
+export async function claim(db, now) {
+  return db.transaction(async tx => {
+    const job = await tx.firstReady(now);
+    if (!job) return null;
+    await tx.lease(job.id, now + 30000);
+    return job;
+  });
+}

--- a/tests/skills/ce-explain-relocated-invariants.test.ts
+++ b/tests/skills/ce-explain-relocated-invariants.test.ts
@@ -2,13 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { readFileSync, readdirSync, statSync } from "fs"
 import path from "path"
 
-// ce-explain's body was thinned toward Codex's 8000-byte skill prompt budget by
-// moving the ask-tool table, the model tiers, the run-directory block, grounding
-// by input shape, and menu sizing into references/orchestration.md, and the
-// operational-question gate into references/intake.md. The body pins live in
-// ce-explain-routing.test.ts (inline post-menu routing is load-bearing); these
-// are the corpus greps for what moved, so a later edit cannot drop them from
-// both places at once.
+// These corpus checks preserve portable tool use, evidence, and non-blocking exercises.
 const SKILL_DIR = path.join(import.meta.dir, "..", "..", "skills", "ce-explain")
 
 function walk(dir: string): string[] {
@@ -29,8 +23,6 @@ describe("ce-explain relocated invariants stay greppable in the corpus", () => {
     // may still name request_user_input; the closed per-host catalog must not return.
     "already in the current tool list",
     "never call a user-facing question tool",
-    "request_user_input",
-    "Never silently skip the question",
     // Model tiers + degradation
     "Extraction tier",
     "Ceiling tier",
@@ -42,11 +34,6 @@ describe("ce-explain relocated invariants stay greppable in the corpus", () => {
     "Unverified — from model knowledge, not checked against current sources",
     "recap-evidence.md",
     "never generate and rank alternatives",
-    // Menu sizing
-    "Pick a number or describe what you want.",
-    "absence hides an option silently",
-    // Operational-question gate
-    "Want me to actually walk you through how this works?",
   ]) {
     test(`corpus keeps: ${invariant.slice(0, 48)}`, () => {
       expect(corpus).toContain(invariant)
@@ -73,7 +60,7 @@ describe("ce-explain relocated invariants stay greppable in the corpus", () => {
     const body = readFileSync(path.join(SKILL_DIR, "SKILL.md"), "utf8")
     expect(body).toContain("references/orchestration.md")
     expect(body).toMatch(
-      /before the first blocking question, subagent dispatch, or run-directory creation/i,
+      /before grounding, the first blocking question, or subagent dispatch/i,
     )
     expect(body.indexOf("references/orchestration.md")).toBeLessThan(body.indexOf("### Phase 1"))
   })

--- a/tests/skills/ce-explain-routing.test.ts
+++ b/tests/skills/ce-explain-routing.test.ts
@@ -2,398 +2,136 @@ import { readFileSync } from "fs"
 import path from "path"
 import { describe, expect, test } from "bun:test"
 
-const SKILL_PATH = path.join(process.cwd(), "skills/ce-explain/SKILL.md")
-const SKILL_BODY = readFileSync(SKILL_PATH, "utf8")
-const CHECK_IN_PATH = path.join(process.cwd(), "skills/ce-explain/references/check-in.md")
-const CHECK_IN_BODY = readFileSync(CHECK_IN_PATH, "utf8")
-const DESTINATIONS_PATH = path.join(
-  process.cwd(),
-  "skills/ce-explain/references/destinations.md",
-)
-const DESTINATIONS_BODY = readFileSync(DESTINATIONS_PATH, "utf8")
-const HTML_REFERENCE_PATH = path.join(
-  process.cwd(),
-  "skills/ce-explain/references/explainer-html.md",
-)
-const HTML_REFERENCE_BODY = readFileSync(HTML_REFERENCE_PATH, "utf8")
+const ROOT = path.join(process.cwd(), "skills/ce-explain")
+const read = (file: string) => readFileSync(path.join(ROOT, file), "utf8")
+const body = read("SKILL.md")
+const intake = read("references/intake.md")
+const destinations = read("references/destinations.md")
+const checkIn = read("references/check-in.md")
+const html = read("references/explainer-html.md")
+const markdown = read("references/explainer-markdown.md")
 
-// The menu and its per-option routing live in references/destinations.md, which
-// SKILL.md names as a required read before the destination phase renders anything. That is the
-// condition #714 turned on: routing may live in a reference the body names as a
-// required read at the step that needs it; it may not live in one the body
-// mentions once in passing. Measured before shipping the move — 4 destination
-// options x 3 trials x Claude Code and Codex, inline vs relocated: 21/21 correct
-// on each arm, and every relocated-arm run opened the reference
-// (docs/solutions/skill-design/post-menu-routing-belongs-inline.md).
-//
-// So these pins guard two things together, and both halves must hold: the body
-// demands the read at the point of use, and the reference carries a firing
-// action for every option. Symptom when this regresses: the agent renders the
-// destination menu, the user picks an option, and the agent stops in prose
-// without firing the action.
-//
-// Phase anchors for the body slices. The check-in's move into the artifact
-// (#1628) renumbered compose to Phase 3 and the destination ask to Phase 4.
-const DESTINATION_PHASE = "### Phase 4"
-const COMPOSE_PHASE = "### Phase 3"
-
-describe("ce-explain destination and handoff routing", () => {
-  test("SKILL.md demands the destinations read before the destination phase renders anything", () => {
-    const destination = sliceSection(SKILL_BODY, DESTINATION_PHASE)
-    expect(destination).toMatch(/Required read before you render anything in this phase/i)
-    expect(destination).toContain("`references/destinations.md`")
-    expect(destination).toMatch(/do not render the menu and do not act on the user's selection without it/i)
-  })
-
-  const phaseRegion = DESTINATIONS_BODY
-
-  test("inline routing exists for every destination option", () => {
-    const optionFragments: { name: string; fragment: string }[] = [
-      { name: "Claude Artifact", fragment: "Claude Artifact" },
-      { name: "Publish publicly to ht-ml.app", fragment: "Publish publicly to ht-ml.app" },
-      { name: "Local file", fragment: "Local file" },
-      { name: "Publish to Proof", fragment: "Publish to Proof" },
-      { name: "Send to Thinkroom", fragment: "Send to Thinkroom" },
-      { name: "Leave it", fragment: "Leave it" },
-    ]
-    for (const { name, fragment } of optionFragments) {
-      const escaped = fragment.replace(/[.*+?^${}()|[\]\\`]/g, "\\$&")
-      // Bullet form: `- **<fragment>**` then a separator and at least one
-      // non-newline character of action text on the SAME line ([ \t]*, not
-      // \s*, so an empty-action bullet cannot match by spilling into the next
-      // bullet's leading `-`). The separator requires surrounding whitespace
-      // (` — ` / ` - `) so a mid-word hyphen in a qualifier like
-      // "(auto-generated)" cannot satisfy the action-separator match.
-      const inlineRoutingPattern = new RegExp(
-        `^- \\*\\*[^\\n]*${escaped}[^\\n]*\\*\\*[^\\n]*[ \\t][—-][ \\t]+[^\\n]+`,
-        "m",
-      )
-      expect(
-        inlineRoutingPattern.test(phaseRegion),
-        `ce-explain references/destinations.md is missing the per-option action for destination "${name}". Every menu option needs an action to fire, in the file SKILL.md names as the required destination-phase read. See docs/solutions/skill-design/post-menu-routing-belongs-inline.md.`,
-      ).toBe(true)
-    }
-  })
-
-  test("ce-ideate and ce-simplify-code handoffs use the skill-invocation primitive", () => {
-    for (const target of ["ce-ideate", "ce-simplify-code"]) {
-      const bullet = phaseRegion.match(
-        new RegExp(`^- \\*\\*[^\\n]+\\*\\*[^\\n]*\`${target}\`[^\\n]+`, "m"),
-      )
-      expect(
-        bullet,
-        `ce-explain references/destinations.md is missing the handoff bullet naming ${target}.`,
-      ).not.toBeNull()
-      expect(
-        /skill[\s-]?invocation|Skill tool|skill primitive/i.test(bullet![0]),
-        `ce-explain references/destinations.md ${target} handoff must name the skill-invocation primitive so the agent fires the invocation rather than announcing a handoff in prose.`,
-      ).toBe(true)
-    }
-  })
-
-  test("`ce-polish` handoff is user-run, never skill-invoked", () => {
-    // `ce-polish` sets disable-model-invocation: true (pinned in
-    // EXPECTED_USER_INVOKED_SKILLS in tests/skill-conventions.test.ts), so the
-    // model cannot dispatch it via the Skill tool. The routing must present
-    // observations in chat and give the user a host-correct `ce-polish`
-    // invocation rather than hardcoding one harness's syntax.
-    const polishBullet = phaseRegion.match(/^- \*\*[^\n]*polish[^\n]*\*\*[^\n]+/im)
-    expect(
-      polishBullet,
-      "`ce-explain` references/destinations.md is missing the UI/UX polish handoff bullet.",
-    ).not.toBeNull()
-    const line = polishBullet![0]
-    const renderingRule = phaseRegion.match(/\*\*User-runnable invocation rendering\.\*\*[^\n]+/i)
-    expect(renderingRule).not.toBeNull()
-    expect(
-      /user-invoked only/i.test(line) &&
-        /rendering rule above/i.test(line) &&
-        renderingRule![0].includes("$ce-polish") &&
-        renderingRule![0].includes("/ce-polish") &&
-        renderingRule![0].includes("/skill:ce-polish") &&
-        /active host|Codex/i.test(renderingRule![0]) &&
-        /default to `\/ce-polish`[^.]{0,180}dollar-prefixed/i.test(renderingRule![0]) &&
-        /oh-my-pi \(`omp`\)[^\n]*\/skill:ce-polish/i.test(renderingRule![0]),
-      "`ce-explain` references/destinations.md polish handoff must present observations in chat and render one host-correct user invocation for `ce-polish`.",
-    ).toBe(true)
-    expect(
-      /invoke the `ce-polish` skill/i.test(line),
-      "`ce-explain` references/destinations.md polish handoff must NOT instruct invoking `ce-polish` via the skill primitive — it is user-invoked only (disable-model-invocation).",
-    ).toBe(false)
-  })
-
-  test("the check-in is a static in-artifact section, never an offer or a chat quiz", () => {
-    // Issue #1628: on Codex the run sat blocked on the "Just the explainer /
-    // Quiz me" offer. The check-in now lives in the artifact as a `Check
-    // yourself` section (questions first, then answers) and the run asks no
-    // question about it. The section's shape is owned by check-in.md; these
-    // are the stable tokens a rendering must carry.
-    expect(CHECK_IN_BODY).toContain("Check yourself")
-    expect(CHECK_IN_BODY).toContain("`Answers`")
-    expect(CHECK_IN_BODY).toMatch(/two to four/i)
-    // Questions before answers is the whole mechanism the static section keeps
-    // from the old predict-then-reveal turn; an interleaved layout is a worked FAQ.
-    expect(CHECK_IN_BODY).toMatch(/attempt every question before any answer is in view/i)
-    // The request decides in both directions; the warrant test decides only
-    // when the request is silent.
-    expect(CHECK_IN_BODY).toMatch(/request wins in both directions/i)
-    expect(CHECK_IN_BODY).toMatch(/When the material and the request disagree, the request wins/i)
-    // The reader no longer changes the decision: the section exercises whoever
-    // reads the document, so the old another-reader skip is gone.
-    expect(CHECK_IN_BODY).not.toMatch(/rendered for another reader, skip/i)
-    // No interactive shape survives anywhere in the reference.
-    expect(CHECK_IN_BODY).not.toMatch(/blocking question/i)
-    expect(CHECK_IN_BODY).not.toMatch(/end the turn/i)
-  })
-
-  test("the compose phase states the non-blocking invariant and keeps the chat summary", () => {
-    // The body must carry the one stop class that has to fire without a
-    // reference read — the run never blocks on the check-in — inside the
-    // compose phase, which sits before Codex's 8000-byte truncation point.
-    const compose = sliceSection(SKILL_BODY, COMPOSE_PHASE, DESTINATION_PHASE)
-    expect(compose).toContain("`references/check-in.md`")
-    expect(compose).toMatch(/never blocks on the check-in/i)
-    // Codex injects only the first 8000 bytes of an over-budget SKILL.md
-    // (MAX_SKILL_PROMPT_BYTES; tests/codex-skill-prompt-budget.test.ts), and
-    // #1628 came from Codex. ce-explain is still over budget, so this sentence
-    // is the only copy of the invariant that host reads; measured the same way
-    // that test measures (CRLF-adjusted), it must stay above the cut.
-    const lf = SKILL_BODY.replace(/\r\n/g, "\n")
-    const beforeInvariant = lf.slice(0, lf.indexOf("never blocks on the check-in"))
-    const crlfOffset = Buffer.byteLength(beforeInvariant, "utf8") + (beforeInvariant.match(/\n/g)?.length ?? 0)
-    expect(crlfOffset).toBeLessThan(8000)
-    // KTD3 (#1628 plan): diff mode gets no path-only chat rule; the summary is
-    // the only explainer content a Codex user sees without opening the file.
-    expect(compose).toMatch(/inline summary plus the file path/i)
-  })
-
-  test("recap evidence is dispatched directly without a main-agent pre-scan", () => {
-    expect(SKILL_BODY).toMatch(/dispatch a generic subagent directly/i)
-    expect(SKILL_BODY).toMatch(/Do not pre-scan, count, or characterize the window/i)
-  })
-
-  test("Claude Artifact owns its adaptation and ht-ml requires post-warning confirmation", () => {
-    expect(DESTINATIONS_BODY).toMatch(/Give the tool the canonical `\$RUN_DIR\/explainer\.html`/i)
-    expect(DESTINATIONS_BODY).toMatch(/tool owns any adaptation needed/i)
-    expect(DESTINATIONS_BODY).toMatch(/do not pre-process the HTML/i)
-    expect(DESTINATIONS_BODY).not.toContain("extract-artifact-fragment.py")
-    expect(DESTINATIONS_BODY).toMatch(/public and may be indexed, crawled, copied, or archived/i)
-    // The one-preferred-publisher rule can suppress ht-ml.app from a menu that
-    // WAS shown; a user naming it anyway has seen no warning and must still get
-    // one. Pin the general condition, not just the narrow "menu skipped" case.
-    expect(DESTINATIONS_BODY).toMatch(/chosen without that warned option in front of the user/i)
-    expect(DESTINATIONS_BODY).toMatch(/kept it off a menu that \*was\* shown/i)
-    expect(DESTINATIONS_BODY).toMatch(/ask for explicit confirmation after the warning before any publish/i)
-    expect(DESTINATIONS_BODY).toMatch(/initial request itself does not count as confirmation/i)
-    expect(DESTINATIONS_BODY).toMatch(/If confirmation cannot be obtained, do not publish; preserve the canonical `\$RUN_DIR\/explainer\.html` and report its local path/i)
-    expect(DESTINATIONS_BODY).toMatch(/pre-warning request does not count as confirmation/i)
-    expect(DESTINATIONS_BODY).toMatch(/If confirmation cannot be obtained, do not publish; preserve the canonical HTML and report its local `\$RUN_DIR\/explainer\.html` path/i)
-    expect(DESTINATIONS_BODY).toMatch(/Publish publicly to ht-ml\.app[^\n]+follow the ht-ml\.app sub-flow below/i)
-    // The stop classes that must hold even if this file is never opened stay in
-    // the body: a publish is never headless or inferred, naming the destination
-    // is not the confirmation, and the body must not read as a runnable publish
-    // sequence — spelling one out there is the paraphrase that suppresses the
-    // read this phase depends on.
-    const destinationBody = sliceSection(SKILL_BODY, DESTINATION_PHASE)
-    expect(destinationBody).toMatch(/never headless and never inferred/i)
-    expect(destinationBody).toMatch(/a choice of destination rather than that confirmation/i)
-    expect(destinationBody).toMatch(/do not run the sequence from this paragraph/i)
-    // A size pass shortened "offered, never auto-fired" to "never fired", which
-    // forbade the acceptance path the reference requires. Pin the condition:
-    // the offer precedes the fire, and acceptance fires it.
-    expect(destinationBody).toMatch(/offered before anything fires/i)
-    expect(destinationBody).toMatch(/once the user accepts one, invoke it through the skill primitive/i)
-    expect(destinationBody).toMatch(/do not publish; preserve the canonical HTML and report its local `\$RUN_DIR\/explainer\.html` path/i)
-    expect(DESTINATIONS_BODY).toMatch(/ht-ml\.app or general HTML-publishing capability/i)
-    expect(DESTINATIONS_BODY).toMatch(/skill-invocation primitive/i)
-    expect(DESTINATIONS_BODY).toMatch(/tool, connector, or browser capability directly/i)
-    expect(DESTINATIONS_BODY).toMatch(/Do not assume a particular skill name or installation path/i)
-    expect(DESTINATIONS_BODY).toContain("https://ht-ml.app/llms.txt")
-    expect(DESTINATIONS_BODY).not.toContain("scripts/publish-ht-ml.sh")
-    expect(DESTINATIONS_BODY).toMatch(/never publish headlessly/i)
-  })
-
-  test("HTML output pins stable metadata and preserves baseline constraints", () => {
-    expect(HTML_REFERENCE_BODY).toMatch(/exact field labels `Date`, `Input shape`, and `Subject`/)
-    expect(HTML_REFERENCE_BODY).toMatch(/exactly one of `concept`, `diff`, `idea`, or `recap`/)
-    expect(HTML_REFERENCE_BODY).toMatch(/`Subject` names the topic, ref, or recap window/)
-    expect(HTML_REFERENCE_BODY).toMatch(/No companion `\.css`, `\.js`, or `\.svg` files/)
-    expect(HTML_REFERENCE_BODY).toMatch(/No external requests of any kind/)
-    expect(HTML_REFERENCE_BODY).toMatch(
-      /No forms, no click handlers, no interactive quizzes, no "submit" affordances, no scripts/,
-    )
-    expect(HTML_REFERENCE_BODY).toMatch(/Class names and element IDs are ASCII-only/)
-  })
-})
-
-// Audience-rendering guards. ce-explain renders personally by default and for
-// another reader on request; behavioral evals confirmed the judgment holds, but
-// these pin the load-bearing wording the judgment reads from. Each assertion is
-// the smallest unit that would have failed before the audience change landed.
-const MARKDOWN_REFERENCE_PATH = path.join(
-  process.cwd(),
-  "skills/ce-explain/references/explainer-markdown.md",
-)
-const MARKDOWN_REFERENCE_BODY = readFileSync(MARKDOWN_REFERENCE_PATH, "utf8")
-const INTAKE_PATH = path.join(process.cwd(), "skills/ce-explain/references/intake.md")
-const INTAKE_BODY = readFileSync(INTAKE_PATH, "utf8")
-
-// The HTML and markdown renderings are authored as a pair; a rule added to one
-// and missed in the other is the drift these guards exist to catch.
-const RENDERING_REFERENCES = [
-  ["explainer-html.md", HTML_REFERENCE_BODY],
-  ["explainer-markdown.md", MARKDOWN_REFERENCE_BODY],
-] as const
-
-// Mirrors the sliceSection helper in ce-work-outcome-spine.test.ts and
-// pipeline-review-contract.test.ts, with the end anchor optional so a region
-// running to end-of-file (the destination phase, the last one) can share it. Asserting the
-// anchor rather than slicing from -1 means a renamed heading fails as itself
-// instead of silently shrinking the searched region to nothing.
-function sliceSection(content: string, startAnchor: string, endAnchor?: string): string {
-  const start = content.indexOf(startAnchor)
-  expect(start, `start anchor not found: ${startAnchor}`).toBeGreaterThanOrEqual(0)
-  if (endAnchor === undefined) return content.slice(start)
-  const end = content.indexOf(endAnchor, start + startAnchor.length)
-  expect(end, `end anchor not found: ${endAnchor}`).toBeGreaterThan(start)
-  return content.slice(start, end)
+function phase(start: string, end?: string): string {
+  const from = body.indexOf(start)
+  expect(from).toBeGreaterThanOrEqual(0)
+  if (!end) return body.slice(from)
+  const to = body.indexOf(end, from)
+  expect(to).toBeGreaterThan(from)
+  return body.slice(from, to)
 }
 
-describe("ce-explain audience rendering", () => {
-  test("the compose-time reference owns the audience rendering, and the body points at it", () => {
-    // The body's own copy of this contract was a paraphrase of what both
-    // rendering references already state in full; it is gone, and the compose
-    // phase names the owner instead.
-    const compose = sliceSection(SKILL_BODY, COMPOSE_PHASE, DESTINATION_PHASE)
-    expect(compose).toMatch(/personal by default, adapted for another reader on request, at unchanged depth/i)
-    for (const [label, body] of RENDERING_REFERENCES) {
-      // Depth must not be traded away when the audience changes.
-      expect(body, `${label} lost the unchanged-depth rule`).toMatch(/Same depth/i)
+describe("ce-explain consumer contract", () => {
+  test("understanding is distinct from judgment and caller identity does not select delivery", () => {
+    expect(body).toContain("documented rationale, inference, and unknowns")
+    expect(body).toContain("Do not infer the output from the caller's identity alone")
+    expect(body).toContain("leave continuation to its owner")
+    expect(body).toContain("Use `ce-pov` to judge")
+    expect(body).toContain("return the unresolved question and its consequence")
+  })
+
+  test("artifact work is conditional before scratch creation and rendering", () => {
+    expect(intake).toMatch(/Select delivery before creating a run directory/)
+    expect(intake).toContain("selects the subject, not whether a document must be created")
+    expect(phase("### Phase 2", "### Phase 3")).toMatch(/only when an artifact or an evidence dossier needs one/)
+    expect(phase("### Phase 3", "### Phase 4")).toMatch(/return that content directly/)
+    expect(body).not.toContain("mode:return-to-caller")
+  })
+
+  test("destinations are requested, and their adapter must be read before action", () => {
+    expect(phase("### Phase 4")).toMatch(/destination was requested, read `references\/destinations.md` before acting/)
+    expect(destinations).toMatch(/Do not require a menu/)
+    for (const adapter of ["Claude Artifact", "Publish publicly to ht-ml.app", "Local file", "Publish to Proof", "Send to Thinkroom"]) {
+      expect(destinations).toContain(`## ${adapter}`)
     }
+    expect(destinations).toContain("verify the resulting file, URL, or document reference")
+    expect(destinations).toContain("Do not substitute another publisher without authorization")
   })
 
-  test("intake owns audience resolution, including the speak-from carve-out", () => {
-    expect(INTAKE_BODY).toMatch(/## Audience resolution/i)
-    expect(INTAKE_BODY).toMatch(/Default: the user personally/i)
-    // The false positive the eval probed: "so I can explain it to the team"
-    // names a group but the user is still the reader.
-    expect(INTAKE_BODY).toMatch(/wanting to \*speak\* from the material is not an audience signal/i)
-    // A share request is not a request to become a status update.
-    expect(INTAKE_BODY).toMatch(/request to share is not a request for a status update/i)
+  test("public publication requires informed confirmation for the actual artifact", () => {
+    expect(destinations).toContain("public and may be indexed, crawled, copied, or archived")
+    expect(destinations).toMatch(/explicit confirmation after that warning for the actual artifact/)
+    expect(destinations).toContain("initial request itself does not count as confirmation")
+    expect(destinations).toContain("If the artifact changes materially, obtain confirmation")
+    expect(destinations).toContain("If confirmation cannot be obtained, do not publish")
+    expect(phase("### Phase 4")).toContain("never headless and never inferred")
+    expect(phase("### Phase 4")).toContain("do not publish; preserve the canonical HTML")
   })
 
-  test("tokens do not eat ordinary prose containing a colon", () => {
-    // Without the reads-as-a-flag test, "walk me through the diff: why did we
-    // split the parser" strips diff:why and forces diff mode on a bogus ref.
-    expect(INTAKE_BODY).toMatch(/flag only when it reads as one/i)
-    expect(INTAKE_BODY).toMatch(/If stripping it would garble the sentence, it was never a flag/i)
-    // The old absolute rule let a corrupted token outrank correct inference.
-    expect(INTAKE_BODY).toMatch(/A token in flag position beats inference\. A colon inside prose does not\./i)
-    expect(INTAKE_BODY).not.toMatch(/An explicit token always beats inference/i)
+  test("destination adapters execute through their owning capability", () => {
+    expect(destinations).toContain("Give the tool the canonical `$RUN_DIR/explainer.html`")
+    expect(destinations).toContain("tool owns any adaptation needed")
+    expect(destinations).toContain("do not pre-process the HTML")
+    expect(destinations).toContain("skill-invocation primitive")
+    expect(destinations).toContain("https://ht-ml.app/llms.txt")
+    expect(destinations).toContain("Do not assume a particular skill name or installation path")
+    expect(destinations).toContain("Never guess at a Thinkroom API shape")
   })
 
-  test("plain-language windows are first-class, not a degraded token path", () => {
-    expect(INTAKE_BODY).toMatch(/names a time window and little else/i)
-    expect(INTAKE_BODY).toMatch(/\*\*Resolving the window \(recap mode\)\.\*\*/i)
-    expect(INTAKE_BODY).toMatch(/a colon must not change the answer/i)
-    expect(INTAKE_BODY).toMatch(/never silently substitute that default for a window the user did name/i)
-  })
-
-  test("both rendering references carry the same voice contract", () => {
-    for (const [label, body] of RENDERING_REFERENCES) {
-      expect(body, `${label} lost its Voice section`).toMatch(/## Voice — personal by default, adapted on request/i)
-      expect(body, `${label} lost the no-second-person rule`).toMatch(/\*\*No second person\.\*\*/i)
-      // A personal recap of team work needs both persons at once.
-      expect(body, `${label} lost the multi-author rule`).toMatch(/naming \*other\* contributors in third person/i)
-      // Honor the audience, refuse the form.
-      expect(body, `${label} lost the status-update refusal`).toMatch(
-        /does not become a status update or a deck/i,
-      )
+  test("reader adaptation preserves accurate attribution without fixing voice or depth", () => {
+    expect(intake).toContain("Someone preparing to speak from the explanation is still its reader")
+    expect(intake).toContain("without changing the evidence or attributing others' work to the user")
+    for (const renderer of [html, markdown]) {
+      expect(renderer).toContain("consumer contract governs depth, voice, and layout")
+      expect(renderer).not.toContain("No second person")
+      expect(renderer).not.toContain("Same depth")
+      expect(renderer).not.toContain("every explainer leads with something to look at")
     }
-  })
-
-  test("an adapted artifact declares its reader in the metadata header", () => {
-    expect(HTML_REFERENCE_BODY).toMatch(/labelled exactly `Rendered for`/i)
-    expect(MARKDOWN_REFERENCE_BODY).toMatch(/`rendered_for: <reader>`/i)
-    // Absent a spec, runs invented divergent variants of this row.
-    expect(HTML_REFERENCE_BODY).toMatch(/a personal rendering omits the row entirely/i)
-  })
-
-  test("the audience-mismatch offer precedes the destination's consent gate", () => {
-    const phase6 = DESTINATIONS_BODY
-    expect(phase6).toMatch(/## Audience mismatch/i)
-    expect(phase6).toMatch(/\*\*This offer comes first\*\*/i)
-    expect(phase6).toMatch(/consent must attach to the artifact actually being published/i)
-    expect(phase6).toMatch(/never re-render unasked, and never block the send on it/i)
-  })
-
-  test("both rendering references own the static check-in section the same way", () => {
-    // "lives in the session" is the superseded wording the static section replaced.
-    for (const [label, body] of RENDERING_REFERENCES) {
-      expect(body, `${label} lost the check-in.md citation`).toContain("`references/check-in.md`")
-      expect(body, `${label} lost the Check yourself section`).toContain("Check yourself")
-      expect(body, `${label} lost the questions-first ordering`).toMatch(/questions first, then their answers/i)
-      expect(body, `${label} still says the check-in lives in the session`).not.toMatch(/lives in the session/i)
-      // KTD4 (#1628 plan): references name phases by role, not number, so a
-      // body renumbering cannot strand a load-time cue.
-      expect(body, `${label} names a phase number in its load-time cue`).not.toMatch(/compose time \(Phase \d\)/i)
-    }
-    expect(MARKDOWN_REFERENCE_BODY).not.toMatch(/No exercise or quiz content in the artifact/i)
   })
 })
 
-// Guards for gaps that behavioral eval runs hit in the pre-existing skill.
-// Each pins the rule that was missing when a run had to improvise, so the
-// improvisation cannot silently become the behavior again.
-describe("ce-explain gaps found by behavioral evals", () => {
-  test("diff mode has an empty-range rule, matching recap's empty-window rule", () => {
-    // Two runs hit `main..HEAD` resolving to zero commits (work uncommitted)
-    // and each invented a different disclosure.
-    expect(SKILL_BODY).toMatch(/\*\*Empty range\*\*/i)
-    expect(SKILL_BODY).toMatch(/do not silently explain something else/i)
-    // A named subject that doesn't exist gets the same treatment.
-    expect(SKILL_BODY).toMatch(/report that before explaining an adjacent thing/i)
+describe("ce-explain preserved regressions", () => {
+  test("input tokens do not consume ordinary prose", () => {
+    expect(intake).toContain("If stripping it would garble the sentence, it was never a flag")
+    expect(intake).toContain("A token in flag position beats inference. A colon inside prose does not.")
+    expect(intake).toContain("a colon must not change the answer")
+    expect(intake).toContain("never silently substitute that default for a window the user did name")
   })
 
-  test("recap's scout dispatch names the degradation path where it fires", () => {
-    // Three runs independently reported that "dispatch a generic subagent"
-    // carried no cross-reference to the Model Tiers degradation rule, which
-    // lives in a separate section far above Phase 2.
-    const phase2 = sliceSection(SKILL_BODY, "### Phase 2", COMPOSE_PHASE)
-    expect(phase2).toMatch(/harness exposes no subagent primitive/i)
-    expect(phase2).toMatch(/run the scout inline/i)
-    // The no-pre-scan protection must survive when the scout IS the main agent.
-    expect(phase2).toMatch(/form no view of the window until it is done/i)
+  test("missing diff scopes cannot silently become another subject", () => {
+    const grounding = phase("### Phase 2", "### Phase 3")
+    expect(grounding).toContain("**Empty range**")
+    expect(grounding).toContain("do not silently explain something else")
+    expect(grounding).toContain("request permits it or the user agrees")
+    expect(grounding).toContain("Otherwise return the unresolved scope to the caller")
   })
 
-  test("an oversized window is selected from, not silently truncated", () => {
-    for (const [label, body] of RENDERING_REFERENCES) {
-      expect(body, `${label} lost the oversized-window rule`).toMatch(
-        /When the evidence exceeds one sitting/i,
-      )
-      expect(body, `${label} lost the no-silent-truncation rule`).toMatch(/Never silently drop the tail/i)
-    }
+  test("recap evidence is independent of the main agent's initial narrative", () => {
+    const grounding = phase("### Phase 2", "### Phase 3")
+    expect(grounding).toContain("Do not pre-scan, count, or characterize the window")
+    expect(grounding).toContain("dispatch a generic subagent directly")
+    expect(grounding).toContain("harness exposes no subagent primitive")
+    expect(grounding).toContain("run the scout inline")
+    expect(grounding).toContain("form no view of the window until it is done")
+    for (const renderer of [html, markdown]) expect(renderer).toContain("Never silently drop the tail")
   })
 
-  test("the destination ask and a publisher's consent gate are distinct asks", () => {
-    const destination = sliceSection(SKILL_BODY, DESTINATION_PHASE)
-    const relocated = DESTINATIONS_BODY
-    // "Ask once" previously read as forbidding the second confirmation the
-    // bypass path requires.
-    expect(destination).toMatch(/that governs the menu itself, not the consent a chosen destination then requires/i)
-    // Naming a suppressed publisher takes the bypassed-menu path.
-    expect(relocated).toMatch(/never as though the menu had warned them/i)
+  test("teaching exercises never block the run (#1628)", () => {
+    expect(checkIn).toContain("Check yourself")
+    expect(checkIn).toContain("`Answers`")
+    expect(checkIn).toContain("attempt every question before any answer is in view")
+    expect(checkIn).toContain("request wins in both directions")
+    const compose = phase("### Phase 3", "### Phase 4")
+    expect(compose).toContain("never blocks on the check-in")
+    expect(compose).toContain("inline summary plus the file path")
+    const prefix = body.slice(0, body.indexOf("never blocks on the check-in"))
+    expect(Buffer.byteLength(prefix.replace(/\r?\n/g, "\r\n"))).toBeLessThan(8000)
+    for (const renderer of [html, markdown]) expect(renderer).toContain("questions first, then their answers")
   })
 
-  test("improvement observations wait for a settled destination and cover stale repo docs", () => {
-    const phase6 = DESTINATIONS_BODY
-    // The gate must name every ask that can be open, not just the destination
-    // one: an enumeration missing the audience re-render offer reads as
-    // permission to interleave handoffs with it.
-    expect(phase6).toMatch(/Never raise them while any of the asks above is still open/i)
-    expect(phase6).toMatch(/the audience re-render offer/i)
-    // A superseded plan/solution doc fit none of the three original routes.
-    expect(phase6).toMatch(/ce-compound-refresh/i)
-    expect(phase6).toMatch(/this skill teaches, it does not maintain repo memory/i)
+  test("standalone artifacts retain portability and metadata", () => {
+    expect(html).toContain("exact field labels `Date`, `Input shape`, and `Subject`")
+    expect(html).toContain("exactly one of `concept`, `diff`, `idea`, or `recap`")
+    expect(html).toContain("labelled exactly `Rendered for`")
+    expect(markdown).toContain("`rendered_for: <reader>`")
+    expect(html).toContain("No companion `.css`, `.js`, or `.svg` files")
+    expect(html).toContain("No external requests of any kind")
+    expect(html).toContain("No forms, no click handlers, no interactive quizzes")
+    expect(html).toContain("Class names and element IDs are ASCII-only")
+    expect(html).toContain("Ordinary source hyperlinks are allowed")
+    expect(markdown).toContain("No HTML elements")
+    expect(markdown).toContain("Label every fenced code block with its language")
+    expect(markdown).toContain("a host-specific file-and-line citation is not a language label")
+    expect(markdown).toContain("when the request identifies another reader")
+    for (const renderer of [html, markdown]) expect(renderer).toContain("a reader who skips them still gets the full explanation in text")
   })
 })

--- a/tests/skills/user-facing-skill-invocation-rendering.test.ts
+++ b/tests/skills/user-facing-skill-invocation-rendering.test.ts
@@ -85,15 +85,6 @@ const modelVisibleRendererCases = [
 
 const explicitOnlyRendererCases = [
   {
-    // The rendering rule travels with the seam that prints the invocation: the
-    // ce-polish handoff now lives in the Phase 6 required-read reference.
-    file: "skills/ce-explain/references/destinations.md",
-    defaults: ["/ce-polish"],
-    codex: ["$ce-polish"],
-    omp: ["/skill:ce-polish"],
-    targets: ["ce-polish"],
-  },
-  {
     file: "skills/ce-setup/SKILL.md",
     defaults: ["/ce-setup"],
     codex: ["$ce-setup"],


### PR DESCRIPTION
## Summary

`ce-explain` and `ce-pov` can contribute to planning, brainstorming, and PR writing without assuming a person is waiting for a teaching document or follow-up menu. Delivery follows the requested use: an answer, text for another document, or a standalone explainer.

`ce-explain` owns understanding how something works and investigating its historical rationale. `ce-pov` owns the recommendation and calls for an explanation only when unresolved understanding could change that recommendation. Planning and brainstorming use the same conditional handoff; no new skills or return-mode flags are introduced.

Standalone teaching retains offline HTML, portable Markdown, source attribution, prose that stands without diagrams, and static exercises with answers. Oracle still requests independent model opinions. Publication remains separate from completing an explanation and retains its consent requirements.

## Validation

- 3,904 repository tests passed, plus release and plugin validation.
- 40 real CLI invocations exercised PR-body explanations, planning judgments, teaching artifacts, and native Oracle activation, including iterations after failures.
- Tested Claude Opus 5 High and Fable 5.1 Low, Codex 5.6 Sol Medium and Astra Low, Grok 4.6 Medium, and Cursor Composer-2.5.
- All six returned content to calling workflows without unnecessary human checkpoints or implementation. Opus and Astra selected `ce-pov` from “Oracle this” and completed real peer calls.
- Reruns corrected Composer's invalid Markdown fence labels and invented audience metadata.

**Grounding is not uniformly passing.** Astra consistently preserved unknowns in the inspected scenarios. Sol's latest outputs passed, but an earlier repeat overclaimed. Opus, Fable, Grok, and Composer still made some unsupported claims about uninspected queue behavior despite revisions. A correct recommendation was not counted as proof that its supporting claims were correct.

These were bounded fixture tests, not a complete `lfg` run or application-repository evaluation. HTML structure was inspected; browser rendering was not tested. The final removal of a duplicate evidence instruction was rerun on Fable and Composer, rather than repeating the entire matrix.

## Security Disclosure

Explanation delivery no longer requires publication or a destination selection. Existing public-publishing confirmation and offline-artifact restrictions remain. No new shell execution, credentials, dependencies, or publisher integrations were introduced.

## Agent Disclosure

- **Model:** Codex CLI · GPT-6
