### PR TITLE
test(ce-commit-push-pr): allow harmless preservation labels

### DIFF
--- a/tests/commit-push-pr-contract.test.ts
+++ b/tests/commit-push-pr-contract.test.ts
@@ -569,7 +569,6 @@ describe("PR concept teaching contract", () => {
     expect(submit).toMatch(/authoritative parent tip/i)
     expect(submit).toContain('git checkout --no-overwrite-ignore -b "<branch-name>" "<parent-tip>"')
     expect(submit).toMatch(/If checkout fails because uncommitted or ignored files would be overwritten/)
-    expect(submit).not.toMatch(/worktree-safety|Worktree preservation/)
     expect(submit).toMatch(/Do not hard-code `origin\/<parent>`/i)
     expect(submit).toMatch(/starts on the resolved default branch.+follow `references\/branch-creation\.md`/is)
     expect(submit).toMatch(/starts on an existing feature branch.+do not follow `references\/branch-creation\.md`/is)

--- a/tests/commit-push-pr-worktree-safety.test.ts
+++ b/tests/commit-push-pr-worktree-safety.test.ts
@@ -95,10 +95,10 @@ function createFixture(root: string) {
 }
 
 describe("commit-push-pr worktree preservation", () => {
-  test("checkout recipes do not stash or load a separate safety reference", () => {
+  test("checkout recipes protect ignored files without automatic stashing", () => {
     for (const name of ["branch-creation.md", "stack-submit.md"]) {
       const content = readReference(name)
-      assert.doesNotMatch(content, /worktree-safety|stash\/pop only|^git stash push -u/m)
+      assert.doesNotMatch(content, /stash\/pop only|^git stash push -u/m)
       assert.match(content, /--no-overwrite-ignore/)
     }
   })
@@ -142,6 +142,24 @@ describe("commit-push-pr worktree preservation", () => {
           assert.equal(after.staged, before.staged)
           assert.equal(after.unstaged, before.unstaged)
           assert.equal(f.git("for-each-ref", "refs/stash"), "")
+        })
+      })
+    }
+
+    for (const alsoUnstaged of [false, true]) {
+      test(`${route} rejects a staged collision${alsoUnstaged ? " with additional unstaged edits" : ""} without changing files, refs, or index`, () => {
+        withRepo((f) => {
+          const tip = f.target("tracked.txt")
+          f.write("tracked.txt", "staged work\n")
+          f.git("add", "tracked.txt")
+          if (alsoUnstaged) f.write("tracked.txt", "unstaged work\n")
+          const before = f.snapshot()
+          const result = f.raw(...checkoutArgs(route, tip))
+          assert.notEqual(result.status, 0)
+          assert.match(result.stderr, /would be overwritten/)
+          assert.equal(f.read("tracked.txt"), alsoUnstaged ? "unstaged work\n" : "staged work\n")
+          assert.equal(f.git("show", ":tracked.txt"), "staged work\n")
+          assert.deepEqual(f.snapshot(), before)
         })
       })
     }

--- a/tests/commit-push-pr-worktree-safety.test.ts
+++ b/tests/commit-push-pr-worktree-safety.test.ts
@@ -95,11 +95,10 @@ function createFixture(root: string) {
 }
 
 describe("commit-push-pr worktree preservation", () => {
-  test("checkout recipes keep ignored-file protection and collision handling inline", () => {
+  test("checkout recipes protect ignored files without automatic stashing", () => {
     for (const name of ["branch-creation.md", "stack-submit.md"]) {
       const content = readReference(name)
-      // The executable cases read the inline checkout, not delegated instructions.
-      assert.doesNotMatch(content, /worktree-safety\.md|stash\/pop only|^git stash push -u/m)
+      assert.doesNotMatch(content, /stash\/pop only|^git stash push -u/m)
       assert.match(content, /--no-overwrite-ignore/)
     }
   })

--- a/tests/commit-push-pr-worktree-safety.test.ts
+++ b/tests/commit-push-pr-worktree-safety.test.ts
@@ -95,10 +95,11 @@ function createFixture(root: string) {
 }
 
 describe("commit-push-pr worktree preservation", () => {
-  test("checkout recipes protect ignored files without automatic stashing", () => {
+  test("checkout recipes keep ignored-file protection and collision handling inline", () => {
     for (const name of ["branch-creation.md", "stack-submit.md"]) {
       const content = readReference(name)
-      assert.doesNotMatch(content, /stash\/pop only|^git stash push -u/m)
+      // The executable cases read the inline checkout, not delegated instructions.
+      assert.doesNotMatch(content, /worktree-safety\.md|stash\/pop only|^git stash push -u/m)
       assert.match(content, /--no-overwrite-ignore/)
     }
   })


### PR DESCRIPTION
Harmless preservation headings and filename mentions no longer fail the checkout tests. The tests continue to check the shipped checkout commands and collision instructions, and now exercise conflicting staged work both with and without additional unstaged edits.

Fixes #1674.

A filename ban cannot establish how an agent follows delegated instructions: it rejects harmless mentions and misses equivalent instructions under another name. This change removes that organizational restriction. Runtime references remain unchanged; the real-Git tests cover the extracted checkout commands.

## Validation

- Bun focused suite: 36 passed, including four staged-collision cases that verify file contents, index, HEAD, branch refs, and stash state.
- Harmless heading and filename-comment controls: 36 passed.
- Destructive controls: enabling ignored-file overwrite failed 7 tests; forced checkout failed 18, including all four staged-collision cases.
- Full `bun run test`: 4,053 passed. An earlier run had one unchanged prototype-server EOF failure; its file passed 41/41 on rerun before the full rerun passed.
- Release and strict marketplace/plugin validation passed.
- [CI on `917be48d`](https://github.com/EveryInc/compound-engineering-plugin/actions/runs/34679016898) passed, including the full test job and Windows checks.
- Independent local correctness, standards, testing, and learnings review: no findings. The GitHub Codex follow-up review was unavailable due to its reported quota limit.

## Security Disclosure

Test-only. Runtime behavior, permissions, dependencies, and credential handling are unchanged. Git tests use synthetic data in isolated temporary repositories.

## Agent Disclosure

- Original implementation: ChatGPT · GPT-6 Astra Pro (contributor disclosure).
- Completion and validation: Codex · GPT-6.
