### PR TITLE
ci: cap the test job at 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # A wedged bun --parallel worker (oven-sh/bun#34069) can sit with no output
+    # forever; green runs take about 4 minutes and a timeout-stack run with the
+    # serial re-run about 15. Fail well before GitHub's 6-hour default so the
+    # babysit loop can see it and rerun.
+    timeout-minutes: 30
 
     env:
       # Single source of truth for the pinned `claude plugin validate` version:


### PR DESCRIPTION
A wedged bun `--parallel` worker (oven-sh/bun#34069) can leave the `test` job with no output until GitHub's 6-hour default kills it. On #1686 the final head sat 45 minutes in "Run tests" before a manual cancel and rerun, which then passed in under 3 minutes. With a 30-minute cap the job fails on its own and the babysit loop can rerun it: green runs take about 4 minutes, and a timeout-stack run that reaches the serial re-run about 15.

## Security Disclosure
No security-relevant changes.

## Agent Disclosure
- **Model:** Claude Code · claude-fable-5-1

https://claude.ai/code/session_01WgzunpwmobwmLycj5YSAKG
