### PR TITLE
fix(ce-code-review): count .mjs and .cjs files as executable changed lines

### DIFF
--- a/skills/ce-code-review/scripts/review-scope.py
+++ b/skills/ce-code-review/scripts/review-scope.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 
 CODE_EXTENSIONS = {
-    ".rb", ".py", ".js", ".jsx", ".ts", ".tsx", ".go", ".rs",
+    ".rb", ".py", ".js", ".mjs", ".cjs", ".jsx", ".ts", ".tsx", ".go", ".rs",
     ".java", ".swift", ".kt", ".c", ".cc", ".cpp", ".cs", ".php",
     ".ex", ".exs", ".scala",
 }

--- a/tests/ce-code-review-mechanics.test.ts
+++ b/tests/ce-code-review-mechanics.test.ts
@@ -51,6 +51,21 @@ describe("ce-code-review deterministic mechanics", () => {
     expect(scope.lite_eligible).toBe(false)
   })
 
+  test("scope helper counts .mjs and .cjs files as executable code", () => {
+    const { dir, base } = fixtureRepo()
+    writeFileSync(path.join(dir, "esm.mjs"), "export const value = 1\n")
+    writeFileSync(path.join(dir, "common.cjs"), "module.exports = 1\n")
+    git(dir, "add", ".")
+
+    const result = run("python3", [SCOPE_SCRIPT, "--base", base], dir)
+    expect(result.status).toBe(0)
+    const scope = JSON.parse(result.stdout)
+
+    expect(scope.exec_lines).toBe(2)
+    expect(scope.uncounted_files).toBe(0)
+    expect(scope.lite_eligible).toBe(true)
+  })
+
   test("scope helper emits UNKNOWN-equivalent state for an invalid endpoint", () => {
     const { dir } = fixtureRepo()
     const result = run("python3", [SCOPE_SCRIPT, "--base", "missing-ref"], dir)


### PR DESCRIPTION
## Summary

`ce-code-review` now recognizes `.mjs` and `.cjs` files as executable code when it scopes a diff. On a Node repo using explicit ESM or CommonJS extensions, the scope helper reported `exec_lines: 0` with `status: complete`, so the small-diff lite path could never fire and the maintainability reviewer's line-count trigger never reached. Both failed toward a full roster, so this is a cost and precision fix, not a correctness one.

A regression test covers an `.mjs` plus `.cjs` diff and asserts it counts and qualifies for lite.

The issue's secondary suggestion, a `reason` field when nothing in a non-empty diff matches the allowlist, is intentionally out of scope here. `uncounted_files > 0` already disqualifies lite and the orchestrator reads it; adding a signal for that state, or widening the allowlist to other languages, is a separate decision.

Fixes #1666

## Validation

- `bun run test`: 4084 pass, 0 fail
- `bun run release:validate` and `bun run plugin:validate`: pass
- The new test fails on `main` with `exec_lines` 0 and passes on this branch

## Security Disclosure
No security-relevant changes.

## Agent Disclosure
- **Model:** `Claude Code · claude-fable-5-1`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

https://claude.ai/code/session_013bA4rtWvEygqJ75cveDSSh
