### PR TITLE
fix(site): make built HTML work at any base path

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ bun run plugin:validate   # Claude marketplace + plugin schema (needs `claude` o
 
 ## Docs site
 
-The public docs at [every.to/compound-engineering](https://every.to/compound-engineering/) are built from `site/` with Jekyll and the `jekyll-vitepress-theme` gem. The site is a build layer, not a second copy: `site/_guides`, `site/assets`, `site/install.md`, and `site/upgrading.md` are symlinks to `docs/guides/`, `assets/`, `README.md`, and `docs/install/upgrading.md`. Never edit a published source to suit the site. Two site-local plugins do the adapting: `site/_plugins/ce_sources.rb` promotes the frontmatter-less sources into Jekyll pages and documents and derives titles, sidebar groups, the homepage data, and last-updated dates from the guides catalog, the README, and git; `site/_plugins/ce_github_markdown.rb` rewrites GitHub alerts, repo-relative links, and asset paths at render time.
+The public docs at [every.to/compound-engineering](https://every.to/compound-engineering/) are built from `site/` with Jekyll and the `jekyll-vitepress-theme` gem. The site is a build layer, not a second copy: `site/_guides`, `site/assets`, `site/install.md`, and `site/upgrading.md` are symlinks to `docs/guides/`, `assets/`, `README.md`, and `docs/install/upgrading.md`. Never edit a published source to suit the site. Two site-local plugins do the adapting: `site/_plugins/ce_sources.rb` promotes the frontmatter-less sources into Jekyll pages and documents and derives titles, sidebar groups, the homepage data, and last-updated dates from the guides catalog, the README, and git; `site/_plugins/ce_github_markdown.rb` rewrites GitHub alerts, repo-relative links, and asset paths at render time; `site/_plugins/ce_relative_urls.rb` turns the built HTML's base-path URLs into page-relative ones, so one build serves every.to, the github.io origin, and a local server alike.
 
 Prerequisites: Ruby 3.3 or newer and Bundler. Then:
 
@@ -37,7 +37,7 @@ The site is served at `https://every.to/compound-engineering/` by every.to's edg
 2. **every.to proxy rule.** Route `https://every.to/compound-engineering/*` to the origin `https://everyinc.github.io/compound-engineering-plugin/*`, replacing the `/compound-engineering` prefix with `/compound-engineering-plugin` on the way to the origin and passing the response through unchanged. The HTML already links with the every.to prefix, so no response rewriting is needed. Forward `/compound-engineering` (no trailing slash) as `/compound-engineering/`.
 3. **Branch protection.** Add the `build` job of the "Docs site" workflow to the required status checks on `main`, alongside `test`, so a site-breaking change cannot merge.
 
-Until step 1 is done the `deploy` job fails on `main`; the `build` job still proves every PR. Visiting the github.io origin directly shows the site with links that point at every.to, which is expected.
+Until step 1 is done the `deploy` job fails on `main`; the `build` job still proves every PR. The github.io origin also works on its own: page links and assets are relative, and only the canonical, Open Graph, sitemap, and llms.txt URLs name every.to.
 
 ## From your local checkout
 

--- a/site/_plugins/ce_relative_urls.rb
+++ b/site/_plugins/ce_relative_urls.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Makes the built HTML work at any base path. Jekyll emits every in-site URL
+# as root-absolute, prefixed with `baseurl` (`/compound-engineering/assets/...`),
+# which is right at every.to and wrong at the GitHub Pages origin
+# (`everyinc.github.io/compound-engineering-plugin/`) and at a local server
+# with a different base. Rewriting those to page-relative paths
+# (`../../assets/...`) after render lets one build serve every host.
+#
+# Full URLs (canonical, Open Graph, sitemap, llms.txt) keep `site.url` and
+# stay absolute, so the every.to address remains the canonical one. Only HTML
+# output is touched; the 404 page stays absolute because a host serves it at
+# arbitrary paths, where a relative link has no fixed anchor.
+module CeRelativeUrls
+  ATTRS = %w[href src srcset poster action data-search-index-url data-url].freeze
+  ATTR = /\b(#{ATTRS.join("|")})=(["'])([^"']*)\2/
+
+  module_function
+
+  # +page_url+ is the page's site-relative URL ("/", "/guides/ce-plan/",
+  # "/guides.md" is not HTML and never reaches here).
+  def rewrite(html, page_url:, baseurl:)
+    prefix = relative_prefix(page_url)
+    html.gsub(ATTR) do
+      attr, quote, value = Regexp.last_match(1), Regexp.last_match(2), Regexp.last_match(3)
+      "#{attr}=#{quote}#{relativize(value, baseurl, prefix)}#{quote}"
+    end
+  end
+
+  # "./" for a page at the root, "../" per directory below it.
+  def relative_prefix(page_url)
+    dir = page_url.end_with?("/") ? page_url : File.dirname(page_url) + "/"
+    depth = dir.split("/").reject(&:empty?).length
+    depth.zero? ? "./" : "../" * depth
+  end
+
+  def relativize(value, baseurl, prefix)
+    return value unless value == baseurl || value.start_with?("#{baseurl}/")
+    return value if value.start_with?("//")
+
+    rest = value.delete_prefix(baseurl).delete_prefix("/")
+    "#{prefix}#{rest}"
+  end
+
+  def apply(item)
+    return unless item.output_ext == ".html" && item.output
+    return if item.url == "/404.html"
+
+    item.output = rewrite(item.output, page_url: item.url, baseurl: item.site.baseurl.to_s)
+  end
+end
+
+Jekyll::Hooks.register [:documents, :pages], :post_render do |item|
+  CeRelativeUrls.apply(item)
+end

--- a/site/test/test_ce_relative_urls.rb
+++ b/site/test/test_ce_relative_urls.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "jekyll"
+require_relative "../_plugins/ce_relative_urls"
+
+class TestCeRelativeUrls < Minitest::Test
+  BASE = "/compound-engineering"
+
+  def rewrite(html, url, baseurl = BASE)
+    CeRelativeUrls.rewrite(html, page_url: url, baseurl: baseurl)
+  end
+
+  def test_root_page_links_become_dot_relative
+    html = '<link href="/compound-engineering/assets/css/core.css"><a href="/compound-engineering/">Home</a>'
+    assert_equal '<link href="./assets/css/core.css"><a href="./">Home</a>', rewrite(html, "/")
+  end
+
+  def test_nested_page_climbs_one_level_per_directory
+    html = '<img src="/compound-engineering/assets/demo/loop.gif"><a href="/compound-engineering/guides/ce-plan/">'
+    assert_equal '<img src="../../assets/demo/loop.gif"><a href="../../guides/ce-plan/">', rewrite(html, "/guides/ce-work/")
+    assert_equal '<img src="../assets/demo/loop.gif"><a href="../guides/ce-plan/">', rewrite(html, "/guides/")
+  end
+
+  def test_data_attributes_the_theme_reads_are_rewritten
+    html = '<div data-search-index-url="/compound-engineering/search.json" data-url="/compound-engineering/guides/ce-plan.md">'
+    assert_equal '<div data-search-index-url="../../search.json" data-url="../../guides/ce-plan.md">', rewrite(html, "/guides/ce-plan/")
+  end
+
+  def test_absolute_external_and_fragment_urls_are_untouched
+    html = '<meta content="https://every.to/compound-engineering/x/"><a href="https://github.com/x">' \
+           '<a href="#install"><script src="//cdn.example/x.js"><a href="/compound-engineering-plugin/">'
+    assert_equal html, rewrite(html, "/guides/ce-plan/")
+  end
+
+  def test_bare_baseurl_home_link_maps_to_the_root
+    assert_equal '<a href="../../">', rewrite('<a href="/compound-engineering">', "/guides/ce-plan/")
+  end
+
+  def test_empty_baseurl_relativizes_root_absolute_paths
+    assert_equal '<a href="../guides/ce-beta/">', rewrite('<a href="/guides/ce-beta/">', "/install/", "")
+    assert_equal '<script src="//cdn.example/x.js">', rewrite('<script src="//cdn.example/x.js">', "/install/", "")
+  end
+
+  def test_html_file_urls_resolve_from_their_directory
+    assert_equal '<a href="./guides/">', rewrite('<a href="/compound-engineering/guides/">', "/404.html")
+    assert_equal '<a href="../">', rewrite('<a href="/compound-engineering/">', "/guides/index.html")
+  end
+end

--- a/site/test/test_ce_sources.rb
+++ b/site/test/test_ce_sources.rb
@@ -426,13 +426,19 @@ class TestSiteBuild < Minitest::Test
       refute File.exist?(File.join(out, "install.md"))
 
       assert File.exist?(File.join(out, "guides", "ce-alpha", "index.html"))
+      home = File.read(File.join(out, "index.html"), encoding: "UTF-8")
+      assert_includes home, 'href="./assets/css/vitepress-core.css"', "homepage stylesheet is not page-relative"
+      alpha = File.read(File.join(out, "guides", "ce-alpha", "index.html"), encoding: "UTF-8")
+      assert_includes alpha, 'href="../../assets/css/vitepress-core.css"', "guide stylesheet is not page-relative"
+      assert_includes alpha, 'data-search-index-url="../../search.json"'
+      refute_match(/\b(href|src)="\/(?!\/)/, alpha, "guide page still carries a root-absolute URL")
       assert File.exist?(File.join(out, "guides", "group-one", "index.html"))
       install = File.read(File.join(out, "install", "index.html"))
       assert_includes install, 'href="https://github.com/EveryInc/compound-engineering-plugin/edit/main/README.md"'
       assert_includes install, "Edit this page on GitHub"
-      alpha = File.read(File.join(out, "guides", "ce-alpha", "index.html"))
+      alpha = File.read(File.join(out, "guides", "ce-alpha", "index.html"), encoding: "UTF-8")
       assert_includes alpha, "edit/main/docs/guides/ce-alpha.md"
-      home = File.read(File.join(out, "index.html"))
+      home = File.read(File.join(out, "index.html"), encoding: "UTF-8")
       refute_includes home, "Edit this page on GitHub"
     end
   end


### PR DESCRIPTION
## Why

The docs site builds for `every.to/compound-engineering`, so on the GitHub Pages origin (`everyinc.github.io/compound-engineering-plugin/`) every stylesheet, image, and link 404ed. Follow-up to #1664.

## What

- `site/_plugins/ce_relative_urls.rb`: a `post_render` hook rewrites the base-path-absolute `href`, `src`, and the theme's `data-search-index-url` / `data-url` attributes to page-relative paths (`../../assets/...`). One build now serves every.to, the github.io origin, and a local server.
- Canonical, Open Graph, sitemap, and llms.txt URLs keep `site.url` and stay absolute on every.to. The 404 page is left absolute since hosts serve it at arbitrary paths.
- Unit tests for the rewrite; the fixture build asserts relative output and no leftover root-absolute URL.
- `docs/development.md` describes the plugin and drops the "github.io shows every.to links" caveat.

## Verification

- `bundle exec rake test`: 62 runs, 200 assertions, green.
- Strict Jekyll build and htmlproofer clean.
- Served the build under a `/compound-engineering-plugin/` prefix and loaded it in a browser: styled, demo GIF loaded, search index resolved.

## Security Disclosure

No security-relevant changes.

## Agent Disclosure

Claude Code · claude-fable-5-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
